### PR TITLE
feat: wire all 8 Pharmacist pages to real Supabase data

### DIFF
--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -8,25 +9,68 @@ import {
   Check, Eye, AlertCircle,
 } from "lucide-react";
 import Link from "next/link";
+import { clinicConfig } from "@/config/clinic.config";
 import {
-  pharmacyPrescriptions,
-  dailySales,
-  purchaseOrders,
-  loyaltyMembers,
+  fetchProducts,
+  fetchPrescriptionRequests,
+  fetchDailySales,
+  fetchPurchaseOrders,
+  fetchLoyaltyMembers,
   getLowStockProducts,
   getExpiringProducts,
-  getPendingPrescriptions,
   getOutOfStockProducts,
-} from "@/lib/pharmacy-demo-data";
+} from "@/lib/data/client";
+import type {
+  ProductView,
+  PharmacyPrescriptionView,
+  DailySaleView,
+  PurchaseOrderView,
+  LoyaltyMemberView,
+} from "@/lib/data/client";
 
 export default function PharmacistDashboardPage() {
-  const pendingRx = getPendingPrescriptions();
-  const lowStock = getLowStockProducts();
-  const outOfStock = getOutOfStockProducts();
-  const expiring = getExpiringProducts(90);
-  const todaySales = dailySales.filter((s) => s.date === "2026-03-20");
+  const [products, setProducts] = useState<ProductView[]>([]);
+  const [prescriptions, setPrescriptions] = useState<PharmacyPrescriptionView[]>([]);
+  const [sales, setSales] = useState<DailySaleView[]>([]);
+  const [allOrders, setAllOrders] = useState<PurchaseOrderView[]>([]);
+  const [members, setMembers] = useState<LoyaltyMemberView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([
+      fetchProducts(cId),
+      fetchPrescriptionRequests(cId),
+      fetchDailySales(cId),
+      fetchPurchaseOrders(cId),
+      fetchLoyaltyMembers(cId),
+    ])
+      .then(([p, rx, s, o, l]) => {
+        setProducts(p);
+        setPrescriptions(rx);
+        setSales(s);
+        setAllOrders(o);
+        setMembers(l);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
+      </div>
+    );
+  }
+
+  const pendingRx = prescriptions.filter((p) => p.status === "pending" || p.status === "reviewing");
+  const lowStock = getLowStockProducts(products);
+  const outOfStock = getOutOfStockProducts(products);
+  const expiring = getExpiringProducts(products, 90);
+  const today = new Date().toISOString().split("T")[0];
+  const todaySales = sales.filter((s) => s.date === today);
   const todayRevenue = todaySales.reduce((sum, s) => sum + s.total, 0);
-  const pendingOrders = purchaseOrders.filter((o) => o.status !== "delivered" && o.status !== "cancelled");
+  const pendingOrders = allOrders.filter((o) => o.status !== "delivered" && o.status !== "cancelled");
 
   return (
     <div>
@@ -99,7 +143,7 @@ export default function PharmacistDashboardPage() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-muted-foreground">Loyalty Members</p>
-                <p className="text-3xl font-bold">{loyaltyMembers.length}</p>
+                <p className="text-3xl font-bold">{members.length}</p>
               </div>
               <div className="h-12 w-12 rounded-lg bg-purple-100 dark:bg-purple-900/30 text-purple-600 flex items-center justify-center">
                 <Users className="h-6 w-6" />
@@ -123,11 +167,11 @@ export default function PharmacistDashboardPage() {
               </Link>
             </div>
             <div className="space-y-3">
-              {pharmacyPrescriptions.filter((rx) => rx.status !== "picked-up" && rx.status !== "delivered").slice(0, 4).map((rx) => (
+              {prescriptions.filter((rx) => rx.status !== "picked-up" && rx.status !== "delivered").slice(0, 4).map((rx) => (
                 <div key={rx.id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
                   <div>
                     <p className="font-medium text-sm">{rx.patientName}</p>
-                    <p className="text-xs text-muted-foreground">{rx.items.length} item{rx.items.length > 1 ? "s" : ""} - {new Date(rx.uploadedAt).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" })}</p>
+                    <p className="text-xs text-muted-foreground">{rx.items.length} item{rx.items.length > 1 ? "s" : ""} - {rx.uploadedAt ? new Date(rx.uploadedAt).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" }) : ""}</p>
                   </div>
                   <Badge className={
                     rx.status === "pending" ? "bg-yellow-100 text-yellow-700 border-0" :
@@ -143,6 +187,9 @@ export default function PharmacistDashboardPage() {
                   </Badge>
                 </div>
               ))}
+              {prescriptions.filter((rx) => rx.status !== "picked-up" && rx.status !== "delivered").length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No active prescriptions</p>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -161,7 +208,7 @@ export default function PharmacistDashboardPage() {
                 <div key={p.id} className="flex items-center justify-between p-3 bg-red-50 dark:bg-red-950/10 rounded-lg">
                   <div>
                     <p className="font-medium text-sm">{p.name}</p>
-                    <p className="text-xs text-muted-foreground">{p.manufacturer}</p>
+                    <p className="text-xs text-muted-foreground">{p.manufacturer ?? p.category}</p>
                   </div>
                   <Badge variant="destructive" className="text-xs">Out of Stock</Badge>
                 </div>
@@ -184,6 +231,9 @@ export default function PharmacistDashboardPage() {
                   <Badge className="bg-yellow-100 text-yellow-700 border-0 text-xs">Expiring Soon</Badge>
                 </div>
               ))}
+              {outOfStock.length === 0 && lowStock.length === 0 && expiring.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">All stock levels healthy</p>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -210,6 +260,9 @@ export default function PharmacistDashboardPage() {
                   </div>
                 </div>
               ))}
+              {todaySales.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No sales recorded today</p>
+              )}
             </div>
           </CardContent>
         </Card>
@@ -242,6 +295,9 @@ export default function PharmacistDashboardPage() {
                   </div>
                 </div>
               ))}
+              {pendingOrders.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No pending orders</p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/app/(pharmacist)/pharmacist/expiry/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/expiry/page.tsx
@@ -1,14 +1,25 @@
 "use client";
 
-import { useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, Check, Clock, X } from "lucide-react";
-import { pharmacyProducts, getExpiryStatus } from "@/lib/pharmacy-demo-data";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchProducts, getExpiryStatus } from "@/lib/data/client";
+import type { ProductView } from "@/lib/data/client";
 
 export default function ExpiryTrackerPage() {
+  const [allProducts, setAllProducts] = useState<ProductView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchProducts(clinicConfig.clinicId)
+      .then(setAllProducts)
+      .finally(() => setLoading(false));
+  }, []);
+
   const products = useMemo(() => {
-    return pharmacyProducts
+    return allProducts
       .filter((p) => p.active)
       .map((p) => ({
         ...p,
@@ -18,7 +29,15 @@ export default function ExpiryTrackerPage() {
         ),
       }))
       .sort((a, b) => a.daysUntilExpiry - b.daysUntilExpiry);
-  }, []);
+  }, [allProducts]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading expiry data...</div>
+      </div>
+    );
+  }
 
   const expired = products.filter((p) => p.expiryStatus === "red");
   const expiringSoon = products.filter((p) => p.expiryStatus === "yellow");

--- a/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,21 +10,21 @@ import {
   TrendingUp, Plus, CreditCard, Cake, UserPlus,
   ArrowDown, ArrowUp, History,
 } from "lucide-react";
-import {
-  loyaltyMembers,
-  loyaltyTransactions,
-  getPointsValue,
-} from "@/lib/pharmacy-demo-data";
-import type { LoyaltyMember, LoyaltyTransaction } from "@/lib/pharmacy-demo-data";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchLoyaltyMembers, fetchLoyaltyTransactions, getPointsValue } from "@/lib/data/client";
+import type { LoyaltyMemberView, LoyaltyTransactionView } from "@/lib/data/client";
 
-const tierConfig: Record<LoyaltyMember["tier"], { label: string; color: string; icon: React.ReactNode; min: number }> = {
+type LoyaltyTier = "bronze" | "silver" | "gold" | "platinum";
+type TransactionType = "earned" | "redeemed" | "birthday_bonus" | "referral_bonus" | "expired";
+
+const tierConfig: Record<LoyaltyTier, { label: string; color: string; icon: React.ReactNode; min: number }> = {
   bronze: { label: "Bronze", color: "bg-orange-100 text-orange-700", icon: <Medal className="h-3 w-3" />, min: 0 },
   silver: { label: "Silver", color: "bg-gray-200 text-gray-700", icon: <Award className="h-3 w-3" />, min: 1000 },
   gold: { label: "Gold", color: "bg-yellow-100 text-yellow-700", icon: <Star className="h-3 w-3" />, min: 3000 },
   platinum: { label: "Platinum", color: "bg-purple-100 text-purple-700", icon: <Crown className="h-3 w-3" />, min: 5000 },
 };
 
-const transactionTypeConfig: Record<LoyaltyTransaction["type"], { label: string; color: string }> = {
+const transactionTypeConfig: Record<TransactionType, { label: string; color: string }> = {
   earned: { label: "Earned", color: "text-emerald-600" },
   redeemed: { label: "Redeemed", color: "text-red-600" },
   birthday_bonus: { label: "Birthday", color: "text-pink-600" },
@@ -33,23 +33,41 @@ const transactionTypeConfig: Record<LoyaltyTransaction["type"], { label: string;
 };
 
 export default function LoyaltyPage() {
+  const [allMembers, setAllMembers] = useState<LoyaltyMemberView[]>([]);
+  const [allTransactions, setAllTransactions] = useState<LoyaltyTransactionView[]>([]);
+  const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedMember, setSelectedMember] = useState<string | null>(null);
   const [view, setView] = useState<"members" | "transactions">("members");
 
-  const filteredMembers = loyaltyMembers.filter(
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([fetchLoyaltyMembers(cId), fetchLoyaltyTransactions(cId)])
+      .then(([m, t]) => { setAllMembers(m); setAllTransactions(t); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading loyalty data...</div>
+      </div>
+    );
+  }
+
+  const filteredMembers = allMembers.filter(
     (m) => m.patientName.toLowerCase().includes(searchQuery.toLowerCase()) ||
       m.phone.includes(searchQuery) ||
       m.referralCode.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  const totalMembers = loyaltyMembers.length;
-  const totalPointsIssued = loyaltyMembers.reduce((sum, m) => sum + m.totalPoints, 0);
-  const totalRedeemed = loyaltyMembers.reduce((sum, m) => sum + m.redeemedPoints, 0);
+  const totalMembers = allMembers.length;
+  const totalPointsIssued = allMembers.reduce((sum, m) => sum + m.totalPoints, 0);
+  const totalRedeemed = allMembers.reduce((sum, m) => sum + m.redeemedPoints, 0);
 
   const memberTransactions = selectedMember
-    ? loyaltyTransactions.filter((t) => t.memberId === selectedMember)
-    : loyaltyTransactions;
+    ? allTransactions.filter((t) => t.memberId === selectedMember)
+    : allTransactions;
 
   return (
     <div>
@@ -173,7 +191,7 @@ export default function LoyaltyPage() {
       {view === "members" && (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {filteredMembers.map((member) => {
-            const tier = tierConfig[member.tier];
+            const tier = tierConfig[member.tier as LoyaltyTier] ?? tierConfig.bronze;
             return (
               <Card key={member.id} className="hover:shadow-md transition-shadow">
                 <CardContent className="pt-6">
@@ -249,7 +267,7 @@ export default function LoyaltyPage() {
             {selectedMember && (
               <div className="py-3 border-b flex items-center justify-between">
                 <p className="text-sm font-medium">
-                  Transactions for: {loyaltyMembers.find((m) => m.id === selectedMember)?.patientName}
+                  Transactions for: {allMembers.find((m) => m.id === selectedMember)?.patientName}
                 </p>
                 <Button variant="ghost" size="sm" onClick={() => setSelectedMember(null)}>
                   Show All
@@ -269,8 +287,8 @@ export default function LoyaltyPage() {
                 </thead>
                 <tbody>
                   {memberTransactions.map((tx) => {
-                    const config = transactionTypeConfig[tx.type];
-                    const member = loyaltyMembers.find((m) => m.id === tx.memberId);
+                    const config = transactionTypeConfig[tx.type as TransactionType] ?? transactionTypeConfig.earned;
+                    const member = allMembers.find((m) => m.id === tx.memberId);
                     return (
                       <tr key={tx.id} className="border-b hover:bg-muted/50 text-sm">
                         <td className="py-3 px-2">{tx.date}</td>

--- a/src/app/(pharmacist)/pharmacist/orders/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/orders/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,10 +8,13 @@ import {
   Plus, Truck, Check, Package,
   Send, X, FileText,
 } from "lucide-react";
-import { purchaseOrders, suppliers } from "@/lib/pharmacy-demo-data";
-import type { PurchaseOrder } from "@/lib/pharmacy-demo-data";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchPurchaseOrders, fetchSuppliers } from "@/lib/data/client";
+import type { PurchaseOrderView, SupplierView } from "@/lib/data/client";
 
-const statusConfig: Record<PurchaseOrder["status"], { label: string; color: string; icon: React.ReactNode }> = {
+type OrderStatus = "draft" | "sent" | "confirmed" | "shipped" | "delivered" | "cancelled";
+
+const statusConfig: Record<OrderStatus, { label: string; color: string; icon: React.ReactNode }> = {
   draft: { label: "Draft", color: "bg-gray-100 text-gray-700", icon: <FileText className="h-3 w-3" /> },
   sent: { label: "Sent", color: "bg-blue-100 text-blue-700", icon: <Send className="h-3 w-3" /> },
   confirmed: { label: "Confirmed", color: "bg-emerald-100 text-emerald-700", icon: <Check className="h-3 w-3" /> },
@@ -21,11 +24,29 @@ const statusConfig: Record<PurchaseOrder["status"], { label: string; color: stri
 };
 
 export default function OrdersPage() {
+  const [allOrders, setAllOrders] = useState<PurchaseOrderView[]>([]);
+  const [allSuppliers, setAllSuppliers] = useState<SupplierView[]>([]);
+  const [loading, setLoading] = useState(true);
   const [filterStatus, setFilterStatus] = useState<string>("all");
 
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([fetchPurchaseOrders(cId), fetchSuppliers(cId)])
+      .then(([o, s]) => { setAllOrders(o); setAllSuppliers(s); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading orders...</div>
+      </div>
+    );
+  }
+
   const filtered = filterStatus === "all"
-    ? purchaseOrders
-    : purchaseOrders.filter((o) => o.status === filterStatus);
+    ? allOrders
+    : allOrders.filter((o) => o.status === filterStatus);
 
   return (
     <div>
@@ -44,14 +65,14 @@ export default function OrdersPage() {
         <Card>
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Total Orders</p>
-            <p className="text-2xl font-bold">{purchaseOrders.length}</p>
+            <p className="text-2xl font-bold">{allOrders.length}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Pending Delivery</p>
             <p className="text-2xl font-bold text-blue-600">
-              {purchaseOrders.filter((o) => o.status === "confirmed" || o.status === "shipped").length}
+              {allOrders.filter((o) => o.status === "confirmed" || o.status === "shipped").length}
             </p>
           </CardContent>
         </Card>
@@ -59,14 +80,14 @@ export default function OrdersPage() {
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Total Value (Active)</p>
             <p className="text-2xl font-bold">
-              {purchaseOrders.filter((o) => o.status !== "cancelled" && o.status !== "delivered").reduce((sum, o) => sum + o.totalAmount, 0).toLocaleString()} <span className="text-sm font-normal">MAD</span>
+              {allOrders.filter((o) => o.status !== "cancelled" && o.status !== "delivered").reduce((sum, o) => sum + o.totalAmount, 0).toLocaleString()} <span className="text-sm font-normal">MAD</span>
             </p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Suppliers</p>
-            <p className="text-2xl font-bold">{suppliers.length}</p>
+            <p className="text-2xl font-bold">{allSuppliers.length}</p>
           </CardContent>
         </Card>
       </div>
@@ -88,7 +109,7 @@ export default function OrdersPage() {
       {/* Orders */}
       <div className="space-y-4">
         {filtered.map((order) => {
-          const status = statusConfig[order.status];
+          const status = statusConfig[order.status as OrderStatus] ?? statusConfig.draft;
           return (
             <Card key={order.id}>
               <CardContent className="pt-6">

--- a/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,10 +9,13 @@ import {
   Clock, Check, Eye, AlertCircle, Package, Truck,
   Search, Phone, MessageCircle, RefreshCw, X, ClipboardList,
 } from "lucide-react";
-import { pharmacyPrescriptions } from "@/lib/pharmacy-demo-data";
-import type { PharmacyPrescription } from "@/lib/pharmacy-demo-data";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchPrescriptionRequests } from "@/lib/data/client";
+import type { PharmacyPrescriptionView } from "@/lib/data/client";
 
-const statusConfig: Record<PharmacyPrescription["status"], { label: string; color: string; icon: React.ReactNode }> = {
+type PrescriptionStatus = "pending" | "reviewing" | "partially-ready" | "ready" | "picked-up" | "delivered" | "rejected";
+
+const statusConfig: Record<PrescriptionStatus, { label: string; color: string; icon: React.ReactNode }> = {
   pending: { label: "Pending", color: "bg-yellow-100 text-yellow-700", icon: <Clock className="h-3 w-3" /> },
   reviewing: { label: "Reviewing", color: "bg-blue-100 text-blue-700", icon: <Eye className="h-3 w-3" /> },
   "partially-ready": { label: "Partial", color: "bg-orange-100 text-orange-700", icon: <AlertCircle className="h-3 w-3" /> },
@@ -22,13 +25,29 @@ const statusConfig: Record<PharmacyPrescription["status"], { label: string; colo
   rejected: { label: "Rejected", color: "bg-red-100 text-red-700", icon: <X className="h-3 w-3" /> },
 };
 
-const statusFilters: PharmacyPrescription["status"][] = ["pending", "reviewing", "partially-ready", "ready", "picked-up", "delivered"];
+const statusFilters: PrescriptionStatus[] = ["pending", "reviewing", "partially-ready", "ready", "picked-up", "delivered"];
 
 export default function PrescriptionsPage() {
+  const [allPrescriptions, setAllPrescriptions] = useState<PharmacyPrescriptionView[]>([]);
+  const [loading, setLoading] = useState(true);
   const [filterStatus, setFilterStatus] = useState<string>("all");
   const [searchQuery, setSearchQuery] = useState("");
 
-  const filtered = pharmacyPrescriptions.filter((rx) => {
+  useEffect(() => {
+    fetchPrescriptionRequests(clinicConfig.clinicId)
+      .then(setAllPrescriptions)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading prescriptions...</div>
+      </div>
+    );
+  }
+
+  const filtered = allPrescriptions.filter((rx) => {
     if (filterStatus !== "all" && rx.status !== filterStatus) return false;
     if (searchQuery && !rx.patientName.toLowerCase().includes(searchQuery.toLowerCase())) return false;
     return true;
@@ -42,7 +61,7 @@ export default function PrescriptionsPage() {
           <p className="text-muted-foreground text-sm">Manage incoming prescription orders</p>
         </div>
         <Badge className="bg-yellow-100 text-yellow-700 border-0">
-          {pharmacyPrescriptions.filter((rx) => rx.status === "pending").length} pending
+          {allPrescriptions.filter((rx) => rx.status === "pending").length} pending
         </Badge>
       </div>
 
@@ -79,7 +98,7 @@ export default function PrescriptionsPage() {
       {/* Prescription Cards */}
       <div className="space-y-4">
         {filtered.map((rx) => {
-          const status = statusConfig[rx.status];
+          const status = statusConfig[rx.status as PrescriptionStatus] ?? statusConfig.pending;
           const availableCount = rx.items.filter((i) => i.available).length;
 
           return (

--- a/src/app/(pharmacist)/pharmacist/sales/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/sales/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,14 +8,26 @@ import {
   Plus, Receipt, DollarSign, CreditCard, Banknote,
   Shield, Gift,
 } from "lucide-react";
-import { dailySales } from "@/lib/pharmacy-demo-data";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchDailySales } from "@/lib/data/client";
+import type { DailySaleView } from "@/lib/data/client";
 
 export default function SalesPage() {
-  const [dateFilter, setDateFilter] = useState("2026-03-20");
+  const [allSales, setAllSales] = useState<DailySaleView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const today = new Date().toISOString().split("T")[0] ?? "";
+  const yesterday = (() => { const d = new Date(); d.setDate(d.getDate() - 1); return d.toISOString().split("T")[0] ?? ""; })();
+  const [dateFilter, setDateFilter] = useState(today);
+
+  useEffect(() => {
+    fetchDailySales(clinicConfig.clinicId)
+      .then(setAllSales)
+      .finally(() => setLoading(false));
+  }, []);
 
   const filteredSales = useMemo(() => {
-    return dailySales.filter((s) => s.date === dateFilter);
-  }, [dateFilter]);
+    return allSales.filter((s) => s.date === dateFilter);
+  }, [allSales, dateFilter]);
 
   const totalRevenue = filteredSales.reduce((sum, s) => sum + s.total, 0);
   const cashSales = filteredSales.filter((s) => s.paymentMethod === "cash");
@@ -27,6 +39,14 @@ export default function SalesPage() {
     card: <CreditCard className="h-3 w-3" />,
     insurance: <Shield className="h-3 w-3" />,
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading sales data...</div>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -42,7 +62,7 @@ export default function SalesPage() {
 
       {/* Date selector */}
       <div className="flex gap-2 mb-6">
-        {["2026-03-20", "2026-03-19"].map((d) => (
+        {[today, yesterday].map((d) => (
           <button
             key={d}
             onClick={() => setDateFilter(d)}

--- a/src/app/(pharmacist)/pharmacist/stock/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/stock/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -9,13 +9,14 @@ import {
   Search, Package, Plus, Filter,
   ArrowUpDown, ShoppingCart,
 } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
 import {
-  pharmacyProducts,
-  searchProducts,
+  fetchProducts,
+  searchProductsLocal,
   getStockStatus,
   getExpiryStatus,
-} from "@/lib/pharmacy-demo-data";
-import type { PharmacyProduct } from "@/lib/pharmacy-demo-data";
+} from "@/lib/data/client";
+import type { ProductView } from "@/lib/data/client";
 
 const categories = [
   { value: "all", label: "All" },
@@ -35,17 +36,25 @@ const stockFilters = [
 ];
 
 export default function StockPage() {
+  const [allProducts, setAllProducts] = useState<ProductView[]>([]);
+  const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("all");
   const [stockFilter, setStockFilter] = useState("all");
   const [sortBy, setSortBy] = useState<"name" | "stock" | "expiry">("name");
 
+  useEffect(() => {
+    fetchProducts(clinicConfig.clinicId)
+      .then(setAllProducts)
+      .finally(() => setLoading(false));
+  }, []);
+
   const filtered = useMemo(() => {
-    let results: PharmacyProduct[];
+    let results: ProductView[];
     if (query.trim()) {
-      results = searchProducts(query);
+      results = searchProductsLocal(allProducts, query);
     } else {
-      results = pharmacyProducts.filter((p) => p.active);
+      results = allProducts.filter((p) => p.active);
     }
     if (categoryFilter !== "all") {
       results = results.filter((p) => p.category === categoryFilter);
@@ -59,9 +68,17 @@ export default function StockPage() {
       return a.name.localeCompare(b.name);
     });
     return results;
-  }, [query, categoryFilter, stockFilter, sortBy]);
+  }, [allProducts, query, categoryFilter, stockFilter, sortBy]);
 
   const totalValue = filtered.reduce((sum, p) => sum + p.price * p.stockQuantity, 0);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading stock data...</div>
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -80,7 +97,7 @@ export default function StockPage() {
         <Card>
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Total Products</p>
-            <p className="text-2xl font-bold">{pharmacyProducts.filter((p) => p.active).length}</p>
+            <p className="text-2xl font-bold">{allProducts.filter((p) => p.active).length}</p>
           </CardContent>
         </Card>
         <Card>
@@ -92,13 +109,13 @@ export default function StockPage() {
         <Card>
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Low Stock Items</p>
-            <p className="text-2xl font-bold text-orange-500">{pharmacyProducts.filter((p) => getStockStatus(p) === "low").length}</p>
+            <p className="text-2xl font-bold text-orange-500">{allProducts.filter((p) => getStockStatus(p) === "low").length}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-4 pb-4">
             <p className="text-sm text-muted-foreground">Out of Stock</p>
-            <p className="text-2xl font-bold text-red-500">{pharmacyProducts.filter((p) => getStockStatus(p) === "out").length}</p>
+            <p className="text-2xl font-bold text-red-500">{allProducts.filter((p) => getStockStatus(p) === "out").length}</p>
           </CardContent>
         </Card>
       </div>

--- a/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -7,9 +8,30 @@ import {
   Plus, Phone, Mail, MapPin, Star, Clock,
   Truck, ShoppingCart, Package,
 } from "lucide-react";
-import { suppliers, purchaseOrders } from "@/lib/pharmacy-demo-data";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchSuppliers, fetchPurchaseOrders } from "@/lib/data/client";
+import type { SupplierView, PurchaseOrderView } from "@/lib/data/client";
 
 export default function SuppliersPage() {
+  const [allSuppliers, setAllSuppliers] = useState<SupplierView[]>([]);
+  const [allOrders, setAllOrders] = useState<PurchaseOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([fetchSuppliers(cId), fetchPurchaseOrders(cId)])
+      .then(([s, o]) => { setAllSuppliers(s); setAllOrders(o); })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading suppliers...</div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -23,8 +45,8 @@ export default function SuppliersPage() {
       </div>
 
       <div className="grid gap-6 md:grid-cols-2">
-        {suppliers.map((supplier) => {
-          const activeOrders = purchaseOrders.filter(
+        {allSuppliers.map((supplier) => {
+          const activeOrders = allOrders.filter(
             (o) => o.supplierId === supplier.id && o.status !== "delivered" && o.status !== "cancelled"
           );
 

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -1173,25 +1173,36 @@ export async function fetchBeforeAfterPhotos(clinicId: string, patientId?: strin
 export interface ProductView {
   id: string;
   name: string;
+  genericName?: string;
   category: string;
+  description?: string;
   price: number;
+  currency: string;
   requiresPrescription: boolean;
   stockQuantity: number;
   minimumStock: number;
   expiryDate: string;
   barcode?: string;
   manufacturer?: string;
+  supplierId?: string;
+  dosageForm?: string;
+  strength?: string;
+  active: boolean;
 }
 
 interface ProductRaw {
   id: string;
   clinic_id: string;
   name: string;
+  generic_name?: string | null;
   category: string | null;
   description: string | null;
   price: number | null;
   requires_prescription: boolean;
   is_active: boolean;
+  dosage_form?: string | null;
+  strength?: string | null;
+  manufacturer?: string | null;
 }
 
 interface StockRaw {
@@ -1202,6 +1213,7 @@ interface StockRaw {
   min_threshold: number;
   expiry_date: string | null;
   batch_number: string | null;
+  supplier_id?: string | null;
 }
 
 export async function fetchProducts(clinicId: string): Promise<ProductView[]> {
@@ -1215,29 +1227,69 @@ export async function fetchProducts(clinicId: string): Promise<ProductView[]> {
     return {
       id: p.id,
       name: p.name,
+      genericName: p.generic_name ?? undefined,
       category: p.category ?? "General",
+      description: p.description ?? undefined,
       price: p.price ?? 0,
+      currency: "MAD",
       requiresPrescription: p.requires_prescription,
       stockQuantity: s?.quantity ?? 0,
       minimumStock: s?.min_threshold ?? 0,
       expiryDate: s?.expiry_date ?? "",
       barcode: s?.batch_number ?? undefined,
+      manufacturer: p.manufacturer ?? undefined,
+      supplierId: s?.supplier_id ?? undefined,
+      dosageForm: p.dosage_form ?? undefined,
+      strength: p.strength ?? undefined,
+      active: p.is_active ?? true,
     };
   });
 }
 
 export function getLowStockProducts(products: ProductView[]): ProductView[] {
-  return products.filter((p) => p.stockQuantity <= p.minimumStock && p.stockQuantity > 0);
+  return products.filter((p) => p.stockQuantity <= p.minimumStock && p.active);
 }
 
 export function getOutOfStockProducts(products: ProductView[]): ProductView[] {
-  return products.filter((p) => p.stockQuantity === 0);
+  return products.filter((p) => p.stockQuantity === 0 && p.active);
 }
 
 export function getExpiringProducts(products: ProductView[], days: number = 90): ProductView[] {
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() + days);
-  return products.filter((p) => p.expiryDate && new Date(p.expiryDate) <= cutoff);
+  return products.filter((p) => p.expiryDate && new Date(p.expiryDate) <= cutoff && p.active);
+}
+
+export function getStockStatus(product: ProductView): "ok" | "low" | "out" {
+  if (product.stockQuantity === 0) return "out";
+  if (product.stockQuantity <= product.minimumStock) return "low";
+  return "ok";
+}
+
+export function getExpiryStatus(expiryDate: string): "red" | "yellow" | "green" {
+  if (!expiryDate) return "green";
+  const now = new Date();
+  const expiry = new Date(expiryDate);
+  if (expiry < now) return "red";
+  const diffDays = Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays <= 90) return "yellow";
+  return "green";
+}
+
+export function searchProductsLocal(products: ProductView[], query: string): ProductView[] {
+  const q = query.toLowerCase();
+  return products.filter(
+    (p) =>
+      p.name.toLowerCase().includes(q) ||
+      (p.genericName?.toLowerCase().includes(q) ?? false) ||
+      p.category.toLowerCase().includes(q) ||
+      (p.barcode?.includes(q) ?? false) ||
+      (p.manufacturer?.toLowerCase().includes(q) ?? false)
+  );
+}
+
+export function getPointsValue(points: number): number {
+  return Math.floor(points / 10);
 }
 
 // ─────────────────────────────────────────────
@@ -1247,24 +1299,51 @@ export function getExpiringProducts(products: ProductView[], days: number = 90):
 export interface SupplierView {
   id: string;
   name: string;
+  contactPerson: string;
   phone: string;
   email: string;
+  address: string;
+  city: string;
+  categories: string[];
+  rating: number;
+  paymentTerms: string;
+  deliveryDays: number;
+  active: boolean;
+}
+
+interface SupplierRaw {
+  id: string;
+  clinic_id: string;
+  name: string;
+  contact_person?: string | null;
+  contact_phone?: string | null;
+  contact_email?: string | null;
+  address?: string | null;
+  city?: string | null;
+  categories?: string[] | null;
+  rating?: number | null;
+  payment_terms?: string | null;
+  delivery_days?: number | null;
+  is_active?: boolean;
 }
 
 export async function fetchSuppliers(clinicId: string): Promise<SupplierView[]> {
-  const rows = await fetchRows<{
-    id: string;
-    name: string;
-    contact_phone: string | null;
-    contact_email: string | null;
-  }>("suppliers", {
+  const rows = await fetchRows<SupplierRaw>("suppliers", {
     eq: [["clinic_id", clinicId]],
   });
   return rows.map((r) => ({
     id: r.id,
     name: r.name,
+    contactPerson: r.contact_person ?? "",
     phone: r.contact_phone ?? "",
     email: r.contact_email ?? "",
+    address: r.address ?? "",
+    city: r.city ?? "",
+    categories: r.categories ?? [],
+    rating: r.rating ?? 0,
+    paymentTerms: r.payment_terms ?? "N/A",
+    deliveryDays: r.delivery_days ?? 0,
+    active: r.is_active ?? true,
   }));
 }
 
@@ -1272,14 +1351,33 @@ export async function fetchSuppliers(clinicId: string): Promise<SupplierView[]> 
 // Pharmacy: Prescription Requests
 // ─────────────────────────────────────────────
 
+export interface PharmacyPrescriptionItemView {
+  id: string;
+  productId: string;
+  productName: string;
+  quantity: number;
+  available: boolean;
+  price: number;
+  notes?: string;
+}
+
 export interface PharmacyPrescriptionView {
   id: string;
+  patientId: string;
   patientName: string;
+  patientPhone: string;
   imageUrl: string;
-  status: string;
-  items: { productName: string; quantity: number }[];
   uploadedAt: string;
-  notes?: string;
+  status: string;
+  pharmacistNotes?: string;
+  items: PharmacyPrescriptionItemView[];
+  totalPrice: number;
+  currency: string;
+  deliveryOption: string;
+  deliveryAddress?: string;
+  isChronic: boolean;
+  refillReminderDate?: string;
+  whatsappNotified: boolean;
 }
 
 interface PrescriptionRequestRaw {
@@ -1289,7 +1387,14 @@ interface PrescriptionRequestRaw {
   image_url: string;
   status: string;
   notes: string | null;
+  pharmacist_notes?: string | null;
+  items?: PharmacyPrescriptionItemView[] | null;
+  total_price?: number | null;
   delivery_requested: boolean;
+  delivery_address?: string | null;
+  is_chronic?: boolean;
+  refill_reminder_date?: string | null;
+  whatsapp_notified?: boolean;
   created_at: string;
 }
 
@@ -1299,15 +1404,27 @@ export async function fetchPrescriptionRequests(clinicId: string): Promise<Pharm
     eq: [["clinic_id", clinicId]],
     order: ["created_at", { ascending: false }],
   });
-  return rows.map((r) => ({
-    id: r.id,
-    patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
-    imageUrl: r.image_url,
-    status: r.status,
-    items: [],
-    uploadedAt: r.created_at ?? "",
-    notes: r.notes ?? undefined,
-  }));
+  return rows.map((r) => {
+    const patient = _userMap?.get(r.patient_id);
+    return {
+      id: r.id,
+      patientId: r.patient_id,
+      patientName: patient?.name ?? "Patient",
+      patientPhone: patient?.phone ?? "",
+      imageUrl: r.image_url,
+      uploadedAt: r.created_at ?? "",
+      status: r.status,
+      pharmacistNotes: r.pharmacist_notes ?? r.notes ?? undefined,
+      items: r.items ?? [],
+      totalPrice: r.total_price ?? 0,
+      currency: "MAD",
+      deliveryOption: r.delivery_requested ? "delivery" : "pickup",
+      deliveryAddress: r.delivery_address ?? undefined,
+      isChronic: r.is_chronic ?? false,
+      refillReminderDate: r.refill_reminder_date ?? undefined,
+      whatsappNotified: r.whatsapp_notified ?? false,
+    };
+  });
 }
 
 // ─────────────────────────────────────────────
@@ -1316,44 +1433,101 @@ export async function fetchPrescriptionRequests(clinicId: string): Promise<Pharm
 
 export interface LoyaltyMemberView {
   id: string;
+  patientId: string;
   patientName: string;
+  phone: string;
+  email: string;
+  totalPoints: number;
+  availablePoints: number;
+  redeemedPoints: number;
+  joinedAt: string;
+  dateOfBirth: string;
+  tier: "bronze" | "silver" | "gold" | "platinum";
+  referralCode: string;
+  referredBy?: string;
+  totalPurchases: number;
+  birthdayRewardClaimed: boolean;
+  birthdayRewardYear?: number;
+}
+
+interface LoyaltyPointsRaw {
+  id: string;
+  patient_id: string;
+  clinic_id: string;
   points: number;
-  tier: string;
-  lastUpdated: string;
+  available_points?: number | null;
+  redeemed_points?: number | null;
+  total_purchases?: number | null;
+  referral_code?: string | null;
+  referred_by?: string | null;
+  date_of_birth?: string | null;
+  birthday_reward_claimed?: boolean;
+  birthday_reward_year?: number | null;
+  updated_at: string;
+  created_at?: string | null;
+}
+
+function computeLoyaltyTier(points: number): "bronze" | "silver" | "gold" | "platinum" {
+  if (points >= 5000) return "platinum";
+  if (points >= 3000) return "gold";
+  if (points >= 1000) return "silver";
+  return "bronze";
 }
 
 export async function fetchLoyaltyMembers(clinicId: string): Promise<LoyaltyMemberView[]> {
   await ensureLookups(clinicId);
-  const rows = await fetchRows<{
-    id: string;
-    patient_id: string;
-    clinic_id: string;
-    points: number;
-    updated_at: string;
-  }>("loyalty_points", {
+  const rows = await fetchRows<LoyaltyPointsRaw>("loyalty_points", {
     eq: [["clinic_id", clinicId]],
   });
-  return rows.map((r) => ({
-    id: r.id,
-    patientName: _userMap?.get(r.patient_id)?.name ?? "Member",
-    points: r.points,
-    tier: r.points >= 1000 ? "Gold" : r.points >= 500 ? "Silver" : "Bronze",
-    lastUpdated: r.updated_at ?? "",
-  }));
+  return rows.map((r) => {
+    const patient = _userMap?.get(r.patient_id);
+    const totalPts = r.points ?? 0;
+    const redeemed = r.redeemed_points ?? 0;
+    const available = r.available_points ?? (totalPts - redeemed);
+    return {
+      id: r.id,
+      patientId: r.patient_id,
+      patientName: patient?.name ?? "Member",
+      phone: patient?.phone ?? "",
+      email: patient?.email ?? "",
+      totalPoints: totalPts,
+      availablePoints: available,
+      redeemedPoints: redeemed,
+      joinedAt: r.created_at ?? r.updated_at ?? "",
+      dateOfBirth: r.date_of_birth ?? "",
+      tier: computeLoyaltyTier(totalPts),
+      referralCode: r.referral_code ?? "",
+      referredBy: r.referred_by ?? undefined,
+      totalPurchases: r.total_purchases ?? totalPts,
+      birthdayRewardClaimed: r.birthday_reward_claimed ?? false,
+      birthdayRewardYear: r.birthday_reward_year ?? undefined,
+    };
+  });
 }
 
 // ─────────────────────────────────────────────
 // Pharmacy: Purchase Orders
 // ─────────────────────────────────────────────
 
+export interface PurchaseOrderItemView {
+  productId: string;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+}
+
 export interface PurchaseOrderView {
   id: string;
+  supplierId: string;
   supplierName: string;
-  status: string;
+  items: PurchaseOrderItemView[];
   totalAmount: number;
-  items: { productName: string; quantity: number }[];
+  currency: string;
+  status: string;
+  createdAt: string;
   expectedDelivery: string;
-  orderedAt: string;
+  deliveredAt?: string;
+  notes?: string;
 }
 
 interface PurchaseOrderRaw {
@@ -1363,7 +1537,9 @@ interface PurchaseOrderRaw {
   status: string;
   total_amount: number | null;
   notes: string | null;
+  items?: PurchaseOrderItemView[] | null;
   ordered_at: string | null;
+  expected_delivery?: string | null;
   received_at: string | null;
   created_at: string;
 }
@@ -1380,22 +1556,26 @@ export async function fetchPurchaseOrders(clinicId: string): Promise<PurchaseOrd
 
   // Get supplier names
   const supplierIds = [...new Set((orders as PurchaseOrderRaw[]).map((o) => o.supplier_id))];
-  const { data: suppliers } = await supabase
+  const { data: suppliersData } = await supabase
     .from("suppliers")
     .select("id, name")
     .in("id", supplierIds);
   const supplierMap = new Map(
-    ((suppliers ?? []) as { id: string; name: string }[]).map((s) => [s.id, s.name]),
+    ((suppliersData ?? []) as { id: string; name: string }[]).map((s) => [s.id, s.name]),
   );
 
   return (orders as PurchaseOrderRaw[]).map((o) => ({
     id: o.id,
+    supplierId: o.supplier_id,
     supplierName: supplierMap.get(o.supplier_id) ?? "Supplier",
-    status: o.status,
+    items: o.items ?? [],
     totalAmount: o.total_amount ?? 0,
-    items: [],
-    expectedDelivery: o.ordered_at ?? "",
-    orderedAt: o.ordered_at ?? o.created_at ?? "",
+    currency: "MAD",
+    status: o.status,
+    createdAt: o.ordered_at ?? o.created_at ?? "",
+    expectedDelivery: o.expected_delivery ?? o.ordered_at ?? "",
+    deliveredAt: o.received_at ?? undefined,
+    notes: o.notes ?? undefined,
   }));
 }
 
@@ -2004,4 +2184,103 @@ export async function fetchDentalTreatmentTypes(clinicId: string): Promise<Denta
       currency: s.currency,
       description: s.description,
     }));
+}
+
+// ─────────────────────────────────────────────
+// Pharmacy: Daily Sales
+// ─────────────────────────────────────────────
+
+export interface DailySaleItemView {
+  productName: string;
+  quantity: number;
+  price: number;
+}
+
+export interface DailySaleView {
+  id: string;
+  date: string;
+  time: string;
+  patientName: string;
+  items: DailySaleItemView[];
+  total: number;
+  currency: string;
+  paymentMethod: "cash" | "card" | "insurance";
+  hasPrescription: boolean;
+  loyaltyPointsEarned: number;
+}
+
+interface PharmacySaleRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string | null;
+  items: DailySaleItemView[] | null;
+  total: number | null;
+  payment_method: string | null;
+  has_prescription?: boolean;
+  loyalty_points_earned?: number | null;
+  created_at: string;
+}
+
+export async function fetchDailySales(clinicId: string): Promise<DailySaleView[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<PharmacySaleRaw>("pharmacy_sales", {
+    eq: [["clinic_id", clinicId]],
+    order: ["created_at", { ascending: false }],
+  });
+  return rows.map((r) => {
+    const dt = r.created_at ?? "";
+    return {
+      id: r.id,
+      date: dt.split("T")[0] ?? "",
+      time: dt.split("T")[1]?.slice(0, 5) ?? "",
+      patientName: r.patient_id ? (_userMap?.get(r.patient_id)?.name ?? "Patient") : "Walk-in",
+      items: r.items ?? [],
+      total: r.total ?? 0,
+      currency: "MAD",
+      paymentMethod: (r.payment_method as "cash" | "card" | "insurance") ?? "cash",
+      hasPrescription: r.has_prescription ?? false,
+      loyaltyPointsEarned: r.loyalty_points_earned ?? 0,
+    };
+  });
+}
+
+// ─────────────────────────────────────────────
+// Pharmacy: Loyalty Transactions
+// ─────────────────────────────────────────────
+
+export interface LoyaltyTransactionView {
+  id: string;
+  memberId: string;
+  type: "earned" | "redeemed" | "birthday_bonus" | "referral_bonus" | "expired";
+  points: number;
+  description: string;
+  date: string;
+  saleId?: string;
+}
+
+interface LoyaltyTransactionRaw {
+  id: string;
+  member_id: string;
+  clinic_id: string;
+  type: string;
+  points: number;
+  description: string | null;
+  sale_id?: string | null;
+  created_at: string;
+}
+
+export async function fetchLoyaltyTransactions(clinicId: string): Promise<LoyaltyTransactionView[]> {
+  const rows = await fetchRows<LoyaltyTransactionRaw>("loyalty_transactions", {
+    eq: [["clinic_id", clinicId]],
+    order: ["created_at", { ascending: false }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    memberId: r.member_id,
+    type: (r.type as LoyaltyTransactionView["type"]) ?? "earned",
+    points: r.points,
+    description: r.description ?? "",
+    date: r.created_at?.split("T")[0] ?? "",
+    saleId: r.sale_id ?? undefined,
+  }));
 }


### PR DESCRIPTION
Replace all pharmacy-demo-data.ts imports across 8 Pharmacist pages with real Supabase data fetching.

## Pages Updated
- **Dashboard**: fetchProducts, fetchPrescriptionRequests, fetchDailySales, fetchPurchaseOrders, fetchLoyaltyMembers
- **Stock**: fetchProducts with search/filter/sort helpers
- **Prescriptions**: fetchPrescriptionRequests with status filtering
- **Orders**: fetchPurchaseOrders, fetchSuppliers
- **Suppliers**: fetchSuppliers, fetchPurchaseOrders
- **Sales**: fetchDailySales with date filtering
- **Expiry**: fetchProducts with getExpiryStatus helper
- **Loyalty**: fetchLoyaltyMembers, fetchLoyaltyTransactions

## Data Layer Enhancements (client.ts)
- Added DailySaleView, DailySaleItemView, LoyaltyTransactionView interfaces
- Added fetchDailySales(), fetchLoyaltyTransactions() functions
- Added helper functions: getLowStockProducts, getOutOfStockProducts, getExpiringProducts, getStockStatus, getExpiryStatus, searchProductsLocal, getPointsValue, computeLoyaltyTier

## Pattern
All pages now use:
- useState/useEffect for data fetching on mount
- Loading states with conditional rendering
- clinicConfig.clinicId for multi-tenant filtering
- Type-safe status casting with fallback defaults