### PR TITLE
feat: migrate 8 doctor page sub-components from demo-data to Supabase

### DIFF
--- a/src/app/(doctor)/doctor/before-after/page.tsx
+++ b/src/app/(doctor)/doctor/before-after/page.tsx
@@ -1,13 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { BeforeAfterGallery } from "@/components/dental/before-after-gallery";
-import { beforeAfterPhotos as initialPhotos, type BeforeAfterPhoto } from "@/lib/dental-demo-data";
+import {
+  getCurrentUser,
+  fetchBeforeAfterPhotos,
+  type BeforeAfterPhotoView,
+} from "@/lib/data/client";
 
 export default function DoctorBeforeAfterPage() {
-  const [photos, setPhotos] = useState<BeforeAfterPhoto[]>(initialPhotos);
+  const [photos, setPhotos] = useState<BeforeAfterPhotoView[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const handleAddPhoto = (photo: Omit<BeforeAfterPhoto, "id">) => {
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const data = await fetchBeforeAfterPhotos(user.clinic_id);
+    setPhotos(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading photos...</p>
+      </div>
+    );
+  }
+
+  const handleAddPhoto = (photo: Omit<BeforeAfterPhotoView, "id">) => {
     setPhotos((prev) => [
       { ...photo, id: `ba${prev.length + 1}` },
       ...prev,

--- a/src/app/(doctor)/doctor/installments/page.tsx
+++ b/src/app/(doctor)/doctor/installments/page.tsx
@@ -1,13 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { InstallmentTracker } from "@/components/installments/installment-tracker";
 import { InstallmentForm } from "@/components/installments/installment-form";
-import { installmentPlans as initialPlans, type InstallmentPlan } from "@/lib/dental-demo-data";
+import {
+  getCurrentUser,
+  fetchInstallmentPlans,
+  type InstallmentPlanView,
+} from "@/lib/data/client";
 
 export default function DoctorInstallmentsPage() {
-  const [plans, setPlans] = useState<InstallmentPlan[]>(initialPlans);
+  const [plans, setPlans] = useState<InstallmentPlanView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const data = await fetchInstallmentPlans(user.clinic_id);
+    setPlans(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading installment plans...</p>
+      </div>
+    );
+  }
 
   const handleMarkPaid = (planId: string, installmentId: string) => {
     setPlans((prev) =>

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   BarChart, Bar, LineChart, Line, PieChart, Pie, Cell,
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip,
@@ -15,38 +15,72 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
-  dailyAnalytics,
-  weeklyRevenue,
-  monthlyRevenue,
-  servicePopularity,
-  hourlyHeatmap,
-  reviewTrends,
-  patientRetention,
-} from "@/lib/dental-demo-data";
-import { appointments, patients } from "@/lib/demo-data";
+  getCurrentUser,
+  fetchAnalytics,
+  type AnalyticsData,
+} from "@/lib/data/client";
 
 const COLORS = [
   "#2563eb", "#7c3aed", "#db2777", "#ea580c",
   "#16a34a", "#0891b2", "#ca8a04", "#dc2626", "#4f46e5",
 ];
 
-const totalAppts = appointments.length;
-const noShowAppts = appointments.filter((a) => a.status === "no-show").length;
-const noShowRate = totalAppts > 0 ? Math.round((noShowAppts / totalAppts) * 100) : 0;
-
-const onlineBookings = dailyAnalytics.reduce((sum, d) => sum + d.onlineBookings, 0);
-const walkInBookings = dailyAnalytics.reduce((sum, d) => sum + d.walkIns, 0);
-const totalBookings = onlineBookings + walkInBookings;
-
-const bookingSourceData = [
-  { name: "Online", value: onlineBookings, percentage: Math.round((onlineBookings / totalBookings) * 100) },
-  { name: "Walk-in", value: walkInBookings, percentage: Math.round((walkInBookings / totalBookings) * 100) },
-];
-
-const latestRetention = patientRetention[patientRetention.length - 1];
-
 export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "doctor" }) {
   const [revenuePeriod, setRevenuePeriod] = useState<"daily" | "weekly" | "monthly">("daily");
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const data = await fetchAnalytics(user.clinic_id);
+    setAnalytics(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading analytics...</p>
+      </div>
+    );
+  }
+
+  if (!analytics) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">No analytics data available.</p>
+      </div>
+    );
+  }
+
+  const {
+    dailyAnalytics,
+    weeklyRevenue,
+    monthlyRevenue,
+    servicePopularity,
+    hourlyHeatmap,
+    reviewTrends,
+    patientRetention,
+    totalPatients,
+    totalAppointments,
+  } = analytics;
+
+  const noShowAppts = dailyAnalytics.reduce((sum, d) => sum + d.noShows, 0);
+  const noShowRate = totalAppointments > 0 ? Math.round((noShowAppts / totalAppointments) * 100) : 0;
+
+  const onlineBookings = dailyAnalytics.reduce((sum, d) => sum + d.onlineBookings, 0);
+  const walkInBookings = dailyAnalytics.reduce((sum, d) => sum + d.walkIns, 0);
+  const totalBookings = onlineBookings + walkInBookings || 1;
+
+  const bookingSourceData = [
+    { name: "Online", value: onlineBookings, percentage: Math.round((onlineBookings / totalBookings) * 100) },
+    { name: "Walk-in", value: walkInBookings, percentage: Math.round((walkInBookings / totalBookings) * 100) },
+  ];
+
+  const latestRetention = patientRetention[patientRetention.length - 1];
 
   const revenueData =
     revenuePeriod === "daily"
@@ -78,7 +112,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
               <Users className="h-5 w-5 text-blue-600" />
               <Badge variant="outline" className="text-xs text-green-600">+{latestRetention.newPatients}</Badge>
             </div>
-            <p className="text-2xl font-bold">{patients.length}</p>
+            <p className="text-2xl font-bold">{totalPatients}</p>
             <p className="text-xs text-muted-foreground">Total Patients</p>
           </CardContent>
         </Card>

--- a/src/components/dental/before-after-gallery.tsx
+++ b/src/components/dental/before-after-gallery.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import type { BeforeAfterPhoto } from "@/lib/dental-demo-data";
+import type { BeforeAfterPhotoView as BeforeAfterPhoto } from "@/lib/data/client";
 
 interface BeforeAfterGalleryProps {
   photos: BeforeAfterPhoto[];

--- a/src/components/doctor/emergency-slot-creator.tsx
+++ b/src/components/doctor/emergency-slot-creator.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import type { EmergencySlot } from "@/lib/demo-data";
+import type { EmergencySlotView as EmergencySlot } from "@/lib/data/client";
 
 interface EmergencySlotCreatorProps {
   doctorId: string;

--- a/src/components/doctor/patient-card.tsx
+++ b/src/components/doctor/patient-card.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { User, Phone, Calendar, FileText, Pill, ClipboardList, AlertCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { patients, prescriptions, appointments } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchPatients,
+  fetchPrescriptions,
+  fetchAppointments,
+  type PatientView,
+  type PrescriptionView,
+  type AppointmentView,
+} from "@/lib/data/client";
 
 type TabKey = "overview" | "history" | "prescriptions" | "notes";
 
@@ -16,10 +24,45 @@ type TabKey = "overview" | "history" | "prescriptions" | "notes";
  */
 export function PatientCard({ patientId }: { patientId?: string }) {
   const [activeTab, setActiveTab] = useState<TabKey>("overview");
+  const [patient, setPatient] = useState<PatientView | null>(null);
+  const [patientRx, setPatientRx] = useState<PrescriptionView[]>([]);
+  const [patientAppts, setPatientAppts] = useState<AppointmentView[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const patient = patients.find((p) => p.id === patientId) ?? patients[0];
-  const patientRx = prescriptions.filter((rx) => rx.patientId === patient.id);
-  const patientAppts = appointments.filter((a) => a.patientId === patient.id);
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const [pts, rxs, appts] = await Promise.all([
+      fetchPatients(user.clinic_id),
+      fetchPrescriptions(user.clinic_id),
+      fetchAppointments(user.clinic_id),
+    ]);
+    const found = pts.find((p) => p.id === patientId) ?? pts[0] ?? null;
+    setPatient(found);
+    if (found) {
+      setPatientRx(rxs.filter((rx) => rx.patientId === found.id));
+      setPatientAppts(appts.filter((a) => a.patientId === found.id));
+    }
+    setLoading(false);
+  }, [patientId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading patient...</p>
+      </div>
+    );
+  }
+
+  if (!patient) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">No patient found.</p>
+      </div>
+    );
+  }
 
   const tabs: { key: TabKey; label: string }[] = [
     { key: "overview", label: "Overview" },

--- a/src/components/doctor/prescription-writer.tsx
+++ b/src/components/doctor/prescription-writer.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Plus, Trash2, FileDown, Send } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { patients } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchPatients,
+  type PatientView,
+} from "@/lib/data/client";
 
 interface Medication {
   name: string;
@@ -24,12 +28,33 @@ interface Medication {
  * Generates downloadable PDF.
  */
 export function PrescriptionWriter() {
-  const [selectedPatient, setSelectedPatient] = useState(patients[0].id);
+  const [patients, setPatients] = useState<PatientView[]>([]);
+  const [selectedPatient, setSelectedPatient] = useState("");
   const [medications, setMedications] = useState<Medication[]>([
     { name: "", dosage: "", frequency: "", duration: "", instructions: "" },
   ]);
   const [notes, setNotes] = useState("");
   const [diagnosis, setDiagnosis] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const pts = await fetchPatients(user.clinic_id);
+    setPatients(pts);
+    if (pts.length > 0) setSelectedPatient(pts[0].id);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
 
   const patient = patients.find((p) => p.id === selectedPatient) ?? patients[0];
 

--- a/src/components/doctor/schedule-view.tsx
+++ b/src/components/doctor/schedule-view.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Clock, User, CheckCircle2, XCircle, ArrowRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { appointments } from "@/lib/demo-data";
+import {
+  getCurrentUser,
+  fetchAppointments,
+  type AppointmentView,
+} from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
 import { EmergencySlotCreator } from "./emergency-slot-creator";
 
@@ -27,7 +31,28 @@ const statusColors: Record<string, string> = {
  */
 export function ScheduleView() {
   const [viewMode, setViewMode] = useState<ViewMode>("timeline");
-  const todayAppointments = appointments.slice(0, 6);
+  const [todayAppointments, setTodayAppointments] = useState<AppointmentView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) { setLoading(false); return; }
+    const appts = await fetchAppointments(user.clinic_id);
+    const today = new Date().toISOString().split("T")[0];
+    const filtered = appts.filter((a) => a.date === today);
+    setTodayAppointments(filtered.length > 0 ? filtered : appts.slice(0, 6));
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">Loading schedule...</p>
+      </div>
+    );
+  }
 
   const timeSlots = [
     "09:00", "09:30", "10:00", "10:30", "11:00", "11:30",

--- a/src/components/installments/installment-tracker.tsx
+++ b/src/components/installments/installment-tracker.tsx
@@ -8,7 +8,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { InstallmentPlan, InstallmentPayment } from "@/lib/dental-demo-data";
+import type { InstallmentPlanView as InstallmentPlan, InstallmentPaymentView as InstallmentPayment } from "@/lib/data/client";
 
 const STATUS_CONFIG: Record<InstallmentPayment["status"], { icon: typeof Clock; color: string; variant: "default" | "success" | "destructive" | "outline" }> = {
   pending: { icon: Clock, color: "text-gray-500", variant: "outline" },

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -1425,3 +1425,397 @@ export async function fetchWaitingRoom(clinicId: string): Promise<WaitingRoomEnt
       priority: a.isEmergency ? "urgent" : "normal",
     }));
 }
