### PR TITLE
feat: wire Groups 7 & 8 super-admin pages to Supabase data

### DIFF
--- a/src/app/(super-admin)/super-admin/announcements/page.tsx
+++ b/src/app/(super-admin)/super-admin/announcements/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Plus, Edit, Trash2, Megaphone, AlertTriangle, Info, AlertCircle,
   Calendar, Users, Search, Eye,
@@ -13,12 +13,32 @@ import { Label } from "@/components/ui/label";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
-import { announcements as initialAnnouncements, type Announcement } from "@/lib/super-admin-data";
+import { Loader2 } from "lucide-react";
+import {
+  fetchAnnouncements,
+  type Announcement,
+} from "@/lib/super-admin-actions";
 
 type TypeFilter = "all" | "info" | "warning" | "critical";
 
 export default function AnnouncementsPage() {
-  const [list, setList] = useState<Announcement[]>(initialAnnouncements);
+  const [list, setList] = useState<Announcement[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadAnnouncements = useCallback(async () => {
+    try {
+      const data = await fetchAnnouncements();
+      setList(data);
+    } catch (err) {
+      console.error("[sa-announcements] failed to load:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAnnouncements();
+  }, [loadAnnouncements]);
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
   const [editOpen, setEditOpen] = useState(false);

--- a/src/app/(super-admin)/super-admin/billing/page.tsx
+++ b/src/app/(super-admin)/super-admin/billing/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   DollarSign, TrendingUp, AlertTriangle, CheckCircle, Clock,
-  Send, Eye, Search, Filter, CreditCard, Receipt,
+  Send, Eye, Search, Filter, CreditCard, Receipt, Loader2,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -14,9 +14,9 @@ import {
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import {
-  billingRecords, getMRR, getOverdueCount, getPaidCount,
+  fetchBillingRecords,
   type BillingRecord,
-} from "@/lib/super-admin-data";
+} from "@/lib/super-admin-actions";
 
 type StatusFilter = "all" | "paid" | "pending" | "overdue" | "cancelled";
 
@@ -26,14 +26,32 @@ export default function BillingPage() {
   const [detailRecord, setDetailRecord] = useState<BillingRecord | null>(null);
   const [reminderOpen, setReminderOpen] = useState(false);
   const [reminderRecord, setReminderRecord] = useState<BillingRecord | null>(null);
-  const [records, setRecords] = useState(billingRecords);
+  const [records, setRecords] = useState<BillingRecord[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const mrr = getMRR();
+  const loadRecords = useCallback(async () => {
+    try {
+      const data = await fetchBillingRecords();
+      setRecords(data);
+    } catch (err) {
+      console.error("[sa-billing] failed to load records:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRecords();
+  }, [loadRecords]);
+
+  const paidRecords = records.filter((r) => r.status === "paid");
+  const overdueRecords = records.filter((r) => r.status === "overdue");
+  const mrr = records.filter((r) => r.status !== "cancelled").reduce((sum, r) => sum + r.amountDue, 0);
   const arr = mrr * 12;
-  const overdueCount = getOverdueCount();
-  const paidCount = getPaidCount();
-  const totalRevenue = records.filter((r) => r.status === "paid").reduce((sum, r) => sum + r.amountPaid, 0);
-  const overdueAmount = records.filter((r) => r.status === "overdue").reduce((sum, r) => sum + r.amountDue - r.amountPaid, 0);
+  const overdueCount = overdueRecords.length;
+  const paidCount = paidRecords.length;
+  const totalRevenue = paidRecords.reduce((sum, r) => sum + r.amountPaid, 0);
+  const overdueAmount = overdueRecords.reduce((sum, r) => sum + r.amountDue - r.amountPaid, 0);
 
   const filtered = records.filter((r) => {
     const q = search.toLowerCase();
@@ -72,6 +90,13 @@ export default function BillingPage() {
           <p className="text-sm text-muted-foreground mt-1">Monitor revenue, subscriptions, and payment status</p>
         </div>
       </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 mb-4 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading billing data...
+        </div>
+      )}
 
       {/* KPI Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/src/app/(super-admin)/super-admin/clinics/page.tsx
+++ b/src/app/(super-admin)/super-admin/clinics/page.tsx
@@ -15,8 +15,27 @@ import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
-import { clinicDetails as demoClinicDetails, type ClinicDetail } from "@/lib/super-admin-data";
 import { fetchClinics, updateClinicStatus, fetchClinicUsers } from "@/lib/super-admin-actions";
+
+interface ClinicDetail {
+  id: string;
+  name: string;
+  type: "doctor" | "dentist" | "pharmacy";
+  plan: string;
+  city: string;
+  patientsCount: number;
+  monthlyRevenue: number;
+  status: "active" | "suspended" | "trial";
+  ownerName: string;
+  ownerEmail: string;
+  ownerPhone: string;
+  createdAt: string;
+  doctorsCount: number;
+  appointmentsThisMonth: number;
+  domain?: string;
+  lastLoginAt: string;
+  features: Record<string, boolean>;
+}
 
 type FilterType = "all" | "doctor" | "dentist" | "pharmacy";
 type FilterStatus = "all" | "active" | "suspended" | "trial";
@@ -30,53 +49,49 @@ export default function AllClinicsPage() {
   const [loginClinic, setLoginClinic] = useState<ClinicDetail | null>(null);
   const [suspendOpen, setSuspendOpen] = useState(false);
   const [suspendClinic, setSuspendClinic] = useState<ClinicDetail | null>(null);
-  const [list, setList] = useState<ClinicDetail[]>(demoClinicDetails);
-  const [isLive, setIsLive] = useState(false);
+  const [list, setList] = useState<ClinicDetail[]>([]);
   const [loadingData, setLoadingData] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
 
   const loadClinics = useCallback(async () => {
     try {
       const clinics = await fetchClinics();
-      if (clinics && clinics.length > 0) {
-        const enriched: ClinicDetail[] = await Promise.all(
-          clinics.map(async (c) => {
-            let patientsCount = 0;
-            let doctorsCount = 0;
-            try {
-              const users = await fetchClinicUsers(c.id);
-              patientsCount = users.filter((u) => u.role === "patient").length;
-              doctorsCount = users.filter((u) => u.role === "doctor" || u.role === "clinic_admin").length;
-            } catch {
-              // ignore
-            }
-            const config = (c.config ?? {}) as Record<string, unknown>;
-            return {
-              id: c.id,
-              name: c.name,
-              type: c.type as "doctor" | "dentist" | "pharmacy",
-              plan: c.tier ?? "pro",
-              city: (config.city as string) ?? "",
-              patientsCount,
-              monthlyRevenue: 0,
-              status: (c.status === "inactive" ? "suspended" : c.status ?? "active") as "active" | "suspended" | "trial",
-              ownerName: (config.ownerName as string) ?? "",
-              ownerEmail: (config.email as string) ?? "",
-              ownerPhone: (config.phone as string) ?? "",
-              createdAt: c.created_at ?? "",
-              doctorsCount,
-              appointmentsThisMonth: 0,
-              domain: (config.domain as string) ?? undefined,
-              lastLoginAt: "",
-              features: {},
-            };
-          }),
-        );
-        setList(enriched);
-        setIsLive(true);
-      }
-    } catch {
-      // Supabase not configured - keep demo data
+      const enriched: ClinicDetail[] = await Promise.all(
+        clinics.map(async (c) => {
+          let patientsCount = 0;
+          let doctorsCount = 0;
+          try {
+            const users = await fetchClinicUsers(c.id);
+            patientsCount = users.filter((u) => u.role === "patient").length;
+            doctorsCount = users.filter((u) => u.role === "doctor" || u.role === "clinic_admin").length;
+          } catch {
+            // ignore
+          }
+          const config = (c.config ?? {}) as Record<string, unknown>;
+          return {
+            id: c.id,
+            name: c.name,
+            type: c.type as "doctor" | "dentist" | "pharmacy",
+            plan: c.tier ?? "pro",
+            city: (config.city as string) ?? "",
+            patientsCount,
+            monthlyRevenue: 0,
+            status: (c.status === "inactive" ? "suspended" : c.status ?? "active") as "active" | "suspended" | "trial",
+            ownerName: (config.ownerName as string) ?? "",
+            ownerEmail: (config.email as string) ?? "",
+            ownerPhone: (config.phone as string) ?? "",
+            createdAt: c.created_at ?? "",
+            doctorsCount,
+            appointmentsThisMonth: 0,
+            domain: (config.domain as string) ?? undefined,
+            lastLoginAt: "",
+            features: {},
+          };
+        }),
+      );
+      setList(enriched);
+    } catch (err) {
+      console.error("[sa-clinics] failed to load clinics:", err);
     } finally {
       setLoadingData(false);
     }
@@ -93,29 +108,19 @@ export default function AllClinicsPage() {
   });
 
   async function toggleStatus(clinic: ClinicDetail) {
-    if (isLive) {
-      setActionLoading(true);
-      try {
-        const newStatus = clinic.status === "suspended" ? "active" : "suspended";
-        await updateClinicStatus(clinic.id, newStatus);
-        setList((prev) =>
-          prev.map((c) =>
-            c.id === clinic.id ? { ...c, status: newStatus as "active" | "suspended" | "trial" } : c,
-          ),
-        );
-      } catch (err) {
-        console.error("Failed to update status:", err);
-      } finally {
-        setActionLoading(false);
-      }
-    } else {
+    setActionLoading(true);
+    try {
+      const newStatus = clinic.status === "suspended" ? "active" : "suspended";
+      await updateClinicStatus(clinic.id, newStatus);
       setList((prev) =>
         prev.map((c) =>
-          c.id === clinic.id
-            ? { ...c, status: c.status === "suspended" ? ("active" as const) : ("suspended" as const) }
-            : c,
+          c.id === clinic.id ? { ...c, status: newStatus as "active" | "suspended" | "trial" } : c,
         ),
       );
+    } catch (err) {
+      console.error("Failed to update status:", err);
+    } finally {
+      setActionLoading(false);
     }
     setSuspendOpen(false);
   }
@@ -127,8 +132,6 @@ export default function AllClinicsPage() {
           <h1 className="text-2xl font-bold">All Clinics</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Manage all {list.length} registered clinics
-            {isLive && <Badge variant="success" className="ml-2 text-[10px]">Live Data</Badge>}
-            {!isLive && !loadingData && <Badge variant="secondary" className="ml-2 text-[10px]">Demo Data</Badge>}
           </p>
         </div>
         <Link href="/super-admin/onboarding">
@@ -295,7 +298,7 @@ export default function AllClinicsPage() {
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setLoginOpen(false)}>Cancel</Button>
-              <Button onClick={() => setLoginOpen(false)}><LogIn className="h-4 w-4 mr-1" />Continue as {loginClinic.ownerName.split(" ")[0]}</Button>
+              <Button onClick={() => setLoginOpen(false)}><LogIn className="h-4 w-4 mr-1" />Continue as {loginClinic.ownerName.split(" ")[0] || "Admin"}</Button>
             </DialogFooter>
           </DialogContent>
         )}

--- a/src/app/(super-admin)/super-admin/dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.tsx
@@ -18,17 +18,23 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-  clinicDetails as demoClinicDetails,
-  activityLogs,
-  announcements,
-  getActiveClinicsCount,
-  getTotalPatientsCount,
-  getTotalMonthlyRevenue,
-  getMRR,
-  getOverdueCount,
-} from "@/lib/super-admin-data";
-import { fetchDashboardStats } from "@/lib/super-admin-actions";
-import type { ClinicDetail } from "@/lib/super-admin-data";
+  fetchDashboardStats,
+  fetchAnnouncements,
+  fetchActivityLogs,
+  type Announcement,
+  type ActivityLog,
+} from "@/lib/super-admin-actions";
+
+interface ClinicDetail {
+  id: string;
+  name: string;
+  type: "doctor" | "dentist" | "pharmacy";
+  plan: string;
+  city: string;
+  patientsCount: number;
+  monthlyRevenue: number;
+  status: "active" | "suspended" | "trial";
+}
 
 const activityTypeIcons: Record<string, string> = {
   clinic: "text-blue-600",
@@ -41,52 +47,49 @@ const activityTypeIcons: Record<string, string> = {
 
 export default function SuperAdminDashboardPage() {
   const [loading, setLoading] = useState(true);
-  const [isLive, setIsLive] = useState(false);
-  const [clinicList, setClinicList] = useState<ClinicDetail[]>(demoClinicDetails);
-  const [totalClinics, setTotalClinics] = useState(demoClinicDetails.length);
-  const [activeClinics, setActiveClinics] = useState(getActiveClinicsCount());
-  const [totalPatients, setTotalPatients] = useState(getTotalPatientsCount());
-  const [totalRevenue, setTotalRevenue] = useState(getTotalMonthlyRevenue());
-  const [mrr, setMrr] = useState(getMRR());
-  const [overdue, setOverdue] = useState(getOverdueCount());
+  const [clinicList, setClinicList] = useState<ClinicDetail[]>([]);
+  const [totalClinics, setTotalClinics] = useState(0);
+  const [activeClinics, setActiveClinics] = useState(0);
+  const [totalPatients, setTotalPatients] = useState(0);
+  const [totalRevenue, setTotalRevenue] = useState(0);
+  const [mrr, setMrr] = useState(0);
+  const [overdue, setOverdue] = useState(0);
+  const [announcementList, setAnnouncementList] = useState<Announcement[]>([]);
+  const [activityLogList, setActivityLogList] = useState<ActivityLog[]>([]);
 
   const loadStats = useCallback(async () => {
     try {
-      const stats = await fetchDashboardStats();
-      if (stats.clinics && stats.clinics.length > 0) {
-        setTotalClinics(stats.totalClinics);
-        setActiveClinics(stats.activeClinics);
-        setTotalPatients(stats.totalPatients);
-        setTotalRevenue(stats.totalRevenue);
-        setMrr(stats.totalRevenue);
-        setOverdue(0);
-        const mapped: ClinicDetail[] = stats.clinics.map((c) => {
-          const config = (c.config ?? {}) as Record<string, unknown>;
-          return {
-            id: c.id,
-            name: c.name,
-            type: c.type as "doctor" | "dentist" | "pharmacy",
-            plan: (c.tier as string) ?? "pro",
-            city: (config.city as string) ?? "",
-            patientsCount: 0,
-            monthlyRevenue: 0,
-            status: (c.status === "inactive" ? "suspended" : c.status ?? "active") as "active" | "suspended" | "trial",
-            ownerName: (config.ownerName as string) ?? "",
-            ownerEmail: (config.email as string) ?? "",
-            ownerPhone: (config.phone as string) ?? "",
-            createdAt: c.created_at ?? "",
-            doctorsCount: 0,
-            appointmentsThisMonth: 0,
-            domain: (config.domain as string) ?? undefined,
-            lastLoginAt: "",
-            features: {},
-          };
-        });
-        setClinicList(mapped);
-        setIsLive(true);
-      }
-    } catch {
-      // Supabase not configured - keep demo data
+      const [stats, announcements, logs] = await Promise.all([
+        fetchDashboardStats(),
+        fetchAnnouncements(),
+        fetchActivityLogs(),
+      ]);
+
+      setTotalClinics(stats.totalClinics);
+      setActiveClinics(stats.activeClinics);
+      setTotalPatients(stats.totalPatients);
+      setTotalRevenue(stats.totalRevenue);
+      setMrr(stats.totalRevenue);
+      setOverdue(0);
+
+      const mapped: ClinicDetail[] = stats.clinics.map((c) => {
+        const config = (c.config ?? {}) as Record<string, unknown>;
+        return {
+          id: c.id,
+          name: c.name,
+          type: c.type as "doctor" | "dentist" | "pharmacy",
+          plan: (c.tier as string) ?? "pro",
+          city: (config.city as string) ?? "",
+          patientsCount: 0,
+          monthlyRevenue: 0,
+          status: (c.status === "inactive" ? "suspended" : c.status ?? "active") as "active" | "suspended" | "trial",
+        };
+      });
+      setClinicList(mapped);
+      setAnnouncementList(announcements);
+      setActivityLogList(logs);
+    } catch (err) {
+      console.error("[sa-dashboard] failed to load data:", err);
     } finally {
       setLoading(false);
     }
@@ -96,15 +99,15 @@ export default function SuperAdminDashboardPage() {
     loadStats();
   }, [loadStats]);
 
-  const activeAnnouncements = announcements.filter((a) => a.active);
-  const recentLogs = activityLogs.slice(0, 8);
+  const activeAnnouncements = announcementList.filter((a) => a.active);
+  const recentLogs = activityLogList.slice(0, 8);
 
   const stats = [
     {
       icon: Building2,
       label: "Total Clinics",
       value: totalClinics.toString(),
-      change: isLive ? `${activeClinics} active` : "+2 this month",
+      change: `${activeClinics} active`,
       color: "text-blue-600",
       bg: "bg-blue-50",
     },
@@ -112,7 +115,7 @@ export default function SuperAdminDashboardPage() {
       icon: Building2,
       label: "Active Clinics",
       value: activeClinics.toString(),
-      change: isLive ? `${totalClinics - activeClinics} inactive` : `${demoClinicDetails.filter((c) => c.status === "suspended").length} suspended`,
+      change: `${totalClinics - activeClinics} inactive`,
       color: "text-green-600",
       bg: "bg-green-50",
     },
@@ -120,7 +123,7 @@ export default function SuperAdminDashboardPage() {
       icon: Users,
       label: "Total Patients",
       value: totalPatients.toLocaleString(),
-      change: isLive ? "from Supabase" : "+89 this month",
+      change: "across all clinics",
       color: "text-purple-600",
       bg: "bg-purple-50",
     },
@@ -128,7 +131,7 @@ export default function SuperAdminDashboardPage() {
       icon: TrendingUp,
       label: "Monthly Revenue",
       value: `${totalRevenue.toLocaleString()} MAD`,
-      change: isLive ? "from Supabase" : "+12% vs last month",
+      change: "from completed payments",
       color: "text-orange-600",
       bg: "bg-orange-50",
     },
@@ -147,8 +150,6 @@ export default function SuperAdminDashboardPage() {
           <h1 className="text-2xl font-bold">Super Admin Dashboard</h1>
           <p className="text-sm text-muted-foreground mt-1">
             Overview of all clinics and system status
-            {isLive && <Badge variant="success" className="ml-2 text-[10px]">Live Data</Badge>}
-            {!isLive && !loading && <Badge variant="secondary" className="ml-2 text-[10px]">Demo Data</Badge>}
           </p>
         </div>
         <div className="flex gap-2">
@@ -328,7 +329,7 @@ export default function SuperAdminDashboardPage() {
               <div className="space-y-3">
                 {recentLogs.map((log) => (
                   <div key={log.id} className="flex items-start gap-3">
-                    <div className={`mt-0.5 h-2 w-2 rounded-full ${activityTypeIcons[log.type].replace("text-", "bg-")}`} />
+                    <div className={`mt-0.5 h-2 w-2 rounded-full ${(activityTypeIcons[log.type] ?? "text-gray-600").replace("text-", "bg-")}`} />
                     <div className="min-w-0 flex-1">
                       <p className="text-sm font-medium">{log.action}</p>
                       <p className="text-xs text-muted-foreground truncate">{log.description}</p>

--- a/src/app/(super-admin)/super-admin/features/page.tsx
+++ b/src/app/(super-admin)/super-admin/features/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   ToggleLeft, Search, Shield, Zap, Globe, Settings,
   CheckCircle, XCircle,
@@ -13,17 +13,40 @@ import { Switch } from "@/components/ui/switch";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
 import {
-  featureDefinitions as initialFeatures, clinicDetails,
+  fetchFeatureDefinitions,
+  fetchClinics,
   type FeatureDefinition,
-} from "@/lib/super-admin-data";
+} from "@/lib/super-admin-actions";
 
 type CategoryFilter = "all" | "core" | "communication" | "integration" | "advanced";
 
 const tiers = ["basic", "standard", "premium"];
 
 export default function FeatureTogglesPage() {
-  const [features, setFeatures] = useState<FeatureDefinition[]>(initialFeatures);
+  const [features, setFeatures] = useState<FeatureDefinition[]>([]);
+  const [totalClinicsCount, setTotalClinicsCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const loadFeatures = useCallback(async () => {
+    try {
+      const [feats, clinics] = await Promise.all([
+        fetchFeatureDefinitions(),
+        fetchClinics(),
+      ]);
+      setFeatures(feats);
+      setTotalClinicsCount(clinics.length);
+    } catch (err) {
+      console.error("[sa-features] failed to load:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadFeatures();
+  }, [loadFeatures]);
   const [search, setSearch] = useState("");
   const [catFilter, setCatFilter] = useState<CategoryFilter>("all");
   const [bulkOpen, setBulkOpen] = useState(false);
@@ -81,7 +104,7 @@ export default function FeatureTogglesPage() {
   }
 
   const enabledCount = features.filter((f) => f.globalEnabled).length;
-  const totalClinics = clinicDetails.length;
+  const totalClinics = totalClinicsCount;
 
   return (
     <div>

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Check, X, Search, Filter, Crown, Building2,
   Stethoscope, Pill, ChevronDown, ChevronUp,
@@ -12,18 +12,20 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
+import { Loader2 } from "lucide-react";
 import {
   pricingTiers,
-  featureToggles,
-  clientSubscriptions,
-  getSubscriptionStats,
-  getTotalMRR,
+  featureToggles as defaultFeatureToggles,
   systemTypeLabels,
   tierColors,
   type SystemType,
   type TierSlug,
   type FeatureToggle,
 } from "@/lib/pricing-data";
+import {
+  fetchClientSubscriptions,
+  type ClientSubscription,
+} from "@/lib/super-admin-actions";
 
 type TabView = "tiers" | "features";
 type SystemFilter = "all" | SystemType;
@@ -42,11 +44,39 @@ export default function PricingPage() {
   const [billingCycle, setBillingCycle] = useState<"monthly" | "yearly">("monthly");
   const [featureSearch, setFeatureSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
-  const [toggles, setToggles] = useState(featureToggles);
+  const [toggles, setToggles] = useState(defaultFeatureToggles);
   const [expandedTier, setExpandedTier] = useState<string | null>(null);
+  const [subscriptions, setSubscriptions] = useState<ClientSubscription[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const stats = getSubscriptionStats();
-  const mrr = getTotalMRR();
+  const loadSubscriptions = useCallback(async () => {
+    try {
+      const data = await fetchClientSubscriptions();
+      setSubscriptions(data);
+    } catch (err) {
+      console.error("[sa-pricing] failed to load subscriptions:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSubscriptions();
+  }, [loadSubscriptions]);
+
+  const stats = {
+    active: subscriptions.filter((s) => s.status === "active").length,
+    trial: subscriptions.filter((s) => s.status === "trial").length,
+    pastDue: subscriptions.filter((s) => s.status === "past_due").length,
+    cancelled: subscriptions.filter((s) => s.status === "cancelled" || s.status === "suspended").length,
+    total: subscriptions.length,
+  };
+  const mrr = subscriptions
+    .filter((s) => s.status === "active" || s.status === "past_due")
+    .reduce((sum, s) => {
+      if (s.billingCycle === "yearly") return sum + Math.round(s.amount / 12);
+      return sum + s.amount;
+    }, 0);
 
   const filteredToggles = toggles.filter((ft) => {
     const q = featureSearch.toLowerCase();
@@ -199,7 +229,7 @@ export default function PricingPage() {
             {pricingTiers.map((tier) => {
               const price = tier.pricing[selectedSystem][billingCycle];
               const isExpanded = expandedTier === tier.id;
-              const subCount = clientSubscriptions.filter((s) => s.tierSlug === tier.slug).length;
+              const subCount = subscriptions.filter((s) => s.tierSlug === tier.slug).length;
 
               return (
                 <Card key={tier.id} className={`relative ${tier.popular ? "border-primary shadow-md" : ""}`}>
@@ -283,7 +313,7 @@ export default function PricingPage() {
             <CardHeader className="py-3 px-4">
               <CardTitle className="text-base flex items-center gap-2">
                 <Users className="h-4 w-4" />
-                Abonnements par tier ({clientSubscriptions.length})
+                Abonnements par tier ({subscriptions.length})
               </CardTitle>
             </CardHeader>
             <CardContent className="p-0">
@@ -300,7 +330,7 @@ export default function PricingPage() {
                     </tr>
                   </thead>
                   <tbody>
-                    {clientSubscriptions.map((sub) => {
+                    {subscriptions.map((sub) => {
                       const Icon = systemIcons[sub.systemType];
                       return (
                         <tr key={sub.id} className="border-b last:border-0 hover:bg-muted/50">

--- a/src/app/(super-admin)/super-admin/subscriptions/page.tsx
+++ b/src/app/(super-admin)/super-admin/subscriptions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Search, Filter, Eye, Send, CreditCard, Receipt,
   CheckCircle, Clock, AlertTriangle, Download,
@@ -14,16 +14,17 @@ import { Separator } from "@/components/ui/separator";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
 import {
-  clientSubscriptions,
-  getTotalMRR,
-  getSubscriptionStats,
   systemTypeLabels,
   tierColors,
   statusColors,
+} from "@/lib/pricing-data";
+import {
+  fetchClientSubscriptions,
   type ClientSubscription,
   type SystemType,
-} from "@/lib/pricing-data";
+} from "@/lib/super-admin-actions";
 
 type StatusFilter = "all" | ClientSubscription["status"];
 type SystemFilter = "all" | SystemType;
@@ -42,12 +43,40 @@ export default function SubscriptionsPage() {
   const [reminderOpen, setReminderOpen] = useState(false);
   const [reminderSub, setReminderSub] = useState<ClientSubscription | null>(null);
   const [expandedInvoices, setExpandedInvoices] = useState<string | null>(null);
+  const [subscriptions, setSubscriptions] = useState<ClientSubscription[]>([]);
+  const [loading, setLoading] = useState(true);
 
-  const stats = getSubscriptionStats();
-  const mrr = getTotalMRR();
+  const loadSubscriptions = useCallback(async () => {
+    try {
+      const data = await fetchClientSubscriptions();
+      setSubscriptions(data);
+    } catch (err) {
+      console.error("[sa-subscriptions] failed to load:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSubscriptions();
+  }, [loadSubscriptions]);
+
+  const stats = {
+    active: subscriptions.filter((s) => s.status === "active").length,
+    trial: subscriptions.filter((s) => s.status === "trial").length,
+    pastDue: subscriptions.filter((s) => s.status === "past_due").length,
+    cancelled: subscriptions.filter((s) => s.status === "cancelled" || s.status === "suspended").length,
+    total: subscriptions.length,
+  };
+  const mrr = subscriptions
+    .filter((s) => s.status === "active" || s.status === "past_due")
+    .reduce((sum, s) => {
+      if (s.billingCycle === "yearly") return sum + Math.round(s.amount / 12);
+      return sum + s.amount;
+    }, 0);
   const arr = mrr * 12;
 
-  const filtered = clientSubscriptions.filter((sub) => {
+  const filtered = subscriptions.filter((sub) => {
     const q = search.toLowerCase();
     const matchSearch = !q || sub.clinicName.toLowerCase().includes(q);
     const matchStatus = statusFilter === "all" || sub.status === statusFilter;
@@ -151,7 +180,7 @@ export default function SubscriptionsPage() {
           <Button key={s} variant={statusFilter === s ? "default" : "outline"} size="sm" onClick={() => setStatusFilter(s)} className="text-xs">
             {s === "all" ? "Tous" : statusLabel(s as ClientSubscription["status"])}
             <Badge variant="secondary" className="ml-1 text-[10px] px-1">
-              {s === "all" ? clientSubscriptions.length : clientSubscriptions.filter((sub) => sub.status === s).length}
+              {s === "all" ? subscriptions.length : subscriptions.filter((sub) => sub.status === s).length}
             </Badge>
           </Button>
         ))}
@@ -247,7 +276,7 @@ export default function SubscriptionsPage() {
 
           {/* Expanded Invoices */}
           {expandedInvoices && (() => {
-            const sub = clientSubscriptions.find((s) => s.id === expandedInvoices);
+            const sub = subscriptions.find((s) => s.id === expandedInvoices);
             if (!sub) return null;
             return (
               <div className="border-t bg-muted/30 p-4">

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -314,3 +314,280 @@ export async function fetchDashboardStats(): Promise<DashboardStats> {
     totalRevenue,
   };
 }
+
+// ---------- Billing Records ----------
+
+export interface BillingRecord {
+  id: string;
+  clinicId: string;
+  clinicName: string;
+  plan: string;
+  amountDue: number;
+  amountPaid: number;
+  currency: string;
+  status: "paid" | "pending" | "overdue" | "cancelled";
+  invoiceDate: string;
+  dueDate: string;
+  paidDate?: string;
+  paymentMethod?: string;
+}
+
+export async function fetchBillingRecords(): Promise<BillingRecord[]> {
+  const supabase = rawClient();
+
+  const [paymentsRes, clinicsRes] = await Promise.all([
+    supabase
+      .from("payments")
+      .select("id, clinic_id, amount, status, payment_type, created_at")
+      .order("created_at", { ascending: false }),
+    supabase.from("clinics").select("id, name, tier"),
+  ]);
+
+  const payments = (paymentsRes.data ?? []) as {
+    id: string;
+    clinic_id: string;
+    amount: number;
+    status: string;
+    payment_type: string | null;
+    created_at: string;
+  }[];
+  const clinics = (clinicsRes.data ?? []) as { id: string; name: string; tier: string | null }[];
+  const clinicMap = new Map(clinics.map((c) => [c.id, c]));
+
+  return payments.map((p) => {
+    const clinic = clinicMap.get(p.clinic_id);
+    const createdDate = p.created_at?.split("T")[0] ?? "";
+    const isPaid = p.status === "completed";
+    return {
+      id: p.id,
+      clinicId: p.clinic_id,
+      clinicName: clinic?.name ?? "Unknown Clinic",
+      plan: clinic?.tier ?? "pro",
+      amountDue: p.amount ?? 0,
+      amountPaid: isPaid ? (p.amount ?? 0) : 0,
+      currency: "MAD",
+      status: (isPaid ? "paid" : p.status === "pending" ? "pending" : "overdue") as BillingRecord["status"],
+      invoiceDate: createdDate,
+      dueDate: createdDate,
+      paidDate: isPaid ? createdDate : undefined,
+      paymentMethod: p.payment_type ?? undefined,
+    };
+  });
+}
+
+// ---------- Announcements ----------
+
+export interface Announcement {
+  id: string;
+  title: string;
+  message: string;
+  type: "info" | "warning" | "critical";
+  target: string;
+  targetLabel: string;
+  publishedAt: string;
+  expiresAt?: string;
+  active: boolean;
+  createdBy: string;
+}
+
+export async function fetchAnnouncements(): Promise<Announcement[]> {
+  const supabase = rawClient();
+  const { data, error } = await supabase
+    .from("announcements")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    title: (row.title as string) ?? "",
+    message: (row.message as string) ?? "",
+    type: ((row.type as string) ?? "info") as Announcement["type"],
+    target: (row.target as string) ?? "all",
+    targetLabel: (row.target_label as string) ?? "All Clinics",
+    publishedAt: ((row.published_at ?? row.created_at) as string)?.split("T")[0] ?? "",
+    expiresAt: row.expires_at ? (row.expires_at as string).split("T")[0] : undefined,
+    active: (row.active as boolean) ?? true,
+    createdBy: (row.created_by as string) ?? "System",
+  }));
+}
+
+// ---------- Activity Logs ----------
+
+export interface ActivityLog {
+  id: string;
+  action: string;
+  description: string;
+  clinicId?: string;
+  clinicName?: string;
+  timestamp: string;
+  actor: string;
+  type: "clinic" | "billing" | "feature" | "announcement" | "template" | "auth";
+}
+
+export async function fetchActivityLogs(): Promise<ActivityLog[]> {
+  const supabase = rawClient();
+  const { data, error } = await supabase
+    .from("activity_logs")
+    .select("*")
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    action: (row.action as string) ?? "",
+    description: (row.description as string) ?? "",
+    clinicId: row.clinic_id as string | undefined,
+    clinicName: row.clinic_name as string | undefined,
+    timestamp: (row.created_at as string) ?? "",
+    actor: (row.actor as string) ?? "System",
+    type: ((row.type as string) ?? "clinic") as ActivityLog["type"],
+  }));
+}
+
+// ---------- Feature Definitions ----------
+
+export interface FeatureDefinition {
+  id: string;
+  name: string;
+  description: string;
+  key: string;
+  category: "core" | "communication" | "integration" | "advanced";
+  availableTiers: string[];
+  globalEnabled: boolean;
+}
+
+export async function fetchFeatureDefinitions(): Promise<FeatureDefinition[]> {
+  const supabase = rawClient();
+  const { data, error } = await supabase
+    .from("feature_definitions")
+    .select("*")
+    .order("name", { ascending: true });
+
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    name: (row.name as string) ?? "",
+    description: (row.description as string) ?? "",
+    key: (row.key as string) ?? "",
+    category: ((row.category as string) ?? "core") as FeatureDefinition["category"],
+    availableTiers: (row.available_tiers as string[]) ?? [],
+    globalEnabled: (row.global_enabled as boolean) ?? true,
+  }));
+}
+
+// ---------- Client Subscriptions ----------
+
+export interface ClientInvoice {
+  id: string;
+  date: string;
+  amount: number;
+  status: "paid" | "pending" | "overdue" | "refunded";
+  paidDate?: string;
+}
+
+export type SystemType = "doctor" | "dentist" | "pharmacy";
+export type TierSlug = "vitrine" | "cabinet" | "pro" | "premium" | "saas-monthly";
+
+export interface ClientSubscription {
+  id: string;
+  clinicId: string;
+  clinicName: string;
+  systemType: SystemType;
+  tierSlug: TierSlug;
+  tierName: string;
+  status: "active" | "trial" | "past_due" | "cancelled" | "suspended";
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+  billingCycle: "monthly" | "yearly";
+  amount: number;
+  currency: string;
+  paymentMethod: string;
+  autoRenew: boolean;
+  trialEndsAt?: string;
+  cancelledAt?: string;
+  invoices: ClientInvoice[];
+}
+
+const TIER_NAMES: Record<string, string> = {
+  vitrine: "Vitrine",
+  cabinet: "Cabinet",
+  pro: "Pro",
+  premium: "Premium",
+  "saas-monthly": "SaaS Monthly",
+};
+
+export async function fetchClientSubscriptions(): Promise<ClientSubscription[]> {
+  const supabase = rawClient();
+
+  const [clinicsRes, paymentsRes] = await Promise.all([
+    supabase.from("clinics").select("id, name, type, tier, status, config, created_at"),
+    supabase
+      .from("payments")
+      .select("id, clinic_id, amount, status, created_at")
+      .order("created_at", { ascending: false }),
+  ]);
+
+  const clinics = (clinicsRes.data ?? []) as ClinicRow[];
+  const payments = (paymentsRes.data ?? []) as {
+    id: string;
+    clinic_id: string;
+    amount: number;
+    status: string;
+    created_at: string;
+  }[];
+
+  const paymentsByClinic = new Map<string, typeof payments>();
+  for (const p of payments) {
+    const list = paymentsByClinic.get(p.clinic_id) ?? [];
+    list.push(p);
+    paymentsByClinic.set(p.clinic_id, list);
+  }
+
+  return clinics.map((c) => {
+    const tierSlug = (c.tier ?? "pro") as TierSlug;
+    const clinicPayments = paymentsByClinic.get(c.id) ?? [];
+    const invoices: ClientInvoice[] = clinicPayments.slice(0, 5).map((p) => ({
+      id: p.id,
+      date: p.created_at?.split("T")[0] ?? "",
+      amount: p.amount ?? 0,
+      status: (p.status === "completed" ? "paid" : p.status === "pending" ? "pending" : "overdue") as ClientInvoice["status"],
+      paidDate: p.status === "completed" ? p.created_at?.split("T")[0] : undefined,
+    }));
+
+    const subStatus: ClientSubscription["status"] =
+      c.status === "active" ? "active"
+        : c.status === "suspended" ? "suspended"
+        : c.status === "trial" ? "trial"
+        : "cancelled";
+
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split("T")[0];
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split("T")[0];
+
+    const latestPayment = clinicPayments[0];
+    const amount = latestPayment?.amount ?? 0;
+
+    return {
+      id: `sub-${c.id}`,
+      clinicId: c.id,
+      clinicName: c.name,
+      systemType: (c.type ?? "doctor") as SystemType,
+      tierSlug,
+      tierName: TIER_NAMES[tierSlug] ?? tierSlug,
+      status: subStatus,
+      currentPeriodStart: monthStart,
+      currentPeriodEnd: monthEnd,
+      billingCycle: "monthly" as const,
+      amount,
+      currency: "MAD",
+      paymentMethod: "Carte bancaire",
+      autoRenew: c.status === "active",
+      invoices,
+    };
+  });
+}


### PR DESCRIPTION
Replace all demo-data imports (super-admin-data, pricing-data) in 7 super-admin pages with real Supabase fetch functions.

## Changes

### New Supabase fetch functions (super-admin-actions.ts)
- `fetchBillingRecords()` - fetch from payments table with clinic lookup
- `fetchAnnouncements()` - fetch from announcements table
- `fetchActivityLogs()` - fetch from activity_logs table
- `fetchFeatureDefinitions()` - fetch from feature_definitions table
- `fetchClientSubscriptions()` - fetch clinics + payments, build subscription view

### Pages wired to Supabase
- **Dashboard** - announcements & activity logs now fetched from Supabase
- **Clinics** - removed demo data fallback, uses fetchClinics exclusively
- **Billing** - uses fetchBillingRecords with loading state
- **Announcements** - uses fetchAnnouncements with loading state
- **Features** - uses fetchFeatureDefinitions with clinic count from Supabase
- **Pricing** - fetches subscriptions from Supabase, computes stats live
- **Subscriptions** - fetches subscriptions from Supabase, computes stats live

### Group 7 (no changes needed)
- clinic-stats.tsx already wired to Supabase
- installment-tracker.tsx only imports types