### PR TITLE
feat: wire all public pages to Supabase, remove demo-data fallbacks

### DIFF
--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Clock, Tag } from "lucide-react";
-import { blogPosts } from "@/lib/demo-data";
+import { getPublicBlogPosts } from "@/lib/data/public";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
@@ -14,8 +14,9 @@ export const metadata: Metadata = {
   },
 };
 
-// Blog posts don't have a DB table yet — uses demo data until a blog_posts table or CMS is added
-export default function BlogPage() {
+export default async function BlogPage() {
+  const blogPosts = await getPublicBlogPosts();
+
   return (
     <div className="container mx-auto px-4 py-12">
       <div className="text-center mb-12">
@@ -26,9 +27,14 @@ export default function BlogPage() {
         </p>
       </div>
 
-      <div className="max-w-3xl mx-auto space-y-6">
-        {blogPosts.map((post) => (
-          <Card key={post.id} className="cursor-pointer hover:shadow-md transition-shadow">
+      {blogPosts.length === 0 ? (
+        <p className="text-center text-muted-foreground">
+          No blog posts published yet. Check back soon!
+        </p>
+      ) : (
+        <div className="max-w-3xl mx-auto space-y-6">
+          {blogPosts.map((post) => (
+            <Card key={post.id} className="cursor-pointer hover:shadow-md transition-shadow">
             <CardHeader>
               <div className="flex items-center gap-2 mb-2">
                 <Badge variant="secondary">
@@ -48,9 +54,10 @@ export default function BlogPage() {
                 Published on {post.date}
               </p>
             </CardContent>
-          </Card>
-        ))}
-      </div>
+            </Card>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -3,7 +3,6 @@ import { HeroSection } from "@/components/public/hero-section";
 import { ServicesPreview } from "@/components/public/services-preview";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 import { getPublicReviews, getPublicAverageRating } from "@/lib/data/public";
-import { reviews as demoReviews, getAverageRating as demoGetAverageRating } from "@/lib/demo-data";
 import { Star, ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
@@ -28,12 +27,8 @@ const linkBtnPrimary =
 export default async function HomePage() {
   const aboutCfg = defaultWebsiteConfig.about;
 
-  // Fetch from Supabase, fall back to demo data if empty
-  const supabaseReviews = await getPublicReviews();
-  const reviews = supabaseReviews.length > 0 ? supabaseReviews : demoReviews;
-  const avgRating = supabaseReviews.length > 0
-    ? await getPublicAverageRating()
-    : demoGetAverageRating();
+  const reviews = await getPublicReviews();
+  const avgRating = await getPublicAverageRating();
   const topReviews = reviews.filter((r) => r.rating >= 4).slice(0, 3);
 
   return (

--- a/src/app/(public)/reviews/page.tsx
+++ b/src/app/(public)/reviews/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Star } from "lucide-react";
 import { getPublicReviews, getPublicAverageRating } from "@/lib/data/public";
-import { reviews as demoReviews, getAverageRating as demoGetAverageRating } from "@/lib/demo-data";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -36,12 +35,8 @@ function StarRating({ rating }: { rating: number }) {
 export default async function ReviewsPage() {
   const cfg = defaultWebsiteConfig.reviews;
 
-  // Fetch from Supabase, fall back to demo data if empty
-  const supabaseReviews = await getPublicReviews();
-  const reviews = supabaseReviews.length > 0 ? supabaseReviews : demoReviews;
-  const avgRating = supabaseReviews.length > 0
-    ? await getPublicAverageRating()
-    : demoGetAverageRating();
+  const reviews = await getPublicReviews();
+  const avgRating = await getPublicAverageRating();
 
   return (
     <div className="container mx-auto px-4 py-12">

--- a/src/app/(public)/services/page.tsx
+++ b/src/app/(public)/services/page.tsx
@@ -1,7 +1,6 @@
 import { Clock, CreditCard } from "lucide-react";
 import Link from "next/link";
 import { getPublicServices } from "@/lib/data/public";
-import { services as demoServices } from "@/lib/demo-data";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 import { buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -9,9 +8,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription }
 export default async function ServicesPage() {
   const cfg = defaultWebsiteConfig.services;
 
-  // Fetch from Supabase, fall back to demo data if empty
-  const supabaseServices = await getPublicServices();
-  const services = supabaseServices.length > 0 ? supabaseServices : demoServices;
+  const services = await getPublicServices();
 
   return (
     <div className="container mx-auto px-4 py-12">

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -12,6 +12,15 @@ import { clinicConfig } from "@/config/clinic.config";
 
 // ── Types (match existing UI shapes) ──
 
+export interface PublicBlogPost {
+  id: string;
+  title: string;
+  excerpt: string;
+  date: string;
+  readTime: string;
+  category: string;
+}
+
 export interface PublicReview {
   id: string;
   patientName: string;
@@ -307,4 +316,29 @@ export async function getPublicAvailableSlots(
 
   const maxPerSlot = clinicConfig.booking.maxPerSlot;
   return allSlots.filter((slot) => (bookingCounts[slot] ?? 0) < maxPerSlot);
+}
+
+// ── Blog Posts ──
+
+export async function getPublicBlogPosts(): Promise<PublicBlogPost[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("blog_posts")
+    .select("id, title, excerpt, published_at, read_time, category")
+    .eq("clinic_id", clinicId)
+    .eq("published", true)
+    .order("published_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  return data.map((p) => ({
+    id: p.id,
+    title: p.title ?? "",
+    excerpt: p.excerpt ?? "",
+    date: p.published_at?.split("T")[0] ?? "",
+    readTime: p.read_time ?? "",
+    category: p.category ?? "",
+  }));
 }


### PR DESCRIPTION
## Summary

Wires all 4 public pages (Home, Reviews, Services, Blog) to real Supabase data and removes demo-data fallbacks.

### Changes

- **Home** (`(public)/page.tsx`): Removed `demoReviews`/`demoGetAverageRating` fallback imports — now uses Supabase-only data via `getPublicReviews()` and `getPublicAverageRating()`
- **Reviews** (`(public)/reviews/page.tsx`): Same cleanup — removed dual demo+Supabase import pattern
- **Services** (`(public)/services/page.tsx`): Removed `demoServices` fallback — uses `getPublicServices()` directly
- **Blog** (`(public)/blog/page.tsx`): Replaced `blogPosts` demo import with new `getPublicBlogPosts()` Supabase fetch. Added empty-state UI for when no blog posts exist yet
- **Data layer** (`src/lib/data/public.ts`): Added `PublicBlogPost` type and `getPublicBlogPosts()` function that queries a `blog_posts` table (gracefully returns `[]` if table does not exist yet)

### Notes

- The `blog_posts` Supabase table does not exist yet — the function handles this gracefully by returning an empty array, and the page shows an empty-state message
- No demo-data imports remain in any public page