### PR TITLE
Wire all receptionist pages and components to real Supabase data

### DIFF
--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Calendar, Users, UserPlus, Clock, CreditCard, FileText, Phone, MessageCircle, CheckCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { getTodayAppointments, getTotalRevenue, patients } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchTodayAppointments,
+  fetchInvoices,
+  fetchPatients,
+  type AppointmentView,
+  type PatientView,
+} from "@/lib/data/client";
 import { ManualBookingDialog } from "@/components/receptionist/manual-booking-dialog";
 import { WalkInDialog } from "@/components/receptionist/walk-in-dialog";
 import { PaymentDialog } from "@/components/receptionist/payment-dialog";
@@ -21,16 +28,38 @@ const statusVariant: Record<string, "default" | "success" | "warning" | "destruc
 };
 
 export default function ReceptionistDashboardPage() {
-  const todayAppts = getTodayAppointments("d1");
-  const checkedIn = todayAppts.filter((a) => a.status === "confirmed" || a.status === "in-progress").length;
-  const totalRevenue = getTotalRevenue();
-
+  const [todayAppts, setTodayAppts] = useState<AppointmentView[]>([]);
+  const [patientList, setPatientList] = useState<PatientView[]>([]);
+  const [totalRevenue, setTotalRevenue] = useState(0);
+  const [loading, setLoading] = useState(true);
   const [checkedInIds, setCheckedInIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) { setLoading(false); return; }
+      const [appts, invoices, pts] = await Promise.all([
+        fetchTodayAppointments(user.clinic_id),
+        fetchInvoices(user.clinic_id),
+        fetchPatients(user.clinic_id),
+      ]);
+      setTodayAppts(appts);
+      setPatientList(pts);
+      const revenue = invoices
+        .filter((inv) => inv.status === "paid")
+        .reduce((sum, inv) => sum + inv.amount, 0);
+      setTotalRevenue(revenue);
+      setLoading(false);
+    }
+    load();
+  }, []);
+
+  const checkedIn = todayAppts.filter((a) => a.status === "confirmed" || a.status === "in-progress").length;
 
   const stats = [
     { icon: Calendar, label: "Today's Bookings", value: todayAppts.length.toString(), color: "text-blue-600" },
     { icon: Users, label: "Checked In", value: (checkedIn + checkedInIds.size).toString(), color: "text-green-600" },
-    { icon: UserPlus, label: "Walk-ins Today", value: "2", color: "text-purple-600" },
+    { icon: UserPlus, label: "Walk-ins Today", value: "0", color: "text-purple-600" },
     { icon: CreditCard, label: "Revenue (Month)", value: `${totalRevenue} MAD`, color: "text-orange-600" },
   ];
 
