### PR TITLE
feat: wire public sub-components (ServicesPreview, BlogSection, DoctorsSection) to Supabase

### DIFF
--- a/src/components/public/sections/blog-section.tsx
+++ b/src/components/public/sections/blog-section.tsx
@@ -1,29 +1,15 @@
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { ArrowRight, FileText } from "lucide-react";
+import { getPublicBlogPosts } from "@/lib/data/public";
 
 const linkBtnOutline =
   "inline-flex items-center justify-center rounded-lg border border-border bg-background px-2.5 py-1.5 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors";
 
-const placeholderPosts = [
-  {
-    title: "Tips for Maintaining Good Health",
-    excerpt: "Simple daily habits that can make a big difference in your overall well-being.",
-    date: "2025-03-15",
-  },
-  {
-    title: "Understanding Preventive Care",
-    excerpt: "Why regular check-ups are essential for catching issues early.",
-    date: "2025-03-10",
-  },
-  {
-    title: "Healthy Eating on a Budget",
-    excerpt: "Nutritious meal planning that won't break the bank.",
-    date: "2025-03-05",
-  },
-];
+export async function BlogSection() {
+  const blogPosts = await getPublicBlogPosts();
+  const previewPosts = blogPosts.slice(0, 3);
 
-export function BlogSection() {
   return (
     <section className="py-16">
       <div className="container mx-auto px-4">
@@ -34,20 +20,26 @@ export function BlogSection() {
           Stay informed with the latest health tips and medical insights from
           our team.
         </p>
-        <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
-          {placeholderPosts.map((post) => (
-            <Card key={post.title}>
-              <CardContent className="pt-6">
-                <div className="flex items-center gap-2 text-xs text-muted-foreground mb-3">
-                  <FileText className="h-3.5 w-3.5" />
-                  {post.date}
-                </div>
-                <h3 className="font-semibold mb-2">{post.title}</h3>
-                <p className="text-sm text-muted-foreground">{post.excerpt}</p>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        {previewPosts.length > 0 ? (
+          <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
+            {previewPosts.map((post) => (
+              <Card key={post.id}>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground mb-3">
+                    <FileText className="h-3.5 w-3.5" />
+                    {post.date}
+                  </div>
+                  <h3 className="font-semibold mb-2">{post.title}</h3>
+                  <p className="text-sm text-muted-foreground">{post.excerpt}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p className="text-center text-muted-foreground">
+            No articles published yet. Check back soon!
+          </p>
+        )}
         <div className="mt-10 text-center">
           <Link href="/blog" className={linkBtnOutline}>
             View All Articles

--- a/src/components/public/sections/doctors-section.tsx
+++ b/src/components/public/sections/doctors-section.tsx
@@ -1,9 +1,9 @@
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
-import { defaultWebsiteConfig } from "@/lib/website-config";
+import { getPublicDoctors } from "@/lib/data/public";
 
-export function DoctorsSection() {
-  const aboutCfg = defaultWebsiteConfig.about;
+export async function DoctorsSection() {
+  const doctors = await getPublicDoctors();
 
   return (
     <section className="py-16 bg-muted/30">
@@ -12,36 +12,43 @@ export function DoctorsSection() {
         <p className="text-center text-muted-foreground mb-12 max-w-2xl mx-auto">
           Meet our experienced medical professionals dedicated to your health.
         </p>
-        <div className="max-w-sm mx-auto">
-          <Card>
-            <CardContent className="pt-6 text-center">
-              {aboutCfg.photoUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={aboutCfg.photoUrl}
-                  alt={aboutCfg.doctorName}
-                  className="rounded-full h-24 w-24 object-cover mx-auto mb-4"
-                />
-              ) : (
-                <Avatar className="h-24 w-24 mx-auto mb-4">
-                  <AvatarFallback className="text-2xl bg-primary/10 text-primary">
-                    {aboutCfg.doctorName
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")}
-                  </AvatarFallback>
-                </Avatar>
-              )}
-              <h3 className="text-lg font-semibold">{aboutCfg.doctorName}</h3>
-              <p className="text-sm text-primary font-medium">
-                {aboutCfg.specialty}
-              </p>
-              <p className="text-sm text-muted-foreground mt-2">
-                {aboutCfg.experience}
-              </p>
-            </CardContent>
-          </Card>
-        </div>
+        {doctors.length > 0 ? (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-4xl mx-auto">
+            {doctors.map((doctor) => (
+              <Card key={doctor.id}>
+                <CardContent className="pt-6 text-center">
+                  {doctor.avatar ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={doctor.avatar}
+                      alt={doctor.name}
+                      className="rounded-full h-24 w-24 object-cover mx-auto mb-4"
+                    />
+                  ) : (
+                    <Avatar className="h-24 w-24 mx-auto mb-4">
+                      <AvatarFallback className="text-2xl bg-primary/10 text-primary">
+                        {doctor.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")}
+                      </AvatarFallback>
+                    </Avatar>
+                  )}
+                  <h3 className="text-lg font-semibold">{doctor.name}</h3>
+                  {doctor.specialty && (
+                    <p className="text-sm text-primary font-medium">
+                      {doctor.specialty}
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p className="text-center text-muted-foreground">
+            Our team information will be available soon.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/components/public/services-preview.tsx
+++ b/src/components/public/services-preview.tsx
@@ -1,49 +1,39 @@
 import Link from "next/link";
-import { Stethoscope, Calendar, FileText, ArrowRight } from "lucide-react";
+import { ArrowRight, Stethoscope } from "lucide-react";
+import { getPublicServices } from "@/lib/data/public";
 
 const linkBtnOutline =
   "inline-flex items-center justify-center rounded-lg border border-border bg-background px-2.5 py-1.5 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors";
 
-const previewServices = [
-  {
-    icon: Stethoscope,
-    title: "General Consultation",
-    description: "Comprehensive health check-ups and medical consultations.",
-  },
-  {
-    icon: Calendar,
-    title: "Easy Booking",
-    description:
-      "Book your appointment online in minutes, 24/7 availability.",
-  },
-  {
-    icon: FileText,
-    title: "Digital Records",
-    description:
-      "Access your medical history, prescriptions, and documents online.",
-  },
-];
+export async function ServicesPreview() {
+  const services = await getPublicServices();
+  const activeServices = services.filter((s) => s.active).slice(0, 3);
 
-export function ServicesPreview() {
   return (
     <section className="py-16">
       <div className="container mx-auto px-4">
         <h2 className="text-center text-3xl font-bold mb-12">Our Services</h2>
         <div className="grid gap-8 md:grid-cols-3">
-          {previewServices.map((service) => (
-            <div
-              key={service.title}
-              className="rounded-xl border bg-card p-6 text-center shadow-sm"
-            >
-              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                <service.icon className="h-6 w-6 text-primary" />
+          {activeServices.length > 0 ? (
+            activeServices.map((service) => (
+              <div
+                key={service.id}
+                className="rounded-xl border bg-card p-6 text-center shadow-sm"
+              >
+                <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
+                  <Stethoscope className="h-6 w-6 text-primary" />
+                </div>
+                <h3 className="text-lg font-semibold mb-2">{service.name}</h3>
+                <p className="text-sm text-muted-foreground">
+                  {service.description}
+                </p>
               </div>
-              <h3 className="text-lg font-semibold mb-2">{service.title}</h3>
-              <p className="text-sm text-muted-foreground">
-                {service.description}
-              </p>
-            </div>
-          ))}
+            ))
+          ) : (
+            <p className="col-span-3 text-center text-muted-foreground">
+              No services available yet. Check back soon!
+            </p>
+          )}
         </div>
         <div className="mt-10 text-center">
           <Link


### PR DESCRIPTION
## Summary

Wires three Home page sub-components from hardcoded/placeholder data to real Supabase queries.

### Changes

- **ServicesPreview** (`services-preview.tsx`): Replaced hardcoded `previewServices` array with `getPublicServices()` from Supabase. Shows up to 3 active services with graceful empty-state fallback.
- **BlogSection** (`sections/blog-section.tsx`): Replaced hardcoded `placeholderPosts` array with `getPublicBlogPosts()` from Supabase. Shows up to 3 recent published posts with empty-state fallback.
- **DoctorsSection** (`sections/doctors-section.tsx`): Replaced `defaultWebsiteConfig.about` (single static doctor) with `getPublicDoctors()` from Supabase. Now renders all doctors in a responsive grid with avatar/specialty display and empty-state fallback.

All three components are now async server components that query Supabase at render time.

[Devin session](https://app.devin.ai/sessions/68e22b2a6d094936af7f664ee888248c)