### PR TITLE
feat: wire pharmacy public pages (Group 10) to real Supabase data

### DIFF
--- a/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
@@ -6,12 +6,48 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Search, Filter, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
-import {
-  type PublicPharmacyProduct,
-  getPublicStockStatus,
-  searchPublicProducts,
-} from "@/lib/data/public";
 import { createClient } from "@/lib/supabase-client";
+
+interface PublicPharmacyProduct {
+  id: string;
+  name: string;
+  genericName?: string;
+  category: string;
+  description: string;
+  price: number;
+  currency: string;
+  requiresPrescription: boolean;
+  stockQuantity: number;
+  minimumStock: number;
+  expiryDate: string;
+  manufacturer?: string;
+  barcode?: string;
+  dosageForm?: string;
+  strength?: string;
+  active: boolean;
+}
+
+function getStockStatus(product: PublicPharmacyProduct): "ok" | "low" | "out" {
+  if (product.stockQuantity === 0) return "out";
+  if (product.stockQuantity <= product.minimumStock) return "low";
+  return "ok";
+}
+
+function searchProducts(
+  products: PublicPharmacyProduct[],
+  query: string,
+): PublicPharmacyProduct[] {
+  const q = query.toLowerCase();
+  return products.filter(
+    (p) =>
+      p.active &&
+      (p.name.toLowerCase().includes(q) ||
+        (p.genericName?.toLowerCase().includes(q) ?? false) ||
+        p.category.toLowerCase().includes(q) ||
+        (p.manufacturer?.toLowerCase().includes(q) ?? false) ||
+        p.description.toLowerCase().includes(q)),
+  );
+}
 
 async function fetchProductsClient(): Promise<PublicPharmacyProduct[]> {
   const clinicId = clinicConfig.clinicId;
@@ -77,7 +113,7 @@ export default function CatalogPage() {
   const filtered = useMemo(() => {
     let results: PublicPharmacyProduct[];
     if (query.trim()) {
-      results = searchPublicProducts(allProducts, query);
+      results = searchProducts(allProducts, query);
     } else {
       results = allProducts.filter((p) => p.active);
     }
@@ -137,7 +173,7 @@ export default function CatalogPage() {
       {/* Product Grid */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {filtered.map((product) => {
-          const stock = getPublicStockStatus(product);
+          const stock = getStockStatus(product);
           return (
             <Card key={product.id} className="hover:shadow-md transition-shadow">
               <CardContent className="pt-6">

--- a/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
@@ -1,12 +1,56 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { Search, Filter } from "lucide-react";
-import { pharmacyProducts, searchProducts, getStockStatus } from "@/lib/pharmacy-demo-data";
-import type { PharmacyProduct } from "@/lib/pharmacy-demo-data";
+import { Search, Filter, Loader2 } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import {
+  type PublicPharmacyProduct,
+  getPublicStockStatus,
+  searchPublicProducts,
+} from "@/lib/data/public";
+import { createClient } from "@/lib/supabase-client";
+
+async function fetchProductsClient(): Promise<PublicPharmacyProduct[]> {
+  const clinicId = clinicConfig.clinicId;
+  const supabase = createClient();
+
+  const [{ data: products }, { data: stockRows }] = await Promise.all([
+    supabase.from("products").select("*").eq("clinic_id", clinicId),
+    supabase.from("stock").select("*").eq("clinic_id", clinicId),
+  ]);
+
+  if (!products) return [];
+
+  const stockMap = new Map(
+    ((stockRows ?? []) as { product_id: string; quantity: number; min_threshold: number; expiry_date: string | null }[])
+      .map((s) => [s.product_id, s]),
+  );
+
+  return products.map((p: Record<string, unknown>) => {
+    const s = stockMap.get(p.id as string);
+    return {
+      id: p.id as string,
+      name: p.name as string,
+      genericName: (p.generic_name as string) ?? undefined,
+      category: (p.category as string) ?? "medication",
+      description: (p.description as string) ?? "",
+      price: (p.price as number) ?? 0,
+      currency: clinicConfig.currency,
+      requiresPrescription: (p.requires_prescription as boolean) ?? false,
+      stockQuantity: s?.quantity ?? 0,
+      minimumStock: s?.min_threshold ?? 0,
+      expiryDate: s?.expiry_date ?? "",
+      manufacturer: (p.manufacturer as string) ?? undefined,
+      barcode: (p.barcode as string) ?? undefined,
+      dosageForm: (p.dosage_form as string) ?? undefined,
+      strength: (p.strength as string) ?? undefined,
+      active: (p.is_active as boolean) ?? true,
+    };
+  });
+}
 
 const categories = [
   { value: "all", label: "All Products" },
@@ -21,19 +65,27 @@ const categories = [
 export default function CatalogPage() {
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
+  const [allProducts, setAllProducts] = useState<PublicPharmacyProduct[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchProductsClient()
+      .then(setAllProducts)
+      .finally(() => setLoading(false));
+  }, []);
 
   const filtered = useMemo(() => {
-    let results: PharmacyProduct[];
+    let results: PublicPharmacyProduct[];
     if (query.trim()) {
-      results = searchProducts(query);
+      results = searchPublicProducts(allProducts, query);
     } else {
-      results = pharmacyProducts.filter((p) => p.active);
+      results = allProducts.filter((p) => p.active);
     }
     if (selectedCategory !== "all") {
       results = results.filter((p) => p.category === selectedCategory);
     }
     return results;
-  }, [query, selectedCategory]);
+  }, [query, selectedCategory, allProducts]);
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -71,6 +123,12 @@ export default function CatalogPage() {
         </div>
       </div>
 
+      {loading ? (
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+        </div>
+      ) : (
+        <>
       {/* Results count */}
       <p className="text-sm text-muted-foreground mb-4">
         Showing {filtered.length} product{filtered.length !== 1 ? "s" : ""}
@@ -79,7 +137,7 @@ export default function CatalogPage() {
       {/* Product Grid */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {filtered.map((product) => {
-          const stock = getStockStatus(product);
+          const stock = getPublicStockStatus(product);
           return (
             <Card key={product.id} className="hover:shadow-md transition-shadow">
               <CardContent className="pt-6">
@@ -106,9 +164,11 @@ export default function CatalogPage() {
                     {product.dosageForm} {product.strength ? `- ${product.strength}` : ""}
                   </p>
                 )}
+                {product.manufacturer && (
                 <p className="text-xs text-muted-foreground mb-3">
                   by {product.manufacturer}
                 </p>
+                )}
                 <div className="flex items-center justify-between pt-3 border-t">
                   <span className="text-lg font-bold text-emerald-600">
                     {product.price} {product.currency}
@@ -132,6 +192,8 @@ export default function CatalogPage() {
           <h3 className="font-semibold text-lg mb-2">No products found</h3>
           <p className="text-muted-foreground">Try adjusting your search or filter criteria</p>
         </div>
+      )}
+        </>
       )}
     </div>
   );

--- a/src/app/(pharmacy-public)/pharmacy/contact/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/contact/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Card, CardContent } from "@/components/ui/card";
 import { Phone, Mail, MapPin, Clock, MessageCircle } from "lucide-react";
-import { onDutySchedule } from "@/lib/pharmacy-demo-data";
+import { getPublicOnDutySchedule } from "@/lib/data/public";
 
 export const metadata: Metadata = {
   title: "Contact Pharmacie",
@@ -13,7 +13,8 @@ export const metadata: Metadata = {
   },
 };
 
-export default function PharmacyContactPage() {
+export default async function PharmacyContactPage() {
+  const onDutySchedule = await getPublicOnDutySchedule();
   const upcomingDuties = onDutySchedule.filter((d) => d.isOnDuty);
 
   return (

--- a/src/app/(pharmacy-public)/pharmacy/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/page.tsx
@@ -7,11 +7,11 @@ import {
   Clock, MapPin, Phone, ArrowRight, Star, ShoppingBag,
 } from "lucide-react";
 import {
-  pharmacyProducts,
-  pharmacyServices,
-  isCurrentlyOnDuty,
-  getNextOnDuty,
-} from "@/lib/pharmacy-demo-data";
+  getPublicPharmacyProducts,
+  getPublicPharmacyServices,
+  isPublicCurrentlyOnDuty,
+  getPublicNextOnDuty,
+} from "@/lib/data/public";
 
 export const metadata: Metadata = {
   title: "Pharmacie — Accueil",
@@ -34,11 +34,16 @@ const serviceIcons: Record<string, React.ReactNode> = {
   Shield: <Shield className="h-6 w-6" />,
 };
 
-export default function PharmacyHomePage() {
-  const onDuty = isCurrentlyOnDuty();
-  const nextDuty = getNextOnDuty();
-  const featuredProducts = pharmacyProducts.filter((p) => p.active).slice(0, 4);
-  const topServices = pharmacyServices.filter((s) => s.available).slice(0, 3);
+export default async function PharmacyHomePage() {
+  const [allProducts, allServices, onDuty, nextDuty] = await Promise.all([
+    getPublicPharmacyProducts(),
+    getPublicPharmacyServices(),
+    isPublicCurrentlyOnDuty(),
+    getPublicNextOnDuty(),
+  ]);
+
+  const featuredProducts = allProducts.filter((p) => p.active).slice(0, 4);
+  const topServices = allServices.filter((s) => s.available).slice(0, 3);
 
   return (
     <>
@@ -85,7 +90,7 @@ export default function PharmacyHomePage() {
                   <div className="flex items-center gap-2">
                     <ShoppingBag className="h-5 w-5 text-emerald-600" />
                     <div>
-                      <p className="text-sm font-semibold">{pharmacyProducts.length}+</p>
+                      <p className="text-sm font-semibold">{allProducts.length}+</p>
                       <p className="text-xs text-muted-foreground">Products</p>
                     </div>
                   </div>

--- a/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
@@ -1,10 +1,88 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Clock, Check, Package, Truck, AlertCircle, RefreshCw, Eye } from "lucide-react";
-import { pharmacyPrescriptions } from "@/lib/pharmacy-demo-data";
-import type { PharmacyPrescription } from "@/lib/pharmacy-demo-data";
+import { Clock, Check, Package, Truck, AlertCircle, RefreshCw, Eye, Loader2 } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { createClient } from "@/lib/supabase-client";
+
+interface PrescriptionItem {
+  id: string;
+  productId: string;
+  productName: string;
+  quantity: number;
+  available: boolean;
+  price: number;
+  notes?: string;
+}
+
+interface PharmacyPrescription {
+  id: string;
+  patientId: string;
+  patientName: string;
+  patientPhone: string;
+  imageUrl: string;
+  uploadedAt: string;
+  status: "pending" | "reviewing" | "partially-ready" | "ready" | "picked-up" | "delivered" | "rejected";
+  pharmacistNotes?: string;
+  items: PrescriptionItem[];
+  totalPrice: number;
+  currency: string;
+  deliveryOption: "pickup" | "delivery";
+  deliveryAddress?: string;
+  isChronic: boolean;
+  refillReminderDate?: string;
+  whatsappNotified: boolean;
+}
+
+async function fetchPrescriptionsClient(): Promise<PharmacyPrescription[]> {
+  const clinicId = clinicConfig.clinicId;
+  const supabase = createClient();
+
+  const { data: requests, error } = await supabase
+    .from("prescription_requests")
+    .select("*")
+    .eq("clinic_id", clinicId)
+    .order("created_at", { ascending: false });
+
+  if (error || !requests) return [];
+
+  const patientIds = [...new Set((requests as Record<string, unknown>[]).map((r) => r.patient_id as string))];
+  const { data: users } = await supabase
+    .from("users")
+    .select("id, name, phone")
+    .in("id", patientIds);
+
+  const userMap = new Map(
+    ((users ?? []) as { id: string; name: string; phone: string | null }[]).map((u) => [u.id, u]),
+  );
+
+  return requests.map((r: Record<string, unknown>) => {
+    const patient = userMap.get(r.patient_id as string);
+    let uiStatus = (r.status as string) ?? "pending";
+    if (uiStatus === "partial") uiStatus = "partially-ready";
+
+    return {
+      id: r.id as string,
+      patientId: (r.patient_id as string) ?? "",
+      patientName: patient?.name ?? "Patient",
+      patientPhone: patient?.phone ?? "",
+      imageUrl: (r.image_url as string) ?? "",
+      uploadedAt: (r.created_at as string) ?? "",
+      status: uiStatus as PharmacyPrescription["status"],
+      pharmacistNotes: (r.notes as string) ?? undefined,
+      items: ((r.items as PrescriptionItem[]) ?? []),
+      totalPrice: (r.total_price as number) ?? 0,
+      currency: clinicConfig.currency,
+      deliveryOption: ((r.delivery_option as string) ?? "pickup") as "pickup" | "delivery",
+      deliveryAddress: (r.delivery_address as string) ?? undefined,
+      isChronic: (r.is_chronic as boolean) ?? false,
+      refillReminderDate: (r.refill_reminder_date as string) ?? undefined,
+      whatsappNotified: (r.whatsapp_notified as boolean) ?? false,
+    };
+  });
+}
 
 const statusConfig: Record<PharmacyPrescription["status"], { label: string; color: string; icon: React.ReactNode }> = {
   pending: { label: "Pending Review", color: "bg-yellow-100 text-yellow-700", icon: <Clock className="h-3 w-3" /> },
@@ -17,6 +95,29 @@ const statusConfig: Record<PharmacyPrescription["status"], { label: string; colo
 };
 
 export default function PrescriptionHistoryPage() {
+  const [prescriptions, setPrescriptions] = useState<PharmacyPrescription[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchPrescriptionsClient()
+      .then(setPrescriptions)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-2">Prescription History</h1>
+        <p className="text-muted-foreground mb-8">
+          Track the status of your uploaded prescriptions
+        </p>
+        <div className="flex justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-2">Prescription History</h1>
@@ -24,9 +125,16 @@ export default function PrescriptionHistoryPage() {
         Track the status of your uploaded prescriptions
       </p>
 
+      {prescriptions.length === 0 ? (
+        <div className="text-center py-16">
+          <Package className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <h3 className="font-semibold text-lg mb-2">No prescriptions yet</h3>
+          <p className="text-muted-foreground">Upload your first prescription to get started</p>
+        </div>
+      ) : (
       <div className="space-y-4">
-        {pharmacyPrescriptions.map((rx) => {
-          const status = statusConfig[rx.status];
+        {prescriptions.map((rx) => {
+          const status = statusConfig[rx.status] ?? statusConfig.pending;
           const availableCount = rx.items.filter((i) => i.available).length;
           const totalItems = rx.items.length;
 
@@ -36,7 +144,7 @@ export default function PrescriptionHistoryPage() {
                 <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
-                      <h3 className="font-semibold">Prescription #{rx.id.toUpperCase()}</h3>
+                      <h3 className="font-semibold">Prescription #{rx.id.slice(0, 8).toUpperCase()}</h3>
                       <Badge className={`${status.color} border-0 gap-1`}>
                         {status.icon}
                         {status.label}
@@ -53,6 +161,7 @@ export default function PrescriptionHistoryPage() {
                     </p>
 
                     {/* Items */}
+                    {rx.items.length > 0 && (
                     <div className="space-y-2 mb-3">
                       {rx.items.map((item) => (
                         <div
@@ -68,12 +177,13 @@ export default function PrescriptionHistoryPage() {
                             <span>{item.productName}</span>
                             <span className="text-muted-foreground">x{item.quantity}</span>
                           </div>
-                          <span className="font-medium">{item.price} MAD</span>
+                          <span className="font-medium">{item.price} {rx.currency}</span>
                         </div>
                       ))}
                     </div>
+                    )}
 
-                    {rx.status === "partially-ready" && (
+                    {rx.status === "partially-ready" && totalItems > 0 && (
                       <div className="flex items-center gap-2 text-sm text-orange-600 mb-2">
                         <AlertCircle className="h-4 w-4" />
                         <span>{availableCount} of {totalItems} items ready</span>
@@ -95,9 +205,11 @@ export default function PrescriptionHistoryPage() {
                   </div>
 
                   <div className="text-right">
+                    {rx.totalPrice > 0 && (
                     <p className="text-lg font-bold text-emerald-600">
                       {rx.totalPrice} {rx.currency}
                     </p>
+                    )}
                     <Badge variant="outline" className="mt-1 capitalize text-xs">
                       {rx.deliveryOption === "delivery" ? (
                         <><Truck className="h-3 w-3 mr-1" /> Delivery</>
@@ -112,6 +224,7 @@ export default function PrescriptionHistoryPage() {
           );
         })}
       </div>
+      )}
     </div>
   );
 }

--- a/src/app/(pharmacy-public)/pharmacy/services/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/services/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Heart, Droplet, Syringe, MessageCircle, Cross, Scale, Truck, Pill } from "lucide-react";
-import { pharmacyServices } from "@/lib/pharmacy-demo-data";
+import { getPublicPharmacyServices } from "@/lib/data/public";
 
 export const metadata: Metadata = {
   title: "Services Pharmaceutiques",
@@ -24,7 +24,9 @@ const iconMap: Record<string, React.ReactNode> = {
   Truck: <Truck className="h-8 w-8" />,
 };
 
-export default function PharmacyServicesPage() {
+export default async function PharmacyServicesPage() {
+  const pharmacyServices = await getPublicPharmacyServices();
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold mb-2">Our Services</h1>

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -308,3 +308,258 @@ export async function getPublicAvailableSlots(
   const maxPerSlot = clinicConfig.booking.maxPerSlot;
   return allSlots.filter((slot) => (bookingCounts[slot] ?? 0) < maxPerSlot);
 }
+
+// ── Pharmacy: Products (public catalog) ──
+
+export interface PublicPharmacyProduct {
+  id: string;
+  name: string;
+  genericName?: string;
+  category: string;
+  description: string;
+  price: number;
+  currency: string;
+  requiresPrescription: boolean;
+  stockQuantity: number;
+  minimumStock: number;
+  expiryDate: string;
+  manufacturer?: string;
+  barcode?: string;
+  dosageForm?: string;
+  strength?: string;
+  active: boolean;
+}
+
+export async function getPublicPharmacyProducts(): Promise<PublicPharmacyProduct[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const [{ data: products }, { data: stockRows }] = await Promise.all([
+    supabase
+      .from("products")
+      .select("*")
+      .eq("clinic_id", clinicId),
+    supabase
+      .from("stock")
+      .select("*")
+      .eq("clinic_id", clinicId),
+  ]);
+
+  if (!products) return [];
+
+  const stockMap = new Map(
+    ((stockRows ?? []) as { product_id: string; quantity: number; min_threshold: number; expiry_date: string | null; supplier_id: string | null }[])
+      .map((s) => [s.product_id, s]),
+  );
+
+  return products.map((p: Record<string, unknown>) => {
+    const s = stockMap.get(p.id as string);
+    return {
+      id: p.id as string,
+      name: p.name as string,
+      genericName: (p.generic_name as string) ?? undefined,
+      category: (p.category as string) ?? "medication",
+      description: (p.description as string) ?? "",
+      price: (p.price as number) ?? 0,
+      currency: clinicConfig.currency,
+      requiresPrescription: (p.requires_prescription as boolean) ?? false,
+      stockQuantity: s?.quantity ?? 0,
+      minimumStock: s?.min_threshold ?? 0,
+      expiryDate: s?.expiry_date ?? "",
+      manufacturer: (p.manufacturer as string) ?? undefined,
+      barcode: (p.barcode as string) ?? undefined,
+      dosageForm: (p.dosage_form as string) ?? undefined,
+      strength: (p.strength as string) ?? undefined,
+      active: (p.is_active as boolean) ?? true,
+    };
+  });
+}
+
+export function getPublicStockStatus(product: PublicPharmacyProduct): "ok" | "low" | "out" {
+  if (product.stockQuantity === 0) return "out";
+  if (product.stockQuantity <= product.minimumStock) return "low";
+  return "ok";
+}
+
+export function searchPublicProducts(
+  products: PublicPharmacyProduct[],
+  query: string,
+): PublicPharmacyProduct[] {
+  const q = query.toLowerCase();
+  return products.filter(
+    (p) =>
+      p.active &&
+      (p.name.toLowerCase().includes(q) ||
+        (p.genericName?.toLowerCase().includes(q) ?? false) ||
+        p.category.toLowerCase().includes(q) ||
+        (p.manufacturer?.toLowerCase().includes(q) ?? false) ||
+        p.description.toLowerCase().includes(q)),
+  );
+}
+
+// ── Pharmacy: Services ──
+
+export interface PublicPharmacyService {
+  id: string;
+  name: string;
+  description: string;
+  price: number;
+  currency: string;
+  duration: number;
+  available: boolean;
+  icon: string;
+}
+
+export async function getPublicPharmacyServices(): Promise<PublicPharmacyService[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("services")
+    .select("*")
+    .eq("clinic_id", clinicId)
+    .order("name", { ascending: true });
+
+  if (error || !data) return [];
+
+  return data.map((s: Record<string, unknown>) => ({
+    id: s.id as string,
+    name: s.name as string,
+    description: (s.description as string) ?? "",
+    price: (s.price as number) ?? 0,
+    currency: clinicConfig.currency,
+    duration: (s.duration_minutes as number) ?? (s.duration_min as number) ?? 0,
+    available: (s.is_active as boolean) ?? true,
+    icon: (s.icon as string) ?? "Pill",
+  }));
+}
+
+// ── Pharmacy: On-Duty Schedule ──
+
+export interface PublicOnDutySchedule {
+  id: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  isOnDuty: boolean;
+  notes?: string;
+}
+
+export async function getPublicOnDutySchedule(): Promise<PublicOnDutySchedule[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  // Try fetching from on_duty_schedule table if it exists
+  const { data, error } = await supabase
+    .from("on_duty_schedule")
+    .select("*")
+    .eq("clinic_id", clinicId)
+    .order("date", { ascending: true });
+
+  // If the table doesn't exist or errors, return empty (graceful fallback)
+  if (error || !data) return [];
+
+  return data.map((d: Record<string, unknown>) => ({
+    id: (d.id as string) ?? "",
+    date: (d.date as string) ?? "",
+    startTime: (d.start_time as string) ?? "",
+    endTime: (d.end_time as string) ?? "",
+    isOnDuty: (d.is_on_duty as boolean) ?? false,
+    notes: (d.notes as string) ?? undefined,
+  }));
+}
+
+export async function isPublicCurrentlyOnDuty(): Promise<boolean> {
+  const schedule = await getPublicOnDutySchedule();
+  const now = new Date();
+  const todayStr = now.toISOString().split("T")[0];
+  return schedule.some((d) => {
+    if (!d.isOnDuty || d.date !== todayStr) return false;
+    const [sh, sm] = d.startTime.split(":").map(Number);
+    const [eh, em] = d.endTime.split(":").map(Number);
+    const startMin = sh * 60 + sm;
+    const endMin = eh * 60 + em;
+    const nowMin = now.getHours() * 60 + now.getMinutes();
+    return nowMin >= startMin && nowMin <= endMin;
+  });
+}
+
+export async function getPublicNextOnDuty(): Promise<PublicOnDutySchedule | null> {
+  const schedule = await getPublicOnDutySchedule();
+  const now = new Date();
+  const upcoming = schedule
+    .filter((d) => d.isOnDuty && new Date(d.date) >= now)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  return upcoming[0] ?? null;
+}
+
+// ── Pharmacy: Prescription Requests (public view) ──
+
+export interface PublicPharmacyPrescription {
+  id: string;
+  patientId: string;
+  patientName: string;
+  patientPhone: string;
+  imageUrl: string;
+  uploadedAt: string;
+  status: "pending" | "reviewing" | "partially-ready" | "ready" | "picked-up" | "delivered" | "rejected";
+  pharmacistNotes?: string;
+  items: { id: string; productId: string; productName: string; quantity: number; available: boolean; price: number; notes?: string }[];
+  totalPrice: number;
+  currency: string;
+  deliveryOption: "pickup" | "delivery";
+  deliveryAddress?: string;
+  isChronic: boolean;
+  refillReminderDate?: string;
+  whatsappNotified: boolean;
+}
+
+export async function getPublicPharmacyPrescriptions(): Promise<PublicPharmacyPrescription[]> {
+  const clinicId = getClinicId();
+  const supabase = await createClient();
+
+  const { data: requests, error } = await supabase
+    .from("prescription_requests")
+    .select("*")
+    .eq("clinic_id", clinicId)
+    .order("created_at", { ascending: false });
+
+  if (error || !requests) return [];
+
+  // Get patient details
+  const patientIds = [...new Set((requests as Record<string, unknown>[]).map((r) => r.patient_id as string))];
+  const { data: users } = await supabase
+    .from("users")
+    .select("id, name, phone")
+    .in("id", patientIds);
+
+  const userMap = new Map(
+    ((users ?? []) as { id: string; name: string; phone: string | null }[]).map((u) => [u.id, u]),
+  );
+
+  return requests.map((r: Record<string, unknown>) => {
+    const patient = userMap.get(r.patient_id as string);
+    // Map DB status to UI status
+    let uiStatus = (r.status as string) ?? "pending";
+    if (uiStatus === "partial") uiStatus = "partially-ready";
+
+    return {
+      id: r.id as string,
+      patientId: (r.patient_id as string) ?? "",
+      patientName: patient?.name ?? "Patient",
+      patientPhone: patient?.phone ?? "",
+      imageUrl: (r.image_url as string) ?? "",
+      uploadedAt: (r.created_at as string) ?? "",
+      status: uiStatus as PublicPharmacyPrescription["status"],
+      pharmacistNotes: (r.notes as string) ?? undefined,
+      items: ((r.items as PublicPharmacyPrescription["items"]) ?? []),
+      totalPrice: (r.total_price as number) ?? 0,
+      currency: clinicConfig.currency,
+      deliveryOption: ((r.delivery_option as string) ?? "pickup") as "pickup" | "delivery",
+      deliveryAddress: (r.delivery_address as string) ?? undefined,
+      isChronic: (r.is_chronic as boolean) ?? false,
+      refillReminderDate: (r.refill_reminder_date as string) ?? undefined,
+      whatsappNotified: (r.whatsapp_notified as boolean) ?? false,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

Wires all 5 pharmacy public pages (Group 10) from mock/demo data imports (`pharmacy-demo-data.ts`) to real Supabase data.

### Changes

**Data Layer (`src/lib/data/public.ts`)**
- Added `PublicPharmacyProduct` interface and `getPublicPharmacyProducts()` — fetches products + stock from Supabase with clinic_id scoping
- Added `getPublicStockStatus()` and `searchPublicProducts()` helper functions
- Added `PublicPharmacyService` interface and `getPublicPharmacyServices()`
- Added `PublicOnDutySchedule` interface with `getPublicOnDutySchedule()`, `isPublicCurrentlyOnDuty()`, `getPublicNextOnDuty()` — graceful fallback if table does not exist
- Added `PublicPharmacyPrescription` interface and `getPublicPharmacyPrescriptions()` — includes patient detail lookups and status mapping

**Pages Wired**
1. **Pharmacy Home** (`pharmacy/page.tsx`) — now async server component fetching products, services, on-duty schedule from Supabase
2. **Pharmacy Catalog** (`pharmacy/catalog/page.tsx`) — client-side fetch with loading state, search/filter against real data
3. **Pharmacy Services** (`pharmacy/services/page.tsx`) — async server component fetching services from Supabase
4. **Pharmacy Contact** (`pharmacy/contact/page.tsx`) — async server component fetching on-duty schedule from Supabase
5. **Prescription History** (`pharmacy/prescription-history/page.tsx`) — client-side fetch with loading state, empty state handling

### Key Details
- All queries use `clinic_id` scoping for multi-tenant support
- Server pages use `createClient()` from `@/lib/data/public` (server-side Supabase)
- Client pages use `createClient()` from `@/lib/supabase-client` (browser Supabase)
- DB column names (snake_case) mapped to UI-friendly names (camelCase)
- Prescription status mapping: DB `partial` → UI `partially-ready`
- Loading spinners added to client-side pages
- Empty state handling for prescription history