### PR TITLE
Fix payment webhook type errors in webhook/route.ts (Task 2e)

### DIFF
--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -60,16 +60,16 @@ export async function POST(request: NextRequest) {
         const clinicId = session.metadata?.clinic_id;
 
         // Record payment in Supabase
-        if (clinicId || patientId) {
+        if (clinicId && patientId) {
           await supabase.from("payments").insert({
-            clinic_id: clinicId || null,
-            patient_id: patientId || null,
+            clinic_id: clinicId,
+            patient_id: patientId,
             appointment_id: appointmentId || null,
             amount: (session.amount_total || 0) / 100, // Convert from centimes
-            method: "stripe",
+            method: "online",
             status: "completed",
             reference: session.id,
-            payment_type: "online",
+            payment_type: "full",
           });
         }
 


### PR DESCRIPTION
## Summary
Fixes type errors in `src/app/api/payments/webhook/route.ts` (Task 2e).

## Changes
- Changed guard condition from `||` to `&&` so `clinic_id` and `patient_id` are guaranteed non-null strings (required by `Payment` Insert type)
- Changed `method` from `"stripe"` to `"online"` (valid `PaymentMethod` union member)
- Changed `payment_type` from `"online"` to `"full"` (valid `PaymentType` union member)

## Why
The `Payment` Insert type requires `clinic_id: string`, `patient_id: string`, and `amount: number`. The previous code could pass `null` for `clinic_id` and `patient_id`, and used invalid enum values for `method` and `payment_type`.