### PR TITLE
fix: add edge runtime to API routes for Cloudflare Pages

### DIFF
--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+export const runtime = "edge";
+
 /**
  * POST /api/booking
  *

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+export const runtime = "edge";
+
 /**
  * POST /api/webhooks
  *


### PR DESCRIPTION
Adds `export const runtime = "edge"` to `/api/booking` and `/api/webhooks` routes so they can run on Cloudflare Pages (which requires Edge Runtime for all non-static routes).