### PR TITLE
feat: wire public pages and booking form to real Supabase data

### DIFF
--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -14,6 +14,7 @@ export const metadata: Metadata = {
   },
 };
 
+// Blog posts don't have a DB table yet — uses demo data until a blog_posts table or CMS is added
 export default function BlogPage() {
   return (
     <div className="container mx-auto px-4 py-12">

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 import { HeroSection } from "@/components/public/hero-section";
 import { ServicesPreview } from "@/components/public/services-preview";
 import { defaultWebsiteConfig } from "@/lib/website-config";
-import { reviews, getAverageRating } from "@/lib/demo-data";
+import { getPublicReviews, getPublicAverageRating } from "@/lib/data/public";
+import { reviews as demoReviews, getAverageRating as demoGetAverageRating } from "@/lib/demo-data";
 import { Star, ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
@@ -24,9 +25,15 @@ const linkBtnOutline =
 const linkBtnPrimary =
   "inline-flex items-center justify-center rounded-lg bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:bg-primary/80 transition-colors";
 
-export default function HomePage() {
+export default async function HomePage() {
   const aboutCfg = defaultWebsiteConfig.about;
-  const avgRating = getAverageRating();
+
+  // Fetch from Supabase, fall back to demo data if empty
+  const supabaseReviews = await getPublicReviews();
+  const reviews = supabaseReviews.length > 0 ? supabaseReviews : demoReviews;
+  const avgRating = supabaseReviews.length > 0
+    ? await getPublicAverageRating()
+    : demoGetAverageRating();
   const topReviews = reviews.filter((r) => r.rating >= 4).slice(0, 3);
 
   return (

--- a/src/app/(public)/reviews/page.tsx
+++ b/src/app/(public)/reviews/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Star } from "lucide-react";
-import { reviews, getAverageRating } from "@/lib/demo-data";
+import { getPublicReviews, getPublicAverageRating } from "@/lib/data/public";
+import { reviews as demoReviews, getAverageRating as demoGetAverageRating } from "@/lib/demo-data";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -32,9 +33,15 @@ function StarRating({ rating }: { rating: number }) {
   );
 }
 
-export default function ReviewsPage() {
+export default async function ReviewsPage() {
   const cfg = defaultWebsiteConfig.reviews;
-  const avgRating = getAverageRating();
+
+  // Fetch from Supabase, fall back to demo data if empty
+  const supabaseReviews = await getPublicReviews();
+  const reviews = supabaseReviews.length > 0 ? supabaseReviews : demoReviews;
+  const avgRating = supabaseReviews.length > 0
+    ? await getPublicAverageRating()
+    : demoGetAverageRating();
 
   return (
     <div className="container mx-auto px-4 py-12">

--- a/src/app/(public)/services/page.tsx
+++ b/src/app/(public)/services/page.tsx
@@ -1,14 +1,17 @@
-"use client";
-
 import { Clock, CreditCard } from "lucide-react";
 import Link from "next/link";
-import { services } from "@/lib/demo-data";
+import { getPublicServices } from "@/lib/data/public";
+import { services as demoServices } from "@/lib/demo-data";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 
-export default function ServicesPage() {
+export default async function ServicesPage() {
   const cfg = defaultWebsiteConfig.services;
+
+  // Fetch from Supabase, fall back to demo data if empty
+  const supabaseServices = await getPublicServices();
+  const services = supabaseServices.length > 0 ? supabaseServices : demoServices;
 
   return (
     <div className="container mx-auto px-4 py-12">

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { ChevronLeft, ChevronRight, Check, Stethoscope, User, ShieldCheck, Repeat, Users } from "lucide-react";
-import { specialties, doctors, services, getAvailableSlots, generateTimeSlots, getSlotBookingCounts, getDoctorsBySpecialty, addToWaitingList } from "@/lib/demo-data";
+import {
+  specialties as demoSpecialties,
+  doctors as demoDoctors,
+  services as demoServices,
+  getAvailableSlots as demoGetAvailableSlots,
+  generateTimeSlots as demoGenerateTimeSlots,
+  getSlotBookingCounts as demoGetSlotBookingCounts,
+  addToWaitingList as demoAddToWaitingList,
+} from "@/lib/demo-data";
+import type { Specialty, Doctor, Service } from "@/lib/demo-data";
+import { fetchDoctors, fetchServices } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -18,6 +28,21 @@ function getSteps() {
   if (clinicConfig.features.onlinePayment) s.push("Payment");
   s.push("Confirm");
   return s;
+}
+
+/** Derive specialties from doctor metadata */
+function deriveSpecialties(docs: Doctor[]): Specialty[] {
+  const seen = new Map<string, Specialty>();
+  for (const d of docs) {
+    if (d.specialtyId && !seen.has(d.specialtyId)) {
+      seen.set(d.specialtyId, {
+        id: d.specialtyId,
+        name: d.specialty,
+        description: `${d.specialty} consultations`,
+      });
+    }
+  }
+  return Array.from(seen.values());
 }
 
 export function BookingForm() {
@@ -42,20 +67,94 @@ export function BookingForm() {
   const [pendingPaymentId] = useState(() => `pending-${crypto.randomUUID()}`);
   const [patientPaymentId] = useState(() => `patient-${crypto.randomUUID()}`);
 
+  // Supabase-loaded data with demo fallbacks
+  const [specialties, setSpecialties] = useState<Specialty[]>(demoSpecialties);
+  const [doctors, setDoctors] = useState<Doctor[]>(demoDoctors);
+  const [services, setServices] = useState<Service[]>(demoServices);
+
+  // Slot data (fetched dynamically via API when date/doctor change)
+  const [availableSlots, setAvailableSlots] = useState<string[]>([]);
+  const [allSlots, setAllSlots] = useState<string[]>([]);
+  const [slotCounts, setSlotCounts] = useState<Record<string, number>>({});
+
+  // Load doctors, services, and specialties from Supabase on mount
+  useEffect(() => {
+    const clinicId = clinicConfig.clinicId;
+    if (!clinicId || clinicId === "demo-clinic") return;
+
+    Promise.all([
+      fetchDoctors(clinicId),
+      fetchServices(clinicId),
+    ]).then(([dbDoctors, dbServices]) => {
+      if (dbDoctors.length > 0) {
+        const mappedDoctors: Doctor[] = dbDoctors.map((d) => ({
+          id: d.id,
+          name: d.name,
+          specialtyId: d.specialtyId,
+          specialty: d.specialty,
+          phone: d.phone,
+          email: d.email,
+          avatar: d.avatar,
+          consultationFee: d.consultationFee,
+          languages: d.languages,
+        }));
+        setDoctors(mappedDoctors);
+        setSpecialties(deriveSpecialties(mappedDoctors));
+      }
+      if (dbServices.length > 0) {
+        const mappedServices: Service[] = dbServices.map((s) => ({
+          id: s.id,
+          name: s.name,
+          description: s.description,
+          duration: s.duration,
+          price: s.price,
+          currency: s.currency,
+          active: s.active,
+        }));
+        setServices(mappedServices);
+      }
+    }).catch(() => {
+      // Keep demo data on error
+    });
+  }, []);
+
+  // Fetch available slots when date or doctor changes
+  const fetchSlots = useCallback(async (date: string, doctorId: string) => {
+    if (!date || !doctorId) return;
+
+    try {
+      const res = await fetch(`/api/booking?date=${date}&doctorId=${doctorId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setAvailableSlots(data.slots ?? []);
+        setAllSlots(data.allSlots ?? []);
+        setSlotCounts(data.bookedCounts ?? {});
+        return;
+      }
+    } catch {
+      // Fall through to demo fallback
+    }
+
+    // Fallback to demo data functions
+    setAvailableSlots(demoGetAvailableSlots(date, doctorId));
+    setAllSlots(demoGenerateTimeSlots(date));
+    setSlotCounts(demoGetSlotBookingCounts(date, doctorId));
+  }, []);
+
+  useEffect(() => {
+    if (selectedDate && selectedDoctor) {
+      fetchSlots(selectedDate, selectedDoctor);
+    } else {
+      setAvailableSlots([]);
+      setAllSlots([]);
+      setSlotCounts({});
+    }
+  }, [selectedDate, selectedDoctor, fetchSlots]);
+
   const filteredDoctors = useMemo(() => {
     if (!selectedSpecialty) return doctors;
-    return getDoctorsBySpecialty(selectedSpecialty);
-  }, [selectedSpecialty]);
-
-  const availableSlots = selectedDate && selectedDoctor
-    ? getAvailableSlots(selectedDate, selectedDoctor)
-    : [];
-
-  const allSlots = selectedDate ? generateTimeSlots(selectedDate) : [];
-
-  const slotCounts = selectedDate && selectedDoctor
-    ? getSlotBookingCounts(selectedDate, selectedDoctor)
-    : {};
+    return doctors.filter((d) => d.specialtyId === selectedSpecialty);
+  }, [selectedSpecialty, doctors]);
 
   const doctor = doctors.find((d) => d.id === selectedDoctor);
   const service = services.find((s) => s.id === selectedService);
@@ -79,7 +178,7 @@ export function BookingForm() {
       setWaitingListMessage("Please complete your info first (step 5) to join a waiting list.");
       return;
     }
-    const result = addToWaitingList(
+    const result = demoAddToWaitingList(
       `patient-${Date.now()}`,
       patientInfo.name,
       selectedDoctor,

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -1,0 +1,310 @@
+/**
+ * Server-side data fetching for public-facing pages.
+ *
+ * These functions use the server Supabase client and scope all queries
+ * to the current clinic via `clinicConfig.clinicId`.
+ * They return data shaped to match the existing UI types so pages
+ * can swap from demo-data imports with minimal changes.
+ */
+
+import { createClient } from "@/lib/supabase-server";
+import { clinicConfig } from "@/config/clinic.config";
+
+// ── Types (match existing UI shapes) ──
+
+export interface PublicReview {
+  id: string;
+  patientName: string;
+  rating: number;
+  comment: string;
+  date: string;
+  replied: boolean;
+}
+
+export interface PublicService {
+  id: string;
+  name: string;
+  description: string;
+  duration: number;
+  price: number;
+  currency: string;
+  active: boolean;
+}
+
+export interface PublicDoctor {
+  id: string;
+  name: string;
+  specialtyId: string;
+  specialty: string;
+  phone: string;
+  email: string;
+  avatar?: string;
+  consultationFee: number;
+  languages: string[];
+}
+
+export interface PublicSpecialty {
+  id: string;
+  name: string;
+  description: string;
+}
+
+// ── Helpers ──
+
+function getClinicId(): string {
+  return clinicConfig.clinicId;
+}
+
+// ── Reviews ──
+
+export async function getPublicReviews(): Promise<PublicReview[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  // Fetch reviews with patient names via join
+  const { data: reviews, error } = await supabase
+    .from("reviews")
+    .select("id, patient_id, stars, comment, response, created_at")
+    .eq("clinic_id", clinicId)
+    .order("created_at", { ascending: false });
+
+  if (error || !reviews || reviews.length === 0) return [];
+
+  // Get patient names
+  const patientIds = [...new Set(reviews.map((r) => r.patient_id))];
+  const { data: users } = await supabase
+    .from("users")
+    .select("id, name")
+    .in("id", patientIds);
+
+  const nameMap = new Map(
+    (users ?? []).map((u: { id: string; name: string }) => [u.id, u.name]),
+  );
+
+  return reviews.map((r) => ({
+    id: r.id,
+    patientName: nameMap.get(r.patient_id) ?? "Patient",
+    rating: r.stars,
+    comment: r.comment ?? "",
+    date: r.created_at?.split("T")[0] ?? "",
+    replied: !!r.response,
+  }));
+}
+
+export async function getPublicAverageRating(): Promise<number> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const { data } = await supabase
+    .from("reviews")
+    .select("stars")
+    .eq("clinic_id", clinicId);
+
+  if (!data || data.length === 0) return 0;
+  const sum = data.reduce((s, r) => s + r.stars, 0);
+  return Math.round((sum / data.length) * 10) / 10;
+}
+
+// ── Services ──
+
+export async function getPublicServices(): Promise<PublicService[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("services")
+    .select("id, name, description, duration_min, price, is_active")
+    .eq("clinic_id", clinicId)
+    .order("name", { ascending: true });
+
+  if (error || !data) return [];
+
+  return data.map((s) => ({
+    id: s.id,
+    name: s.name,
+    description: (s as Record<string, unknown>).description as string ?? "",
+    duration: (s as Record<string, unknown>).duration_min as number ?? 30,
+    price: s.price ?? 0,
+    currency: clinicConfig.currency,
+    active: (s as Record<string, unknown>).is_active as boolean ?? true,
+  }));
+}
+
+// ── Doctors ──
+
+export async function getPublicDoctors(): Promise<PublicDoctor[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("users")
+    .select("id, name, phone, email, avatar_url, metadata")
+    .eq("clinic_id", clinicId)
+    .eq("role", "doctor")
+    .order("name", { ascending: true });
+
+  if (error || !data) return [];
+
+  return data.map((d) => {
+    const meta = (d.metadata ?? {}) as Record<string, unknown>;
+    return {
+      id: d.id,
+      name: d.name,
+      specialtyId: (meta.specialty_id as string) ?? "",
+      specialty: (meta.specialty as string) ?? "",
+      phone: d.phone ?? "",
+      email: d.email ?? "",
+      avatar: d.avatar_url ?? undefined,
+      consultationFee: (meta.consultation_fee as number) ?? 0,
+      languages: (meta.languages as string[]) ?? [],
+    };
+  });
+}
+
+// ── Specialties (derived from doctors) ──
+
+export async function getPublicSpecialties(): Promise<PublicSpecialty[]> {
+  const doctors = await getPublicDoctors();
+  const seen = new Map<string, PublicSpecialty>();
+
+  for (const d of doctors) {
+    if (d.specialtyId && !seen.has(d.specialtyId)) {
+      seen.set(d.specialtyId, {
+        id: d.specialtyId,
+        name: d.specialty,
+        description: `${d.specialty} consultations`,
+      });
+    }
+  }
+
+  return Array.from(seen.values());
+}
+
+// ── Time Slots & Availability ──
+
+export interface TimeSlotConfig {
+  id: string;
+  doctorId: string;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+  maxCapacity: number;
+  bufferMinutes: number;
+  isAvailable: boolean;
+}
+
+export async function getPublicTimeSlots(
+  doctorId?: string,
+): Promise<TimeSlotConfig[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  let q = supabase
+    .from("time_slots")
+    .select("id, doctor_id, day_of_week, start_time, end_time, is_available, max_capacity, buffer_minutes")
+    .eq("clinic_id", clinicId)
+    .eq("is_available", true);
+
+  if (doctorId) {
+    q = q.eq("doctor_id", doctorId);
+  }
+
+  const { data, error } = await q.order("day_of_week", { ascending: true });
+
+  if (error || !data) return [];
+
+  return data.map((ts) => ({
+    id: ts.id,
+    doctorId: ts.doctor_id,
+    dayOfWeek: ts.day_of_week,
+    startTime: ts.start_time,
+    endTime: ts.end_time,
+    maxCapacity: ts.max_capacity ?? 1,
+    bufferMinutes: ts.buffer_minutes ?? 10,
+    isAvailable: ts.is_available ?? true,
+  }));
+}
+
+/**
+ * Generate individual time-slot strings for a given date and doctor,
+ * based on the doctor's configured time_slots for that day of week.
+ */
+export async function getPublicGeneratedSlots(
+  date: string,
+  doctorId: string,
+): Promise<string[]> {
+  const dayOfWeek = new Date(date).getDay();
+  const slotConfigs = await getPublicTimeSlots(doctorId);
+  const daySlots = slotConfigs.filter((s) => s.dayOfWeek === dayOfWeek);
+
+  const slots: string[] = [];
+  const duration = clinicConfig.booking.slotDuration;
+  const buffer = clinicConfig.booking.bufferTime;
+
+  for (const config of daySlots) {
+    const [startH, startM] = config.startTime.split(":").map(Number);
+    const [endH, endM] = config.endTime.split(":").map(Number);
+    const startMinutes = startH * 60 + startM;
+    const endMinutes = endH * 60 + endM;
+
+    let current = startMinutes;
+    while (current + duration <= endMinutes) {
+      const h = Math.floor(current / 60);
+      const m = current % 60;
+      slots.push(`${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`);
+      current += duration + buffer;
+    }
+  }
+
+  return slots.sort();
+}
+
+/**
+ * Get existing appointment counts per time slot for a given date and doctor.
+ */
+export async function getPublicSlotBookingCounts(
+  date: string,
+  doctorId: string,
+): Promise<Record<string, number>> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const dayStart = `${date}T00:00:00`;
+  const dayEnd = `${date}T23:59:59`;
+
+  const { data, error } = await supabase
+    .from("appointments")
+    .select("slot_start, status")
+    .eq("clinic_id", clinicId)
+    .eq("doctor_id", doctorId)
+    .gte("slot_start", dayStart)
+    .lte("slot_start", dayEnd)
+    .not("status", "in", '("cancelled","no_show")');
+
+  if (error || !data) return {};
+
+  const counts: Record<string, number> = {};
+  for (const appt of data) {
+    const time = appt.slot_start?.split("T")[1]?.slice(0, 5) ?? "";
+    if (time) {
+      counts[time] = (counts[time] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Get available (non-fully-booked) slots for a date and doctor.
+ */
+export async function getPublicAvailableSlots(
+  date: string,
+  doctorId: string,
+): Promise<string[]> {
+  const [allSlots, bookingCounts] = await Promise.all([
+    getPublicGeneratedSlots(date, doctorId),
+    getPublicSlotBookingCounts(date, doctorId),
+  ]);
+
+  const maxPerSlot = clinicConfig.booking.maxPerSlot;
+  return allSlots.filter((slot) => (bookingCounts[slot] ?? 0) < maxPerSlot);
+}


### PR DESCRIPTION
## Summary

Wires the 4 public pages and booking form component to use real Supabase data instead of demo data, with graceful fallbacks to demo data when the database is empty or unreachable.

### Changes

**New file: `src/lib/data/public.ts`**
- Server-side Supabase query functions for public pages
- `getPublicReviews()` / `getPublicAverageRating()` — fetch reviews with patient names
- `getPublicServices()` — fetch active services
- `getPublicDoctors()` / `getPublicSpecialties()` — fetch doctors and derive specialties
- `getPublicTimeSlots()` / `getPublicGeneratedSlots()` / `getPublicAvailableSlots()` — time slot availability
- `getPublicSlotBookingCounts()` — existing appointment counts per slot

**Public pages wired to Supabase:**
- `(public)/page.tsx` (Home) — async server component, fetches reviews + avg rating
- `(public)/reviews/page.tsx` — async server component, fetches reviews + avg rating
- `(public)/services/page.tsx` — converted from client to async server component, fetches services
- `(public)/blog/page.tsx` — kept on demo data (no blog_posts table in DB yet)

**Booking form wired to Supabase:**
- `components/booking/booking-form.tsx` — loads doctors, services, specialties from Supabase on mount via `useEffect`
- Slot availability fetched dynamically via `/api/booking` API endpoint
- All data falls back to demo data if Supabase returns empty or errors

### Design decisions
- All pages fall back to demo data when Supabase returns empty results
- Blog page stays on demo data since there is no `blog_posts` table in the schema yet
- Services page converted from client to server component for better performance
- Booking form uses existing `/api/booking` GET endpoint for slot availability