### PR TITLE
feat: wire patient components to real Supabase data (Group 6)

### DIFF
--- a/src/app/(patient)/patient/before-after/page.tsx
+++ b/src/app/(patient)/patient/before-after/page.tsx
@@ -2,19 +2,21 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { BeforeAfterGallery } from "@/components/dental/before-after-gallery";
-import { getCurrentUser } from "@/lib/data/client";
-import type { BeforeAfterPhoto } from "@/lib/dental-demo-data";
+import {
+  getCurrentUser,
+  fetchBeforeAfterPhotos,
+  type BeforeAfterPhotoView,
+} from "@/lib/data/client";
 
 export default function PatientBeforeAfterPage() {
-  const [myPhotos, setMyPhotos] = useState<BeforeAfterPhoto[]>([]);
+  const [myPhotos, setMyPhotos] = useState<BeforeAfterPhotoView[]>([]);
   const [loading, setLoading] = useState(true);
 
   const load = useCallback(async () => {
     const user = await getCurrentUser();
-    if (!user) { setLoading(false); return; }
-    // Before/after photos are not yet stored in Supabase DB;
-    // will show empty state until R2 image upload is implemented.
-    setMyPhotos([]);
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const photos = await fetchBeforeAfterPhotos(user.clinic_id, user.id);
+    setMyPhotos(photos);
     setLoading(false);
   }, []);
 

--- a/src/components/dental/before-after-gallery.tsx
+++ b/src/components/dental/before-after-gallery.tsx
@@ -7,12 +7,12 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { BeforeAfterPhoto } from "@/lib/dental-demo-data";
+import type { BeforeAfterPhotoView } from "@/lib/data/client";
 
 interface BeforeAfterGalleryProps {
-  photos: BeforeAfterPhoto[];
+  photos: BeforeAfterPhotoView[];
   editable?: boolean;
-  onAddPhoto?: (photo: Omit<BeforeAfterPhoto, "id">) => void;
+  onAddPhoto?: (photo: Omit<BeforeAfterPhotoView, "id">) => void;
 }
 
 export function BeforeAfterGallery({ photos, editable = false, onAddPhoto }: BeforeAfterGalleryProps) {

--- a/src/components/patient/appointment-list.tsx
+++ b/src/components/patient/appointment-list.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState } from "react";
-import { Calendar, Clock, User, MapPin, X, RefreshCw, AlertTriangle, Repeat } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Calendar, Clock, User, MapPin, X, RefreshCw, AlertTriangle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { appointments, canCancelAppointment } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchPatientAppointments,
+  type AppointmentView,
+} from "@/lib/data/client";
 import { RescheduleDialog } from "./reschedule-dialog";
+
+const CANCELLATION_WINDOW_HOURS = 24;
 
 const statusVariant: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
   scheduled: "default",
@@ -18,6 +24,23 @@ const statusVariant: Record<string, "default" | "secondary" | "destructive" | "o
   "in-progress": "default",
 };
 
+function canCancelAppointment(
+  appt: AppointmentView,
+): { canCancel: boolean; reason?: string } {
+  if (appt.status === "cancelled" || appt.status === "completed" || appt.status === "rescheduled") {
+    return { canCancel: false, reason: "Appointment cannot be cancelled in its current state" };
+  }
+  const appointmentDateTime = new Date(`${appt.date}T${appt.time}:00`);
+  const hoursUntil = (appointmentDateTime.getTime() - Date.now()) / (1000 * 60 * 60);
+  if (hoursUntil < CANCELLATION_WINDOW_HOURS) {
+    return {
+      canCancel: false,
+      reason: `Cancellations must be made at least ${CANCELLATION_WINDOW_HOURS} hours before the appointment`,
+    };
+  }
+  return { canCancel: true };
+}
+
 /**
  * AppointmentList
  *
@@ -25,27 +48,39 @@ const statusVariant: Record<string, "default" | "secondary" | "destructive" | "o
  * Supports cancel and reschedule actions.
  */
 export function AppointmentList({ patientId }: { patientId?: string }) {
+  const [allAppts, setAllAppts] = useState<AppointmentView[]>([]);
+  const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
   const [rescheduleAppt, setRescheduleAppt] = useState<string | null>(null);
   const [cancellingId, setCancellingId] = useState<string | null>(null);
   const [cancelError, setCancelError] = useState<string | null>(null);
 
-  // Re-read appointments on refresh
-  void refreshKey;
-  const patientAppts = patientId
-    ? appointments.filter((a) => a.patientId === patientId)
-    : appointments.slice(0, 4);
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const pid = patientId ?? user.id;
+    const appts = await fetchPatientAppointments(user.clinic_id, pid);
+    setAllAppts(appts);
+    setLoading(false);
+  }, [patientId, refreshKey]);
 
