### PR TITLE
feat: implement subdomain routing for multi-tenant clinic access

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,3 +10,9 @@ WHATSAPP_VERIFY_TOKEN=your-webhook-verify-token
 # Optional: CMI Payment Gateway
 CMI_MERCHANT_ID=
 CMI_SECRET_KEY=
+
+# Subdomain routing
+# Set to your root domain (e.g., "yourdomain.com") to enable
+# clinic subdomains like clinicname.yourdomain.com
+# For local dev, subdomains work automatically via *.localhost
+ROOT_DOMAIN=

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ supabase/
 
 All clinics share one Supabase project. Data isolation is enforced via **Row Level Security (RLS)** - every table has a `clinic_id` column and RLS policies automatically filter queries.
 
+### Subdomain Routing
+
+Each clinic is accessible at `clinicname.yourdomain.com`. The middleware extracts the subdomain, looks up the clinic in Supabase, and injects tenant info into request headers for all downstream pages and API routes.
+
+**Setup:**
+
+1. Add a `subdomain` value to each clinic row in the `clinics` table (run migration `00004_add_clinic_subdomain.sql`)
+2. Set `ROOT_DOMAIN=yourdomain.com` in `.env.local`
+3. Configure a wildcard DNS record: `*.yourdomain.com → your server`
+
+For local development, subdomains work automatically via `*.localhost` (e.g., `demo.localhost:3000`).
+
+**How it works:**
+
+- `middleware.ts` extracts the subdomain and queries the `clinics` table
+- Resolved clinic info is passed via `x-tenant-*` headers
+- Server Components use `getTenant()` from `src/lib/tenant.ts`
+- Client Components use `useTenant()` from `src/components/tenant-provider.tsx`
+- Unknown subdomains redirect to the root domain
+
 ## Per-Client Deployment
 
 To deploy for a new client, only edit `src/config/clinic.config.ts` with their details (name, contact, features, working hours).

--- a/src/components/tenant-provider.tsx
+++ b/src/components/tenant-provider.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/** Tenant info available to client components. */
+export interface ClientTenantInfo {
+  clinicId: string;
+  clinicName: string;
+  subdomain: string;
+  clinicType: string;
+  clinicTier: string;
+}
+
+const TenantContext = createContext<ClientTenantInfo | null>(null);
+
+/**
+ * Hook to access the current tenant in client components.
+ * Returns null when on the root domain (no subdomain).
+ */
+export function useTenant(): ClientTenantInfo | null {
+  return useContext(TenantContext);
+}
+
+/**
+ * Provider that passes tenant info from server to client components.
+ * Wrap this around your layout children.
+ */
+export function TenantProvider({
+  tenant,
+  children,
+}: {
+  tenant: ClientTenantInfo | null;
+  children: ReactNode;
+}) {
+  return (
+    <TenantContext.Provider value={tenant}>{children}</TenantContext.Provider>
+  );
+}