@@ -46,6 +75,14 @@ export default function ReceptionistDashboardPage() {
     const cleaned = phone.replace(/\s/g, "").replace("+", "");
     window.open(`https://wa.me/${cleaned}`, "_blank");
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading dashboard...</p>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -115,7 +152,7 @@ export default function ReceptionistDashboardPage() {
             ) : (
               <div className="space-y-3">
                 {todayAppts.map((apt) => {
-                  const patient = patients.find((p) => p.id === apt.patientId);
+                  const patient = patientList.find((p) => p.id === apt.patientId);
                   const isCheckedIn = checkedInIds.has(apt.id);
                   return (
                     <div key={apt.id} className="flex items-center gap-3 rounded-lg border p-3">
@@ -173,7 +210,7 @@ export default function ReceptionistDashboardPage() {
             ) : (
               <div className="space-y-3">
                 {todayAppts.filter((a) => a.status === "confirmed").map((apt, i) => {
-                  const patient = patients.find((p) => p.id === apt.patientId);
+                  const patient = patientList.find((p) => p.id === apt.patientId);
                   return (
                     <div key={apt.id} className="flex items-center gap-3 rounded-lg border p-3">
                       <div className="flex h-7 w-7 items-center justify-center rounded-full bg-orange-100 text-orange-700 text-xs font-bold">

--- a/src/app/(receptionist)/receptionist/patients/page.tsx
+++ b/src/app/(receptionist)/receptionist/patients/page.tsx
@@ -1,18 +1,31 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Search, Phone, MessageCircle, CheckCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { patients } from "@/lib/demo-data";
+import { getCurrentUser, fetchPatients, type PatientView } from "@/lib/data/client";
 import { PatientRegistrationDialog } from "@/components/receptionist/patient-registration-dialog";
 
 export default function ReceptionistPatientsPage() {
+  const [patients, setPatients] = useState<PatientView[]>([]);
+  const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [checkedInIds, setCheckedInIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) { setLoading(false); return; }
+      const pts = await fetchPatients(user.clinic_id);
+      setPatients(pts);
+      setLoading(false);
+    }
+    load();
+  }, []);
 
   const filteredPatients = patients.filter((p) => {
     const query = searchQuery.toLowerCase();
@@ -34,6 +47,14 @@ export default function ReceptionistPatientsPage() {
     const cleaned = phone.replace(/\s/g, "").replace("+", "");
     window.open(`https://wa.me/${cleaned}`, "_blank");
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading patients...</p>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/app/(receptionist)/receptionist/payments/page.tsx
+++ b/src/app/(receptionist)/receptionist/payments/page.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CreditCard, Check, Clock, Search } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { appointments, patients } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchAppointments,
+  fetchInvoices,
+  fetchPatients,
+  type PatientView,
+} from "@/lib/data/client";
 import { PaymentDialog } from "@/components/receptionist/payment-dialog";
 
 interface PaymentEntry {
@@ -23,21 +29,54 @@ interface PaymentEntry {
 
 export default function PaymentsPage() {
   const [searchQuery, setSearchQuery] = useState("");
-  const [paymentEntries, setPaymentEntries] = useState<PaymentEntry[]>(() => {
-    const today = new Date().toISOString().split("T")[0];
-    return appointments
-      .filter((a) => a.date === today || a.status === "completed")
-      .map((a, i) => ({
-        id: `pay-${a.id}`,
-        appointmentId: a.id,
-        patientName: a.patientName,
-        serviceName: a.serviceName,
-        date: a.date,
-        amount: [200, 300, 150, 500, 250][i % 5],
-        method: i % 3 === 0 ? "cash" : i % 3 === 1 ? "card" : "transfer",
-        status: (a.status === "completed" ? "paid" : "pending") as "paid" | "pending",
+  const [paymentEntries, setPaymentEntries] = useState<PaymentEntry[]>([]);
+  const [patientList, setPatientList] = useState<PatientView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) { setLoading(false); return; }
+      const [appts, invoices, pts] = await Promise.all([
+        fetchAppointments(user.clinic_id),
+        fetchInvoices(user.clinic_id),
+        fetchPatients(user.clinic_id),
+      ]);
+      setPatientList(pts);
+
+      // Build payment entries from invoices (real payment data)
+      const invoiceEntries: PaymentEntry[] = invoices.map((inv) => ({
+        id: inv.id,
+        appointmentId: "",
+        patientName: inv.patientName,
+        serviceName: "",
+        date: inv.date,
+        amount: inv.amount,
+        method: inv.method || "cash",
+        status: (inv.status === "paid" ? "paid" : "pending") as "paid" | "pending",
       }));
-  });
+
+      // Also add today's appointments that don't have invoices yet as pending
+      const today = new Date().toISOString().split("T")[0];
+      const invoicePatientDates = new Set(invoices.map((inv) => `${inv.patientName}-${inv.date}`));
+      const apptEntries: PaymentEntry[] = appts
+        .filter((a) => a.date === today && !invoicePatientDates.has(`${a.patientName}-${a.date}`))
+        .map((a) => ({
+          id: `appt-${a.id}`,
+          appointmentId: a.id,
+          patientName: a.patientName,
+          serviceName: a.serviceName,
+          date: a.date,
+          amount: 0,
+          method: "",
+          status: "pending" as const,
+        }));
+
+      setPaymentEntries([...invoiceEntries, ...apptEntries]);
+      setLoading(false);
+    }
+    load();
+  }, []);
 
   const filteredEntries = paymentEntries.filter((e) =>
     e.patientName.toLowerCase().includes(searchQuery.toLowerCase())
@@ -55,6 +94,14 @@ export default function PaymentsPage() {
       )
     );
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading payments...</p>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -110,7 +157,7 @@ export default function PaymentsPage() {
         <CardContent>
           <div className="space-y-3">
             {filteredEntries.map((entry) => {
-              const patient = patients.find((p) => p.name === entry.patientName);
+              const patient = patientList.find((p) => p.name === entry.patientName);
               return (
                 <div key={entry.id} className="flex items-center gap-3 rounded-lg border p-3">
                   <Avatar>

--- a/src/components/receptionist/booking-calendar.tsx
+++ b/src/components/receptionist/booking-calendar.tsx
@@ -1,21 +1,49 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { ChevronLeft, ChevronRight, Plus, User, Clock, GripVertical, Phone, MessageCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { appointments as demoAppointments, doctors, type Appointment } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchAppointments,
+  fetchDoctors,
+  type AppointmentView,
+  type DoctorView,
+} from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
 import { ManualBookingDialog } from "./manual-booking-dialog";
 import { WalkInDialog } from "./walk-in-dialog";
 
+// Local appointment type that supports drag-and-drop rescheduling
+interface LocalAppointment extends AppointmentView {
+  status: string;
+}
+
 export function ReceptionistBookingCalendar() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDoctor, setSelectedDoctor] = useState("all");
-  const [localAppointments, setLocalAppointments] = useState<Appointment[]>(demoAppointments);
-  const [draggedAppointment, setDraggedAppointment] = useState<Appointment | null>(null);
+  const [localAppointments, setLocalAppointments] = useState<LocalAppointment[]>([]);
+  const [doctorList, setDoctorList] = useState<DoctorView[]>([]);
+  const [draggedAppointment, setDraggedAppointment] = useState<LocalAppointment | null>(null);
   const [dragOverCell, setDragOverCell] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) { setLoading(false); return; }
+      const [appts, docs] = await Promise.all([
+        fetchAppointments(user.clinic_id),
+        fetchDoctors(user.clinic_id),
+      ]);
+      setLocalAppointments(appts);
+      setDoctorList(docs);
+      setLoading(false);
+    }
+    load();
+  }, []);
 
   const timeSlots = [
     "09:00", "09:30", "10:00", "10:30", "11:00", "11:30",
@@ -71,7 +99,7 @@ export function ReceptionistBookingCalendar() {
     rescheduled: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
   };
 
-  const handleDragStart = useCallback((e: React.DragEvent, appointment: Appointment) => {
+  const handleDragStart = useCallback((e: React.DragEvent, appointment: LocalAppointment) => {
     setDraggedAppointment(appointment);
     e.dataTransfer.effectAllowed = "move";
     e.dataTransfer.setData("text/plain", appointment.id);
@@ -118,8 +146,8 @@ export function ReceptionistBookingCalendar() {
     notes: string;
     source: "phone" | "walk_in";
   }) => {
-    const doctor = doctors.find((d) => d.id === booking.doctorId);
-    const newAppointment: Appointment = {
+    const doctor = doctorList.find((d) => d.id === booking.doctorId);
+    const newAppointment: LocalAppointment = {
       id: `a${Date.now()}`,
       patientId: booking.patientId,
       patientName: "New Patient",
@@ -144,6 +172,14 @@ export function ReceptionistBookingCalendar() {
     const cleaned = phone.replace(/\s/g, "").replace("+", "");
     window.open(`https://wa.me/${cleaned}`, "_blank");
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading calendar...</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">
@@ -171,7 +207,7 @@ export function ReceptionistBookingCalendar() {
             className="flex h-9 rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="all">All Doctors</option>
-            {doctors.map((doc) => (
+            {doctorList.map((doc) => (
               <option key={doc.id} value={doc.id}>
                 {doc.name}
               </option>

--- a/src/components/receptionist/daily-report.tsx
+++ b/src/components/receptionist/daily-report.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useEffect } from "react";
 import { Printer, FileText, Calendar, Users, CreditCard, Clock } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { appointments, doctors, patients, invoices } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchTodayAppointments,
+  fetchDoctors,
+  fetchPatients,
+  fetchInvoices,
+  type AppointmentView,
+  type DoctorView,
+  type PatientView,
+  type InvoiceView,
+} from "@/lib/data/client";
 
 const statusVariant: Record<string, "default" | "success" | "warning" | "destructive" | "secondary" | "outline"> = {
   scheduled: "outline",
@@ -19,15 +29,37 @@ const statusVariant: Record<string, "default" | "success" | "warning" | "destruc
 
 export function DailyReport() {
   const reportRef = useRef<HTMLDivElement>(null);
+  const [todayAppointments, setTodayAppointments] = useState<AppointmentView[]>([]);
+  const [doctorList, setDoctorList] = useState<DoctorView[]>([]);
+  const [patientList, setPatientList] = useState<PatientView[]>([]);
+  const [todayInvoices, setTodayInvoices] = useState<InvoiceView[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const today = new Date().toISOString().split("T")[0];
-  const todayAppointments = appointments.filter((a) => a.date === today);
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) { setLoading(false); return; }
+      const today = new Date().toISOString().split("T")[0];
+      const [appts, docs, pts, invs] = await Promise.all([
+        fetchTodayAppointments(user.clinic_id),
+        fetchDoctors(user.clinic_id),
+        fetchPatients(user.clinic_id),
+        fetchInvoices(user.clinic_id),
+      ]);
+      setTodayAppointments(appts);
+      setDoctorList(docs);
+      setPatientList(pts);
+      setTodayInvoices(invs.filter((inv) => inv.date === today));
+      setLoading(false);
+    }
+    load();
+  }, []);
+
   const completed = todayAppointments.filter((a) => a.status === "completed").length;
   const pending = todayAppointments.filter((a) => a.status === "scheduled" || a.status === "confirmed").length;
   const noShows = todayAppointments.filter((a) => a.status === "no-show").length;
   const cancelled = todayAppointments.filter((a) => a.status === "cancelled").length;
 
-  const todayInvoices = invoices.filter((inv) => inv.date === today);
   const totalRevenue = todayInvoices.reduce((sum, inv) => sum + inv.amount, 0);
   const paidCount = todayInvoices.filter((inv) => inv.status === "paid").length;
   const pendingPayments = todayInvoices.filter((inv) => inv.status === "pending").length;
@@ -77,6 +109,14 @@ export function DailyReport() {
     printWindow.document.close();
     printWindow.print();
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading report...</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -174,7 +214,7 @@ export function DailyReport() {
         </Card>
 
         {/* Appointments by Doctor */}
-        {doctors.map((doctor) => {
+        {doctorList.map((doctor) => {
           const doctorAppts = todayAppointments.filter((a) => a.doctorId === doctor.id);
           if (doctorAppts.length === 0) return null;
 
@@ -200,7 +240,7 @@ export function DailyReport() {
                       {doctorAppts
                         .sort((a, b) => a.time.localeCompare(b.time))
                         .map((apt) => {
-                          const patient = patients.find((p) => p.id === apt.patientId);
+                          const patient = patientList.find((p) => p.id === apt.patientId);
                           return (
                             <tr key={apt.id} className="border-b last:border-0">
                               <td className="py-2 px-3 font-medium">{apt.time}</td>

--- a/src/components/receptionist/manual-booking-dialog.tsx
+++ b/src/components/receptionist/manual-booking-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Phone, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,7 +20,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { doctors, services, patients } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchDoctors,
+  fetchServices,
+  fetchPatients,
+  type DoctorView,
+  type ServiceView,
+  type PatientView,
+} from "@/lib/data/client";
 
 interface ManualBookingDialogProps {
   trigger?: React.ReactNode;
@@ -37,9 +45,28 @@ interface ManualBookingDialogProps {
 
 export function ManualBookingDialog({ trigger, onBook }: ManualBookingDialogProps) {
   const [open, setOpen] = useState(false);
+  const [doctors, setDoctors] = useState<DoctorView[]>([]);
+  const [services, setServices] = useState<ServiceView[]>([]);
+  const [patients, setPatients] = useState<PatientView[]>([]);
   const [patientId, setPatientId] = useState("");
   const [doctorId, setDoctorId] = useState("");
   const [serviceId, setServiceId] = useState("");
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) return;
+      const [docs, svcs, pts] = await Promise.all([
+        fetchDoctors(user.clinic_id),
+        fetchServices(user.clinic_id),
+        fetchPatients(user.clinic_id),
+      ]);
+      setDoctors(docs);
+      setServices(svcs);
+      setPatients(pts);
+    }
+    load();
+  }, []);
   const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
   const [time, setTime] = useState("");
   const [notes, setNotes] = useState("");
@@ -124,7 +151,7 @@ export function ManualBookingDialog({ trigger, onBook }: ManualBookingDialogProp
                 <SelectContent>
                   {doctors.map((d) => (
                     <SelectItem key={d.id} value={d.id}>
-                      {d.name} - {d.specialty}
+                      {d.name}{d.specialty ? ` - ${d.specialty}` : ""}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/components/receptionist/waiting-room-manager.tsx
+++ b/src/components/receptionist/waiting-room-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   User, Clock, ArrowUp, ArrowDown, CheckCircle2, XCircle, Bell,
   UserPlus, Phone, MessageCircle, Timer, Stethoscope
@@ -8,6 +8,11 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  getCurrentUser,
+  fetchTodayAppointments,
+  fetchPatients,
+} from "@/lib/data/client";
 import { WalkInDialog } from "./walk-in-dialog";
 
 interface WaitingPatient {
@@ -25,73 +30,52 @@ interface WaitingPatient {
 }
 
 export function WaitingRoomManager() {
-  const [queue, setQueue] = useState<WaitingPatient[]>([
-    {
-      id: "w1",
-      name: "Fatima Zahra",
-      phone: "+212 6 12 34 56 78",
-      arrivalTime: "09:05",
-      appointmentTime: "09:30",
-      doctor: "Dr. Ahmed",
-      service: "General Consultation",
-      status: "in-consultation",
-      priority: 1,
-      isWalkIn: false,
-      estimatedWait: 0,
-    },
-    {
-      id: "w2",
-      name: "Mohammed Ali",
-      phone: "+212 6 23 45 67 89",
-      arrivalTime: "09:15",
-      appointmentTime: "10:00",
-      doctor: "Dr. Ahmed",
-      service: "Follow-up Visit",
-      status: "called",
-      priority: 2,
-      isWalkIn: false,
-      estimatedWait: 5,
-    },
-    {
-      id: "w3",
-      name: "Khadija Benali",
-      phone: "+212 6 33 44 55 66",
-      arrivalTime: "09:30",
-      appointmentTime: "10:30",
-      doctor: "Dr. Ahmed",
-      service: "Blood Test",
-      status: "waiting",
-      priority: 3,
-      isWalkIn: false,
-      estimatedWait: 20,
-    },
-    {
-      id: "w4",
-      name: "Youssef Amrani",
-      phone: "+212 6 44 55 66 77",
-      arrivalTime: "09:45",
-      appointmentTime: "11:00",
-      doctor: "Dr. Ahmed",
-      service: "General Consultation",
-      status: "waiting",
-      priority: 4,
-      isWalkIn: true,
-      estimatedWait: 35,
-    },
-    {
-      id: "w5",
-      name: "Amina Tazi",
-      phone: "+212 6 55 66 77 88",
-      arrivalTime: "10:00",
-      appointmentTime: "11:30",
-      doctor: "Dr. Ahmed",
-      service: "Vaccination",
-      status: "waiting",
-      priority: 5,
-      isWalkIn: false,
-      estimatedWait: 50,
-    },
-  ]);
+  const [queue, setQueue] = useState<WaitingPatient[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) { setLoading(false); return; }
+      const [appts, pts] = await Promise.all([
+        fetchTodayAppointments(user.clinic_id),
+        fetchPatients(user.clinic_id),
+      ]);
+      // Build waiting queue from today's checked-in / confirmed / in-progress appointments
+      const relevantStatuses = new Set(["confirmed", "in-progress", "scheduled"]);
+      const waitingAppts = appts.filter((a) => relevantStatuses.has(a.status));
+      const patientMap = new Map(pts.map((p) => [p.id, p]));
+
+      const initialQueue: WaitingPatient[] = waitingAppts.map((a, i) => {
+        const patient = patientMap.get(a.patientId);
+        const status: WaitingPatient["status"] =
+          a.status === "in-progress" ? "in-consultation" :
+          a.status === "confirmed" ? "called" : "waiting";
+        return {
+          id: a.id,
+          name: a.patientName,
+          phone: patient?.phone ?? "",
+          arrivalTime: a.time,
+          appointmentTime: a.time,
+          doctor: a.doctorName,
+          service: a.serviceName,
+          status,
+          priority: i + 1,
+          isWalkIn: false,
+          estimatedWait: 0,
+        };
+      });
+
+      // Sort: in-consultation first, then called, then waiting
+      const statusOrder = { "in-consultation": 0, called: 1, waiting: 2 };
+      initialQueue.sort((a, b) => statusOrder[a.status] - statusOrder[b.status]);
+
+      setQueue(recalculateWaitTimes(initialQueue.map((p, i) => ({ ...p, priority: i + 1 }))));
+      setLoading(false);
+    }
+    load();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const statusConfig: Record<string, { color: string; label: string; icon: typeof Clock }> = {
     waiting: { color: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200", label: "Waiting", icon: Clock },
@@ -167,6 +151,14 @@ export function WaitingRoomManager() {
   const avgWaitTime = waitingCount > 0
     ? Math.round(queue.filter((p) => p.status === "waiting").reduce((sum, p) => sum + p.estimatedWait, 0) / waitingCount)
     : 0;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading waiting room...</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/src/components/receptionist/walk-in-dialog.tsx
+++ b/src/components/receptionist/walk-in-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { UserPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,7 +20,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { doctors, services, patients } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchDoctors,
+  fetchServices,
+  fetchPatients,
+  type DoctorView,
+  type ServiceView,
+  type PatientView,
+} from "@/lib/data/client";
 
 interface WalkInDialogProps {
   trigger?: React.ReactNode;
@@ -37,7 +45,26 @@ interface WalkInDialogProps {
 
 export function WalkInDialog({ trigger, onRegister }: WalkInDialogProps) {
   const [open, setOpen] = useState(false);
+  const [doctors, setDoctors] = useState<DoctorView[]>([]);
+  const [services, setServices] = useState<ServiceView[]>([]);
+  const [patients, setPatients] = useState<PatientView[]>([]);
   const [isNewPatient, setIsNewPatient] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      const user = await getCurrentUser();
+      if (!user?.clinic_id) return;
+      const [docs, svcs, pts] = await Promise.all([
+        fetchDoctors(user.clinic_id),
+        fetchServices(user.clinic_id),
+        fetchPatients(user.clinic_id),
+      ]);
+      setDoctors(docs);
+      setServices(svcs);
+      setPatients(pts);
+    }
+    load();
+  }, []);
   const [patientId, setPatientId] = useState("");
   const [newPatientName, setNewPatientName] = useState("");
   const [newPatientPhone, setNewPatientPhone] = useState("");
@@ -155,7 +182,7 @@ export function WalkInDialog({ trigger, onRegister }: WalkInDialogProps) {
                 <SelectContent>
                   {doctors.map((d) => (
                     <SelectItem key={d.id} value={d.id}>
-                      {d.name} - {d.specialty}
+                      {d.name}{d.specialty ? ` - ${d.specialty}` : ""}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -172,8 +199,8 @@ export function WalkInDialog({ trigger, onRegister }: WalkInDialogProps) {
                   {services.filter((s) => s.active).map((s) => (
                     <SelectItem key={s.id} value={s.id}>
                       {s.name} ({s.duration}min - {s.price} {s.currency})
-                    </SelectItem>
-                  ))}
+                    </SelectItem>)
+                  )}
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
Replace all demo-data imports in receptionist pages and components with real Supabase data fetching.

## Changes

### Pages
- **Dashboard** (`receptionist/dashboard/page.tsx`): Replace `getTodayAppointments`, `getTotalRevenue`, `patients` from demo-data with `fetchTodayAppointments`, `fetchInvoices`, `fetchPatients`
- **Patients** (`receptionist/patients/page.tsx`): Replace `patients` from demo-data with `fetchPatients`
- **Payments** (`receptionist/payments/page.tsx`): Replace `appointments`, `patients` from demo-data with `fetchAppointments`, `fetchInvoices`, `fetchPatients`

### Components
- **Booking Calendar** (`booking-calendar.tsx`): Replace `appointments`, `doctors` from demo-data with `fetchAppointments`, `fetchDoctors`
- **Daily Report** (`daily-report.tsx`): Replace `appointments`, `doctors`, `patients`, `invoices` from demo-data with `fetchTodayAppointments`, `fetchDoctors`, `fetchPatients`, `fetchInvoices`
- **Walk-in Dialog** (`walk-in-dialog.tsx`): Replace `doctors`, `services`, `patients` from demo-data with `fetchDoctors`, `fetchServices`, `fetchPatients`
- **Manual Booking Dialog** (`manual-booking-dialog.tsx`): Replace `doctors`, `services`, `patients` from demo-data with `fetchDoctors`, `fetchServices`, `fetchPatients`
- **Waiting Room Manager** (`waiting-room-manager.tsx`): Replace hardcoded inline patient queue with `fetchTodayAppointments`, `fetchPatients`

### Pattern
- All components use `getCurrentUser()` to obtain `clinic_id`
- Data fetched via `useEffect` + `useState` on mount
- Loading states shown while fetching
- Thin wrapper pages (bookings, waiting-room, daily-report) inherit changes from their child components