-  const upcoming = patientAppts.filter(
+  useEffect(() => { load(); }, [load]);
+
+  const upcoming = allAppts.filter(
     (a) => a.status === "scheduled" || a.status === "confirmed" || a.status === "in-progress",
   );
-  const past = patientAppts.filter(
+  const past = allAppts.filter(
     (a) => a.status === "completed" || a.status === "cancelled" || a.status === "no-show" || a.status === "rescheduled",
   );
 
   const handleCancel = async (appointmentId: string) => {
     setCancelError(null);
-    const check = canCancelAppointment(appointmentId);
+    const appt = allAppts.find((a) => a.id === appointmentId);
+    if (!appt) {
+      setCancelError("Appointment not found");
+      return;
+    }
+    const check = canCancelAppointment(appt);
     if (!check.canCancel) {
       setCancelError(check.reason ?? "Cannot cancel this appointment");
       return;
@@ -73,8 +108,16 @@ export function AppointmentList({ patientId }: { patientId?: string }) {
     }
   };
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading appointments...</p>
+      </div>
+    );
+  }
+
   const apptToReschedule = rescheduleAppt
-    ? appointments.find((a) => a.id === rescheduleAppt)
+    ? allAppts.find((a) => a.id === rescheduleAppt)
     : null;
 
   if (apptToReschedule) {
@@ -122,10 +165,9 @@ export function AppointmentList({ patientId }: { patientId?: string }) {
                             Emergency
                           </Badge>
                         )}
-                        {appt.recurrenceGroupId && (
+                        {appt.notes && (
                           <Badge variant="outline" className="text-xs">
-                            <Repeat className="h-3 w-3 mr-1" />
-                            {appt.recurrencePattern}
+                            {appt.notes}
                           </Badge>
                         )}
                       </div>

--- a/src/components/patient/medical-record.tsx
+++ b/src/components/patient/medical-record.tsx
@@ -1,9 +1,18 @@
 "use client";
 
+import { useState, useEffect, useCallback } from "react";
 import { Activity, Pill, FileText, Stethoscope, AlertTriangle, TrendingUp } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { patients, prescriptions, appointments } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchPatientAppointments,
+  fetchPatientPrescriptions,
+  fetchPatients,
+  type PatientView,
+  type AppointmentView,
+  type PrescriptionView,
+} from "@/lib/data/client";
 
 /**
  * MedicalRecord
@@ -11,11 +20,50 @@ import { patients, prescriptions, appointments } from "@/lib/demo-data";
  * Displays a patient's medical history: past visits, diagnoses, prescriptions.
  */
 export function MedicalRecord({ patientId }: { patientId?: string }) {
-  const patient = patients.find((p) => p.id === patientId) ?? patients[0];
-  const patientRx = prescriptions.filter((rx) => rx.patientId === patient.id);
-  const patientAppts = appointments
-    .filter((a) => a.patientId === patient.id && a.status === "completed")
-    .slice(0, 5);
+  const [patient, setPatient] = useState<PatientView | null>(null);
+  const [patientRx, setPatientRx] = useState<PrescriptionView[]>([]);
+  const [patientAppts, setPatientAppts] = useState<AppointmentView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const pid = patientId ?? user.id;
+
+    const [patients, appointments, prescriptions] = await Promise.all([
+      fetchPatients(user.clinic_id),
+      fetchPatientAppointments(user.clinic_id, pid),
+      fetchPatientPrescriptions(user.clinic_id, pid),
+    ]);
+
+    const found = patients.find((p) => p.id === pid) ?? null;
+    setPatient(found);
+    setPatientRx(prescriptions);
+    setPatientAppts(
+      appointments
+        .filter((a) => a.status === "completed")
+        .slice(0, 5),
+    );
+    setLoading(false);
+  }, [patientId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading medical record...</p>
+      </div>
+    );
+  }
+
+  if (!patient) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Patient not found.</p>
+      </div>
+    );
+  }
 
   const vitals = [
     { label: "Blood Pressure", value: "120/80 mmHg", icon: Activity, trend: "stable" },
@@ -49,7 +97,7 @@ export function MedicalRecord({ patientId }: { patientId?: string }) {
             </div>
             <div>
               <p className="text-sm text-muted-foreground">Insurance</p>
-              <p className="text-sm font-medium">CNSS</p>
+              <p className="text-sm font-medium">{patient.insurance ?? "N/A"}</p>
             </div>
           </div>
           {patient.allergies && patient.allergies.length > 0 && (

--- a/src/components/patient/waiting-list-status.tsx
+++ b/src/components/patient/waiting-list-status.tsx
@@ -5,7 +5,7 @@ import { Clock, X, Bell } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { WaitingListEntry } from "@/lib/demo-data";
+import type { WaitingListView } from "@/lib/data/client";
 
 interface WaitingListStatusProps {
   patientId: string;
@@ -25,7 +25,7 @@ const statusVariant: Record<string, "default" | "secondary" | "destructive" | "o
  * and allows them to remove themselves.
  */
 export function WaitingListStatus({ patientId }: WaitingListStatusProps) {
-  const [entries, setEntries] = useState<WaitingListEntry[]>([]);
+  const [entries, setEntries] = useState<WaitingListView[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchEntries = useCallback(async () => {

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -1118,6 +1118,49 @@ export async function fetchInstallments(clinicId: string): Promise<InstallmentVi
 }
 
 // ─────────────────────────────────────────────
+// Dental: Before/After Photos
+// ─────────────────────────────────────────────
+
+export interface BeforeAfterPhotoView {
+  id: string;
+  patientId: string;
+  patientName: string;
+  treatmentPlanId: string;
+  description: string;
+  beforeDate: string;
+  afterDate: string | null;
+  category: string;
+}
+
+export async function fetchBeforeAfterPhotos(clinicId: string, patientId?: string): Promise<BeforeAfterPhotoView[]> {
+  await ensureLookups(clinicId);
+  const eq: [string, unknown][] = [["clinic_id", clinicId]];
+  if (patientId) eq.push(["patient_id", patientId]);
+  const rows = await fetchRows<{
+    id: string;
+    patient_id: string;
+    treatment_plan_id: string | null;
+    description: string | null;
+    before_date: string | null;
+    after_date: string | null;
+    category: string | null;
+  }>("before_after_photos", {
+    eq,
+    order: ["before_date", { ascending: false }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    patientId: r.patient_id,
+    patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
+    treatmentPlanId: r.treatment_plan_id ?? "",
+    description: r.description ?? "",
+    beforeDate: r.before_date ?? "",
+    afterDate: r.after_date ?? null,
+    category: r.category ?? "General",
+  }));
+}
+
+// ─────────────────────────────────────────────
 // Pharmacy: Products / Stock
 // ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Wires all 4 patient components in Group 6 to real Supabase data, removing all imports from `demo-data.ts` and `dental-demo-data.ts`.

## Changes

### 6.1 — `components/patient/medical-record.tsx`
- Replaced static `patients`, `prescriptions`, `appointments` imports from demo-data
- Now uses `fetchPatients`, `fetchPatientAppointments`, `fetchPatientPrescriptions` from `@/lib/data/client`
- Added loading/empty states
- Insurance field now reads from patient data instead of hardcoded "CNSS"

### 6.2 — `components/patient/appointment-list.tsx`
- Replaced `appointments` and `canCancelAppointment` imports from demo-data
- Now fetches appointments via `fetchPatientAppointments` with proper loading state
- Inlined `canCancelAppointment` logic using `AppointmentView` type (24h cancellation window)
- Replaced `recurrenceGroupId`/`recurrencePattern` badge with `notes` badge (fields not in Supabase schema)

### 6.3 — `components/patient/waiting-list-status.tsx`
- Replaced `WaitingListEntry` type import from demo-data with `WaitingListView` from `@/lib/data/client`

### 6.4 — Before/After (page + gallery)
- Added `BeforeAfterPhotoView` interface and `fetchBeforeAfterPhotos` function to `@/lib/data/client.ts`
- Updated `before-after/page.tsx` to fetch photos from Supabase instead of showing hardcoded empty state
- Updated `before-after-gallery.tsx` to use `BeforeAfterPhotoView` type

---

*Note: Pre-existing type error in `src/app/(doctor)/doctor/consultation/page.tsx:136` (`doctorId` not found) is unrelated to this PR.*