--- a/src/lib/subdomain.ts
+++ b/src/lib/subdomain.ts
@@ -1,0 +1,57 @@
+/**
+ * Subdomain utilities for multi-tenant routing.
+ *
+ * Each clinic can be accessed at: clinicname.yourdomain.com
+ * The ROOT_DOMAIN env var defines the base domain (e.g., "yourdomain.com").
+ * For local dev, subdomains work via "clinicname.localhost:3000".
+ */
+
+/**
+ * Extract the subdomain from a hostname.
+ *
+ * Examples:
+ *   "demo.example.com"      → "demo"       (ROOT_DOMAIN = "example.com")
+ *   "demo.localhost"         → "demo"       (localhost dev)
+ *   "example.com"            → null         (root domain, no subdomain)
+ *   "localhost"              → null
+ *   "www.example.com"        → null         ("www" is ignored)
+ */
+export function extractSubdomain(
+  hostname: string,
+  rootDomain?: string,
+): string | null {
+  // Strip port if present
+  const host = hostname.split(":")[0];
+
+  // Local development: *.localhost
+  if (host.endsWith(".localhost")) {
+    const sub = host.replace(".localhost", "");
+    if (sub && sub !== "www") return sub;
+    return null;
+  }
+
+  // If no root domain configured, cannot extract subdomain
+  if (!rootDomain) return null;
+
+  const root = rootDomain.split(":")[0];
+
+  // Host must end with .rootDomain and be longer than rootDomain
+  if (!host.endsWith(`.${root}`)) return null;
+
+  const sub = host.slice(0, -(root.length + 1)); // remove ".rootDomain"
+
+  // Ignore empty, "www", or multi-level subdomains (e.g., "a.b")
+  if (!sub || sub === "www" || sub.includes(".")) return null;
+
+  return sub;
+}
+
+/**
+ * Check whether the current hostname is the root domain (no subdomain).
+ */
+export function isRootDomain(
+  hostname: string,
+  rootDomain?: string,
+): boolean {
+  return extractSubdomain(hostname, rootDomain) === null;
+}

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -1,0 +1,47 @@
+/**
+ * Server-side tenant resolution.
+ *
+ * In middleware, the resolved clinic is stored in request headers.
+ * Server Components and API routes read it from headers().
+ */
+
+import { headers } from "next/headers";
+
+/** Minimal tenant info passed via request headers from middleware. */
+export interface TenantInfo {
+  clinicId: string;
+  clinicName: string;
+  subdomain: string;
+  clinicType: string;
+  clinicTier: string;
+}
+
+/** Header names used to pass tenant info from middleware. */
+export const TENANT_HEADERS = {
+  clinicId: "x-tenant-clinic-id",
+  clinicName: "x-tenant-clinic-name",
+  subdomain: "x-tenant-subdomain",
+  clinicType: "x-tenant-clinic-type",
+  clinicTier: "x-tenant-clinic-tier",
+} as const;
+
+/**
+ * Get the current tenant from request headers (set by middleware).
+ * Returns null if no subdomain was resolved (i.e., root domain / super-admin).
+ *
+ * Use in Server Components and API routes.
+ */
+export async function getTenant(): Promise<TenantInfo | null> {
+  const h = await headers();
+  const clinicId = h.get(TENANT_HEADERS.clinicId);
+
+  if (!clinicId) return null;
+
+  return {
+    clinicId,
+    clinicName: h.get(TENANT_HEADERS.clinicName) ?? "",
+    subdomain: h.get(TENANT_HEADERS.subdomain) ?? "",
+    clinicType: h.get(TENANT_HEADERS.clinicType) ?? "",
+    clinicTier: h.get(TENANT_HEADERS.clinicTier) ?? "",
+  };
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -94,6 +94,7 @@ export interface Clinic {
   name: string;
   type: ClinicType;
   tier: ClinicTier;
+  subdomain: string | null;
   domain: string | null;
   config: Record<string, unknown>;
   is_active: boolean;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
+import { extractSubdomain } from "@/lib/subdomain";
+import { TENANT_HEADERS } from "@/lib/tenant";
 
 // Role to allowed route prefix mapping
 const ROLE_ROUTE_MAP: Record<string, string> = {
@@ -61,8 +63,28 @@ function isProtectedRoute(pathname: string): boolean {
   return PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
 
+/**
+ * Set tenant headers on a response so downstream Server Components
+ * and API routes can read them via getTenant().
+ */
+function setTenantHeaders(
+  response: NextResponse,
+  clinic: { id: string; name: string; subdomain: string; type: string; tier: string },
+) {
+  response.headers.set(TENANT_HEADERS.clinicId, clinic.id);
+  response.headers.set(TENANT_HEADERS.clinicName, clinic.name);
+  response.headers.set(TENANT_HEADERS.subdomain, clinic.subdomain);
+  response.headers.set(TENANT_HEADERS.clinicType, clinic.type);
+  response.headers.set(TENANT_HEADERS.clinicTier, clinic.tier);
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const hostname = request.headers.get("host") ?? "";
+  const rootDomain = process.env.ROOT_DOMAIN;
+
+  // --- Subdomain resolution ---
+  const subdomain = extractSubdomain(hostname, rootDomain);
 
   // If Supabase is not configured, allow all requests through
   // so the site renders with demo data instead of crashing
@@ -106,6 +128,32 @@ export async function middleware(request: NextRequest) {
       },
     }
   );
+
+  // --- Resolve clinic from subdomain ---
+  if (subdomain) {
+    const { data: clinic } = await supabase
+      .from("clinics")
+      .select("id, name, type, tier, subdomain")
+      .eq("subdomain", subdomain)
+      .single();
+
+    if (!clinic) {
+      // Unknown subdomain → redirect to root domain
+      const rootUrl = rootDomain
+        ? `${request.nextUrl.protocol}//${rootDomain}`
+        : request.nextUrl.origin;
+      return NextResponse.redirect(rootUrl);
+    }
+
+    // Attach tenant info to all responses so pages can read it
+    setTenantHeaders(supabaseResponse, {
+      id: clinic.id,
+      name: clinic.name,
+      subdomain: clinic.subdomain ?? subdomain,
+      type: clinic.type,
+      tier: clinic.tier,
+    });
+  }
 
   // IMPORTANT: Do NOT use getSession() here — it reads from cookies and
   // can be tampered with. Use getUser() which validates with Supabase.

--- a/supabase/migrations/00004_add_clinic_subdomain.sql
+++ b/supabase/migrations/00004_add_clinic_subdomain.sql
@@ -1,0 +1,12 @@
+-- ============================================================
+-- Migration 00004: Add subdomain column to clinics
+-- Enables subdomain-based multi-tenant routing
+-- (e.g., clinicname.yourdomain.com)
+-- ============================================================
+
+ALTER TABLE clinics
+  ADD COLUMN IF NOT EXISTS subdomain TEXT UNIQUE;
+
+-- Index for fast subdomain lookups in middleware
+CREATE INDEX IF NOT EXISTS idx_clinics_subdomain ON clinics(subdomain)
+  WHERE subdomain IS NOT NULL;


### PR DESCRIPTION
## Summary

Implements subdomain-based multi-tenant routing so each clinic can be accessed at `clinicname.yourdomain.com`.

## Changes

### Database
- **`supabase/migrations/00004_add_clinic_subdomain.sql`**: Adds `subdomain TEXT UNIQUE` column to `clinics` table with index
- **`src/lib/types/database.ts`**: Added `subdomain` field to `Clinic` interface

### Subdomain Resolution
- **`src/lib/subdomain.ts`**: Utility to extract subdomain from hostname. Supports `*.localhost` for local dev and configurable `ROOT_DOMAIN` for production. Ignores `www` and multi-level subdomains.
- **`src/middleware.ts`**: Extracts subdomain, looks up clinic in Supabase, sets `x-tenant-*` headers on all responses. Unknown subdomains redirect to root domain.

### Tenant Context
- **`src/lib/tenant.ts`**: Server-side `getTenant()` helper reads clinic info from request headers (for Server Components and API routes)
- **`src/components/tenant-provider.tsx`**: Client-side `TenantProvider` and `useTenant()` hook for React components

### Config
- **`.env.local.example`**: Added `ROOT_DOMAIN` env var
- **`README.md`**: Added subdomain routing documentation with setup instructions

## How It Works

1. User visits `demo.yourdomain.com`
2. Middleware extracts `demo` as subdomain
3. Queries `clinics` table for `subdomain = "demo"`
4. Sets `x-tenant-clinic-id`, `x-tenant-clinic-name`, etc. headers
5. Server Components call `getTenant()`, Client Components use `useTenant()`
6. Unknown subdomains → redirect to root domain

## Setup

1. Run migration `00004_add_clinic_subdomain.sql`
2. Set `ROOT_DOMAIN=yourdomain.com` in `.env.local`
3. Configure wildcard DNS: `*.yourdomain.com → your server`
4. For local dev: use `demo.localhost:3000` (no DNS config needed)