### PR TITLE
fix: add missing email field to ClinicBranding type

### DIFF
--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -74,6 +74,7 @@ export interface ClinicBranding {
   sectionVisibility: Record<string, boolean>;
   phone: string | null;
   address: string | null;
+  email: string | null;
 }
 
 // ── Helpers ──
@@ -90,7 +91,7 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
 
   const { data, error } = await supabase
     .from("clinics")
-    .select("name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, phone, address")
+    .select("name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, phone, address, owner_email")
     .eq("id", clinicId)
     .single();
 
@@ -110,6 +111,7 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
       sectionVisibility: {},
       phone: clinicConfig.contact.phone ?? null,
       address: clinicConfig.contact.address ?? null,
+      email: clinicConfig.contact.email ?? null,
     };
   }
 
@@ -128,6 +130,7 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
     sectionVisibility: ((data as Record<string, unknown>).section_visibility as Record<string, boolean>) ?? {},
     phone: (data as Record<string, unknown>).phone as string | null ?? clinicConfig.contact.phone ?? null,
     address: (data as Record<string, unknown>).address as string | null ?? clinicConfig.contact.address ?? null,
+    email: (data as Record<string, unknown>).owner_email as string | null ?? clinicConfig.contact.email ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes type errors on public pages by adding the missing `email` field to the `ClinicBranding` interface.

### Changes
- Added `email: string | null` to the `ClinicBranding` interface
- Added `owner_email` to the Supabase select query in `getPublicBranding()`
- Mapped `owner_email` → `email` in both the fallback and success return paths
- Resolves TS2339 errors in `pharmacy/store-info/page.tsx` (lines 103, 108)

### Note on PublicService.category
`PublicService` already had `category: string` defined on the type, so dentist/prices, dentist/services, and doctor-services pages had no type errors related to `category`.

[Devin session](https://app.devin.ai/sessions/69af373999444c1db502ae18f78204f7)