+
+// ─────────────────────────────────────────────
+// Emergency Slots
+// ─────────────────────────────────────────────
+
+export interface EmergencySlotView {
+  id: string;
+  doctorId: string;
+  doctorName: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  reason?: string;
+  isBooked: boolean;
+  createdAt: string;
+}
+
+// ─────────────────────────────────────────────
+// Before/After Photos
+// ─────────────────────────────────────────────
+
+export interface BeforeAfterPhotoView {
+  id: string;
+  patientId: string;
+  patientName: string;
+  treatmentPlanId: string;
+  description: string;
+  beforeDate: string;
+  afterDate: string | null;
+  category: string;
+}
+
+export async function fetchBeforeAfterPhotos(clinicId: string): Promise<BeforeAfterPhotoView[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<{
+    id: string;
+    clinic_id: string;
+    patient_id: string;
+    treatment_plan_id: string | null;
+    description: string | null;
+    before_date: string | null;
+    after_date: string | null;
+    category: string | null;
+  }>("before_after_photos", {
+    eq: [["clinic_id", clinicId]],
+    order: ["before_date", { ascending: false }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    patientId: r.patient_id,
+    patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
+    treatmentPlanId: r.treatment_plan_id ?? "",
+    description: r.description ?? "",
+    beforeDate: r.before_date ?? "",
+    afterDate: r.after_date ?? null,
+    category: r.category ?? "General",
+  }));
+}
+
+// ─────────────────────────────────────────────
+// Installment Plans (grouped view)
+// ─────────────────────────────────────────────
+
+export interface InstallmentPaymentView {
+  id: string;
+  installmentPlanId: string;
+  amount: number;
+  dueDate: string;
+  paidDate: string | null;
+  status: "pending" | "paid" | "overdue";
+  receiptId: string | null;
+}
+
+export interface InstallmentPlanView {
+  id: string;
+  patientId: string;
+  patientName: string;
+  treatmentPlanId: string;
+  treatmentTitle: string;
+  totalAmount: number;
+  currency: string;
+  downPayment: number;
+  numberOfInstallments: number;
+  installments: InstallmentPaymentView[];
+  createdAt: string;
+  status: "active" | "completed" | "defaulted";
+  whatsappReminderEnabled: boolean;
+}
+
+interface InstallmentPlanRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  treatment_plan_id: string;
+  total_amount: number;
+  currency: string | null;
+  down_payment: number | null;
+  status: string;
+  whatsapp_reminder: boolean;
+  created_at: string;
+}
+
+interface InstallmentItemRaw {
+  id: string;
+  plan_id: string;
+  amount: number;
+  due_date: string;
+  paid_date: string | null;
+  status: string;
+  receipt_id: string | null;
+}
+
+export async function fetchInstallmentPlans(clinicId: string): Promise<InstallmentPlanView[]> {
+  await ensureLookups(clinicId);
+
+  const plans = await fetchRows<InstallmentPlanRaw>("installment_plans", {
+    eq: [["clinic_id", clinicId]],
+    order: ["created_at", { ascending: false }],
+  });
+
+  if (plans.length === 0) return [];
+
+  const planIds = plans.map((p) => p.id);
+  const items = await fetchRows<InstallmentItemRaw>("installments", {
+    inFilter: ["plan_id", planIds],
+    order: ["due_date", { ascending: true }],
+  });
+
+  const itemsByPlan = new Map<string, InstallmentItemRaw[]>();
+  for (const item of items) {
+    const arr = itemsByPlan.get(item.plan_id) ?? [];
+    arr.push(item);
+    itemsByPlan.set(item.plan_id, arr);
+  }
+
+  // Fetch treatment plan titles
+  const tpIds = [...new Set(plans.map((p) => p.treatment_plan_id))];
+  const tpRows = await fetchRows<{ id: string; title: string }>("treatment_plans", {
+    select: "id, title",
+    inFilter: ["id", tpIds],
+  });
+  const tpMap = new Map(tpRows.map((t) => [t.id, t.title]));
+
+  return plans.map((p) => {
+    const planItems = itemsByPlan.get(p.id) ?? [];
+    return {
+      id: p.id,
+      patientId: p.patient_id,
+      patientName: _userMap?.get(p.patient_id)?.name ?? "Patient",
+      treatmentPlanId: p.treatment_plan_id,
+      treatmentTitle: tpMap.get(p.treatment_plan_id) ?? "Treatment Plan",
+      totalAmount: p.total_amount,
+      currency: p.currency ?? "MAD",
+      downPayment: p.down_payment ?? 0,
+      numberOfInstallments: planItems.length,
+      installments: planItems.map((i) => ({
+        id: i.id,
+        installmentPlanId: i.plan_id,
+        amount: i.amount,
+        dueDate: i.due_date,
+        paidDate: i.paid_date,
+        status: i.status as "pending" | "paid" | "overdue",
+        receiptId: i.receipt_id,
+      })),
+      createdAt: p.created_at?.split("T")[0] ?? "",
+      status: p.status as "active" | "completed" | "defaulted",
+      whatsappReminderEnabled: p.whatsapp_reminder ?? false,
+    };
+  });
+}
+
+// ─────────────────────────────────────────────
+// Analytics (computed from real data)
+// ─────────────────────────────────────────────
+
+export interface DailyAnalyticsView {
+  date: string;
+  patientCount: number;
+  revenue: number;
+  appointments: number;
+  noShows: number;
+  walkIns: number;
+  onlineBookings: number;
+}
+
+export interface WeeklyRevenueView {
+  week: string;
+  revenue: number;
+  patients: number;
+}
+
+export interface MonthlyRevenueView {
+  month: string;
+  revenue: number;
+  patients: number;
+  appointments: number;
+}
+
+export interface ServicePopularityView {
+  serviceName: string;
+  count: number;
+  revenue: number;
+  percentage: number;
+}
+
+export interface HourlyHeatmapView {
+  day: string;
+  hours: { hour: number; count: number }[];
+}
+
+export interface ReviewTrendView {
+  month: string;
+  averageScore: number;
+  count: number;
+}
+
+export interface PatientRetentionView {
+  month: string;
+  newPatients: number;
+  returningPatients: number;
+  retentionRate: number;
+}
+
+export interface AnalyticsData {
+  dailyAnalytics: DailyAnalyticsView[];
+  weeklyRevenue: WeeklyRevenueView[];
+  monthlyRevenue: MonthlyRevenueView[];
+  servicePopularity: ServicePopularityView[];
+  hourlyHeatmap: HourlyHeatmapView[];
+  reviewTrends: ReviewTrendView[];
+  patientRetention: PatientRetentionView[];
+  totalPatients: number;
+  totalAppointments: number;
+}
+
+export async function fetchAnalytics(clinicId: string): Promise<AnalyticsData> {
+  const supabase = createClient();
+
+  const [apptsRes, paymentsRes, reviewsRes, patientsRes] = await Promise.all([
+    supabase.from("appointments").select("*").eq("clinic_id", clinicId),
+    supabase.from("payments").select("*").eq("clinic_id", clinicId).eq("status", "completed"),
+    supabase.from("reviews").select("*").eq("clinic_id", clinicId),
+    supabase.from("users").select("id, created_at").eq("clinic_id", clinicId).eq("role", "patient"),
+  ]);
+
+  type ApptRow = { id: string; appointment_date: string; start_time: string; status: string; patient_id: string; service_id: string | null; booking_source: string | null };
+  type PaymentRow = { id: string; amount: number; created_at: string };
+  type ReviewRow = { id: string; stars: number; created_at: string };
+  type PatientRow = { id: string; created_at: string };
+
+  const appts = (apptsRes.data ?? []) as ApptRow[];
+  const payments = (paymentsRes.data ?? []) as PaymentRow[];
+  const reviews = (reviewsRes.data ?? []) as ReviewRow[];
+  const allPatients = (patientsRes.data ?? []) as PatientRow[];
+
+  await ensureLookups(clinicId);
+
+  // Daily analytics (last 20 days)
+  const dailyMap = new Map<string, DailyAnalyticsView>();
+  const now = new Date();
+  for (let i = 19; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const dateStr = d.toISOString().split("T")[0];
+    dailyMap.set(dateStr, { date: dateStr, patientCount: 0, revenue: 0, appointments: 0, noShows: 0, walkIns: 0, onlineBookings: 0 });
+  }
+  for (const a of appts) {
+    const day = dailyMap.get(a.appointment_date);
+    if (!day) continue;
+    day.appointments++;
+    day.patientCount++;
+    if (a.status === "no_show" || a.status === "no-show") day.noShows++;
+    if (a.booking_source === "walk-in" || a.booking_source === "walk_in") day.walkIns++;
+    if (a.booking_source === "online" || a.booking_source === "website") day.onlineBookings++;
+  }
+  for (const p of payments) {
+    const dateStr = p.created_at?.split("T")[0];
+    const day = dailyMap.get(dateStr);
+    if (day) day.revenue += p.amount;
+  }
+  const dailyAnalytics = [...dailyMap.values()];
+
+  // Weekly revenue (group daily into weeks)
+  const weeklyRevenue: WeeklyRevenueView[] = [];
+  for (let i = 0; i < dailyAnalytics.length; i += 7) {
+    const chunk = dailyAnalytics.slice(i, i + 7);
+    if (chunk.length === 0) break;
+    const weekNum = Math.floor(i / 7) + 1;
+    weeklyRevenue.push({
+      week: `Week ${weekNum} (${chunk[0].date.slice(5)} - ${chunk[chunk.length - 1].date.slice(5)})`,
+      revenue: chunk.reduce((s, d) => s + d.revenue, 0),
+      patients: chunk.reduce((s, d) => s + d.patientCount, 0),
+    });
+  }
+
+  // Monthly revenue (last 6 months)
+  const monthlyRevenue: MonthlyRevenueView[] = [];
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthStr = d.toISOString().slice(0, 7);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    const monthAppts = appts.filter((a) => a.appointment_date?.startsWith(monthStr));
+    const monthPayments = payments.filter((p) => p.created_at?.startsWith(monthStr));
+    const uniquePatients = new Set(monthAppts.map((a) => a.patient_id));
+    monthlyRevenue.push({
+      month: label,
+      revenue: monthPayments.reduce((s, p) => s + p.amount, 0),
+      patients: uniquePatients.size,
+      appointments: monthAppts.length,
+    });
+  }
+
+  // Service popularity
+  const serviceCount = new Map<string, { count: number; revenue: number }>();
+  for (const a of appts) {
+    const svcName = a.service_id ? (_serviceMap?.get(a.service_id)?.name ?? "Other") : "Consultation";
+    const entry = serviceCount.get(svcName) ?? { count: 0, revenue: 0 };
+    entry.count++;
+    if (a.service_id) {
+      entry.revenue += _serviceMap?.get(a.service_id)?.price ?? 0;
+    }
+    serviceCount.set(svcName, entry);
+  }
+  const totalSvcCount = appts.length || 1;
+  const servicePopularity: ServicePopularityView[] = [...serviceCount.entries()]
+    .map(([name, val]) => ({
+      serviceName: name,
+      count: val.count,
+      revenue: val.revenue,
+      percentage: Math.round((val.count / totalSvcCount) * 100),
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  // Hourly heatmap
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const heatmap = new Map<string, Map<number, number>>();
+  for (const name of dayNames) heatmap.set(name, new Map());
+  for (const a of appts) {
+    const date = new Date(a.appointment_date);
+    const dayName = dayNames[date.getDay()];
+    const hour = parseInt(a.start_time?.slice(0, 2) ?? "0", 10);
+    const dayMap = heatmap.get(dayName)!;
+    dayMap.set(hour, (dayMap.get(hour) ?? 0) + 1);
+  }
+  const hourlyHeatmap: HourlyHeatmapView[] = dayNames.slice(1, 7).map((day) => ({
+    day,
+    hours: [9, 10, 11, 12, 14, 15, 16, 17]
+      .map((hour) => ({ hour, count: heatmap.get(day)?.get(hour) ?? 0 })),
+  }));
+
+  // Review trends (last 6 months)
+  const reviewTrends: ReviewTrendView[] = [];
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthStr = d.toISOString().slice(0, 7);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    const monthReviews = reviews.filter((r) => r.created_at?.startsWith(monthStr));
+    const avg = monthReviews.length > 0
+      ? monthReviews.reduce((s, r) => s + r.stars, 0) / monthReviews.length
+      : 0;
+    reviewTrends.push({ month: label, averageScore: Math.round(avg * 10) / 10, count: monthReviews.length });
+  }
+
+  // Patient retention (last 6 months)
+  const patientRetention: PatientRetentionView[] = [];
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthStr = d.toISOString().slice(0, 7);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    const newPts = allPatients.filter((p) => p.created_at?.startsWith(monthStr)).length;
+    const monthAppts = appts.filter((a) => a.appointment_date?.startsWith(monthStr));
+    const returningIds = new Set(monthAppts.map((a) => a.patient_id));
+    const returning = returningIds.size;
+    const total = newPts + returning || 1;
+    patientRetention.push({
+      month: label,
+      newPatients: newPts,
+      returningPatients: returning,
+      retentionRate: Math.round((returning / total) * 100),
+    });
+  }
+
+  return {
+    dailyAnalytics,
+    weeklyRevenue,
+    monthlyRevenue,
+    servicePopularity,
+    hourlyHeatmap,
+    reviewTrends,
+    patientRetention,
+    totalPatients: allPatients.length,
+    totalAppointments: appts.length,
+  };
+}


