### PR TITLE
Wire remaining pages to real Supabase data

### DIFF
--- a/src/app/(admin)/admin/billing/page.tsx
+++ b/src/app/(admin)/admin/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   CreditCard, Receipt, Download, CheckCircle, Clock,
   AlertTriangle, ArrowUpRight, Crown, Shield, Zap,
@@ -13,20 +13,43 @@ import { Separator } from "@/components/ui/separator";
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog";
+import { Loader2 } from "lucide-react";
+import { tierColors, type TierSlug } from "@/lib/config/pricing";
+import { clinicConfig } from "@/config/clinic.config";
 import {
-  pricingTiers,
-  clientSubscriptions,
-  tierColors,
-  type TierSlug,
-} from "@/lib/pricing-data";
-
-// Simulate the current client's subscription (Cabinet Dr. Ahmed Benali = premium)
-const currentSub = clientSubscriptions[0];
-const currentTier = pricingTiers.find((t) => t.slug === currentSub.tierSlug)!;
+  fetchClinicSubscription,
+  type ClinicSubscriptionView,
+} from "@/lib/data/client";
+import {
+  fetchPricingTiers,
+  type PricingTierRow,
+} from "@/lib/super-admin-actions";
 
 export default function ClientBillingPage() {
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const [selectedUpgrade, setSelectedUpgrade] = useState<TierSlug | null>(null);
+  const [currentSub, setCurrentSub] = useState<ClinicSubscriptionView | null>(null);
+  const [allTiers, setAllTiers] = useState<PricingTierRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadData = useCallback(async () => {
+    try {
+      const [sub, tiers] = await Promise.all([
+        fetchClinicSubscription(clinicConfig.clinicId),
+        fetchPricingTiers(),
+      ]);
+      setCurrentSub(sub);
+      setAllTiers(tiers);
+    } catch (err) {
+      console.error("[billing] failed to load:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const statusIcon = (status: string) => {
     switch (status) {
@@ -37,7 +60,7 @@ export default function ClientBillingPage() {
     }
   };
 
-  const tierIcon = (slug: TierSlug) => {
+  const tierIcon = (slug: string) => {
     switch (slug) {
       case "vitrine": return <Shield className="h-5 w-5" />;
       case "cabinet": return <CreditCard className="h-5 w-5" />;
@@ -46,6 +69,24 @@ export default function ClientBillingPage() {
       default: return <CreditCard className="h-5 w-5" />;
     }
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!currentSub) {
+    return (
+      <div className="text-center py-20 text-muted-foreground">
+        Aucun abonnement trouvé pour cette clinique.
+      </div>
+    );
+  }
+
+  const currentTier = currentSub.tier;
 
   return (
     <div>
@@ -66,8 +107,8 @@ export default function ClientBillingPage() {
               {tierIcon(currentSub.tierSlug)}
               Votre plan actuel
             </CardTitle>
-            <Badge className={`${tierColors[currentSub.tierSlug]} text-sm px-3 py-1`}>
-              {currentTier.name}
+            <Badge className={`${tierColors[currentSub.tierSlug as TierSlug] ?? ""} text-sm px-3 py-1`}>
+              {currentSub.tierName}
             </Badge>
           </div>
         </CardHeader>
@@ -82,7 +123,9 @@ export default function ClientBillingPage() {
               <p className="text-xs text-muted-foreground mb-1">Statut</p>
               <div className="flex items-center gap-1.5">
                 <CheckCircle className="h-4 w-4 text-green-600" />
-                <span className="font-medium text-green-600">Actif</span>
+                <span className="font-medium text-green-600">
+                  {currentSub.status === "active" ? "Actif" : currentSub.status === "trial" ? "Essai" : currentSub.status === "past_due" ? "Impayé" : currentSub.status === "suspended" ? "Suspendu" : "Annulé"}
+                </span>
               </div>
             </div>
             <div>
@@ -99,55 +142,59 @@ export default function ClientBillingPage() {
             </div>
           </div>
 
-          <Separator className="my-4" />
+          {currentTier && (
+            <>
+              <Separator className="my-4" />
 
-          {/* Current plan features */}
-          <div>
-            <h4 className="text-sm font-semibold mb-3">Fonctionnalités incluses</h4>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-              {currentTier.features.map((f) => (
-                <div key={f.key} className="flex items-center gap-2 text-sm">
-                  {f.included ? (
-                    <Check className="h-4 w-4 text-green-600 shrink-0" />
-                  ) : (
-                    <X className="h-4 w-4 text-gray-300 shrink-0" />
-                  )}
-                  <span className={f.included ? "" : "text-muted-foreground"}>
-                    {f.label}
-                    {f.limit && <span className="text-muted-foreground text-xs"> ({f.limit})</span>}
-                  </span>
+              {/* Current plan features */}
+              <div>
+                <h4 className="text-sm font-semibold mb-3">Fonctionnalités incluses</h4>
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                  {currentTier.features.map((f) => (
+                    <div key={f.key} className="flex items-center gap-2 text-sm">
+                      {f.included ? (
+                        <Check className="h-4 w-4 text-green-600 shrink-0" />
+                      ) : (
+                        <X className="h-4 w-4 text-gray-300 shrink-0" />
+                      )}
+                      <span className={f.included ? "" : "text-muted-foreground"}>
+                        {f.label}
+                        {f.limit && <span className="text-muted-foreground text-xs"> ({f.limit})</span>}
+                      </span>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
+              </div>
 
-          <Separator className="my-4" />
+              <Separator className="my-4" />
 
-          {/* Limits */}
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <div className="rounded-lg border p-3">
-              <p className="text-xs text-muted-foreground">Praticiens</p>
-              <p className="text-lg font-bold">
-                {currentTier.limits.maxDoctors === -1 ? "Illimité" : currentTier.limits.maxDoctors}
-              </p>
-            </div>
-            <div className="rounded-lg border p-3">
-              <p className="text-xs text-muted-foreground">Patients max</p>
-              <p className="text-lg font-bold">
-                {currentTier.limits.maxPatients === -1 ? "Illimité" : currentTier.limits.maxPatients.toLocaleString()}
-              </p>
-            </div>
-            <div className="rounded-lg border p-3">
-              <p className="text-xs text-muted-foreground">RDV / mois</p>
-              <p className="text-lg font-bold">
-                {currentTier.limits.maxAppointmentsPerMonth === -1 ? "Illimité" : currentTier.limits.maxAppointmentsPerMonth.toLocaleString()}
-              </p>
-            </div>
-            <div className="rounded-lg border p-3">
-              <p className="text-xs text-muted-foreground">Stockage</p>
-              <p className="text-lg font-bold">{currentTier.limits.storageGB} GB</p>
-            </div>
-          </div>
+              {/* Limits */}
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Praticiens</p>
+                  <p className="text-lg font-bold">
+                    {currentTier.limits.maxDoctors === -1 ? "Illimité" : currentTier.limits.maxDoctors}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Patients max</p>
+                  <p className="text-lg font-bold">
+                    {currentTier.limits.maxPatients === -1 ? "Illimité" : currentTier.limits.maxPatients.toLocaleString()}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">RDV / mois</p>
+                  <p className="text-lg font-bold">
+                    {currentTier.limits.maxAppointmentsPerMonth === -1 ? "Illimité" : currentTier.limits.maxAppointmentsPerMonth.toLocaleString()}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs text-muted-foreground">Stockage</p>
+                  <p className="text-lg font-bold">{currentTier.limits.storageGB} GB</p>
+                </div>
+              </div>
+            </>
+          )}
         </CardContent>
       </Card>
 
@@ -199,11 +246,12 @@ export default function ClientBillingPage() {
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
-              {pricingTiers
+              {allTiers
                 .filter((t) => t.slug !== "saas-monthly")
                 .map((tier) => {
                   const isCurrent = tier.slug === currentSub.tierSlug;
-                  const price = tier.pricing[currentSub.systemType].monthly;
+                  const pricing = tier.pricing[currentSub.systemType];
+                  const price = pricing?.monthly ?? 0;
                   return (
                     <div
                       key={tier.id}
@@ -228,9 +276,9 @@ export default function ClientBillingPage() {
                             variant="outline"
                             size="sm"
                             className="mt-1 text-xs"
-                            onClick={() => { setSelectedUpgrade(tier.slug); setUpgradeOpen(true); }}
+                            onClick={() => { setSelectedUpgrade(tier.slug as TierSlug); setUpgradeOpen(true); }}
                           >
-                            {pricingTiers.indexOf(tier) > pricingTiers.findIndex((t) => t.slug === currentSub.tierSlug) ? "Upgrader" : "Changer"}
+                            {allTiers.indexOf(tier) > allTiers.findIndex((t) => t.slug === currentSub.tierSlug) ? "Upgrader" : "Changer"}
                           </Button>
                         )}
                       </div>
@@ -245,22 +293,22 @@ export default function ClientBillingPage() {
       {/* Upgrade Dialog */}
       <Dialog open={upgradeOpen} onOpenChange={setUpgradeOpen}>
         {selectedUpgrade && (() => {
-          const upgradeTier = pricingTiers.find((t) => t.slug === selectedUpgrade);
+          const upgradeTier = allTiers.find((t) => t.slug === selectedUpgrade);
           if (!upgradeTier) return null;
-          const newPrice = upgradeTier.pricing[currentSub.systemType].monthly;
+          const newPrice = upgradeTier.pricing[currentSub.systemType]?.monthly ?? 0;
           return (
             <DialogContent onClose={() => setUpgradeOpen(false)}>
               <DialogHeader>
                 <DialogTitle>Changer de plan</DialogTitle>
                 <DialogDescription>
-                  Passer du plan {currentTier.name} au plan {upgradeTier.name}
+                  Passer du plan {currentSub.tierName} au plan {upgradeTier.name}
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4 py-4">
                 <div className="flex items-center justify-between rounded-lg border p-4">
                   <div>
                     <p className="text-sm text-muted-foreground">Plan actuel</p>
-                    <p className="font-medium">{currentTier.name}</p>
+                    <p className="font-medium">{currentSub.tierName}</p>
                     <p className="text-sm text-muted-foreground">{currentSub.amount.toLocaleString()} MAD/mois</p>
                   </div>
                   <ArrowUpRight className="h-5 w-5 text-muted-foreground" />
@@ -270,24 +318,26 @@ export default function ClientBillingPage() {
                     <p className="text-sm font-bold text-primary">{newPrice.toLocaleString()} MAD/mois</p>
                   </div>
                 </div>
-                <div>
-                  <h4 className="text-sm font-semibold mb-2">Nouvelles fonctionnalités</h4>
-                  <div className="space-y-1.5">
-                    {upgradeTier.features
-                      .filter((f) => f.included && !currentTier.features.find((cf) => cf.key === f.key)?.included)
-                      .map((f) => (
-                        <div key={f.key} className="flex items-center gap-2 text-sm">
-                          <Check className="h-4 w-4 text-green-600" />
-                          <span>{f.label}</span>
-                        </div>
-                      ))}
-                    {upgradeTier.features
-                      .filter((f) => f.included && !currentTier.features.find((cf) => cf.key === f.key)?.included)
-                      .length === 0 && (
-                      <p className="text-sm text-muted-foreground">Mêmes fonctionnalités</p>
-                    )}
+                {currentTier && (
+                  <div>
+                    <h4 className="text-sm font-semibold mb-2">Nouvelles fonctionnalités</h4>
+                    <div className="space-y-1.5">
+                      {upgradeTier.features
+                        .filter((f) => f.included && !currentTier.features.find((cf) => cf.key === f.key)?.included)
+                        .map((f) => (
+                          <div key={f.key} className="flex items-center gap-2 text-sm">
+                            <Check className="h-4 w-4 text-green-600" />
+                            <span>{f.label}</span>
+                          </div>
+                        ))}
+                      {upgradeTier.features
+                        .filter((f) => f.included && !currentTier.features.find((cf) => cf.key === f.key)?.included)
+                        .length === 0 && (
+                        <p className="text-sm text-muted-foreground">Mêmes fonctionnalités</p>
+                      )}
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
               <DialogFooter>
                 <Button variant="outline" onClick={() => setUpgradeOpen(false)}>Annuler</Button>

--- a/src/app/(doctor)/doctor/lab-orders/page.tsx
+++ b/src/app/(doctor)/doctor/lab-orders/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { LabOrdersPanel } from "@/components/dental/lab-orders-panel";
 import { getCurrentUser, fetchLabOrders, type LabOrderView } from "@/lib/data/client";
-import type { LabOrder } from "@/lib/dental-demo-data";
+import type { LabOrder } from "@/lib/types/dental";
 
 export default function DoctorLabOrdersPage() {
   const [orders, setOrders] = useState<LabOrder[]>([]);

--- a/src/app/(doctor)/doctor/odontogram/page.tsx
+++ b/src/app/(doctor)/doctor/odontogram/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { OdontogramChart } from "@/components/dental/odontogram-chart";
 import { getCurrentUser, fetchPatients, fetchOdontogram, type PatientView, type OdontogramView } from "@/lib/data/client";
-import type { ToothStatus, OdontogramEntry } from "@/lib/dental-demo-data";
+import type { ToothStatus, OdontogramEntry } from "@/lib/types/dental";
 
 export default function DoctorOdontogramPage() {
   const [patients, setPatients] = useState<PatientView[]>([]);

--- a/src/app/(doctor)/doctor/sterilization/page.tsx
+++ b/src/app/(doctor)/doctor/sterilization/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { SterilizationLogPanel } from "@/components/dental/sterilization-log-panel";
 import { getCurrentUser, fetchSterilizationLog, type SterilizationView } from "@/lib/data/client";
-import type { SterilizationEntry } from "@/lib/dental-demo-data";
+import type { SterilizationEntry } from "@/lib/types/dental";
 
 export default function DoctorSterilizationPage() {
   const [log, setLog] = useState<SterilizationEntry[]>([]);

--- a/src/app/(doctor)/doctor/treatment-plans/page.tsx
+++ b/src/app/(doctor)/doctor/treatment-plans/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { TreatmentPlanBuilder } from "@/components/dental/treatment-plan-builder";
 import { getCurrentUser, fetchTreatmentPlans, type TreatmentPlanView } from "@/lib/data/client";
-import type { TreatmentPlan, TreatmentStep } from "@/lib/dental-demo-data";
+import type { TreatmentPlan, TreatmentStep } from "@/lib/types/dental";
 
 export default function DoctorTreatmentPlansPage() {
   const [plans, setPlans] = useState<TreatmentPlan[]>([]);

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -14,22 +14,23 @@ import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Loader2 } from "lucide-react";
 import {
-  pricingTiers,
-  featureToggles as defaultFeatureToggles,
   systemTypeLabels,
   tierColors,
   type SystemType,
   type TierSlug,
-  type FeatureToggle,
-} from "@/lib/pricing-data";
+} from "@/lib/config/pricing";
 import {
   fetchClientSubscriptions,
+  fetchPricingTiers,
+  fetchFeatureToggles,
   type ClientSubscription,
+  type PricingTierRow,
+  type FeatureToggleRow,
 } from "@/lib/super-admin-actions";
 
 type TabView = "tiers" | "features";
 type SystemFilter = "all" | SystemType;
-type CategoryFilter = "all" | FeatureToggle["category"];
+type CategoryFilter = "all" | FeatureToggleRow["category"];
 
 const systemIcons: Record<SystemType, typeof Stethoscope> = {
   doctor: Stethoscope,
@@ -44,25 +45,32 @@ export default function PricingPage() {
   const [billingCycle, setBillingCycle] = useState<"monthly" | "yearly">("monthly");
   const [featureSearch, setFeatureSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
-  const [toggles, setToggles] = useState(defaultFeatureToggles);
+  const [tiers, setTiers] = useState<PricingTierRow[]>([]);
+  const [toggles, setToggles] = useState<FeatureToggleRow[]>([]);
   const [expandedTier, setExpandedTier] = useState<string | null>(null);
   const [subscriptions, setSubscriptions] = useState<ClientSubscription[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const loadSubscriptions = useCallback(async () => {
+  const loadData = useCallback(async () => {
     try {
-      const data = await fetchClientSubscriptions();
-      setSubscriptions(data);
+      const [subs, tiersData, togglesData] = await Promise.all([
+        fetchClientSubscriptions(),
+        fetchPricingTiers(),
+        fetchFeatureToggles(),
+      ]);
+      setSubscriptions(subs);
+      setTiers(tiersData);
+      setToggles(togglesData);
     } catch (err) {
-      console.error("[sa-pricing] failed to load subscriptions:", err);
+      console.error("[sa-pricing] failed to load data:", err);
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    loadSubscriptions();
-  }, [loadSubscriptions]);
+    loadData();
+  }, [loadData]);
 
   const stats = {
     active: subscriptions.filter((s) => s.status === "active").length,
@@ -226,7 +234,7 @@ export default function PricingPage() {
 
           {/* Pricing Cards */}
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
-            {pricingTiers.map((tier) => {
+            {tiers.map((tier) => {
               const price = tier.pricing[selectedSystem][billingCycle];
               const isExpanded = expandedTier === tier.id;
               const subCount = subscriptions.filter((s) => s.tierSlug === tier.slug).length;
@@ -240,7 +248,7 @@ export default function PricingPage() {
                   )}
                   <CardHeader className="pb-3">
                     <div className="flex items-center justify-between">
-                      <Badge className={`text-[10px] ${tierColors[tier.slug]}`}>{tier.name}</Badge>
+                      <Badge className={`text-[10px] ${tierColors[tier.slug as TierSlug] ?? ""}`}>{tier.name}</Badge>
                       <span className="text-xs text-muted-foreground">{subCount} clients</span>
                     </div>
                     <CardTitle className="text-lg mt-2">
@@ -456,8 +464,8 @@ export default function PricingPage() {
                         <td className="py-3 px-4 text-center">
                           <div className="flex items-center justify-center gap-1">
                             {ft.systemTypes.map((st) => {
-                              const Icon = systemIcons[st];
-                              return <span key={st} title={systemTypeLabels[st]}><Icon className="h-3.5 w-3.5 text-muted-foreground" /></span>;
+                              const Icon = systemIcons[st as SystemType];
+                              return <span key={st} title={systemTypeLabels[st as SystemType]}><Icon className="h-3.5 w-3.5 text-muted-foreground" /></span>;
                             })}
                           </div>
                         </td>

--- a/src/app/(super-admin)/super-admin/subscriptions/page.tsx
+++ b/src/app/(super-admin)/super-admin/subscriptions/page.tsx
@@ -19,7 +19,7 @@ import {
   systemTypeLabels,
   tierColors,
   statusColors,
-} from "@/lib/pricing-data";
+} from "@/lib/config/pricing";
 import {
   fetchClientSubscriptions,
   type ClientSubscription,

--- a/src/lib/config/pricing.ts
+++ b/src/lib/config/pricing.ts
@@ -1,0 +1,79 @@
+/**
+ * Pricing UI constants — display labels, color mappings, and type definitions.
+ * These are pure presentation constants, not database data.
+ */
+
+export type SystemType = "doctor" | "dentist" | "pharmacy";
+export type TierSlug = "vitrine" | "cabinet" | "pro" | "premium" | "saas-monthly";
+
+export type SubscriptionStatus = "active" | "trial" | "past_due" | "cancelled" | "suspended";
+
+export const systemTypeLabels: Record<SystemType, string> = {
+  doctor: "Médecin",
+  dentist: "Dentiste",
+  pharmacy: "Pharmacie",
+};
+
+export const tierColors: Record<TierSlug, string> = {
+  vitrine: "bg-gray-100 text-gray-700",
+  cabinet: "bg-blue-100 text-blue-700",
+  pro: "bg-purple-100 text-purple-700",
+  premium: "bg-amber-100 text-amber-700",
+  "saas-monthly": "bg-emerald-100 text-emerald-700",
+};
+
+export const statusColors: Record<SubscriptionStatus, string> = {
+  active: "bg-emerald-100 text-emerald-700",
+  trial: "bg-blue-100 text-blue-700",
+  past_due: "bg-orange-100 text-orange-700",
+  cancelled: "bg-gray-100 text-gray-500",
+  suspended: "bg-red-100 text-red-700",
+};
+
+export interface PricingFeature {
+  key: string;
+  label: string;
+  included: boolean;
+  limit?: string;
+}
+
+export interface TierLimits {
+  maxDoctors: number;
+  maxPatients: number;
+  maxAppointmentsPerMonth: number;
+  storageGB: number;
+  customDomain: boolean;
+  apiAccess: boolean;
+  whiteLabel: boolean;
+}
+
+export interface PricingTier {
+  id: string;
+  slug: TierSlug;
+  name: string;
+  description: string;
+  popular?: boolean;
+  pricing: Record<SystemType, { monthly: number; yearly: number }>;
+  features: PricingFeature[];
+  limits: TierLimits;
+}
+
+export interface FeatureToggle {
+  id: string;
+  key: string;
+  label: string;
+  description: string;
+  category: "core" | "communication" | "integration" | "advanced" | "pharmacy";
+  systemTypes: SystemType[];
+  tiers: TierSlug[];
+  enabled: boolean;
+}
+
+export interface ClientInvoice {
+  id: string;
+  date: string;
+  amount: number;
+  status: "paid" | "pending" | "overdue" | "refunded";
+  paidDate?: string;
+  downloadUrl?: string;
+}

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -2284,3 +2284,138 @@ export async function fetchLoyaltyTransactions(clinicId: string): Promise<Loyalt
     saleId: r.sale_id ?? undefined,
   }));
 }
+
+// ─────────────────────────────────────────────
+// Clinic Subscription (for admin billing page)
+// ─────────────────────────────────────────────
+
+export interface ClinicSubscriptionView {
+  id: string;
+  clinicId: string;
+  tierSlug: string;
+  tierName: string;
+  status: "active" | "trial" | "past_due" | "cancelled" | "suspended";
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+  billingCycle: "monthly" | "yearly";
+  amount: number;
+  currency: string;
+  paymentMethod: string;
+  autoRenew: boolean;
+  systemType: string;
+  invoices: {
+    id: string;
+    date: string;
+    amount: number;
+    status: "paid" | "pending" | "overdue" | "refunded";
+    paidDate?: string;
+  }[];
+  tier: {
+    slug: string;
+    name: string;
+    description: string;
+    features: { key: string; label: string; included: boolean; limit?: string }[];
+    limits: {
+      maxDoctors: number;
+      maxPatients: number;
+      maxAppointmentsPerMonth: number;
+      storageGB: number;
+      customDomain: boolean;
+      apiAccess: boolean;
+      whiteLabel: boolean;
+    };
+    pricing: Record<string, { monthly: number; yearly: number }>;
+  } | null;
+}
+
+const TIER_NAMES: Record<string, string> = {
+  vitrine: "Vitrine",
+  cabinet: "Cabinet",
+  pro: "Pro",
+  premium: "Premium",
+  "saas-monthly": "SaaS Mensuel",
+};
+
+export async function fetchClinicSubscription(clinicId: string): Promise<ClinicSubscriptionView | null> {
+  const supabase = createClient();
+
+  // Fetch the clinic to get tier and type info
+  const { data: clinic, error: clinicError } = await supabase
+    .from("clinics")
+    .select("id, name, type, tier, status")
+    .eq("id", clinicId)
+    .single();
+
+  if (clinicError || !clinic) return null;
+
+  const c = clinic as Record<string, unknown>;
+  const tierSlug = (c.tier as string) ?? "vitrine";
+  const systemType = (c.type as string) ?? "doctor";
+
+  // Fetch pricing tier details
+  const { data: tierData } = await supabase
+    .from("pricing_tiers")
+    .select("*")
+    .eq("slug", tierSlug)
+    .single();
+
+  // Fetch recent payments as invoices
+  const { data: paymentsData } = await supabase
+    .from("payments")
+    .select("id, amount, status, created_at")
+    .eq("clinic_id", clinicId)
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  const payments = (paymentsData ?? []) as { id: string; amount: number; status: string; created_at: string }[];
+  const invoices = payments.map((p) => ({
+    id: p.id,
+    date: p.created_at?.split("T")[0] ?? "",
+    amount: p.amount ?? 0,
+    status: (p.status === "completed" ? "paid" : p.status === "pending" ? "pending" : "overdue") as "paid" | "pending" | "overdue" | "refunded",
+    paidDate: p.status === "completed" ? p.created_at?.split("T")[0] : undefined,
+  }));
+
+  const subStatus: ClinicSubscriptionView["status"] =
+    c.status === "active" ? "active"
+      : c.status === "suspended" ? "suspended"
+      : c.status === "trial" ? "trial"
+      : "cancelled";
+
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split("T")[0];
+  const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split("T")[0];
+
+  const latestPayment = payments[0];
+  const amount = latestPayment?.amount ?? 0;
+
+  const t = tierData as Record<string, unknown> | null;
+
+  return {
+    id: `sub-${c.id as string}`,
+    clinicId: c.id as string,
+    tierSlug,
+    tierName: TIER_NAMES[tierSlug] ?? tierSlug,
+    status: subStatus,
+    currentPeriodStart: monthStart,
+    currentPeriodEnd: monthEnd,
+    billingCycle: "monthly",
+    amount,
+    currency: "MAD",
+    paymentMethod: "Carte bancaire",
+    autoRenew: c.status === "active",
+    systemType,
+    invoices,
+    tier: t ? {
+      slug: (t.slug as string) ?? "",
+      name: (t.name as string) ?? "",
+      description: (t.description as string) ?? "",
+      features: (t.features as { key: string; label: string; included: boolean; limit?: string }[]) ?? [],
+      limits: (t.limits as NonNullable<ClinicSubscriptionView["tier"]>["limits"]) ?? {
+        maxDoctors: 1, maxPatients: 0, maxAppointmentsPerMonth: 0,
+        storageGB: 1, customDomain: false, apiAccess: false, whiteLabel: false,
+      },
+      pricing: (t.pricing as Record<string, { monthly: number; yearly: number }>) ?? {},
+    } : null,
+  };
+}

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -480,6 +480,85 @@ export async function fetchFeatureDefinitions(): Promise<FeatureDefinition[]> {
   }));
 }
 
+// ---------- Pricing Tiers ----------
+
+export interface PricingTierRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  popular: boolean;
+  pricing: Record<string, { monthly: number; yearly: number }>;
+  features: { key: string; label: string; included: boolean; limit?: string }[];
+  limits: {
+    maxDoctors: number;
+    maxPatients: number;
+    maxAppointmentsPerMonth: number;
+    storageGB: number;
+    customDomain: boolean;
+    apiAccess: boolean;
+    whiteLabel: boolean;
+  };
+}
+
+export async function fetchPricingTiers(): Promise<PricingTierRow[]> {
+  const supabase = rawClient();
+  const { data, error } = await supabase
+    .from("pricing_tiers")
+    .select("*")
+    .order("created_at", { ascending: true });
+
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    slug: (row.slug as string) ?? "",
+    name: (row.name as string) ?? "",
+    description: (row.description as string) ?? "",
+    popular: (row.popular as boolean) ?? false,
+    pricing: (row.pricing as Record<string, { monthly: number; yearly: number }>) ?? {},
+    features: (row.features as { key: string; label: string; included: boolean; limit?: string }[]) ?? [],
+    limits: (row.limits as PricingTierRow["limits"]) ?? {
+      maxDoctors: 1, maxPatients: 0, maxAppointmentsPerMonth: 0,
+      storageGB: 1, customDomain: false, apiAccess: false, whiteLabel: false,
+    },
+  }));
+}
+
+// ---------- Feature Toggles ----------
+
+export interface FeatureToggleRow {
+  id: string;
+  key: string;
+  label: string;
+  description: string;
+  category: "core" | "communication" | "integration" | "advanced" | "pharmacy";
+  systemTypes: string[];
+  tiers: string[];
+  enabled: boolean;
+}
+
+export async function fetchFeatureToggles(): Promise<FeatureToggleRow[]> {
+  const supabase = rawClient();
+  const { data, error } = await supabase
+    .from("feature_toggles")
+    .select("*")
+    .order("created_at", { ascending: true });
+
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    key: (row.key as string) ?? "",
+    label: (row.label as string) ?? "",
+    description: (row.description as string) ?? "",
+    category: ((row.category as string) ?? "core") as FeatureToggleRow["category"],
+    systemTypes: (row.system_types as string[]) ?? [],
+    tiers: (row.tiers as string[]) ?? [],
+    enabled: (row.enabled as boolean) ?? true,
+  }));
+}
+
 // ---------- Client Subscriptions ----------
 
 export interface ClientInvoice {


### PR DESCRIPTION
## Summary

Wire all remaining pages to real Supabase data instead of demo/hardcoded data.

### Changes

- **Fix 4 dental type imports**: Doctor pages (odontogram, treatment-plans, sterilization, lab-orders) now import types from `@/lib/types/dental` instead of `dental-demo-data`
- **Create shared pricing config** (`@/lib/config/pricing.ts`): Centralized UI constants (tierColors, statusColors, systemTypeLabels) and type definitions
- **Add `fetchPricingTiers()` and `fetchFeatureToggles()`** to `super-admin-actions.ts`: Fetch pricing tiers and feature toggles from Supabase
- **Add `fetchClinicSubscription()`** to `client.ts`: Fetch clinic subscription with tier details and invoices from Supabase
- **Update SA Pricing page**: Uses real Supabase data via new fetch functions
- **Update SA Subscriptions page**: Imports from shared config instead of pricing-data
- **Update Admin Billing page**: Fetches real subscription and pricing data from Supabase

### Files Changed

- `src/lib/config/pricing.ts` (new)
- `src/lib/data/client.ts`
- `src/lib/super-admin-actions.ts`
- `src/app/(super-admin)/super-admin/pricing/page.tsx`
- `src/app/(super-admin)/super-admin/subscriptions/page.tsx`
- `src/app/(admin)/admin/billing/page.tsx`
- `src/app/(doctor)/doctor/odontogram/page.tsx`
- `src/app/(doctor)/doctor/treatment-plans/page.tsx`
- `src/app/(doctor)/doctor/sterilization/page.tsx`
- `src/app/(doctor)/doctor/lab-orders/page.tsx`