### PR TITLE
ci: add GitHub Actions workflow for auto-deploy to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Build & Deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for Cloudflare
+        run: npm run build:cf
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -89,9 +89,21 @@ Run the initial migration against your Supabase project:
 supabase db push
 ```
 
-## Deploy on Cloudflare Pages
+## Deploy on Cloudflare Workers
+
+### Manual Deploy
 
 ```bash
-npm run build
-# Deploy the .next output to Cloudflare Pages
+npm run deploy
 ```
+
+### Auto-Deploy via GitHub Actions
+
+Pushes to `main` automatically build and deploy to Cloudflare Workers. Add these secrets in your GitHub repo settings (**Settings > Secrets and variables > Actions**):
+
+| Secret | Description |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with Workers edit permissions |
+| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL (used at build time) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key (used at build time) |


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically builds and deploys the project to Cloudflare Workers on every push to `main`.

## Changes

- **`.github/workflows/deploy.yml`**: New workflow that:
  - Checks out the code
  - Sets up Node.js 22 with npm cache
  - Installs dependencies via `npm ci`
  - Runs `npm run build:cf` (opennextjs-cloudflare build + post-build patch)
  - Deploys via `cloudflare/wrangler-action@v3`
  - Passes Supabase env vars at build time

- **`README.md`**: Updated deploy section with required GitHub repo secrets table

## Required GitHub Secrets

Add these in **Settings > Secrets and variables > Actions**:

| Secret | Description |
|---|---|
| `CLOUDFLARE_API_TOKEN` | Cloudflare API token with Workers edit permissions |
| `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID |
| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL (used at build time) |
| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key (used at build time) |