### PR TITLE
fix: remove all unused imports and variables across 13 files

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { Users, Calendar, CreditCard, TrendingUp, Star, Activity } from "lucide-react";
+import { Users, Calendar, CreditCard, Star, Activity } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { appointments, patients, doctors, getTotalRevenue, getAverageRating } from "@/lib/demo-data";

--- a/src/app/(admin)/admin/patients/page.tsx
+++ b/src/app/(admin)/admin/patients/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Search, User, Phone, Mail, Calendar, Shield } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/app/(admin)/admin/reports/page.tsx
+++ b/src/app/(admin)/admin/reports/page.tsx
@@ -7,7 +7,6 @@ const totalAppts = appointments.length;
 const completedAppts = appointments.filter((a) => a.status === "completed").length;
 const noShowAppts = appointments.filter((a) => a.status === "no-show").length;
 const noShowRate = totalAppts > 0 ? Math.round((noShowAppts / totalAppts) * 100) : 0;
-const cancelledAppts = appointments.filter((a) => a.status === "cancelled").length;
 
 const monthlyData = [
   { month: "Jan", revenue: 12500, patients: 42, appointments: 68 },

--- a/src/app/(admin)/admin/reviews/page.tsx
+++ b/src/app/(admin)/admin/reviews/page.tsx
@@ -1,5 +1,5 @@
 import { Star, MessageSquare } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,4 +1,4 @@
-import { Clock, CreditCard, MessageCircle, Calendar, Shield } from "lucide-react";
+import { Clock, CreditCard, MessageCircle, Calendar } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/src/app/(patient)/patient/documents/page.tsx
+++ b/src/app/(patient)/patient/documents/page.tsx
@@ -1,5 +1,5 @@
 import { Upload, FileText, Image, CreditCard } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 

--- a/src/app/(patient)/patient/feedback/page.tsx
+++ b/src/app/(patient)/patient/feedback/page.tsx
@@ -5,7 +5,6 @@ import { Star, Send, MessageSquare } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { doctors } from "@/lib/demo-data";
 

--- a/src/app/(patient)/patient/notifications/page.tsx
+++ b/src/app/(patient)/patient/notifications/page.tsx
@@ -1,5 +1,5 @@
 import { Bell, Calendar, Pill, CreditCard, CheckCircle2 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 

--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -3,10 +3,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { appointments, getTodayAppointments, getTotalRevenue } from "@/lib/demo-data";
+import { getTodayAppointments, getTotalRevenue } from "@/lib/demo-data";
 
 const todayAppts = getTodayAppointments("d1");
-const allTodayAppts = appointments.filter((a) => a.date === new Date().toISOString().split("T")[0]);
 const checkedIn = todayAppts.filter((a) => a.status === "confirmed" || a.status === "in-progress").length;
 const totalRevenue = getTotalRevenue();
 

--- a/src/app/(super-admin)/super-admin/clinics/page.tsx
+++ b/src/app/(super-admin)/super-admin/clinics/page.tsx
@@ -1,5 +1,5 @@
 import { Plus, LogIn, Search, Ban } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/app/(super-admin)/super-admin/dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { Building2, Users, TrendingUp, AlertCircle, Megaphone } from "lucide-react";
+import { Building2, Users, TrendingUp, Megaphone } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/src/app/(super-admin)/super-admin/features/page.tsx
+++ b/src/app/(super-admin)/super-admin/features/page.tsx
@@ -1,5 +1,5 @@
 import { ToggleLeft, ToggleRight } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 

--- a/src/app/(super-admin)/super-admin/templates/page.tsx
+++ b/src/app/(super-admin)/super-admin/templates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { FileText, Copy, Edit, Trash2, Plus, Eye } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 


### PR DESCRIPTION
## Summary

Removes all 20 ESLint warnings (unused imports and variables) across 13 files. Both `npm run lint` and `npm run build` pass cleanly with zero warnings/errors.

## Changes

### Admin pages
- `admin/dashboard/page.tsx` — removed unused `TrendingUp` import
- `admin/patients/page.tsx` — removed unused `CardHeader`, `CardTitle` imports
- `admin/reports/page.tsx` — removed unused `cancelledAppts` variable
- `admin/reviews/page.tsx` — removed unused `CardHeader`, `CardTitle` imports
- `admin/settings/page.tsx` — removed unused `Shield` import

### Patient pages
- `patient/documents/page.tsx` — removed unused `CardHeader`, `CardTitle` imports
- `patient/feedback/page.tsx` — removed unused `Input` import
- `patient/notifications/page.tsx` — removed unused `CardHeader`, `CardTitle` imports

### Super-admin pages
- `super-admin/dashboard/page.tsx` — removed unused `AlertCircle` import
- `super-admin/clinics/page.tsx` — removed unused `CardHeader`, `CardTitle` imports
- `super-admin/features/page.tsx` — removed unused `CardHeader`, `CardTitle` imports
- `super-admin/templates/page.tsx` — removed unused `CardHeader`, `CardTitle` imports

### Receptionist pages
- `receptionist/dashboard/page.tsx` — removed unused `allTodayAppts` variable and `appointments` import

## Verification
- ✅ `npm run lint` — 0 warnings, 0 errors
- ✅ `npm run build` — compiles and generates all 45 routes successfully