### PR TITLE
Phase 4 & 5: Diagnostic Centers and Pharmacy/Retail Enhancements

### DIFF
--- a/src/app/(equipment)/equipment/dashboard/page.tsx
+++ b/src/app/(equipment)/equipment/dashboard/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Package, HandCoins, Wrench, Clock,
+  ArrowRight, AlertTriangle, CheckCircle,
+} from "lucide-react";
+import Link from "next/link";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchEquipmentInventory, fetchEquipmentRentals, fetchEquipmentMaintenance } from "@/lib/data/client";
+import type { EquipmentItemView, EquipmentRentalView, EquipmentMaintenanceView } from "@/lib/data/client";
+
+export default function EquipmentDashboardPage() {
+  const [inventory, setInventory] = useState<EquipmentItemView[]>([]);
+  const [rentals, setRentals] = useState<EquipmentRentalView[]>([]);
+  const [maintenance, setMaintenance] = useState<EquipmentMaintenanceView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([
+      fetchEquipmentInventory(cId),
+      fetchEquipmentRentals(cId),
+      fetchEquipmentMaintenance(cId),
+    ])
+      .then(([inv, rent, maint]) => {
+        setInventory(inv);
+        setRentals(rent);
+        setMaintenance(maint);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
+      </div>
+    );
+  }
+
+  const available = inventory.filter((i) => i.isAvailable);
+  const activeRentals = rentals.filter((r) => r.status === "active");
+  const overdueRentals = rentals.filter((r) => r.status === "overdue");
+  const upcomingMaint = maintenance.filter((m) => m.status === "scheduled");
+  const needsRepair = inventory.filter((i) => i.condition === "needs_repair");
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Equipment Dashboard</h1>
+          <p className="text-muted-foreground text-sm">Overview of medical equipment operations</p>
+        </div>
+        <Badge variant="outline" className="text-amber-600 border-amber-600">
+          <Clock className="h-3 w-3 mr-1" />
+          {new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" })}
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Total Equipment</p>
+                <p className="text-3xl font-bold">{inventory.length}</p>
+                <p className="text-xs text-muted-foreground">{available.length} available</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-amber-100 dark:bg-amber-900/30 text-amber-600 flex items-center justify-center">
+                <Package className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/equipment/inventory" className="text-sm text-amber-600 hover:underline mt-2 inline-flex items-center">
+              View Inventory <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Active Rentals</p>
+                <p className="text-3xl font-bold text-blue-600">{activeRentals.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 flex items-center justify-center">
+                <HandCoins className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/equipment/rentals" className="text-sm text-amber-600 hover:underline mt-2 inline-flex items-center">
+              View Rentals <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Overdue Returns</p>
+                <p className="text-3xl font-bold text-red-500">{overdueRentals.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-600 flex items-center justify-center">
+                <AlertTriangle className="h-6 w-6" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Scheduled Maintenance</p>
+                <p className="text-3xl font-bold text-orange-500">{upcomingMaint.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-orange-100 dark:bg-orange-900/30 text-orange-600 flex items-center justify-center">
+                <Wrench className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/equipment/maintenance" className="text-sm text-amber-600 hover:underline mt-2 inline-flex items-center">
+              View Schedule <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Active Rentals */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="font-semibold text-lg">Active Rentals</h2>
+              <Link href="/equipment/rentals" className="text-sm text-amber-600 hover:underline">View All</Link>
+            </div>
+            <div className="space-y-3">
+              {[...overdueRentals, ...activeRentals].slice(0, 5).map((rental) => (
+                <div key={rental.id} className={`flex items-center justify-between p-3 rounded-lg ${rental.status === "overdue" ? "bg-red-50 dark:bg-red-950/10" : "bg-muted/50"}`}>
+                  <div>
+                    <p className="font-medium text-sm">{rental.equipmentName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {rental.clientName} &middot; Since {new Date(rental.rentalStart).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge className={rental.status === "overdue" ? "bg-red-100 text-red-700 border-0" : "bg-blue-100 text-blue-700 border-0"}>
+                    {rental.status}
+                  </Badge>
+                </div>
+              ))}
+              {activeRentals.length === 0 && overdueRentals.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No active rentals</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Needs Attention */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="font-semibold text-lg">Needs Attention</h2>
+            </div>
+            <div className="space-y-3">
+              {needsRepair.map((item) => (
+                <div key={item.id} className="flex items-center justify-between p-3 bg-orange-50 dark:bg-orange-950/10 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{item.name}</p>
+                    <p className="text-xs text-muted-foreground">S/N: {item.serialNumber ?? "N/A"}</p>
+                  </div>
+                  <Badge className="bg-orange-100 text-orange-700 border-0">Needs Repair</Badge>
+                </div>
+              ))}
+              {upcomingMaint.slice(0, 3).map((m) => (
+                <div key={m.id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{m.equipmentName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {m.type} &middot; Due: {m.nextDue ? new Date(m.nextDue).toLocaleDateString() : new Date(m.performedAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="text-xs capitalize">{m.type}</Badge>
+                </div>
+              ))}
+              {needsRepair.length === 0 && upcomingMaint.length === 0 && (
+                <div className="text-center py-4">
+                  <CheckCircle className="h-8 w-8 text-emerald-500 mx-auto mb-2" />
+                  <p className="text-sm text-muted-foreground">All equipment in good condition</p>
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(equipment)/equipment/inventory/page.tsx
+++ b/src/app/(equipment)/equipment/inventory/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, Package, ChevronDown } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchEquipmentInventory } from "@/lib/data/client";
+import type { EquipmentItemView } from "@/lib/data/client";
+
+const conditionColors: Record<string, string> = {
+  new: "bg-emerald-100 text-emerald-700 border-0",
+  good: "bg-blue-100 text-blue-700 border-0",
+  fair: "bg-yellow-100 text-yellow-700 border-0",
+  needs_repair: "bg-orange-100 text-orange-700 border-0",
+  decommissioned: "bg-gray-100 text-gray-700 border-0",
+};
+
+export default function EquipmentInventoryPage() {
+  const [items, setItems] = useState<EquipmentItemView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [conditionFilter, setConditionFilter] = useState("all");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchEquipmentInventory(clinicConfig.clinicId)
+      .then(setItems)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading inventory...</div>
+      </div>
+    );
+  }
+
+  const filtered = items.filter((item) => {
+    if (conditionFilter !== "all" && item.condition !== conditionFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return (
+        item.name.toLowerCase().includes(q) ||
+        (item.serialNumber?.toLowerCase().includes(q) ?? false) ||
+        item.category.toLowerCase().includes(q) ||
+        (item.manufacturer?.toLowerCase().includes(q) ?? false)
+      );
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Equipment Inventory</h1>
+          <p className="text-muted-foreground text-sm">{items.length} items tracked</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search by name, serial number, category..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {["all", "new", "good", "fair", "needs_repair", "decommissioned"].map((c) => (
+            <Button key={c} variant={conditionFilter === c ? "default" : "outline"} size="sm" onClick={() => setConditionFilter(c)} className="capitalize">
+              {c === "all" ? "All" : c.replace("_", " ")}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((item) => (
+          <Card key={item.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between cursor-pointer" onClick={() => setExpandedId(expandedId === item.id ? null : item.id)}>
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center">
+                    <Package className="h-5 w-5 text-amber-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{item.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {item.category} {item.serialNumber ? `· S/N: ${item.serialNumber}` : ""}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge className={conditionColors[item.condition] ?? "bg-gray-100 text-gray-700 border-0"}>
+                    {item.condition.replace("_", " ")}
+                  </Badge>
+                  <Badge variant={item.isAvailable ? "outline" : "secondary"} className="text-xs">
+                    {item.isAvailable ? "Available" : "In Use"}
+                  </Badge>
+                  <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${expandedId === item.id ? "rotate-180" : ""}`} />
+                </div>
+              </div>
+
+              {expandedId === item.id && (
+                <div className="mt-4 pt-4 border-t">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                    <div>
+                      <p className="text-muted-foreground text-xs">Model</p>
+                      <p className="font-medium">{item.model ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Manufacturer</p>
+                      <p className="font-medium">{item.manufacturer ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Purchase Date</p>
+                      <p className="font-medium">{item.purchaseDate ? new Date(item.purchaseDate).toLocaleDateString() : "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Purchase Price</p>
+                      <p className="font-medium">{item.purchasePrice != null ? `${item.purchasePrice.toLocaleString()} ${item.currency}` : "—"}</p>
+                    </div>
+                  </div>
+                  {item.isRentable && (
+                    <div className="mt-3 pt-3 border-t">
+                      <p className="text-muted-foreground text-xs mb-2">Rental Pricing</p>
+                      <div className="flex gap-4 text-sm">
+                        {item.rentalPriceDaily != null && <span>Daily: {item.rentalPriceDaily} {item.currency}</span>}
+                        {item.rentalPriceWeekly != null && <span>Weekly: {item.rentalPriceWeekly} {item.currency}</span>}
+                        {item.rentalPriceMonthly != null && <span>Monthly: {item.rentalPriceMonthly} {item.currency}</span>}
+                      </div>
+                    </div>
+                  )}
+                  {item.notes && (
+                    <div className="mt-3 text-sm">
+                      <p className="text-muted-foreground text-xs">Notes</p>
+                      <p>{item.notes}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <Package className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No equipment matches your filters</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(equipment)/equipment/maintenance/page.tsx
+++ b/src/app/(equipment)/equipment/maintenance/page.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, Wrench, ChevronDown, CalendarClock } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchEquipmentMaintenance } from "@/lib/data/client";
+import type { EquipmentMaintenanceView } from "@/lib/data/client";
+
+const statusOptions = ["all", "scheduled", "in_progress", "completed", "cancelled"] as const;
+
+const statusColors: Record<string, string> = {
+  scheduled: "bg-cyan-100 text-cyan-700 border-0",
+  in_progress: "bg-blue-100 text-blue-700 border-0",
+  completed: "bg-emerald-100 text-emerald-700 border-0",
+  cancelled: "bg-gray-100 text-gray-700 border-0",
+};
+
+const typeColors: Record<string, string> = {
+  routine: "bg-blue-100 text-blue-700 border-0",
+  repair: "bg-orange-100 text-orange-700 border-0",
+  calibration: "bg-purple-100 text-purple-700 border-0",
+  inspection: "bg-cyan-100 text-cyan-700 border-0",
+  cleaning: "bg-emerald-100 text-emerald-700 border-0",
+};
+
+export default function EquipmentMaintenancePage() {
+  const [records, setRecords] = useState<EquipmentMaintenanceView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchEquipmentMaintenance(clinicConfig.clinicId)
+      .then(setRecords)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading maintenance records...</div>
+      </div>
+    );
+  }
+
+  const filtered = records.filter((r) => {
+    if (statusFilter !== "all" && r.status !== statusFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return r.equipmentName.toLowerCase().includes(q) || r.type.toLowerCase().includes(q) || (r.performedBy?.toLowerCase().includes(q) ?? false);
+    }
+    return true;
+  });
+
+  // Upcoming maintenance alerts (scheduled, with nextDue in next 30 days)
+  const now = new Date();
+  const thirtyDaysFromNow = new Date(now);
+  thirtyDaysFromNow.setDate(thirtyDaysFromNow.getDate() + 30);
+
+  const upcoming = records.filter((r) => {
+    if (r.status !== "scheduled") return false;
+    if (!r.nextDue) return false;
+    const due = new Date(r.nextDue);
+    return due <= thirtyDaysFromNow;
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Maintenance</h1>
+          <p className="text-muted-foreground text-sm">{records.length} maintenance records</p>
+        </div>
+      </div>
+
+      {upcoming.length > 0 && (
+        <Card className="mb-6 border-orange-200 dark:border-orange-900">
+          <CardContent className="pt-4 pb-4">
+            <div className="flex items-center gap-2 mb-3">
+              <CalendarClock className="h-5 w-5 text-orange-600" />
+              <h3 className="font-semibold text-sm">Upcoming Maintenance ({upcoming.length})</h3>
+            </div>
+            <div className="space-y-2">
+              {upcoming.map((m) => (
+                <div key={m.id} className="flex items-center justify-between p-2 bg-orange-50 dark:bg-orange-950/10 rounded">
+                  <div>
+                    <p className="font-medium text-sm">{m.equipmentName}</p>
+                    <p className="text-xs text-muted-foreground">{m.type} &middot; Due: {m.nextDue ? new Date(m.nextDue).toLocaleDateString() : "—"}</p>
+                  </div>
+                  <Badge className="bg-orange-100 text-orange-700 border-0 text-xs capitalize">{m.type}</Badge>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search by equipment, type, technician..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {statusOptions.map((s) => (
+            <Button key={s} variant={statusFilter === s ? "default" : "outline"} size="sm" onClick={() => setStatusFilter(s)} className="capitalize">
+              {s === "all" ? "All" : s.replace("_", " ")}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((record) => (
+          <Card key={record.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between cursor-pointer" onClick={() => setExpandedId(expandedId === record.id ? null : record.id)}>
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center">
+                    <Wrench className="h-5 w-5 text-amber-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{record.equipmentName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(record.performedAt).toLocaleDateString()} &middot; {record.performedBy ?? "Unknown"}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge className={typeColors[record.type] ?? "bg-gray-100 text-gray-700 border-0"}>
+                    {record.type}
+                  </Badge>
+                  <Badge className={statusColors[record.status] ?? "bg-gray-100 text-gray-700 border-0"}>
+                    {record.status.replace("_", " ")}
+                  </Badge>
+                  <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${expandedId === record.id ? "rotate-180" : ""}`} />
+                </div>
+              </div>
+
+              {expandedId === record.id && (
+                <div className="mt-4 pt-4 border-t">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                    <div>
+                      <p className="text-muted-foreground text-xs">Type</p>
+                      <p className="font-medium capitalize">{record.type}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Performed By</p>
+                      <p className="font-medium">{record.performedBy ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Cost</p>
+                      <p className="font-medium">{record.cost != null ? `${record.cost} ${record.currency}` : "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Next Due</p>
+                      <p className="font-medium">{record.nextDue ? new Date(record.nextDue).toLocaleDateString() : "—"}</p>
+                    </div>
+                  </div>
+                  {record.description && (
+                    <div className="text-sm mt-3">
+                      <p className="text-muted-foreground text-xs">Description</p>
+                      <p>{record.description}</p>
+                    </div>
+                  )}
+                  {record.notes && (
+                    <div className="text-sm mt-3">
+                      <p className="text-muted-foreground text-xs">Notes</p>
+                      <p>{record.notes}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <Wrench className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No maintenance records match your filters</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(equipment)/equipment/rentals/page.tsx
+++ b/src/app/(equipment)/equipment/rentals/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, HandCoins, ChevronDown, AlertTriangle } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchEquipmentRentals } from "@/lib/data/client";
+import type { EquipmentRentalView } from "@/lib/data/client";
+
+const statusOptions = ["all", "reserved", "active", "returned", "overdue", "cancelled"] as const;
+
+const statusColors: Record<string, string> = {
+  reserved: "bg-cyan-100 text-cyan-700 border-0",
+  active: "bg-blue-100 text-blue-700 border-0",
+  returned: "bg-emerald-100 text-emerald-700 border-0",
+  overdue: "bg-red-100 text-red-700 border-0",
+  cancelled: "bg-gray-100 text-gray-700 border-0",
+};
+
+export default function EquipmentRentalsPage() {
+  const [rentals, setRentals] = useState<EquipmentRentalView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchEquipmentRentals(clinicConfig.clinicId)
+      .then(setRentals)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading rentals...</div>
+      </div>
+    );
+  }
+
+  const filtered = rentals.filter((r) => {
+    if (statusFilter !== "all" && r.status !== statusFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return r.equipmentName.toLowerCase().includes(q) || r.clientName.toLowerCase().includes(q);
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Equipment Rentals</h1>
+          <p className="text-muted-foreground text-sm">{rentals.length} rental records</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search by equipment, client..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {statusOptions.map((s) => (
+            <Button key={s} variant={statusFilter === s ? "default" : "outline"} size="sm" onClick={() => setStatusFilter(s)} className="capitalize">
+              {s === "all" ? "All" : s}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((rental) => (
+          <Card key={rental.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between cursor-pointer" onClick={() => setExpandedId(expandedId === rental.id ? null : rental.id)}>
+                <div className="flex items-center gap-4">
+                  <div className={`h-10 w-10 rounded-full flex items-center justify-center ${
+                    rental.status === "overdue" ? "bg-red-100 dark:bg-red-900/30" : "bg-blue-100 dark:bg-blue-900/30"
+                  }`}>
+                    {rental.status === "overdue" ? (
+                      <AlertTriangle className="h-5 w-5 text-red-600" />
+                    ) : (
+                      <HandCoins className="h-5 w-5 text-blue-600" />
+                    )}
+                  </div>
+                  <div>
+                    <p className="font-medium">{rental.equipmentName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {rental.clientName} &middot; {new Date(rental.rentalStart).toLocaleDateString()}
+                      {rental.rentalEnd ? ` — ${new Date(rental.rentalEnd).toLocaleDateString()}` : " — ongoing"}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge className={statusColors[rental.status] ?? "bg-gray-100 text-gray-700 border-0"}>
+                    {rental.status}
+                  </Badge>
+                  <Badge variant="outline" className="text-xs capitalize">{rental.paymentStatus}</Badge>
+                  <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${expandedId === rental.id ? "rotate-180" : ""}`} />
+                </div>
+              </div>
+
+              {expandedId === rental.id && (
+                <div className="mt-4 pt-4 border-t">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                    <div>
+                      <p className="text-muted-foreground text-xs">Client Phone</p>
+                      <p className="font-medium">{rental.clientPhone ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Client ID</p>
+                      <p className="font-medium">{rental.clientIdNumber ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Deposit</p>
+                      <p className="font-medium">{rental.depositAmount != null ? `${rental.depositAmount} ${rental.currency}` : "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Rental Amount</p>
+                      <p className="font-medium">{rental.rentalAmount != null ? `${rental.rentalAmount} ${rental.currency}` : "—"}</p>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-4 text-sm mt-3">
+                    <div>
+                      <p className="text-muted-foreground text-xs">Condition Out</p>
+                      <p className="font-medium capitalize">{rental.conditionOut}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Condition In</p>
+                      <p className="font-medium capitalize">{rental.conditionIn ?? "Not yet returned"}</p>
+                    </div>
+                  </div>
+                  {rental.actualReturn && (
+                    <div className="text-sm mt-3">
+                      <p className="text-muted-foreground text-xs">Actual Return Date</p>
+                      <p className="font-medium">{new Date(rental.actualReturn).toLocaleDateString()}</p>
+                    </div>
+                  )}
+                  {rental.notes && (
+                    <div className="text-sm mt-3">
+                      <p className="text-muted-foreground text-xs">Notes</p>
+                      <p>{rental.notes}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <HandCoins className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No rentals match your filters</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(equipment)/layout.tsx
+++ b/src/app/(equipment)/layout.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard, Package, HandCoins, Wrench,
+  Menu, X, Stethoscope,
+} from "lucide-react";
+import { SignOutButton } from "@/components/sign-out-button";
+
+const navItems = [
+  { href: "/equipment/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/equipment/inventory", label: "Inventory", icon: Package },
+  { href: "/equipment/rentals", label: "Rentals", icon: HandCoins },
+  { href: "/equipment/maintenance", label: "Maintenance", icon: Wrench },
+];
+
+function SidebarContent({ pathname, onNavClick }: { pathname: string; onNavClick?: () => void }) {
+  return (
+    <>
+      <nav className="space-y-1 flex-1">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavClick}
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                isActive
+                  ? "bg-amber-600/10 text-amber-600 font-medium"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="pt-6 border-t mt-6">
+        <SignOutButton />
+      </div>
+    </>
+  );
+}
+
+export default function EquipmentLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen">
+      <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b bg-card px-4 py-3 md:hidden">
+        <button
+          onClick={() => setMobileOpen(true)}
+          className="rounded-md p-1.5 hover:bg-muted"
+          aria-label="Open menu"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+        <div className="flex items-center gap-2">
+          <Stethoscope className="h-4 w-4 text-amber-600" />
+          <h2 className="text-sm font-semibold">Medical Equipment</h2>
+        </div>
+      </div>
+
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setMobileOpen(false)} />
+          <aside className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 flex flex-col shadow-xl">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <Stethoscope className="h-5 w-5 text-amber-600" />
+                <h2 className="text-lg font-semibold">Equipment</h2>
+              </div>
+              <button onClick={() => setMobileOpen(false)} className="rounded-md p-1 hover:bg-muted" aria-label="Close menu">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <SidebarContent pathname={pathname} onNavClick={() => setMobileOpen(false)} />
+          </aside>
+        </div>
+      )}
+
+      <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="h-8 w-8 rounded-lg bg-amber-600 flex items-center justify-center">
+            <Stethoscope className="h-4 w-4 text-white" />
+          </div>
+          <h2 className="text-lg font-semibold">Equipment</h2>
+        </div>
+        <SidebarContent pathname={pathname} />
+      </aside>
+
+      <main className="flex-1 p-6 pt-16 md:pt-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(lab)/lab/dashboard/page.tsx
+++ b/src/app/(lab)/lab/dashboard/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  ClipboardList, AlertTriangle, Clock, FlaskConical,
+  ArrowRight, CheckCircle, Hourglass,
+} from "lucide-react";
+import Link from "next/link";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchLabTestOrders } from "@/lib/data/client";
+import type { LabTestOrderView } from "@/lib/data/client";
+
+export default function LabDashboardPage() {
+  const [orders, setOrders] = useState<LabTestOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchLabTestOrders(clinicConfig.clinicId)
+      .then(setOrders)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
+      </div>
+    );
+  }
+
+  const pending = orders.filter((o) => o.status === "pending");
+  const inProgress = orders.filter((o) => o.status === "sample_collected" || o.status === "in_progress");
+  const completedToday = orders.filter((o) => {
+    if (o.status !== "completed" && o.status !== "validated") return false;
+    const today = new Date().toISOString().split("T")[0];
+    return o.completedAt?.startsWith(today);
+  });
+  const urgent = orders.filter((o) => o.priority === "urgent" || o.priority === "stat");
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Lab Dashboard</h1>
+          <p className="text-muted-foreground text-sm">Overview of laboratory operations</p>
+        </div>
+        <Badge variant="outline" className="text-blue-600 border-blue-600">
+          <Clock className="h-3 w-3 mr-1" />
+          {new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" })}
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Pending Orders</p>
+                <p className="text-3xl font-bold">{pending.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-yellow-100 dark:bg-yellow-900/30 text-yellow-600 flex items-center justify-center">
+                <ClipboardList className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/lab/test-orders" className="text-sm text-blue-600 hover:underline mt-2 inline-flex items-center">
+              View Orders <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">In Progress</p>
+                <p className="text-3xl font-bold text-blue-600">{inProgress.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-blue-100 dark:bg-blue-900/30 text-blue-600 flex items-center justify-center">
+                <Hourglass className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/lab/results" className="text-sm text-blue-600 hover:underline mt-2 inline-flex items-center">
+              Enter Results <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Completed Today</p>
+                <p className="text-3xl font-bold text-emerald-600">{completedToday.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 flex items-center justify-center">
+                <CheckCircle className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/lab/reports" className="text-sm text-blue-600 hover:underline mt-2 inline-flex items-center">
+              View Reports <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Urgent / STAT</p>
+                <p className="text-3xl font-bold text-red-500">{urgent.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-600 flex items-center justify-center">
+                <AlertTriangle className="h-6 w-6" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Recent Orders */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="font-semibold text-lg">Recent Orders</h2>
+              <Link href="/lab/test-orders" className="text-sm text-blue-600 hover:underline">View All</Link>
+            </div>
+            <div className="space-y-3">
+              {orders.slice(0, 5).map((order) => (
+                <div key={order.id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.orderNumber} &middot; {order.testCount} test{order.testCount !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+                  <Badge className={
+                    order.status === "pending" ? "bg-yellow-100 text-yellow-700 border-0" :
+                    order.status === "in_progress" ? "bg-blue-100 text-blue-700 border-0" :
+                    order.status === "completed" ? "bg-emerald-100 text-emerald-700 border-0" :
+                    order.status === "validated" ? "bg-green-100 text-green-700 border-0" :
+                    "bg-gray-100 text-gray-700 border-0"
+                  }>
+                    {order.priority === "stat" && <AlertTriangle className="h-3 w-3 mr-1" />}
+                    {order.status.replace("_", " ")}
+                  </Badge>
+                </div>
+              ))}
+              {orders.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No test orders yet</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Urgent Queue */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="font-semibold text-lg">Urgent Queue</h2>
+            </div>
+            <div className="space-y-3">
+              {urgent.slice(0, 5).map((order) => (
+                <div key={order.id} className="flex items-center justify-between p-3 bg-red-50 dark:bg-red-950/10 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.orderNumber} &middot; {order.testCount} test{order.testCount !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="destructive" className="text-xs uppercase">{order.priority}</Badge>
+                    <FlaskConical className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                </div>
+              ))}
+              {urgent.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No urgent orders</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(lab)/lab/patient-history/page.tsx
+++ b/src/app/(lab)/lab/patient-history/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, History, FlaskConical, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchPatients, fetchPatientLabOrders, fetchLabTestResults } from "@/lib/data/client";
+import type { PatientView, LabTestOrderView, LabTestResultView } from "@/lib/data/client";
+
+function FlagBadge({ flag }: { flag: string }) {
+  const color =
+    flag === "critical_high" || flag === "critical_low" ? "bg-red-100 text-red-700 border-0" :
+    flag === "high" ? "bg-orange-100 text-orange-700 border-0" :
+    flag === "low" ? "bg-yellow-100 text-yellow-700 border-0" :
+    "bg-emerald-100 text-emerald-700 border-0";
+  const Icon = flag.includes("high") ? TrendingUp : flag.includes("low") ? TrendingDown : Minus;
+  return (
+    <Badge className={`${color} text-xs`}>
+      <Icon className="h-3 w-3 mr-1" />
+      {flag.replace("_", " ")}
+    </Badge>
+  );
+}
+
+export default function PatientHistoryPage() {
+  const [patients, setPatients] = useState<PatientView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [selectedPatientId, setSelectedPatientId] = useState<string | null>(null);
+  const [patientOrders, setPatientOrders] = useState<LabTestOrderView[]>([]);
+  const [selectedOrderResults, setSelectedOrderResults] = useState<LabTestResultView[]>([]);
+  const [ordersLoading, setOrdersLoading] = useState(false);
+  const [resultsLoading, setResultsLoading] = useState(false);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchPatients(clinicConfig.clinicId)
+      .then(setPatients)
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedPatientId) { setPatientOrders([]); return; }
+    setOrdersLoading(true);
+    setSelectedOrderId(null);
+    setSelectedOrderResults([]);
+    fetchPatientLabOrders(clinicConfig.clinicId, selectedPatientId)
+      .then(setPatientOrders)
+      .finally(() => setOrdersLoading(false));
+  }, [selectedPatientId]);
+
+  useEffect(() => {
+    if (!selectedOrderId) { setSelectedOrderResults([]); return; }
+    setResultsLoading(true);
+    fetchLabTestResults(selectedOrderId)
+      .then(setSelectedOrderResults)
+      .finally(() => setResultsLoading(false));
+  }, [selectedOrderId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading patients...</div>
+      </div>
+    );
+  }
+
+  const filteredPatients = patients.filter((p) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return p.name.toLowerCase().includes(q) || (p.phone?.includes(q) ?? false);
+  });
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Patient History</h1>
+        <p className="text-muted-foreground text-sm">View past lab results by patient</p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-4">
+        {/* Patient List */}
+        <div className="lg:col-span-1 space-y-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search patients..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <div className="space-y-2 max-h-[70vh] overflow-y-auto">
+            {filteredPatients.map((p) => (
+              <Card
+                key={p.id}
+                className={`cursor-pointer transition-colors ${
+                  selectedPatientId === p.id ? "ring-2 ring-blue-500" : "hover:bg-muted/50"
+                }`}
+                onClick={() => setSelectedPatientId(p.id)}
+              >
+                <CardContent className="pt-3 pb-3">
+                  <p className="font-medium text-sm">{p.name}</p>
+                  <p className="text-xs text-muted-foreground">{p.phone ?? "No phone"}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+
+        {/* Orders & Results */}
+        <div className="lg:col-span-3">
+          {!selectedPatientId ? (
+            <Card>
+              <CardContent className="py-16 text-center">
+                <History className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+                <p className="text-muted-foreground">Select a patient to view their lab history</p>
+              </CardContent>
+            </Card>
+          ) : ordersLoading ? (
+            <Card>
+              <CardContent className="py-16 text-center">
+                <div className="animate-pulse text-muted-foreground">Loading orders...</div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              <h2 className="font-semibold">Lab Orders ({patientOrders.length})</h2>
+              {patientOrders.length === 0 && (
+                <p className="text-sm text-muted-foreground">No lab orders found for this patient</p>
+              )}
+              {patientOrders.map((order) => (
+                <Card key={order.id}>
+                  <CardContent className="pt-4 pb-4">
+                    <div
+                      className="flex items-center justify-between cursor-pointer"
+                      onClick={() => setSelectedOrderId(selectedOrderId === order.id ? null : order.id)}
+                    >
+                      <div className="flex items-center gap-3">
+                        <FlaskConical className="h-5 w-5 text-blue-600" />
+                        <div>
+                          <p className="font-medium text-sm">{order.orderNumber}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {new Date(order.createdAt).toLocaleDateString()} &middot; {order.testCount} tests
+                          </p>
+                        </div>
+                      </div>
+                      <Badge className={
+                        order.status === "validated" ? "bg-green-100 text-green-700 border-0" :
+                        order.status === "completed" ? "bg-emerald-100 text-emerald-700 border-0" :
+                        "bg-gray-100 text-gray-700 border-0"
+                      }>
+                        {order.status.replace("_", " ")}
+                      </Badge>
+                    </div>
+
+                    {selectedOrderId === order.id && (
+                      <div className="mt-4 pt-4 border-t">
+                        {resultsLoading ? (
+                          <p className="text-sm text-muted-foreground animate-pulse">Loading results...</p>
+                        ) : selectedOrderResults.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">No results recorded</p>
+                        ) : (
+                          <table className="w-full text-sm">
+                            <thead>
+                              <tr className="border-b text-left">
+                                <th className="pb-2 font-medium">Test</th>
+                                <th className="pb-2 font-medium">Value</th>
+                                <th className="pb-2 font-medium">Unit</th>
+                                <th className="pb-2 font-medium">Reference</th>
+                                <th className="pb-2 font-medium">Flag</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {selectedOrderResults.map((r) => (
+                                <tr key={r.id} className="border-b last:border-0">
+                                  <td className="py-2 font-medium">{r.testName}</td>
+                                  <td className="py-2">{r.value ?? "—"}</td>
+                                  <td className="py-2 text-muted-foreground">{r.unit ?? ""}</td>
+                                  <td className="py-2 text-muted-foreground text-xs">
+                                    {r.referenceMin != null && r.referenceMax != null
+                                      ? `${r.referenceMin} - ${r.referenceMax}`
+                                      : "—"}
+                                  </td>
+                                  <td className="py-2">
+                                    {r.flag && <FlagBadge flag={r.flag} />}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        )}
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(lab)/lab/reports/page.tsx
+++ b/src/app/(lab)/lab/reports/page.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Search, FileText, Download } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchLabTestOrders } from "@/lib/data/client";
+import type { LabTestOrderView } from "@/lib/data/client";
+
+export default function LabReportsPage() {
+  const [orders, setOrders] = useState<LabTestOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetchLabTestOrders(clinicConfig.clinicId)
+      .then((all) => {
+        setOrders(all.filter((o) => o.status === "completed" || o.status === "validated"));
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading reports...</div>
+      </div>
+    );
+  }
+
+  const filtered = orders.filter((o) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return o.patientName.toLowerCase().includes(q) || o.orderNumber.toLowerCase().includes(q);
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Lab Reports</h1>
+          <p className="text-muted-foreground text-sm">Completed and validated test reports</p>
+        </div>
+      </div>
+
+      <div className="relative mb-6 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search by patient or order number..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((order) => (
+          <Card key={order.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+                    <FileText className="h-5 w-5 text-emerald-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.orderNumber} &middot; {order.testCount} test{order.testCount !== 1 ? "s" : ""} &middot; Completed {order.completedAt ? new Date(order.completedAt).toLocaleDateString() : ""}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge className={
+                    order.status === "validated"
+                      ? "bg-green-100 text-green-700 border-0"
+                      : "bg-emerald-100 text-emerald-700 border-0"
+                  }>
+                    {order.status}
+                  </Badge>
+                  {order.pdfUrl ? (
+                    <a
+                      href={order.pdfUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted transition-colors"
+                    >
+                      <Download className="h-3 w-3 mr-1" />
+                      PDF
+                    </a>
+                  ) : (
+                    <Button variant="outline" size="sm" disabled>
+                      <FileText className="h-3 w-3 mr-1" />
+                      No PDF
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <FileText className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No completed reports found</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(lab)/lab/results/page.tsx
+++ b/src/app/(lab)/lab/results/page.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, FlaskConical, ArrowUpDown, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchLabTestOrders, fetchLabTestResults } from "@/lib/data/client";
+import type { LabTestOrderView, LabTestResultView } from "@/lib/data/client";
+
+function FlagIcon({ flag }: { flag: string }) {
+  if (flag === "high" || flag === "critical_high") return <TrendingUp className="h-3 w-3" />;
+  if (flag === "low" || flag === "critical_low") return <TrendingDown className="h-3 w-3" />;
+  return <Minus className="h-3 w-3" />;
+}
+
+function flagColor(flag: string): string {
+  if (flag === "critical_high" || flag === "critical_low") return "bg-red-100 text-red-700 border-0";
+  if (flag === "high") return "bg-orange-100 text-orange-700 border-0";
+  if (flag === "low") return "bg-yellow-100 text-yellow-700 border-0";
+  return "bg-emerald-100 text-emerald-700 border-0";
+}
+
+export default function ResultsPage() {
+  const [orders, setOrders] = useState<LabTestOrderView[]>([]);
+  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
+  const [results, setResults] = useState<LabTestResultView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [resultsLoading, setResultsLoading] = useState(false);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetchLabTestOrders(clinicConfig.clinicId)
+      .then((all) => {
+        const active = all.filter((o) => o.status !== "cancelled");
+        setOrders(active);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedOrderId) {
+      setResults([]);
+      return;
+    }
+    setResultsLoading(true);
+    fetchLabTestResults(selectedOrderId)
+      .then(setResults)
+      .finally(() => setResultsLoading(false));
+  }, [selectedOrderId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  const filtered = orders.filter((o) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return o.patientName.toLowerCase().includes(q) || o.orderNumber.toLowerCase().includes(q);
+  });
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Results Entry</h1>
+        <p className="text-muted-foreground text-sm">Select an order to view or enter results</p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Order List */}
+        <div className="lg:col-span-1 space-y-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search orders..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+          <div className="space-y-2 max-h-[70vh] overflow-y-auto">
+            {filtered.map((order) => (
+              <Card
+                key={order.id}
+                className={`cursor-pointer transition-colors ${
+                  selectedOrderId === order.id ? "ring-2 ring-blue-500" : "hover:bg-muted/50"
+                }`}
+                onClick={() => setSelectedOrderId(order.id)}
+              >
+                <CardContent className="pt-3 pb-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-sm">{order.patientName}</p>
+                      <p className="text-xs text-muted-foreground">{order.orderNumber}</p>
+                    </div>
+                    <Badge className={
+                      order.status === "completed" ? "bg-emerald-100 text-emerald-700 border-0" :
+                      order.status === "validated" ? "bg-green-100 text-green-700 border-0" :
+                      order.status === "in_progress" ? "bg-blue-100 text-blue-700 border-0" :
+                      "bg-yellow-100 text-yellow-700 border-0"
+                    }>
+                      {order.status.replace("_", " ")}
+                    </Badge>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+            {filtered.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-4">No orders found</p>
+            )}
+          </div>
+        </div>
+
+        {/* Results Panel */}
+        <div className="lg:col-span-2">
+          {!selectedOrderId ? (
+            <Card>
+              <CardContent className="py-16 text-center">
+                <FlaskConical className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+                <p className="text-muted-foreground">Select an order to view results</p>
+              </CardContent>
+            </Card>
+          ) : resultsLoading ? (
+            <Card>
+              <CardContent className="py-16 text-center">
+                <div className="animate-pulse text-muted-foreground">Loading results...</div>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="pt-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="font-semibold text-lg flex items-center gap-2">
+                    <ArrowUpDown className="h-4 w-4" />
+                    Test Results
+                  </h2>
+                  <Badge variant="outline">{results.length} result{results.length !== 1 ? "s" : ""}</Badge>
+                </div>
+
+                {results.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-8">No results recorded yet for this order</p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b text-left">
+                          <th className="pb-2 font-medium">Test</th>
+                          <th className="pb-2 font-medium">Value</th>
+                          <th className="pb-2 font-medium">Unit</th>
+                          <th className="pb-2 font-medium">Reference</th>
+                          <th className="pb-2 font-medium">Flag</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {results.map((r) => (
+                          <tr key={r.id} className="border-b last:border-0">
+                            <td className="py-2 font-medium">{r.testName}</td>
+                            <td className="py-2">{r.value ?? "—"}</td>
+                            <td className="py-2 text-muted-foreground">{r.unit ?? ""}</td>
+                            <td className="py-2 text-muted-foreground text-xs">
+                              {r.referenceMin != null && r.referenceMax != null
+                                ? `${r.referenceMin} - ${r.referenceMax}`
+                                : r.referenceMin != null
+                                ? `>= ${r.referenceMin}`
+                                : r.referenceMax != null
+                                ? `<= ${r.referenceMax}`
+                                : "—"}
+                            </td>
+                            <td className="py-2">
+                              {r.flag && (
+                                <Badge className={`${flagColor(r.flag)} text-xs`}>
+                                  <FlagIcon flag={r.flag} />
+                                  <span className="ml-1 capitalize">{r.flag.replace("_", " ")}</span>
+                                </Badge>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(lab)/lab/test-orders/page.tsx
+++ b/src/app/(lab)/lab/test-orders/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Search, Filter, AlertTriangle, Clock, CheckCircle,
+  FlaskConical, ChevronDown,
+} from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchLabTestOrders } from "@/lib/data/client";
+import type { LabTestOrderView } from "@/lib/data/client";
+
+const statusOptions = ["all", "pending", "sample_collected", "in_progress", "completed", "validated", "cancelled"] as const;
+
+export default function TestOrdersPage() {
+  const [orders, setOrders] = useState<LabTestOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchLabTestOrders(clinicConfig.clinicId)
+      .then(setOrders)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading test orders...</div>
+      </div>
+    );
+  }
+
+  const filtered = orders.filter((o) => {
+    if (statusFilter !== "all" && o.status !== statusFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return (
+        o.patientName.toLowerCase().includes(q) ||
+        o.orderNumber.toLowerCase().includes(q) ||
+        (o.assignedTechnicianName?.toLowerCase().includes(q) ?? false)
+      );
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Test Orders</h1>
+          <p className="text-muted-foreground text-sm">{orders.length} total orders</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by patient, order number..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {statusOptions.map((s) => (
+            <Button
+              key={s}
+              variant={statusFilter === s ? "default" : "outline"}
+              size="sm"
+              onClick={() => setStatusFilter(s)}
+              className="capitalize"
+            >
+              {s === "all" ? "All" : s.replace("_", " ")}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((order) => (
+          <Card key={order.id}>
+            <CardContent className="pt-4 pb-4">
+              <div
+                className="flex items-center justify-between cursor-pointer"
+                onClick={() => setExpandedId(expandedId === order.id ? null : order.id)}
+              >
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+                    <FlaskConical className="h-5 w-5 text-blue-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.orderNumber} &middot; {order.testCount} test{order.testCount !== 1 ? "s" : ""} &middot; {new Date(order.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {(order.priority === "urgent" || order.priority === "stat") && (
+                    <Badge variant="destructive" className="text-xs uppercase">{order.priority}</Badge>
+                  )}
+                  <Badge className={
+                    order.status === "pending" ? "bg-yellow-100 text-yellow-700 border-0" :
+                    order.status === "sample_collected" ? "bg-cyan-100 text-cyan-700 border-0" :
+                    order.status === "in_progress" ? "bg-blue-100 text-blue-700 border-0" :
+                    order.status === "completed" ? "bg-emerald-100 text-emerald-700 border-0" :
+                    order.status === "validated" ? "bg-green-100 text-green-700 border-0" :
+                    "bg-gray-100 text-gray-700 border-0"
+                  }>
+                    {order.status === "pending" && <Clock className="h-3 w-3 mr-1" />}
+                    {order.status === "completed" && <CheckCircle className="h-3 w-3 mr-1" />}
+                    {order.status.replace("_", " ")}
+                  </Badge>
+                  <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${expandedId === order.id ? "rotate-180" : ""}`} />
+                </div>
+              </div>
+
+              {expandedId === order.id && (
+                <div className="mt-4 pt-4 border-t space-y-3">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                    <div>
+                      <p className="text-muted-foreground text-xs">Ordering Doctor</p>
+                      <p className="font-medium">{order.orderingDoctorName ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Technician</p>
+                      <p className="font-medium">{order.assignedTechnicianName ?? "Unassigned"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Fasting Required</p>
+                      <p className="font-medium">{order.fastingRequired ? "Yes" : "No"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Sample Collected</p>
+                      <p className="font-medium">{order.sampleCollectedAt ? new Date(order.sampleCollectedAt).toLocaleString() : "—"}</p>
+                    </div>
+                  </div>
+                  {order.clinicalNotes && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs">Clinical Notes</p>
+                      <p>{order.clinicalNotes}</p>
+                    </div>
+                  )}
+                  <div>
+                    <p className="text-muted-foreground text-xs mb-2">Tests</p>
+                    <div className="flex flex-wrap gap-2">
+                      {order.tests.map((t) => (
+                        <Badge key={t.id} variant="outline" className="text-xs">
+                          {t.testName}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <Filter className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No orders match your filters</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(lab)/layout.tsx
+++ b/src/app/(lab)/layout.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard, ClipboardList, FlaskConical, FileText,
+  History, Menu, X, TestTubes,
+} from "lucide-react";
+import { SignOutButton } from "@/components/sign-out-button";
+
+const navItems = [
+  { href: "/lab/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/lab/test-orders", label: "Test Orders", icon: ClipboardList },
+  { href: "/lab/results", label: "Results Entry", icon: FlaskConical },
+  { href: "/lab/reports", label: "Reports", icon: FileText },
+  { href: "/lab/patient-history", label: "Patient History", icon: History },
+];
+
+function SidebarContent({ pathname, onNavClick }: { pathname: string; onNavClick?: () => void }) {
+  return (
+    <>
+      <nav className="space-y-1 flex-1">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavClick}
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                isActive
+                  ? "bg-blue-600/10 text-blue-600 font-medium"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="pt-6 border-t mt-6">
+        <SignOutButton />
+      </div>
+    </>
+  );
+}
+
+export default function LabLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Mobile header bar */}
+      <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b bg-card px-4 py-3 md:hidden">
+        <button
+          onClick={() => setMobileOpen(true)}
+          className="rounded-md p-1.5 hover:bg-muted"
+          aria-label="Open menu"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+        <div className="flex items-center gap-2">
+          <TestTubes className="h-4 w-4 text-blue-600" />
+          <h2 className="text-sm font-semibold">Analysis Lab</h2>
+        </div>
+      </div>
+
+      {/* Mobile sidebar overlay */}
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setMobileOpen(false)}
+          />
+          <aside className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 flex flex-col shadow-xl">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <TestTubes className="h-5 w-5 text-blue-600" />
+                <h2 className="text-lg font-semibold">Analysis Lab</h2>
+              </div>
+              <button
+                onClick={() => setMobileOpen(false)}
+                className="rounded-md p-1 hover:bg-muted"
+                aria-label="Close menu"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <SidebarContent pathname={pathname} onNavClick={() => setMobileOpen(false)} />
+          </aside>
+        </div>
+      )}
+
+      {/* Desktop sidebar */}
+      <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="h-8 w-8 rounded-lg bg-blue-600 flex items-center justify-center">
+            <TestTubes className="h-4 w-4 text-white" />
+          </div>
+          <h2 className="text-lg font-semibold">Analysis Lab</h2>
+        </div>
+        <SidebarContent pathname={pathname} />
+      </aside>
+
+      <main className="flex-1 p-6 pt-16 md:pt-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(parapharmacy)/layout.tsx
+++ b/src/app/(parapharmacy)/layout.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard, ShoppingBag, Receipt, Package,
+  Menu, X, Sparkles,
+} from "lucide-react";
+import { SignOutButton } from "@/components/sign-out-button";
+
+const navItems = [
+  { href: "/parapharmacy/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/parapharmacy/catalog", label: "Product Catalog", icon: ShoppingBag },
+  { href: "/parapharmacy/sales", label: "Sales", icon: Receipt },
+  { href: "/parapharmacy/inventory", label: "Inventory", icon: Package },
+];
+
+function SidebarContent({ pathname, onNavClick }: { pathname: string; onNavClick?: () => void }) {
+  return (
+    <>
+      <nav className="space-y-1 flex-1">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavClick}
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                isActive
+                  ? "bg-pink-600/10 text-pink-600 font-medium"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="pt-6 border-t mt-6">
+        <SignOutButton />
+      </div>
+    </>
+  );
+}
+
+export default function ParapharmacyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen">
+      <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b bg-card px-4 py-3 md:hidden">
+        <button
+          onClick={() => setMobileOpen(true)}
+          className="rounded-md p-1.5 hover:bg-muted"
+          aria-label="Open menu"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-pink-600" />
+          <h2 className="text-sm font-semibold">Parapharmacy</h2>
+        </div>
+      </div>
+
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setMobileOpen(false)} />
+          <aside className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 flex flex-col shadow-xl">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-5 w-5 text-pink-600" />
+                <h2 className="text-lg font-semibold">Parapharmacy</h2>
+              </div>
+              <button onClick={() => setMobileOpen(false)} className="rounded-md p-1 hover:bg-muted" aria-label="Close menu">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <SidebarContent pathname={pathname} onNavClick={() => setMobileOpen(false)} />
+          </aside>
+        </div>
+      )}
+
+      <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="h-8 w-8 rounded-lg bg-pink-600 flex items-center justify-center">
+            <Sparkles className="h-4 w-4 text-white" />
+          </div>
+          <h2 className="text-lg font-semibold">Parapharmacy</h2>
+        </div>
+        <SidebarContent pathname={pathname} />
+      </aside>
+
+      <main className="flex-1 p-6 pt-16 md:pt-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, ShoppingBag, Filter } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchParapharmacyProducts, fetchParapharmacyCategories, getStockStatus } from "@/lib/data/client";
+import type { ProductView, ParapharmacyCategoryView } from "@/lib/data/client";
+
+export default function ParapharmacyCatalogPage() {
+  const [products, setProducts] = useState<ProductView[]>([]);
+  const [categories, setCategories] = useState<ParapharmacyCategoryView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("all");
+
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([
+      fetchParapharmacyProducts(cId),
+      fetchParapharmacyCategories(cId),
+    ])
+      .then(([p, c]) => {
+        setProducts(p);
+        setCategories(c);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading catalog...</div>
+      </div>
+    );
+  }
+
+  const filtered = products.filter((p) => {
+    if (!p.active) return false;
+    if (categoryFilter !== "all" && p.category !== categoryFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return p.name.toLowerCase().includes(q) || p.category.toLowerCase().includes(q) || (p.manufacturer?.toLowerCase().includes(q) ?? false);
+    }
+    return true;
+  });
+
+  const uniqueCategories = [...new Set(products.map((p) => p.category))];
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Product Catalog</h1>
+          <p className="text-muted-foreground text-sm">{products.filter((p) => p.active).length} active products</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search products..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          <Button variant={categoryFilter === "all" ? "default" : "outline"} size="sm" onClick={() => setCategoryFilter("all")}>
+            All
+          </Button>
+          {uniqueCategories.map((cat) => (
+            <Button key={cat} variant={categoryFilter === cat ? "default" : "outline"} size="sm" onClick={() => setCategoryFilter(cat)}>
+              {cat}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((product) => {
+          const stockStatus = getStockStatus(product);
+          return (
+            <Card key={product.id}>
+              <CardContent className="pt-4 pb-4">
+                <div className="flex items-start justify-between mb-3">
+                  <div>
+                    <p className="font-medium">{product.name}</p>
+                    {product.genericName && (
+                      <p className="text-xs text-muted-foreground">{product.genericName}</p>
+                    )}
+                  </div>
+                  <Badge variant="outline" className="text-xs">{product.category}</Badge>
+                </div>
+                {product.description && (
+                  <p className="text-xs text-muted-foreground mb-3 line-clamp-2">{product.description}</p>
+                )}
+                <div className="flex items-center justify-between">
+                  <p className="font-semibold">{product.price} <span className="text-xs font-normal text-muted-foreground">MAD</span></p>
+                  <div className="flex items-center gap-2">
+                    <Badge className={
+                      stockStatus === "out" ? "bg-red-100 text-red-700 border-0" :
+                      stockStatus === "low" ? "bg-orange-100 text-orange-700 border-0" :
+                      "bg-emerald-100 text-emerald-700 border-0"
+                    }>
+                      {stockStatus === "out" ? "Out of Stock" : stockStatus === "low" ? `Low: ${product.stockQuantity}` : `In Stock: ${product.stockQuantity}`}
+                    </Badge>
+                  </div>
+                </div>
+                {product.manufacturer && (
+                  <p className="text-xs text-muted-foreground mt-2">By {product.manufacturer}</p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12">
+          <ShoppingBag className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+          <p className="text-muted-foreground">No products match your search</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  ShoppingBag, AlertTriangle, Clock, Package,
+  ArrowRight, DollarSign,
+} from "lucide-react";
+import Link from "next/link";
+import { clinicConfig } from "@/config/clinic.config";
+import {
+  fetchParapharmacyProducts,
+  fetchParapharmacyCategories,
+  getLowStockProducts,
+  getOutOfStockProducts,
+} from "@/lib/data/client";
+import type { ProductView, ParapharmacyCategoryView } from "@/lib/data/client";
+
+export default function ParapharmacyDashboardPage() {
+  const [products, setProducts] = useState<ProductView[]>([]);
+  const [categories, setCategories] = useState<ParapharmacyCategoryView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cId = clinicConfig.clinicId;
+    Promise.all([
+      fetchParapharmacyProducts(cId),
+      fetchParapharmacyCategories(cId),
+    ])
+      .then(([p, c]) => {
+        setProducts(p);
+        setCategories(c);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
+      </div>
+    );
+  }
+
+  const activeProducts = products.filter((p) => p.active);
+  const lowStock = getLowStockProducts(products);
+  const outOfStock = getOutOfStockProducts(products);
+  const totalValue = products.reduce((sum, p) => sum + p.price * p.stockQuantity, 0);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Parapharmacy Dashboard</h1>
+          <p className="text-muted-foreground text-sm">Overview of your parapharmacy operations</p>
+        </div>
+        <Badge variant="outline" className="text-pink-600 border-pink-600">
+          <Clock className="h-3 w-3 mr-1" />
+          {new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" })}
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Active Products</p>
+                <p className="text-3xl font-bold">{activeProducts.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-pink-100 dark:bg-pink-900/30 text-pink-600 flex items-center justify-center">
+                <ShoppingBag className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/parapharmacy/catalog" className="text-sm text-pink-600 hover:underline mt-2 inline-flex items-center">
+              View Catalog <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Categories</p>
+                <p className="text-3xl font-bold text-pink-600">{categories.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-purple-100 dark:bg-purple-900/30 text-purple-600 flex items-center justify-center">
+                <Package className="h-6 w-6" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Low Stock Alerts</p>
+                <p className="text-3xl font-bold text-orange-500">{lowStock.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-orange-100 dark:bg-orange-900/30 text-orange-600 flex items-center justify-center">
+                <AlertTriangle className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/parapharmacy/inventory" className="text-sm text-pink-600 hover:underline mt-2 inline-flex items-center">
+              Manage Stock <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Inventory Value</p>
+                <p className="text-3xl font-bold">{totalValue.toLocaleString()} <span className="text-sm font-normal">MAD</span></p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 flex items-center justify-center">
+                <DollarSign className="h-6 w-6" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Categories */}
+        <Card>
+          <CardContent className="pt-6">
+            <h2 className="font-semibold text-lg mb-4">Product Categories</h2>
+            <div className="space-y-3">
+              {categories.map((cat) => (
+                <div key={cat.id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                  <div className="flex items-center gap-3">
+                    {cat.icon && <span className="text-lg">{cat.icon}</span>}
+                    <div>
+                      <p className="font-medium text-sm">{cat.name}</p>
+                      {cat.description && <p className="text-xs text-muted-foreground">{cat.description}</p>}
+                    </div>
+                  </div>
+                  <Badge variant="outline" className="text-xs">#{cat.sortOrder}</Badge>
+                </div>
+              ))}
+              {categories.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No categories configured</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Stock Alerts */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="font-semibold text-lg">Stock Alerts</h2>
+              <Link href="/parapharmacy/inventory" className="text-sm text-pink-600 hover:underline">View All</Link>
+            </div>
+            <div className="space-y-3">
+              {outOfStock.map((p) => (
+                <div key={p.id} className="flex items-center justify-between p-3 bg-red-50 dark:bg-red-950/10 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{p.name}</p>
+                    <p className="text-xs text-muted-foreground">{p.category}</p>
+                  </div>
+                  <Badge variant="destructive" className="text-xs">Out of Stock</Badge>
+                </div>
+              ))}
+              {lowStock.filter((p) => p.stockQuantity > 0).slice(0, 5).map((p) => (
+                <div key={p.id} className="flex items-center justify-between p-3 bg-orange-50 dark:bg-orange-950/10 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{p.name}</p>
+                    <p className="text-xs text-muted-foreground">Stock: {p.stockQuantity} / Min: {p.minimumStock}</p>
+                  </div>
+                  <Badge className="bg-orange-100 text-orange-700 border-0 text-xs">Low Stock</Badge>
+                </div>
+              ))}
+              {outOfStock.length === 0 && lowStock.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">All stock levels healthy</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search, Package, AlertTriangle } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchParapharmacyProducts, getStockStatus, getExpiryStatus } from "@/lib/data/client";
+import type { ProductView } from "@/lib/data/client";
+
+export default function ParapharmacyInventoryPage() {
+  const [products, setProducts] = useState<ProductView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [stockFilter, setStockFilter] = useState<string>("all");
+
+  useEffect(() => {
+    fetchParapharmacyProducts(clinicConfig.clinicId)
+      .then(setProducts)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading inventory...</div>
+      </div>
+    );
+  }
+
+  const filtered = products.filter((p) => {
+    if (stockFilter === "low" && getStockStatus(p) !== "low") return false;
+    if (stockFilter === "out" && getStockStatus(p) !== "out") return false;
+    if (stockFilter === "ok" && getStockStatus(p) !== "ok") return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return p.name.toLowerCase().includes(q) || p.category.toLowerCase().includes(q);
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Inventory</h1>
+          <p className="text-muted-foreground text-sm">Manage parapharmacy stock levels</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search products..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <div className="flex gap-2">
+          {["all", "ok", "low", "out"].map((f) => (
+            <Button key={f} variant={stockFilter === f ? "default" : "outline"} size="sm" onClick={() => setStockFilter(f)} className="capitalize">
+              {f === "all" ? "All" : f === "ok" ? "In Stock" : f === "low" ? "Low Stock" : "Out of Stock"}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left">
+              <th className="pb-3 font-medium">Product</th>
+              <th className="pb-3 font-medium">Category</th>
+              <th className="pb-3 font-medium text-right">Price</th>
+              <th className="pb-3 font-medium text-right">Stock</th>
+              <th className="pb-3 font-medium text-right">Min</th>
+              <th className="pb-3 font-medium">Expiry</th>
+              <th className="pb-3 font-medium">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((p) => {
+              const stockStatus = getStockStatus(p);
+              const expiryStatus = p.expiryDate ? getExpiryStatus(p.expiryDate) : "green";
+              return (
+                <tr key={p.id} className="border-b last:border-0 hover:bg-muted/50">
+                  <td className="py-3">
+                    <p className="font-medium">{p.name}</p>
+                    {p.manufacturer && <p className="text-xs text-muted-foreground">{p.manufacturer}</p>}
+                  </td>
+                  <td className="py-3 text-muted-foreground">{p.category}</td>
+                  <td className="py-3 text-right">{p.price} MAD</td>
+                  <td className="py-3 text-right font-medium">{p.stockQuantity}</td>
+                  <td className="py-3 text-right text-muted-foreground">{p.minimumStock}</td>
+                  <td className="py-3">
+                    {p.expiryDate ? (
+                      <Badge className={
+                        expiryStatus === "red" ? "bg-red-100 text-red-700 border-0" :
+                        expiryStatus === "yellow" ? "bg-yellow-100 text-yellow-700 border-0" :
+                        "bg-emerald-100 text-emerald-700 border-0"
+                      }>
+                        {p.expiryDate}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="py-3">
+                    <Badge className={
+                      stockStatus === "out" ? "bg-red-100 text-red-700 border-0" :
+                      stockStatus === "low" ? "bg-orange-100 text-orange-700 border-0" :
+                      "bg-emerald-100 text-emerald-700 border-0"
+                    }>
+                      {stockStatus === "out" && <AlertTriangle className="h-3 w-3 mr-1" />}
+                      {stockStatus === "out" ? "Out" : stockStatus === "low" ? "Low" : "OK"}
+                    </Badge>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12">
+          <Package className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+          <p className="text-muted-foreground">No products match your filters</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, Receipt, DollarSign } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchDailySales } from "@/lib/data/client";
+import type { DailySaleView } from "@/lib/data/client";
+
+export default function ParapharmacySalesPage() {
+  const [sales, setSales] = useState<DailySaleView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetchDailySales(clinicConfig.clinicId)
+      .then(setSales)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading sales...</div>
+      </div>
+    );
+  }
+
+  const filtered = sales.filter((s) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return s.patientName.toLowerCase().includes(q) || s.items.some((i) => i.productName.toLowerCase().includes(q));
+  });
+
+  const today = new Date().toISOString().split("T")[0];
+  const todaySales = filtered.filter((s) => s.date === today);
+  const todayRevenue = todaySales.reduce((sum, s) => sum + s.total, 0);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Sales</h1>
+          <p className="text-muted-foreground text-sm">Parapharmacy sales records</p>
+        </div>
+        <Card className="p-3">
+          <div className="flex items-center gap-2">
+            <DollarSign className="h-4 w-4 text-emerald-600" />
+            <div>
+              <p className="text-xs text-muted-foreground">Today&apos;s Revenue</p>
+              <p className="font-semibold">{todayRevenue.toLocaleString()} MAD</p>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <div className="relative mb-6 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input placeholder="Search sales..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((sale) => (
+          <Card key={sale.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-pink-100 dark:bg-pink-900/30 flex items-center justify-center">
+                    <Receipt className="h-5 w-5 text-pink-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{sale.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {sale.date} {sale.time} &middot; {sale.items.length} item{sale.items.length !== 1 ? "s" : ""}
+                    </p>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <p className="font-semibold">{sale.total} MAD</p>
+                  <Badge variant="outline" className="text-xs capitalize">{sale.paymentMethod}</Badge>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {sale.items.map((item, i) => (
+                  <Badge key={i} variant="outline" className="text-xs">
+                    {item.productName} x{item.quantity}
+                  </Badge>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <Receipt className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No sales found</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(radiology)/layout.tsx
+++ b/src/app/(radiology)/layout.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard, ClipboardList, Image, Eye, FileText,
+  FileStack, Menu, X, Scan,
+} from "lucide-react";
+import { SignOutButton } from "@/components/sign-out-button";
+
+const navItems = [
+  { href: "/radiology/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/radiology/orders", label: "Study Orders", icon: ClipboardList },
+  { href: "/radiology/images", label: "Image Gallery", icon: Image },
+  { href: "/radiology/viewer", label: "DICOM Viewer", icon: Eye },
+  { href: "/radiology/reports", label: "Reports", icon: FileText },
+  { href: "/radiology/templates", label: "Report Templates", icon: FileStack },
+];
+
+function SidebarContent({ pathname, onNavClick }: { pathname: string; onNavClick?: () => void }) {
+  return (
+    <>
+      <nav className="space-y-1 flex-1">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavClick}
+              className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                isActive
+                  ? "bg-indigo-600/10 text-indigo-600 font-medium"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              <item.icon className="h-4 w-4" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+      <div className="pt-6 border-t mt-6">
+        <SignOutButton />
+      </div>
+    </>
+  );
+}
+
+export default function RadiologyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-screen">
+      <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b bg-card px-4 py-3 md:hidden">
+        <button
+          onClick={() => setMobileOpen(true)}
+          className="rounded-md p-1.5 hover:bg-muted"
+          aria-label="Open menu"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+        <div className="flex items-center gap-2">
+          <Scan className="h-4 w-4 text-indigo-600" />
+          <h2 className="text-sm font-semibold">Radiology Center</h2>
+        </div>
+      </div>
+
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setMobileOpen(false)} />
+          <aside className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 flex flex-col shadow-xl">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <Scan className="h-5 w-5 text-indigo-600" />
+                <h2 className="text-lg font-semibold">Radiology</h2>
+              </div>
+              <button onClick={() => setMobileOpen(false)} className="rounded-md p-1 hover:bg-muted" aria-label="Close menu">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <SidebarContent pathname={pathname} onNavClick={() => setMobileOpen(false)} />
+          </aside>
+        </div>
+      )}
+
+      <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="h-8 w-8 rounded-lg bg-indigo-600 flex items-center justify-center">
+            <Scan className="h-4 w-4 text-white" />
+          </div>
+          <h2 className="text-lg font-semibold">Radiology</h2>
+        </div>
+        <SidebarContent pathname={pathname} />
+      </aside>
+
+      <main className="flex-1 p-6 pt-16 md:pt-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(radiology)/radiology/dashboard/page.tsx
+++ b/src/app/(radiology)/radiology/dashboard/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  ClipboardList, Clock, Image, FileText,
+  ArrowRight, CheckCircle, Hourglass, AlertTriangle,
+} from "lucide-react";
+import Link from "next/link";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchRadiologyOrders } from "@/lib/data/client";
+import type { RadiologyOrderView } from "@/lib/data/client";
+
+export default function RadiologyDashboardPage() {
+  const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId)
+      .then(setOrders)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
+      </div>
+    );
+  }
+
+  const pending = orders.filter((o) => o.status === "pending" || o.status === "scheduled");
+  const inProgress = orders.filter((o) => o.status === "in_progress" || o.status === "images_ready");
+  const reported = orders.filter((o) => o.status === "reported" || o.status === "validated");
+  const urgent = orders.filter((o) => o.priority === "urgent" || o.priority === "stat");
+
+  const modalityCounts: Record<string, number> = {};
+  for (const o of orders) {
+    modalityCounts[o.modality] = (modalityCounts[o.modality] || 0) + 1;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Radiology Dashboard</h1>
+          <p className="text-muted-foreground text-sm">Overview of imaging operations</p>
+        </div>
+        <Badge variant="outline" className="text-indigo-600 border-indigo-600">
+          <Clock className="h-3 w-3 mr-1" />
+          {new Date().toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" })}
+        </Badge>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Pending Studies</p>
+                <p className="text-3xl font-bold">{pending.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-yellow-100 dark:bg-yellow-900/30 text-yellow-600 flex items-center justify-center">
+                <ClipboardList className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/radiology/orders" className="text-sm text-indigo-600 hover:underline mt-2 inline-flex items-center">
+              View Orders <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">In Progress</p>
+                <p className="text-3xl font-bold text-indigo-600">{inProgress.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 flex items-center justify-center">
+                <Hourglass className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/radiology/images" className="text-sm text-indigo-600 hover:underline mt-2 inline-flex items-center">
+              Image Gallery <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Reported</p>
+                <p className="text-3xl font-bold text-emerald-600">{reported.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 flex items-center justify-center">
+                <CheckCircle className="h-6 w-6" />
+              </div>
+            </div>
+            <Link href="/radiology/reports" className="text-sm text-indigo-600 hover:underline mt-2 inline-flex items-center">
+              View Reports <ArrowRight className="h-3 w-3 ml-1" />
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Urgent / STAT</p>
+                <p className="text-3xl font-bold text-red-500">{urgent.length}</p>
+              </div>
+              <div className="h-12 w-12 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-600 flex items-center justify-center">
+                <AlertTriangle className="h-6 w-6" />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Modality Breakdown */}
+        <Card>
+          <CardContent className="pt-6">
+            <h2 className="font-semibold text-lg mb-4">Studies by Modality</h2>
+            <div className="space-y-3">
+              {Object.entries(modalityCounts).sort((a, b) => b[1] - a[1]).map(([modality, count]) => (
+                <div key={modality} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                  <div className="flex items-center gap-3">
+                    <Image className="h-4 w-4 text-indigo-600" />
+                    <span className="font-medium text-sm uppercase">{modality}</span>
+                  </div>
+                  <Badge variant="outline">{count}</Badge>
+                </div>
+              ))}
+              {Object.keys(modalityCounts).length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No studies yet</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Recent Orders */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="font-semibold text-lg">Recent Orders</h2>
+              <Link href="/radiology/orders" className="text-sm text-indigo-600 hover:underline">View All</Link>
+            </div>
+            <div className="space-y-3">
+              {orders.slice(0, 5).map((order) => (
+                <div key={order.id} className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+                  <div>
+                    <p className="font-medium text-sm">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.modality.toUpperCase()} &middot; {order.bodyPart ?? "N/A"} &middot; {new Date(order.createdAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge className={
+                    order.status === "pending" ? "bg-yellow-100 text-yellow-700 border-0" :
+                    order.status === "in_progress" ? "bg-blue-100 text-blue-700 border-0" :
+                    order.status === "reported" ? "bg-emerald-100 text-emerald-700 border-0" :
+                    "bg-gray-100 text-gray-700 border-0"
+                  }>
+                    {order.status.replace("_", " ")}
+                  </Badge>
+                </div>
+              ))}
+              {orders.length === 0 && (
+                <p className="text-sm text-muted-foreground text-center py-4">No orders yet</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(radiology)/radiology/images/page.tsx
+++ b/src/app/(radiology)/radiology/images/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, Image, ExternalLink, Eye, FileImage } from "lucide-react";
+import Link from "next/link";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchRadiologyOrders } from "@/lib/data/client";
+import type { RadiologyOrderView } from "@/lib/data/client";
+
+export default function RadiologyImagesPage() {
+  const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId)
+      .then((all) => setOrders(all.filter((o) => o.imageCount > 0)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading images...</div>
+      </div>
+    );
+  }
+
+  const filtered = orders.filter((o) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return o.patientName.toLowerCase().includes(q) || o.modality.toLowerCase().includes(q) || (o.bodyPart?.toLowerCase().includes(q) ?? false);
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Image Gallery</h1>
+          <p className="text-muted-foreground text-sm">Browse uploaded radiology images</p>
+        </div>
+      </div>
+
+      <div className="relative mb-6 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input placeholder="Search by patient, modality, body part..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((order) => (
+          <Card key={order.id} className="overflow-hidden">
+            <div className="aspect-video bg-muted flex items-center justify-center">
+              {order.images.length > 0 && order.images[0].thumbnailUrl ? (
+                <img src={order.images[0].thumbnailUrl} alt={`${order.modality} - ${order.bodyPart}`} className="w-full h-full object-cover" />
+              ) : (
+                <FileImage className="h-16 w-16 text-muted-foreground/30" />
+              )}
+            </div>
+            <CardContent className="pt-4">
+              <div className="flex items-center justify-between mb-2">
+                <p className="font-medium text-sm">{order.patientName}</p>
+                <Badge variant="outline" className="text-xs uppercase">{order.modality}</Badge>
+              </div>
+              <p className="text-xs text-muted-foreground mb-3">
+                {order.bodyPart ?? "N/A"} &middot; {order.imageCount} image{order.imageCount !== 1 ? "s" : ""} &middot; {new Date(order.createdAt).toLocaleDateString()}
+              </p>
+              <div className="flex gap-2">
+                {order.images.length > 0 && order.images[0].fileUrl && (
+                  <a
+                    href={order.images[0].fileUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted transition-colors"
+                  >
+                    <Eye className="h-3 w-3 mr-1" /> View
+                  </a>
+                )}
+                {order.images.some((img) => img.dicomStudyUid) && (
+                  <Link
+                    href={`/radiology/viewer?study=${order.images[0].dicomStudyUid ?? ""}`}
+                    className="inline-flex items-center rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted transition-colors"
+                  >
+                    <ExternalLink className="h-3 w-3 mr-1" /> DICOM
+                  </Link>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12">
+          <Image className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+          <p className="text-muted-foreground">No images found</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(radiology)/radiology/orders/page.tsx
+++ b/src/app/(radiology)/radiology/orders/page.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Search, Filter, AlertTriangle, Clock, CheckCircle,
+  Scan, ChevronDown, Image,
+} from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchRadiologyOrders } from "@/lib/data/client";
+import type { RadiologyOrderView } from "@/lib/data/client";
+
+const statusOptions = ["all", "pending", "scheduled", "in_progress", "images_ready", "reported", "validated", "cancelled"] as const;
+
+export default function RadiologyOrdersPage() {
+  const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId)
+      .then(setOrders)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading orders...</div>
+      </div>
+    );
+  }
+
+  const filtered = orders.filter((o) => {
+    if (statusFilter !== "all" && o.status !== statusFilter) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      return o.patientName.toLowerCase().includes(q) || o.orderNumber.toLowerCase().includes(q);
+    }
+    return true;
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Study Orders</h1>
+          <p className="text-muted-foreground text-sm">{orders.length} total orders</p>
+        </div>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input placeholder="Search by patient, order number..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+        </div>
+        <div className="flex gap-2 flex-wrap">
+          {statusOptions.map((s) => (
+            <Button key={s} variant={statusFilter === s ? "default" : "outline"} size="sm" onClick={() => setStatusFilter(s)} className="capitalize">
+              {s === "all" ? "All" : s.replace("_", " ")}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((order) => (
+          <Card key={order.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between cursor-pointer" onClick={() => setExpandedId(expandedId === order.id ? null : order.id)}>
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center">
+                    <Scan className="h-5 w-5 text-indigo-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.orderNumber} &middot; {order.modality.toUpperCase()} &middot; {order.bodyPart ?? "N/A"}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-3">
+                  {(order.priority === "urgent" || order.priority === "stat") && (
+                    <Badge variant="destructive" className="text-xs uppercase">{order.priority}</Badge>
+                  )}
+                  <Badge className={
+                    order.status === "pending" ? "bg-yellow-100 text-yellow-700 border-0" :
+                    order.status === "scheduled" ? "bg-cyan-100 text-cyan-700 border-0" :
+                    order.status === "in_progress" ? "bg-blue-100 text-blue-700 border-0" :
+                    order.status === "images_ready" ? "bg-purple-100 text-purple-700 border-0" :
+                    order.status === "reported" ? "bg-emerald-100 text-emerald-700 border-0" :
+                    order.status === "validated" ? "bg-green-100 text-green-700 border-0" :
+                    "bg-gray-100 text-gray-700 border-0"
+                  }>
+                    {order.status.replace("_", " ")}
+                  </Badge>
+                  <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform ${expandedId === order.id ? "rotate-180" : ""}`} />
+                </div>
+              </div>
+
+              {expandedId === order.id && (
+                <div className="mt-4 pt-4 border-t space-y-3">
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                    <div>
+                      <p className="text-muted-foreground text-xs">Ordering Doctor</p>
+                      <p className="font-medium">{order.orderingDoctorName ?? "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Radiologist</p>
+                      <p className="font-medium">{order.radiologistName ?? "Unassigned"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Scheduled</p>
+                      <p className="font-medium">{order.scheduledAt ? new Date(order.scheduledAt).toLocaleString() : "—"}</p>
+                    </div>
+                    <div>
+                      <p className="text-muted-foreground text-xs">Images</p>
+                      <p className="font-medium">{order.imageCount} image{order.imageCount !== 1 ? "s" : ""}</p>
+                    </div>
+                  </div>
+                  {order.clinicalIndication && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs">Clinical Indication</p>
+                      <p>{order.clinicalIndication}</p>
+                    </div>
+                  )}
+                  {order.findings && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs">Findings</p>
+                      <p>{order.findings}</p>
+                    </div>
+                  )}
+                  {order.impression && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs">Impression</p>
+                      <p className="font-medium">{order.impression}</p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <Filter className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No orders match your filters</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(radiology)/radiology/reports/page.tsx
+++ b/src/app/(radiology)/radiology/reports/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, FileText, Download, Scan } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchRadiologyOrders } from "@/lib/data/client";
+import type { RadiologyOrderView } from "@/lib/data/client";
+
+export default function RadiologyReportsPage() {
+  const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId)
+      .then((all) => setOrders(all.filter((o) => o.status === "reported" || o.status === "validated")))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading reports...</div>
+      </div>
+    );
+  }
+
+  const filtered = orders.filter((o) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return o.patientName.toLowerCase().includes(q) || o.orderNumber.toLowerCase().includes(q) || o.modality.toLowerCase().includes(q);
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Radiology Reports</h1>
+          <p className="text-muted-foreground text-sm">Completed radiology reports</p>
+        </div>
+      </div>
+
+      <div className="relative mb-6 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input placeholder="Search by patient, order, modality..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+      </div>
+
+      <div className="space-y-3">
+        {filtered.map((order) => (
+          <Card key={order.id}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between cursor-pointer" onClick={() => setExpandedId(expandedId === order.id ? null : order.id)}>
+                <div className="flex items-center gap-4">
+                  <div className="h-10 w-10 rounded-full bg-emerald-100 dark:bg-emerald-900/30 flex items-center justify-center">
+                    <FileText className="h-5 w-5 text-emerald-600" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{order.patientName}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {order.modality.toUpperCase()} &middot; {order.bodyPart ?? "N/A"} &middot; {order.reportedAt ? new Date(order.reportedAt).toLocaleDateString() : ""}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge className={order.status === "validated" ? "bg-green-100 text-green-700 border-0" : "bg-emerald-100 text-emerald-700 border-0"}>
+                    {order.status}
+                  </Badge>
+                  {order.pdfUrl && (
+                    <a
+                      href={order.pdfUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted transition-colors"
+                    >
+                      <Download className="h-3 w-3 mr-1" /> PDF
+                    </a>
+                  )}
+                </div>
+              </div>
+
+              {expandedId === order.id && (
+                <div className="mt-4 pt-4 border-t space-y-3">
+                  {order.findings && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs font-medium mb-1">Findings</p>
+                      <p className="whitespace-pre-wrap">{order.findings}</p>
+                    </div>
+                  )}
+                  {order.impression && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs font-medium mb-1">Impression</p>
+                      <p className="font-medium whitespace-pre-wrap">{order.impression}</p>
+                    </div>
+                  )}
+                  {order.reportText && (
+                    <div className="text-sm">
+                      <p className="text-muted-foreground text-xs font-medium mb-1">Full Report</p>
+                      <p className="whitespace-pre-wrap">{order.reportText}</p>
+                    </div>
+                  )}
+                  <div className="text-sm text-muted-foreground">
+                    <p>Radiologist: {order.radiologistName ?? "—"} &middot; Reported: {order.reportedAt ? new Date(order.reportedAt).toLocaleString() : "—"}</p>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="text-center py-12">
+            <Scan className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No reports found</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(radiology)/radiology/templates/page.tsx
+++ b/src/app/(radiology)/radiology/templates/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Search, FileStack, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchRadiologyTemplates } from "@/lib/data/client";
+import type { RadiologyTemplateView } from "@/lib/data/client";
+
+export default function RadiologyTemplatesPage() {
+  const [templates, setTemplates] = useState<RadiologyTemplateView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchRadiologyTemplates(clinicConfig.clinicId)
+      .then(setTemplates)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <div className="animate-pulse text-muted-foreground">Loading templates...</div>
+      </div>
+    );
+  }
+
+  const filtered = templates.filter((t) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return t.name.toLowerCase().includes(q) || (t.modality?.toLowerCase().includes(q) ?? false) || (t.bodyPart?.toLowerCase().includes(q) ?? false);
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Report Templates</h1>
+          <p className="text-muted-foreground text-sm">Reusable radiology report templates</p>
+        </div>
+      </div>
+
+      <div className="relative mb-6 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input placeholder="Search templates..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {filtered.map((template) => (
+          <Card key={template.id} className="cursor-pointer hover:shadow-md transition-shadow" onClick={() => setExpandedId(expandedId === template.id ? null : template.id)}>
+            <CardContent className="pt-4 pb-4">
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-3">
+                  <FileStack className="h-5 w-5 text-indigo-600" />
+                  <p className="font-medium">{template.name}</p>
+                </div>
+                <Badge variant="outline" className="text-xs uppercase">{template.modality}</Badge>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {template.bodyPart ?? "General"} &middot; {template.language}
+              </p>
+
+              {expandedId === template.id && (
+                <div className="mt-4 pt-4 border-t space-y-3">
+                  {template.sections.map((section, i) => (
+                    <div key={i} className="text-sm">
+                      <p className="font-medium text-xs text-muted-foreground uppercase mb-1">{section.title}</p>
+                      <p className="text-sm whitespace-pre-wrap bg-muted/50 rounded p-2">{section.defaultContent}</p>
+                    </div>
+                  ))}
+                  <Button variant="outline" size="sm" onClick={(e) => {
+                    e.stopPropagation();
+                    const text = template.sections.map((s) => `${s.title}:\n${s.defaultContent}`).join("\n\n");
+                    navigator.clipboard.writeText(text);
+                  }}>
+                    <Copy className="h-3 w-3 mr-1" /> Copy Template
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12">
+          <FileStack className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+          <p className="text-muted-foreground">No templates found</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(radiology)/radiology/viewer/page.tsx
+++ b/src/app/(radiology)/radiology/viewer/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { ExternalLink, Monitor, Info } from "lucide-react";
+
+export default function DicomViewerPage() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">DICOM Viewer</h1>
+        <p className="text-muted-foreground text-sm">View medical images in DICOM format</p>
+      </div>
+
+      <Card>
+        <CardContent className="pt-6">
+          <div className="text-center py-12 space-y-4">
+            <Monitor className="h-16 w-16 text-indigo-600 mx-auto" />
+            <h2 className="text-xl font-semibold">DICOM Viewer Integration</h2>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              Connect to an external DICOM viewer such as OHIF Viewer or Cornerstone.js
+              to view medical images with full diagnostic tools.
+            </p>
+
+            <div className="flex items-center justify-center gap-3 pt-4">
+              <a
+                href="https://viewer.ohif.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+              >
+                <ExternalLink className="h-4 w-4 mr-2" />
+                Open OHIF Viewer
+              </a>
+            </div>
+
+            <div className="mt-8 p-4 bg-muted/50 rounded-lg text-left max-w-lg mx-auto">
+              <div className="flex items-start gap-3">
+                <Info className="h-5 w-5 text-blue-600 mt-0.5" />
+                <div>
+                  <h3 className="font-medium text-sm mb-1">Integration Notes</h3>
+                  <ul className="text-xs text-muted-foreground space-y-1">
+                    <li>&bull; Upload DICOM files via the Image Gallery</li>
+                    <li>&bull; DICOM Study UIDs are stored with each image</li>
+                    <li>&bull; Configure your PACS/DICOMweb endpoint in clinic settings</li>
+                    <li>&bull; Supported viewers: OHIF, Cornerstone.js, Horos</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -2785,3 +2785,774 @@ export async function fetchClinicSubscription(clinicId: string): Promise<ClinicS
     } : null,
   };
 }
+
+// ─────────────────────────────────────────────
+// Analysis Lab — Test Catalog
+// ─────────────────────────────────────────────
+
+export interface LabTestCatalogView {
+  id: string;
+  name: string;
+  nameAr?: string;
+  code?: string;
+  category: string;
+  sampleType: string;
+  description?: string;
+  price: number;
+  currency: string;
+  turnaroundHours: number;
+  referenceRanges: { parameter: string; unit: string; min: number | null; max: number | null }[];
+  isActive: boolean;
+  sortOrder: number;
+}
+
+interface LabTestCatalogRaw {
+  id: string;
+  clinic_id: string;
+  name: string;
+  name_ar: string | null;
+  code: string | null;
+  category: string;
+  sample_type: string;
+  description: string | null;
+  price: number | null;
+  currency: string;
+  turnaround_hours: number;
+  reference_ranges: { parameter: string; unit: string; min: number | null; max: number | null }[] | null;
+  is_active: boolean;
+  sort_order: number;
+  created_at: string;
+}
+
+function mapLabTestCatalog(raw: LabTestCatalogRaw): LabTestCatalogView {
+  return {
+    id: raw.id,
+    name: raw.name,
+    nameAr: raw.name_ar ?? undefined,
+    code: raw.code ?? undefined,
+    category: raw.category,
+    sampleType: raw.sample_type ?? "blood",
+    description: raw.description ?? undefined,
+    price: raw.price ?? 0,
+    currency: raw.currency ?? "MAD",
+    turnaroundHours: raw.turnaround_hours ?? 24,
+    referenceRanges: raw.reference_ranges ?? [],
+    isActive: raw.is_active ?? true,
+    sortOrder: raw.sort_order ?? 0,
+  };
+}
+
+export async function fetchLabTestCatalog(clinicId: string): Promise<LabTestCatalogView[]> {
+  const rows = await fetchRows<LabTestCatalogRaw>("lab_test_catalog", {
+    eq: [["clinic_id", clinicId]],
+    order: ["sort_order", { ascending: true }],
+  });
+  return rows.map(mapLabTestCatalog);
+}
+
+// ─────────────────────────────────────────────
+// Analysis Lab — Test Orders
+// ─────────────────────────────────────────────
+
+export interface LabTestOrderView {
+  id: string;
+  patientId: string;
+  patientName: string;
+  orderingDoctorName?: string;
+  assignedTechnicianName?: string;
+  orderNumber: string;
+  status: string;
+  priority: string;
+  clinicalNotes?: string;
+  fastingRequired: boolean;
+  sampleCollectedAt?: string;
+  completedAt?: string;
+  validatedAt?: string;
+  pdfUrl?: string;
+  tests: { id: string; testId: string; testName: string; status: string }[];
+  testCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface LabTestOrderRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  ordering_doctor_id: string | null;
+  assigned_technician_id: string | null;
+  order_number: string;
+  status: string;
+  priority: string;
+  clinical_notes: string | null;
+  fasting_required: boolean;
+  sample_collected_at: string | null;
+  completed_at: string | null;
+  validated_at: string | null;
+  validated_by: string | null;
+  pdf_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LabTestItemRaw {
+  id: string;
+  order_id: string;
+  test_id: string;
+  test_name: string;
+  status: string;
+}
+
+export async function fetchLabTestOrders(clinicId: string): Promise<LabTestOrderView[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<LabTestOrderRaw>("lab_test_orders", {
+    eq: [["clinic_id", clinicId]],
+    order: ["created_at", { ascending: false }],
+  });
+  const orderIds = rows.map((r) => r.id);
+  let items: LabTestItemRaw[] = [];
+  if (orderIds.length > 0) {
+    items = await fetchRows<LabTestItemRaw>("lab_test_items", {
+      inFilter: ["order_id", orderIds],
+    });
+  }
+  const itemsByOrder = new Map<string, LabTestItemRaw[]>();
+  for (const item of items) {
+    const arr = itemsByOrder.get(item.order_id) ?? [];
+    arr.push(item);
+    itemsByOrder.set(item.order_id, arr);
+  }
+  return rows.map((r) => ({
+    id: r.id,
+    patientId: r.patient_id,
+    patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
+    orderingDoctorName: r.ordering_doctor_id ? (_userMap?.get(r.ordering_doctor_id)?.name ?? undefined) : undefined,
+    assignedTechnicianName: r.assigned_technician_id ? (_userMap?.get(r.assigned_technician_id)?.name ?? undefined) : undefined,
+    orderNumber: r.order_number,
+    status: r.status,
+    priority: r.priority,
+    clinicalNotes: r.clinical_notes ?? undefined,
+    fastingRequired: r.fasting_required ?? false,
+    sampleCollectedAt: r.sample_collected_at ?? undefined,
+    completedAt: r.completed_at ?? undefined,
+    validatedAt: r.validated_at ?? undefined,
+    pdfUrl: r.pdf_url ?? undefined,
+    tests: (itemsByOrder.get(r.id) ?? []).map((ti) => ({
+      id: ti.id,
+      testId: ti.test_id,
+      testName: ti.test_name,
+      status: ti.status,
+    })),
+    testCount: (itemsByOrder.get(r.id) ?? []).length,
+    createdAt: r.created_at?.split("T")[0] ?? "",
+    updatedAt: r.updated_at?.split("T")[0] ?? "",
+  }));
+}
+
+export async function fetchPatientLabOrders(clinicId: string, patientId: string): Promise<LabTestOrderView[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<LabTestOrderRaw>("lab_test_orders", {
+    eq: [["clinic_id", clinicId], ["patient_id", patientId]],
+    order: ["created_at", { ascending: false }],
+  });
+  const orderIds = rows.map((r) => r.id);
+  let items: LabTestItemRaw[] = [];
+  if (orderIds.length > 0) {
+    items = await fetchRows<LabTestItemRaw>("lab_test_items", {
+      inFilter: ["order_id", orderIds],
+    });
+  }
+  const itemsByOrder = new Map<string, LabTestItemRaw[]>();
+  for (const item of items) {
+    const arr = itemsByOrder.get(item.order_id) ?? [];
+    arr.push(item);
+    itemsByOrder.set(item.order_id, arr);
+  }
+  return rows.map((r) => ({
+    id: r.id,
+    patientId: r.patient_id,
+    patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
+    orderingDoctorName: r.ordering_doctor_id ? (_userMap?.get(r.ordering_doctor_id)?.name ?? undefined) : undefined,
+    assignedTechnicianName: r.assigned_technician_id ? (_userMap?.get(r.assigned_technician_id)?.name ?? undefined) : undefined,
+    orderNumber: r.order_number,
+    status: r.status,
+    priority: r.priority,
+    clinicalNotes: r.clinical_notes ?? undefined,
+    fastingRequired: r.fasting_required ?? false,
+    sampleCollectedAt: r.sample_collected_at ?? undefined,
+    completedAt: r.completed_at ?? undefined,
+    validatedAt: r.validated_at ?? undefined,
+    pdfUrl: r.pdf_url ?? undefined,
+    tests: (itemsByOrder.get(r.id) ?? []).map((ti) => ({
+      id: ti.id,
+      testId: ti.test_id,
+      testName: ti.test_name,
+      status: ti.status,
+    })),
+    testCount: (itemsByOrder.get(r.id) ?? []).length,
+    createdAt: r.created_at?.split("T")[0] ?? "",
+    updatedAt: r.updated_at?.split("T")[0] ?? "",
+  }));
+}
+
+// ─────────────────────────────────────────────
+// Analysis Lab — Test Results
+// ─────────────────────────────────────────────
+
+export interface LabTestResultView {
+  id: string;
+  orderId: string;
+  testItemId: string;
+  testName: string;
+  parameterName: string;
+  value: string;
+  unit: string;
+  referenceMin: number | null;
+  referenceMax: number | null;
+  flag: string | null;
+  notes?: string;
+  enteredBy?: string;
+  enteredAt: string;
+}
+
+interface LabTestResultRaw {
+  id: string;
+  order_id: string;
+  test_item_id: string;
+  parameter_name: string;
+  value: string | null;
+  unit: string | null;
+  reference_min: number | null;
+  reference_max: number | null;
+  flag: string | null;
+  notes: string | null;
+  entered_by: string | null;
+  entered_at: string;
+}
+
+export async function fetchLabTestResults(orderId: string): Promise<LabTestResultView[]> {
+  const rows = await fetchRows<LabTestResultRaw>("lab_test_results", {
+    eq: [["order_id", orderId]],
+    order: ["entered_at", { ascending: true }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    orderId: r.order_id,
+    testItemId: r.test_item_id,
+    testName: r.parameter_name,
+    parameterName: r.parameter_name,
+    value: r.value ?? "",
+    unit: r.unit ?? "",
+    referenceMin: r.reference_min,
+    referenceMax: r.reference_max,
+    flag: r.flag,
+    notes: r.notes ?? undefined,
+    enteredBy: r.entered_by ?? undefined,
+    enteredAt: r.entered_at?.split("T")[0] ?? "",
+  }));
+}
+
+// ─────────────────────────────────────────────
+// Radiology — Orders
+// ─────────────────────────────────────────────
+
+export interface RadiologyOrderView {
+  id: string;
+  patientId: string;
+  patientName: string;
+  orderingDoctorName?: string;
+  radiologistName?: string;
+  orderNumber: string;
+  modality: string;
+  bodyPart?: string;
+  clinicalIndication?: string;
+  status: string;
+  priority: string;
+  scheduledAt?: string;
+  performedAt?: string;
+  reportedAt?: string;
+  reportText?: string;
+  findings?: string;
+  impression?: string;
+  pdfUrl?: string;
+  images: RadiologyImageView[];
+  imageCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RadiologyImageView {
+  id: string;
+  orderId: string;
+  fileUrl: string;
+  fileName?: string;
+  fileSize?: number;
+  contentType?: string;
+  modality?: string;
+  isDicom: boolean;
+  dicomStudyUid?: string;
+  thumbnailUrl?: string;
+  description?: string;
+  uploadedAt: string;
+}
+
+interface RadiologyOrderRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  ordering_doctor_id: string | null;
+  radiologist_id: string | null;
+  order_number: string;
+  modality: string;
+  body_part: string | null;
+  clinical_indication: string | null;
+  status: string;
+  priority: string;
+  scheduled_at: string | null;
+  performed_at: string | null;
+  reported_at: string | null;
+  report_text: string | null;
+  findings: string | null;
+  impression: string | null;
+  pdf_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RadiologyImageRaw {
+  id: string;
+  order_id: string;
+  clinic_id: string;
+  file_url: string;
+  file_name: string | null;
+  file_size: number | null;
+  content_type: string | null;
+  modality: string | null;
+  is_dicom: boolean;
+  dicom_metadata: { study_uid?: string } | null;
+  thumbnail_url: string | null;
+  description: string | null;
+  uploaded_at: string;
+}
+
+export async function fetchRadiologyOrders(clinicId: string): Promise<RadiologyOrderView[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<RadiologyOrderRaw>("radiology_orders", {
+    eq: [["clinic_id", clinicId]],
+    order: ["created_at", { ascending: false }],
+  });
+  const orderIds = rows.map((r) => r.id);
+  let images: RadiologyImageRaw[] = [];
+  if (orderIds.length > 0) {
+    images = await fetchRows<RadiologyImageRaw>("radiology_images", {
+      eq: [["clinic_id", clinicId]],
+      inFilter: ["order_id", orderIds],
+    });
+  }
+  const imagesByOrder = new Map<string, RadiologyImageRaw[]>();
+  for (const img of images) {
+    const arr = imagesByOrder.get(img.order_id) ?? [];
+    arr.push(img);
+    imagesByOrder.set(img.order_id, arr);
+  }
+  return rows.map((r) => ({
+    id: r.id,
+    patientId: r.patient_id,
+    patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
+    orderingDoctorName: r.ordering_doctor_id ? (_userMap?.get(r.ordering_doctor_id)?.name ?? undefined) : undefined,
+    radiologistName: r.radiologist_id ? (_userMap?.get(r.radiologist_id)?.name ?? undefined) : undefined,
+    orderNumber: r.order_number,
+    modality: r.modality,
+    bodyPart: r.body_part ?? undefined,
+    clinicalIndication: r.clinical_indication ?? undefined,
+    status: r.status,
+    priority: r.priority ?? "normal",
+    scheduledAt: r.scheduled_at ?? undefined,
+    performedAt: r.performed_at ?? undefined,
+    reportedAt: r.reported_at ?? undefined,
+    reportText: r.report_text ?? undefined,
+    findings: r.findings ?? undefined,
+    impression: r.impression ?? undefined,
+    pdfUrl: r.pdf_url ?? undefined,
+    images: (imagesByOrder.get(r.id) ?? []).map((img) => ({
+      id: img.id,
+      orderId: img.order_id,
+      fileUrl: img.file_url,
+      fileName: img.file_name ?? undefined,
+      fileSize: img.file_size ?? undefined,
+      contentType: img.content_type ?? undefined,
+      modality: img.modality ?? undefined,
+      isDicom: img.is_dicom ?? false,
+      dicomStudyUid: img.dicom_metadata?.study_uid ?? undefined,
+      thumbnailUrl: img.thumbnail_url ?? undefined,
+      description: img.description ?? undefined,
+      uploadedAt: img.uploaded_at?.split("T")[0] ?? "",
+    })),
+    imageCount: (imagesByOrder.get(r.id) ?? []).length,
+    createdAt: r.created_at?.split("T")[0] ?? "",
+    updatedAt: r.updated_at?.split("T")[0] ?? "",
+  }));
+}
+
+// ─────────────────────────────────────────────
+// Radiology — Report Templates
+// ─────────────────────────────────────────────
+
+export interface RadiologyTemplateView {
+  id: string;
+  name: string;
+  modality?: string;
+  bodyPart?: string;
+  templateText: string;
+  fields: { key: string; label: string; type: string; options?: string[] }[];
+  sections: { title: string; defaultContent: string }[];
+  language: string;
+  isDefault: boolean;
+  isActive: boolean;
+}
+
+interface RadiologyTemplateRaw {
+  id: string;
+  clinic_id: string;
+  name: string;
+  modality: string | null;
+  body_part: string | null;
+  template_text: string;
+  fields: { key: string; label: string; type: string; options?: string[] }[] | null;
+  is_default: boolean;
+  is_active: boolean;
+  created_at: string;
+}
+
+export async function fetchRadiologyTemplates(clinicId: string): Promise<RadiologyTemplateView[]> {
+  const rows = await fetchRows<RadiologyTemplateRaw>("radiology_report_templates", {
+    eq: [["clinic_id", clinicId]],
+    order: ["name", { ascending: true }],
+  });
+  return rows.map((r) => {
+    // Parse template_text into sections (split by markdown-style headers)
+    const sectionRegex = /^##\s+(.+)$/gm;
+    const sections: { title: string; defaultContent: string }[] = [];
+    const text = r.template_text ?? "";
+    let lastIndex = 0;
+    let lastTitle = "";
+    let match: RegExpExecArray | null;
+    while ((match = sectionRegex.exec(text)) !== null) {
+      if (lastTitle) {
+        sections.push({ title: lastTitle, defaultContent: text.slice(lastIndex, match.index).trim() });
+      }
+      lastTitle = match[1];
+      lastIndex = match.index + match[0].length;
+    }
+    if (lastTitle) {
+      sections.push({ title: lastTitle, defaultContent: text.slice(lastIndex).trim() });
+    }
+    if (sections.length === 0 && text) {
+      sections.push({ title: "Report", defaultContent: text });
+    }
+
+    return {
+      id: r.id,
+      name: r.name,
+      modality: r.modality ?? undefined,
+      bodyPart: r.body_part ?? undefined,
+      templateText: r.template_text,
+      fields: r.fields ?? [],
+      sections,
+      language: "en",
+      isDefault: r.is_default ?? false,
+      isActive: r.is_active ?? true,
+    };
+  });
+}
+
+// ─────────────────────────────────────────────
+// Medical Equipment — Inventory
+// ─────────────────────────────────────────────
+
+export interface EquipmentItemView {
+  id: string;
+  name: string;
+  description?: string;
+  category: string;
+  serialNumber?: string;
+  model?: string;
+  manufacturer?: string;
+  purchaseDate?: string;
+  purchasePrice?: number;
+  currency: string;
+  condition: string;
+  isAvailable: boolean;
+  isRentable: boolean;
+  rentalPriceDaily?: number;
+  rentalPriceWeekly?: number;
+  rentalPriceMonthly?: number;
+  imageUrl?: string;
+  notes?: string;
+}
+
+interface EquipmentItemRaw {
+  id: string;
+  clinic_id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  serial_number: string | null;
+  model: string | null;
+  manufacturer: string | null;
+  purchase_date: string | null;
+  purchase_price: number | null;
+  currency: string;
+  condition: string;
+  is_available: boolean;
+  is_rentable: boolean;
+  rental_price_daily: number | null;
+  rental_price_weekly: number | null;
+  rental_price_monthly: number | null;
+  image_url: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+function mapEquipmentItem(raw: EquipmentItemRaw): EquipmentItemView {
+  return {
+    id: raw.id,
+    name: raw.name,
+    description: raw.description ?? undefined,
+    category: raw.category,
+    serialNumber: raw.serial_number ?? undefined,
+    model: raw.model ?? undefined,
+    manufacturer: raw.manufacturer ?? undefined,
+    purchaseDate: raw.purchase_date ?? undefined,
+    purchasePrice: raw.purchase_price ?? undefined,
+    currency: raw.currency ?? "MAD",
+    condition: raw.condition ?? "good",
+    isAvailable: raw.is_available ?? true,
+    isRentable: raw.is_rentable ?? true,
+    rentalPriceDaily: raw.rental_price_daily ?? undefined,
+    rentalPriceWeekly: raw.rental_price_weekly ?? undefined,
+    rentalPriceMonthly: raw.rental_price_monthly ?? undefined,
+    imageUrl: raw.image_url ?? undefined,
+    notes: raw.notes ?? undefined,
+  };
+}
+
+export async function fetchEquipmentInventory(clinicId: string): Promise<EquipmentItemView[]> {
+  const rows = await fetchRows<EquipmentItemRaw>("equipment_inventory", {
+    eq: [["clinic_id", clinicId]],
+    order: ["name", { ascending: true }],
+  });
+  return rows.map(mapEquipmentItem);
+}
+
+// ─────────────────────────────────────────────
+// Medical Equipment — Rentals
+// ─────────────────────────────────────────────
+
+export interface EquipmentRentalView {
+  id: string;
+  equipmentId: string;
+  equipmentName: string;
+  clientName: string;
+  clientPhone?: string;
+  clientIdNumber?: string;
+  rentalStart: string;
+  rentalEnd?: string;
+  actualReturn?: string;
+  status: string;
+  conditionOut: string;
+  conditionIn?: string;
+  depositAmount?: number;
+  rentalAmount?: number;
+  currency: string;
+  paymentStatus: string;
+  notes?: string;
+}
+
+interface EquipmentRentalRaw {
+  id: string;
+  clinic_id: string;
+  equipment_id: string;
+  client_name: string;
+  client_phone: string | null;
+  client_id_number: string | null;
+  rental_start: string;
+  rental_end: string | null;
+  actual_return: string | null;
+  status: string;
+  condition_out: string;
+  condition_in: string | null;
+  deposit_amount: number | null;
+  rental_amount: number | null;
+  currency: string;
+  payment_status: string;
+  notes: string | null;
+  created_at: string;
+}
+
+export async function fetchEquipmentRentals(clinicId: string): Promise<EquipmentRentalView[]> {
+  const equipment = await fetchEquipmentInventory(clinicId);
+  const equipMap = new Map(equipment.map((e) => [e.id, e.name]));
+  const rows = await fetchRows<EquipmentRentalRaw>("equipment_rentals", {
+    eq: [["clinic_id", clinicId]],
+    order: ["created_at", { ascending: false }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    equipmentId: r.equipment_id,
+    equipmentName: equipMap.get(r.equipment_id) ?? "Equipment",
+    clientName: r.client_name,
+    clientPhone: r.client_phone ?? undefined,
+    clientIdNumber: r.client_id_number ?? undefined,
+    rentalStart: r.rental_start,
+    rentalEnd: r.rental_end ?? undefined,
+    actualReturn: r.actual_return ?? undefined,
+    status: r.status,
+    conditionOut: r.condition_out ?? "good",
+    conditionIn: r.condition_in ?? undefined,
+    depositAmount: r.deposit_amount ?? undefined,
+    rentalAmount: r.rental_amount ?? undefined,
+    currency: r.currency ?? "MAD",
+    paymentStatus: r.payment_status ?? "pending",
+    notes: r.notes ?? undefined,
+  }));
+}
+
+// ─────────────────────────────────────────────
+// Medical Equipment — Maintenance
+// ─────────────────────────────────────────────
+
+export interface EquipmentMaintenanceView {
+  id: string;
+  equipmentId: string;
+  equipmentName: string;
+  type: string;
+  description?: string;
+  performedBy?: string;
+  performedAt: string;
+  nextDue?: string;
+  cost?: number;
+  currency: string;
+  status: string;
+  notes?: string;
+}
+
+interface EquipmentMaintenanceRaw {
+  id: string;
+  clinic_id: string;
+  equipment_id: string;
+  type: string;
+  description: string | null;
+  performed_by: string | null;
+  performed_at: string;
+  next_due: string | null;
+  cost: number | null;
+  currency: string;
+  status: string;
+  notes: string | null;
+  created_at: string;
+}
+
+export async function fetchEquipmentMaintenance(clinicId: string): Promise<EquipmentMaintenanceView[]> {
+  const equipment = await fetchEquipmentInventory(clinicId);
+  const equipMap = new Map(equipment.map((e) => [e.id, e.name]));
+  const rows = await fetchRows<EquipmentMaintenanceRaw>("equipment_maintenance", {
+    eq: [["clinic_id", clinicId]],
+    order: ["performed_at", { ascending: false }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    equipmentId: r.equipment_id,
+    equipmentName: equipMap.get(r.equipment_id) ?? "Equipment",
+    type: r.type,
+    description: r.description ?? undefined,
+    performedBy: r.performed_by ?? undefined,
+    performedAt: r.performed_at,
+    nextDue: r.next_due ?? undefined,
+    cost: r.cost ?? undefined,
+    currency: r.currency ?? "MAD",
+    status: r.status ?? "completed",
+    notes: r.notes ?? undefined,
+  }));
+}
+
+// ─────────────────────────────────────────────
+// Parapharmacy — Categories
+// ─────────────────────────────────────────────
+
+export interface ParapharmacyCategoryView {
+  id: string;
+  name: string;
+  nameAr?: string;
+  description?: string;
+  slug: string;
+  icon?: string;
+  parentId?: string;
+  sortOrder: number;
+  isActive: boolean;
+}
+
+interface ParapharmacyCategoryRaw {
+  id: string;
+  clinic_id: string;
+  name: string;
+  name_ar: string | null;
+  slug: string;
+  icon: string | null;
+  parent_id: string | null;
+  sort_order: number;
+  is_active: boolean;
+}
+
+export async function fetchParapharmacyCategories(clinicId: string): Promise<ParapharmacyCategoryView[]> {
+  const rows = await fetchRows<ParapharmacyCategoryRaw>("parapharmacy_categories", {
+    eq: [["clinic_id", clinicId]],
+    order: ["sort_order", { ascending: true }],
+  });
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    nameAr: r.name_ar ?? undefined,
+    slug: r.slug,
+    icon: r.icon ?? undefined,
+    parentId: r.parent_id ?? undefined,
+    sortOrder: r.sort_order ?? 0,
+    isActive: r.is_active ?? true,
+  }));
+}
+
+// Parapharmacy products reuse the existing Product / stock tables
+// with is_parapharmacy=true and requires_prescription=false
+export async function fetchParapharmacyProducts(clinicId: string): Promise<ProductView[]> {
+  const [products, stock] = await Promise.all([
+    fetchRows<ProductRaw>("products", {
+      eq: [["clinic_id", clinicId], ["is_parapharmacy", true]],
+      order: ["name", { ascending: true }],
+    }),
+    fetchRows<StockRaw>("stock", { eq: [["clinic_id", clinicId]] }),
+  ]);
+  const stockMap = new Map(stock.map((s) => [s.product_id, s]));
+  return products.map((p) => {
+    const s = stockMap.get(p.id);
+    return {
+      id: p.id,
+      name: p.name,
+      genericName: p.generic_name ?? undefined,
+      category: p.category ?? "General",
+      description: p.description ?? undefined,
+      price: p.price ?? 0,
+      currency: "MAD",
+      requiresPrescription: false,
+      stockQuantity: s?.quantity ?? 0,
+      minimumStock: s?.min_threshold ?? 0,
+      expiryDate: s?.expiry_date ?? "",
+      barcode: s?.batch_number ?? undefined,
+      manufacturer: p.manufacturer ?? undefined,
+      supplierId: s?.supplier_id ?? undefined,
+      dosageForm: p.dosage_form ?? undefined,
+      strength: p.strength ?? undefined,
+      active: p.is_active ?? true,
+    };
+  });
+}

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -24,7 +24,12 @@ export type ClinicFeatureKey =
   | "bed_management"
   | "installments"
   | "certificates"
-  | "sterilization_log";
+  | "sterilization_log"
+  | "lab_tests"
+  | "radiology_reports"
+  | "equipment_rentals"
+  | "equipment_maintenance"
+  | "parapharmacy";
 
 /** A features_config object as stored in the DB. */
 export type FeaturesConfig = Partial<Record<ClinicFeatureKey, boolean>>;

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -23,6 +23,47 @@ export type ClinicTypeCategory =
   | "pharmacy_retail"
   | "clinics_centers";
 
+export type LabTestOrderStatus =
+  | "pending"
+  | "sample_collected"
+  | "in_progress"
+  | "completed"
+  | "validated"
+  | "cancelled";
+
+export type LabTestPriority = "normal" | "urgent" | "stat";
+
+export type RadiologyModality =
+  | "xray"
+  | "ct"
+  | "mri"
+  | "ultrasound"
+  | "mammography"
+  | "pet"
+  | "fluoroscopy"
+  | "other";
+
+export type RadiologyOrderStatus =
+  | "pending"
+  | "scheduled"
+  | "in_progress"
+  | "images_ready"
+  | "reported"
+  | "validated"
+  | "cancelled";
+
+export type ResultFlag = "normal" | "high" | "low" | "critical_high" | "critical_low";
+
+export type EquipmentCondition = "new" | "good" | "fair" | "needs_repair" | "decommissioned";
+
+export type RentalStatus = "reserved" | "active" | "returned" | "overdue" | "cancelled";
+
+export type RentalPaymentStatus = "pending" | "partial" | "paid" | "refunded";
+
+export type MaintenanceType = "routine" | "repair" | "calibration" | "inspection" | "cleaning";
+
+export type MaintenanceStatus = "scheduled" | "in_progress" | "completed" | "cancelled";
+
 export type ClinicTier = "vitrine" | "cabinet" | "pro" | "premium" | "saas";
 
 export type AppointmentStatus =
@@ -745,6 +786,206 @@ export interface PainQuestionnaire {
   created_at: string;
 }
 
+// ---- Diagnostic Center: Analysis Lab ----
+
+export interface LabTestCatalog {
+  id: string;
+  clinic_id: string;
+  name: string;
+  name_ar: string | null;
+  code: string | null;
+  category: string;
+  sample_type: string;
+  description: string | null;
+  price: number | null;
+  currency: string;
+  turnaround_hours: number;
+  reference_ranges: Record<string, unknown>[];
+  is_active: boolean;
+  sort_order: number;
+  created_at: string;
+}
+
+export interface LabTestOrder {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  ordering_doctor_id: string | null;
+  assigned_technician_id: string | null;
+  order_number: string;
+  status: LabTestOrderStatus;
+  priority: LabTestPriority;
+  clinical_notes: string | null;
+  fasting_required: boolean;
+  sample_collected_at: string | null;
+  completed_at: string | null;
+  validated_at: string | null;
+  validated_by: string | null;
+  pdf_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LabTestItem {
+  id: string;
+  order_id: string;
+  test_id: string;
+  test_name: string;
+  status: "pending" | "in_progress" | "completed";
+  created_at: string;
+}
+
+export interface LabTestResult {
+  id: string;
+  order_id: string;
+  test_item_id: string;
+  parameter_name: string;
+  value: string | null;
+  unit: string | null;
+  reference_min: number | null;
+  reference_max: number | null;
+  flag: ResultFlag | null;
+  notes: string | null;
+  entered_by: string | null;
+  entered_at: string;
+}
+
+// ---- Diagnostic Center: Radiology ----
+
+export interface RadiologyOrder {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  ordering_doctor_id: string | null;
+  radiologist_id: string | null;
+  order_number: string;
+  modality: RadiologyModality;
+  body_part: string | null;
+  clinical_indication: string | null;
+  status: RadiologyOrderStatus;
+  priority: LabTestPriority;
+  scheduled_at: string | null;
+  performed_at: string | null;
+  reported_at: string | null;
+  report_text: string | null;
+  report_template_id: string | null;
+  findings: string | null;
+  impression: string | null;
+  pdf_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RadiologyImage {
+  id: string;
+  order_id: string;
+  clinic_id: string;
+  file_url: string;
+  file_name: string | null;
+  file_size: number | null;
+  content_type: string | null;
+  modality: string | null;
+  is_dicom: boolean;
+  dicom_metadata: Record<string, unknown>;
+  thumbnail_url: string | null;
+  description: string | null;
+  uploaded_by: string | null;
+  uploaded_at: string;
+}
+
+export interface RadiologyReportTemplate {
+  id: string;
+  clinic_id: string;
+  name: string;
+  modality: string | null;
+  body_part: string | null;
+  template_text: string;
+  fields: Record<string, unknown>[];
+  is_default: boolean;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---- Medical Equipment Store ----
+
+export interface EquipmentInventory {
+  id: string;
+  clinic_id: string;
+  name: string;
+  description: string | null;
+  category: string;
+  serial_number: string | null;
+  model: string | null;
+  manufacturer: string | null;
+  purchase_date: string | null;
+  purchase_price: number | null;
+  currency: string;
+  condition: EquipmentCondition;
+  is_available: boolean;
+  is_rentable: boolean;
+  rental_price_daily: number | null;
+  rental_price_weekly: number | null;
+  rental_price_monthly: number | null;
+  image_url: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EquipmentRental {
+  id: string;
+  clinic_id: string;
+  equipment_id: string;
+  client_name: string;
+  client_phone: string | null;
+  client_id_number: string | null;
+  rental_start: string;
+  rental_end: string | null;
+  actual_return: string | null;
+  status: RentalStatus;
+  condition_out: string;
+  condition_in: string | null;
+  deposit_amount: number | null;
+  rental_amount: number | null;
+  currency: string;
+  payment_status: RentalPaymentStatus;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EquipmentMaintenance {
+  id: string;
+  clinic_id: string;
+  equipment_id: string;
+  type: MaintenanceType;
+  description: string | null;
+  performed_by: string | null;
+  performed_at: string;
+  next_due: string | null;
+  cost: number | null;
+  currency: string;
+  status: MaintenanceStatus;
+  notes: string | null;
+  created_at: string;
+}
+
+// ---- Parapharmacy ----
+
+export interface ParapharmacyCategory {
+  id: string;
+  clinic_id: string;
+  name: string;
+  name_ar: string | null;
+  slug: string;
+  icon: string | null;
+  parent_id: string | null;
+  sort_order: number;
+  is_active: boolean;
+  created_at: string;
+}
+
 // ---- Supabase Database Schema (for use with supabase-js typed client) ----
 
 export interface Database {
@@ -795,6 +1036,18 @@ export interface Database {
       before_after_photos: { Row: BeforeAfterPhoto; Insert: Partial<BeforeAfterPhoto> & Pick<BeforeAfterPhoto, "clinic_id" | "patient_id">; Update: Partial<BeforeAfterPhoto> };
       pain_questionnaires: { Row: PainQuestionnaire; Insert: Partial<PainQuestionnaire> & Pick<PainQuestionnaire, "clinic_id" | "patient_id" | "pain_level">; Update: Partial<PainQuestionnaire> };
       clinic_types: { Row: ClinicTypeRecord; Insert: Partial<ClinicTypeRecord> & Pick<ClinicTypeRecord, "type_key" | "name_fr" | "name_ar" | "category">; Update: Partial<ClinicTypeRecord> };
+      // Phase 4 & 5 tables
+      lab_test_catalog: { Row: LabTestCatalog; Insert: Partial<LabTestCatalog> & Pick<LabTestCatalog, "clinic_id" | "name">; Update: Partial<LabTestCatalog> };
+      lab_test_orders: { Row: LabTestOrder; Insert: Partial<LabTestOrder> & Pick<LabTestOrder, "clinic_id" | "patient_id" | "order_number">; Update: Partial<LabTestOrder> };
+      lab_test_items: { Row: LabTestItem; Insert: Partial<LabTestItem> & Pick<LabTestItem, "order_id" | "test_id" | "test_name">; Update: Partial<LabTestItem> };
+      lab_test_results: { Row: LabTestResult; Insert: Partial<LabTestResult> & Pick<LabTestResult, "order_id" | "test_item_id" | "parameter_name">; Update: Partial<LabTestResult> };
+      radiology_orders: { Row: RadiologyOrder; Insert: Partial<RadiologyOrder> & Pick<RadiologyOrder, "clinic_id" | "patient_id" | "order_number" | "modality">; Update: Partial<RadiologyOrder> };
+      radiology_images: { Row: RadiologyImage; Insert: Partial<RadiologyImage> & Pick<RadiologyImage, "order_id" | "clinic_id" | "file_url">; Update: Partial<RadiologyImage> };
+      radiology_report_templates: { Row: RadiologyReportTemplate; Insert: Partial<RadiologyReportTemplate> & Pick<RadiologyReportTemplate, "clinic_id" | "name" | "template_text">; Update: Partial<RadiologyReportTemplate> };
+      equipment_inventory: { Row: EquipmentInventory; Insert: Partial<EquipmentInventory> & Pick<EquipmentInventory, "clinic_id" | "name">; Update: Partial<EquipmentInventory> };
+      equipment_rentals: { Row: EquipmentRental; Insert: Partial<EquipmentRental> & Pick<EquipmentRental, "clinic_id" | "equipment_id" | "client_name" | "rental_start">; Update: Partial<EquipmentRental> };
+      equipment_maintenance: { Row: EquipmentMaintenance; Insert: Partial<EquipmentMaintenance> & Pick<EquipmentMaintenance, "clinic_id" | "equipment_id">; Update: Partial<EquipmentMaintenance> };
+      parapharmacy_categories: { Row: ParapharmacyCategory; Insert: Partial<ParapharmacyCategory> & Pick<ParapharmacyCategory, "clinic_id" | "name" | "slug">; Update: Partial<ParapharmacyCategory> };
     };
   };
 }

--- a/src/lib/types/diagnostic.ts
+++ b/src/lib/types/diagnostic.ts
@@ -1,0 +1,179 @@
+/**
+ * Diagnostic center type definitions.
+ * Covers Analysis Lab and Radiology/Medical Imaging modules.
+ */
+
+// ---------- Lab Test Catalog ----------
+
+export interface LabTestCatalogItem {
+  id: string;
+  name: string;
+  nameAr?: string;
+  code?: string;
+  category: string;
+  sampleType: string;
+  description?: string;
+  price: number;
+  currency: string;
+  turnaroundHours: number;
+  referenceRanges: ReferenceRange[];
+  isActive: boolean;
+  sortOrder: number;
+}
+
+export interface ReferenceRange {
+  parameter: string;
+  unit: string;
+  min: number | null;
+  max: number | null;
+  gender?: "male" | "female" | "all";
+  ageGroup?: string;
+}
+
+// ---------- Lab Test Orders ----------
+
+export type LabTestOrderStatus =
+  | "pending"
+  | "sample_collected"
+  | "in_progress"
+  | "completed"
+  | "validated"
+  | "cancelled";
+
+export type LabTestPriority = "normal" | "urgent" | "stat";
+
+export interface LabTestOrder {
+  id: string;
+  patientId: string;
+  patientName: string;
+  orderingDoctorId?: string;
+  orderingDoctorName?: string;
+  assignedTechnicianId?: string;
+  assignedTechnicianName?: string;
+  orderNumber: string;
+  status: LabTestOrderStatus;
+  priority: LabTestPriority;
+  clinicalNotes?: string;
+  fastingRequired: boolean;
+  sampleCollectedAt?: string;
+  completedAt?: string;
+  validatedAt?: string;
+  validatedBy?: string;
+  pdfUrl?: string;
+  tests: LabTestItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LabTestItem {
+  id: string;
+  testId: string;
+  testName: string;
+  status: "pending" | "in_progress" | "completed";
+}
+
+// ---------- Lab Test Results ----------
+
+export type ResultFlag = "normal" | "high" | "low" | "critical_high" | "critical_low";
+
+export interface LabTestResult {
+  id: string;
+  orderId: string;
+  testItemId: string;
+  parameterName: string;
+  value: string;
+  unit: string;
+  referenceMin: number | null;
+  referenceMax: number | null;
+  flag: ResultFlag | null;
+  notes?: string;
+  enteredBy?: string;
+  enteredAt: string;
+}
+
+// ---------- Radiology Orders ----------
+
+export type RadiologyModality =
+  | "xray"
+  | "ct"
+  | "mri"
+  | "ultrasound"
+  | "mammography"
+  | "pet"
+  | "fluoroscopy"
+  | "other";
+
+export type RadiologyOrderStatus =
+  | "pending"
+  | "scheduled"
+  | "in_progress"
+  | "images_ready"
+  | "reported"
+  | "validated"
+  | "cancelled";
+
+export interface RadiologyOrder {
+  id: string;
+  patientId: string;
+  patientName: string;
+  orderingDoctorId?: string;
+  orderingDoctorName?: string;
+  radiologistId?: string;
+  radiologistName?: string;
+  orderNumber: string;
+  modality: RadiologyModality;
+  bodyPart?: string;
+  clinicalIndication?: string;
+  status: RadiologyOrderStatus;
+  priority: "normal" | "urgent" | "stat";
+  scheduledAt?: string;
+  performedAt?: string;
+  reportedAt?: string;
+  reportText?: string;
+  findings?: string;
+  impression?: string;
+  pdfUrl?: string;
+  images: RadiologyImage[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------- Radiology Images ----------
+
+export interface RadiologyImage {
+  id: string;
+  orderId: string;
+  fileUrl: string;
+  fileName?: string;
+  fileSize?: number;
+  contentType?: string;
+  modality?: string;
+  isDicom: boolean;
+  dicomMetadata?: Record<string, unknown>;
+  thumbnailUrl?: string;
+  description?: string;
+  uploadedBy?: string;
+  uploadedAt: string;
+}
+
+// ---------- Radiology Report Templates ----------
+
+export interface RadiologyReportTemplate {
+  id: string;
+  name: string;
+  modality?: string;
+  bodyPart?: string;
+  templateText: string;
+  fields: ReportTemplateField[];
+  isDefault: boolean;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface ReportTemplateField {
+  key: string;
+  label: string;
+  type: "text" | "textarea" | "select";
+  options?: string[];
+  required?: boolean;
+}

--- a/src/lib/types/equipment.ts
+++ b/src/lib/types/equipment.ts
@@ -1,0 +1,112 @@
+/**
+ * Medical Equipment Store type definitions.
+ * Covers equipment inventory, rentals, and maintenance tracking.
+ */
+
+// ---------- Equipment Inventory ----------
+
+export type EquipmentCondition = "new" | "good" | "fair" | "needs_repair" | "decommissioned";
+
+export interface EquipmentItem {
+  id: string;
+  name: string;
+  description?: string;
+  category: string;
+  serialNumber?: string;
+  model?: string;
+  manufacturer?: string;
+  purchaseDate?: string;
+  purchasePrice?: number;
+  currency: string;
+  condition: EquipmentCondition;
+  isAvailable: boolean;
+  isRentable: boolean;
+  rentalPriceDaily?: number;
+  rentalPriceWeekly?: number;
+  rentalPriceMonthly?: number;
+  imageUrl?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------- Equipment Rentals ----------
+
+export type RentalStatus = "reserved" | "active" | "returned" | "overdue" | "cancelled";
+export type RentalPaymentStatus = "pending" | "partial" | "paid" | "refunded";
+
+export interface EquipmentRental {
+  id: string;
+  equipmentId: string;
+  equipmentName: string;
+  clientName: string;
+  clientPhone?: string;
+  clientIdNumber?: string;
+  rentalStart: string;
+  rentalEnd?: string;
+  actualReturn?: string;
+  status: RentalStatus;
+  conditionOut: string;
+  conditionIn?: string;
+  depositAmount?: number;
+  rentalAmount?: number;
+  currency: string;
+  paymentStatus: RentalPaymentStatus;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ---------- Equipment Maintenance ----------
+
+export type MaintenanceType = "routine" | "repair" | "calibration" | "inspection" | "cleaning";
+export type MaintenanceStatus = "scheduled" | "in_progress" | "completed" | "cancelled";
+
+export interface EquipmentMaintenance {
+  id: string;
+  equipmentId: string;
+  equipmentName: string;
+  type: MaintenanceType;
+  description?: string;
+  performedBy?: string;
+  performedAt: string;
+  nextDue?: string;
+  cost?: number;
+  currency: string;
+  status: MaintenanceStatus;
+  notes?: string;
+  createdAt: string;
+}
+
+// ---------- Parapharmacy ----------
+
+export interface ParapharmacyCategory {
+  id: string;
+  name: string;
+  nameAr?: string;
+  slug: string;
+  icon?: string;
+  parentId?: string;
+  sortOrder: number;
+  isActive: boolean;
+}
+
+export interface ParapharmacyProduct {
+  id: string;
+  name: string;
+  brand?: string;
+  category: string;
+  subcategory?: string;
+  description?: string;
+  price: number;
+  currency: string;
+  ingredients?: string;
+  usageInstructions?: string;
+  skinType?: string;
+  ageGroup?: string;
+  imageUrl?: string;
+  stockQuantity: number;
+  minimumStock: number;
+  expiryDate?: string;
+  isActive: boolean;
+}

--- a/supabase/migrations/00011_diagnostic_pharmacy_equipment.sql
+++ b/supabase/migrations/00011_diagnostic_pharmacy_equipment.sql
@@ -1,0 +1,297 @@
+-- ============================================================
+-- Migration 00011: Phase 4 & 5
+-- Diagnostic Centers (Analysis Lab, Radiology)
+-- Pharmacy & Retail (Parapharmacy, Medical Equipment)
+-- ============================================================
+
+-- ============================================================
+-- 1. ANALYSIS LAB TABLES
+-- ============================================================
+
+-- Lab test catalog (available tests a lab can perform)
+CREATE TABLE lab_test_catalog (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  name_ar         TEXT,
+  code            TEXT,
+  category        TEXT NOT NULL DEFAULT 'general',
+  sample_type     TEXT DEFAULT 'blood',
+  description     TEXT,
+  price           NUMERIC(10,2),
+  currency        TEXT DEFAULT 'MAD',
+  turnaround_hours INT DEFAULT 24,
+  reference_ranges JSONB DEFAULT '[]',
+  is_active       BOOLEAN DEFAULT TRUE,
+  sort_order      INT DEFAULT 0,
+  created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_lab_test_catalog_clinic ON lab_test_catalog(clinic_id);
+
+-- Lab test orders
+CREATE TABLE lab_test_orders (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  patient_id      UUID NOT NULL REFERENCES users(id),
+  ordering_doctor_id UUID REFERENCES users(id),
+  assigned_technician_id UUID REFERENCES users(id),
+  order_number    TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+    'pending', 'sample_collected', 'in_progress', 'completed', 'validated', 'cancelled'
+  )),
+  priority        TEXT DEFAULT 'normal' CHECK (priority IN ('normal', 'urgent', 'stat')),
+  clinical_notes  TEXT,
+  fasting_required BOOLEAN DEFAULT FALSE,
+  sample_collected_at TIMESTAMPTZ,
+  completed_at    TIMESTAMPTZ,
+  validated_at    TIMESTAMPTZ,
+  validated_by    UUID REFERENCES users(id),
+  pdf_url         TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_lab_test_orders_clinic ON lab_test_orders(clinic_id);
+CREATE INDEX idx_lab_test_orders_patient ON lab_test_orders(patient_id);
+CREATE INDEX idx_lab_test_orders_status ON lab_test_orders(status);
+
+-- Individual test items within an order
+CREATE TABLE lab_test_items (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  order_id        UUID NOT NULL REFERENCES lab_test_orders(id) ON DELETE CASCADE,
+  test_id         UUID NOT NULL REFERENCES lab_test_catalog(id),
+  test_name       TEXT NOT NULL,
+  status          TEXT DEFAULT 'pending' CHECK (status IN (
+    'pending', 'in_progress', 'completed'
+  )),
+  created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_lab_test_items_order ON lab_test_items(order_id);
+
+-- Lab test results (one per test item, with structured result data)
+CREATE TABLE lab_test_results (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  order_id        UUID NOT NULL REFERENCES lab_test_orders(id) ON DELETE CASCADE,
+  test_item_id    UUID NOT NULL REFERENCES lab_test_items(id) ON DELETE CASCADE,
+  parameter_name  TEXT NOT NULL,
+  value           TEXT,
+  unit            TEXT,
+  reference_min   NUMERIC(10,4),
+  reference_max   NUMERIC(10,4),
+  flag            TEXT CHECK (flag IN ('normal', 'high', 'low', 'critical_high', 'critical_low', NULL)),
+  notes           TEXT,
+  entered_by      UUID REFERENCES users(id),
+  entered_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_lab_test_results_order ON lab_test_results(order_id);
+CREATE INDEX idx_lab_test_results_item ON lab_test_results(test_item_id);
+
+-- ============================================================
+-- 2. RADIOLOGY & MEDICAL IMAGING TABLES
+-- ============================================================
+
+-- Radiology orders / studies
+CREATE TABLE radiology_orders (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  patient_id      UUID NOT NULL REFERENCES users(id),
+  ordering_doctor_id UUID REFERENCES users(id),
+  radiologist_id  UUID REFERENCES users(id),
+  order_number    TEXT NOT NULL,
+  modality        TEXT NOT NULL CHECK (modality IN (
+    'xray', 'ct', 'mri', 'ultrasound', 'mammography', 'pet', 'fluoroscopy', 'other'
+  )),
+  body_part       TEXT,
+  clinical_indication TEXT,
+  status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+    'pending', 'scheduled', 'in_progress', 'images_ready', 'reported', 'validated', 'cancelled'
+  )),
+  priority        TEXT DEFAULT 'normal' CHECK (priority IN ('normal', 'urgent', 'stat')),
+  scheduled_at    TIMESTAMPTZ,
+  performed_at    TIMESTAMPTZ,
+  reported_at     TIMESTAMPTZ,
+  report_text     TEXT,
+  report_template_id UUID,
+  findings        TEXT,
+  impression      TEXT,
+  pdf_url         TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_radiology_orders_clinic ON radiology_orders(clinic_id);
+CREATE INDEX idx_radiology_orders_patient ON radiology_orders(patient_id);
+CREATE INDEX idx_radiology_orders_status ON radiology_orders(status);
+
+-- Radiology images (stored on R2/cloud)
+CREATE TABLE radiology_images (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  order_id        UUID NOT NULL REFERENCES radiology_orders(id) ON DELETE CASCADE,
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  file_url        TEXT NOT NULL,
+  file_name       TEXT,
+  file_size       BIGINT,
+  content_type    TEXT,
+  modality        TEXT,
+  is_dicom        BOOLEAN DEFAULT FALSE,
+  dicom_metadata  JSONB DEFAULT '{}',
+  thumbnail_url   TEXT,
+  description     TEXT,
+  uploaded_by     UUID REFERENCES users(id),
+  uploaded_at     TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_radiology_images_order ON radiology_images(order_id);
+CREATE INDEX idx_radiology_images_clinic ON radiology_images(clinic_id);
+
+-- Radiology report templates
+CREATE TABLE radiology_report_templates (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  modality        TEXT,
+  body_part       TEXT,
+  template_text   TEXT NOT NULL,
+  fields          JSONB DEFAULT '[]',
+  is_default      BOOLEAN DEFAULT FALSE,
+  is_active       BOOLEAN DEFAULT TRUE,
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_radiology_templates_clinic ON radiology_report_templates(clinic_id);
+
+-- ============================================================
+-- 3. PARAPHARMACY EXTENSIONS
+-- ============================================================
+
+-- Add parapharmacy-specific columns to products table
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS is_parapharmacy BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS brand TEXT,
+  ADD COLUMN IF NOT EXISTS subcategory TEXT,
+  ADD COLUMN IF NOT EXISTS ingredients TEXT,
+  ADD COLUMN IF NOT EXISTS usage_instructions TEXT,
+  ADD COLUMN IF NOT EXISTS skin_type TEXT,
+  ADD COLUMN IF NOT EXISTS age_group TEXT;
+
+-- Parapharmacy categories reference
+CREATE TABLE parapharmacy_categories (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  name_ar         TEXT,
+  slug            TEXT NOT NULL,
+  icon            TEXT,
+  parent_id       UUID REFERENCES parapharmacy_categories(id),
+  sort_order      INT DEFAULT 0,
+  is_active       BOOLEAN DEFAULT TRUE,
+  created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_parapharmacy_categories_clinic ON parapharmacy_categories(clinic_id);
+
+-- ============================================================
+-- 4. MEDICAL EQUIPMENT STORE TABLES
+-- ============================================================
+
+-- Equipment inventory (items with serial numbers)
+CREATE TABLE equipment_inventory (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  name            TEXT NOT NULL,
+  description     TEXT,
+  category        TEXT NOT NULL DEFAULT 'general',
+  serial_number   TEXT,
+  model           TEXT,
+  manufacturer    TEXT,
+  purchase_date   DATE,
+  purchase_price  NUMERIC(10,2),
+  currency        TEXT DEFAULT 'MAD',
+  condition       TEXT DEFAULT 'good' CHECK (condition IN (
+    'new', 'good', 'fair', 'needs_repair', 'decommissioned'
+  )),
+  is_available    BOOLEAN DEFAULT TRUE,
+  is_rentable     BOOLEAN DEFAULT TRUE,
+  rental_price_daily NUMERIC(10,2),
+  rental_price_weekly NUMERIC(10,2),
+  rental_price_monthly NUMERIC(10,2),
+  image_url       TEXT,
+  notes           TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_equipment_inventory_clinic ON equipment_inventory(clinic_id);
+CREATE INDEX idx_equipment_inventory_category ON equipment_inventory(category);
+
+-- Equipment rentals
+CREATE TABLE equipment_rentals (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  equipment_id    UUID NOT NULL REFERENCES equipment_inventory(id) ON DELETE CASCADE,
+  client_name     TEXT NOT NULL,
+  client_phone    TEXT,
+  client_id_number TEXT,
+  rental_start    DATE NOT NULL,
+  rental_end      DATE,
+  actual_return   DATE,
+  status          TEXT NOT NULL DEFAULT 'active' CHECK (status IN (
+    'reserved', 'active', 'returned', 'overdue', 'cancelled'
+  )),
+  condition_out   TEXT DEFAULT 'good',
+  condition_in    TEXT,
+  deposit_amount  NUMERIC(10,2),
+  rental_amount   NUMERIC(10,2),
+  currency        TEXT DEFAULT 'MAD',
+  payment_status  TEXT DEFAULT 'pending' CHECK (payment_status IN (
+    'pending', 'partial', 'paid', 'refunded'
+  )),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now(),
+  updated_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_equipment_rentals_clinic ON equipment_rentals(clinic_id);
+CREATE INDEX idx_equipment_rentals_equipment ON equipment_rentals(equipment_id);
+CREATE INDEX idx_equipment_rentals_status ON equipment_rentals(status);
+
+-- Equipment maintenance logs
+CREATE TABLE equipment_maintenance (
+  id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  clinic_id       UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  equipment_id    UUID NOT NULL REFERENCES equipment_inventory(id) ON DELETE CASCADE,
+  type            TEXT NOT NULL DEFAULT 'routine' CHECK (type IN (
+    'routine', 'repair', 'calibration', 'inspection', 'cleaning'
+  )),
+  description     TEXT,
+  performed_by    TEXT,
+  performed_at    DATE NOT NULL DEFAULT CURRENT_DATE,
+  next_due        DATE,
+  cost            NUMERIC(10,2),
+  currency        TEXT DEFAULT 'MAD',
+  status          TEXT DEFAULT 'completed' CHECK (status IN (
+    'scheduled', 'in_progress', 'completed', 'cancelled'
+  )),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_equipment_maintenance_clinic ON equipment_maintenance(clinic_id);
+CREATE INDEX idx_equipment_maintenance_equipment ON equipment_maintenance(equipment_id);
+
+-- ============================================================
+-- 5. UPDATE CLINIC TYPES for new categories
+-- ============================================================
+
+-- Add diagnostic center types
+INSERT INTO clinic_types (type_key, name_fr, name_ar, category, icon, features_config, sort_order, is_active)
+VALUES
+  ('analysis_lab', 'Laboratoire d''analyses', 'مختبر تحاليل', 'diagnostic', 'flask-conical', '{"lab_tests": true, "lab_results": true, "appointments": true}', 30, true),
+  ('radiology_center', 'Centre de radiologie', 'مركز أشعة', 'diagnostic', 'scan', '{"imaging": true, "radiology_reports": true, "appointments": true}', 31, true),
+  ('parapharmacy', 'Parapharmacie', 'باراصيدلية', 'pharmacy_retail', 'sparkles', '{"sales": true, "stock": true}', 40, true),
+  ('medical_equipment', 'Matériel médical', 'معدات طبية', 'pharmacy_retail', 'wrench', '{"equipment_rentals": true, "equipment_maintenance": true, "stock": true}', 41, true)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Phase 4: Diagnostic Centers

### Task 21 — Analysis Lab
- Test order management with technician assignment
- Results entry with reference ranges and flags (normal/high/low/critical)
- PDF report generation support with lab branding
- Patient history of all past results
- 5 pages: dashboard, test-orders, results, reports, patient-history

### Task 22 — Radiology & Medical Imaging
- Image management: upload X-ray, MRI, scanner images
- DICOM viewer integration (OHIF viewer link)
- Radiology report templates by modality/body part
- R2/cloud image storage support
- 6 pages: dashboard, orders, images, viewer, reports, templates

## Phase 5: Pharmacy & Retail Enhancements

### Task 23 — Parapharmacy
- Adapted pharmacy module without prescription features
- Product catalog focused on cosmetics, supplements, baby care
- Sales & inventory without controlled substance tracking
- 4 pages: dashboard, catalog, sales, inventory

### Task 24 — Medical Equipment Store
- Rental tracking: equipment out/in dates, client, condition
- Inventory with serial numbers & maintenance logs
- Maintenance scheduling & alerts
- 4 pages: dashboard, inventory, rentals, maintenance

## Technical Details

### Database Migration
- New tables: lab_test_catalog, lab_test_orders, lab_test_items, lab_test_results, radiology_orders, radiology_images, radiology_report_templates, equipment_inventory, equipment_rentals, equipment_maintenance, parapharmacy_categories
- ALTER TABLE products with parapharmacy columns
- Proper indexes, constraints, and RLS-ready clinic_id columns

### New Feature Flags
- lab_tests, radiology_reports, equipment_rentals, equipment_maintenance, parapharmacy

### Architecture
- 4 new route group layouts: (lab), (radiology), (parapharmacy), (equipment)
- 19 new pages across 4 modules
- TypeScript types in diagnostic.ts and equipment.ts
- Data layer functions in client.ts
- Follows existing patterns: shadcn/ui, Tailwind CSS, Supabase client