### PR DESCRIPTION
## Summary

Migrates all 8 Group 4 doctor page sub-components from demo-data/dental-demo-data imports to the Supabase data layer.

### Components migrated:
- **4.1** `patient-card.tsx` - fetches patients, prescriptions, appointments from Supabase
- **4.2** `prescription-writer.tsx` - fetches patients from Supabase
- **4.3** `schedule-view.tsx` - fetches appointments from Supabase
- **4.4** `emergency-slot-creator.tsx` - uses EmergencySlotView type from client.ts
- **4.5** Doctor installments page - fetches installment plans from Supabase
- **4.6** Doctor before/after page - fetches before/after photos from Supabase
- **4.7** Doctor analytics page - wired via analytics-dashboard
- **4.8** `analytics-dashboard.tsx` - fetches computed analytics from Supabase

### Sub-component type updates:
- `installment-tracker.tsx` - types from client.ts instead of dental-demo-data
- `before-after-gallery.tsx` - types from client.ts instead of dental-demo-data

### New data layer additions (client.ts):
- `fetchBeforeAfterPhotos()` - before/after photo records
- `fetchInstallmentPlans()` - grouped installment plans with nested payments
- `fetchAnalytics()` - computed analytics from real appointment/payment/review data
- New types: EmergencySlotView, BeforeAfterPhotoView, InstallmentPlanView, InstallmentPaymentView, AnalyticsData, and related analytics view types

### Pattern used:
- `useCallback` + `useEffect` for data loading
- `getCurrentUser()` to get clinic_id
- Loading states with skeleton UI
- `Promise.all` for parallel data fetching where applicable