### PR TITLE
Fix waiting-room page type error: string index into typed object (Task 2f)

### DIFF
--- a/src/app/(doctor)/doctor/waiting-room/page.tsx
+++ b/src/app/(doctor)/doctor/waiting-room/page.tsx
@@ -58,7 +58,7 @@ export default function WaitingRoomPage() {
     );
   };
 
-  const priorityOrder = { urgent: 0, normal: 1, "follow-up": 2 };
+  const priorityOrder: Record<string, number> = { urgent: 0, normal: 1, "follow-up": 2 };
   const sortedWaiting = [...waitingEntries].sort(
     (a, b) => priorityOrder[a.priority] - priorityOrder[b.priority]
   );


### PR DESCRIPTION
## Summary
Fixes the type error at `waiting-room/page.tsx:63` where `a.priority` (typed as `string`) was used to index into the `priorityOrder` object literal.

## Change
Added `Record<string, number>` type annotation to `priorityOrder` so that any string key (including `priority`) can safely index into it.

---

[Devin session](https://app.devin.ai/sessions/d2f55c7d6f184bf88d8aa4dac3bc1122)