### PR TITLE
fix: align data layer types with canonical DB schema (Task 2d)

### DIFF
--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -118,16 +118,20 @@ export interface AppointmentView {
 
 interface AppointmentRaw {
   id: string;
+  clinic_id: string;
   patient_id: string;
   doctor_id: string;
   service_id: string | null;
+  slot_start: string;
+  slot_end: string;
   appointment_date: string;
   start_time: string;
   end_time: string;
   status: string;
   is_first_visit: boolean;
+  is_walk_in: boolean;
   insurance_flag: boolean;
-  booking_source: string | null;
+  booking_source: string;
   notes: string | null;
   cancelled_at: string | null;
   cancellation_reason: string | null;
@@ -135,7 +139,9 @@ interface AppointmentRaw {
   is_emergency: boolean;
   recurrence_group_id: string | null;
   recurrence_pattern: string | null;
+  recurrence_index: number | null;
   created_at: string;
+  updated_at: string;
 }
 
 // lookup maps built lazily
@@ -273,8 +279,9 @@ interface UserRaw {
   clinic_id: string | null;
   avatar_url: string | null;
   is_active: boolean;
-  metadata: Record<string, unknown> | null;
+  metadata: Record<string, unknown>;
   created_at: string;
+  updated_at: string;
 }
 
 function mapDoctor(raw: UserRaw): DoctorView {
@@ -357,10 +364,12 @@ interface ServiceRaw {
   clinic_id: string;
   name: string;
   description: string | null;
+  duration_minutes: number;
   duration_min: number;
   price: number | null;
-  is_active: boolean;
   category: string | null;
+  is_active: boolean;
+  created_at: string;
 }
 
 function mapService(raw: ServiceRaw): ServiceView {
@@ -512,13 +521,14 @@ export interface InvoiceView {
 interface PaymentRaw {
   id: string;
   clinic_id: string;
-  patient_id: string;
   appointment_id: string | null;
+  patient_id: string;
   amount: number;
   method: string | null;
   status: string;
   reference: string | null;
   payment_type: string;
+  gateway_session_id: string | null;
   refunded_amount: number;
   created_at: string;
 }
@@ -568,6 +578,7 @@ interface WaitingListRaw {
   preferred_time: string | null;
   service_id: string | null;
   status: string;
+  notified_at: string | null;
   created_at: string;
 }
 
@@ -624,6 +635,7 @@ interface ConsultationNoteRaw {
   notes: string | null;
   diagnosis: string | null;
   created_at: string;
+  updated_at: string;
 }
 
 export async function fetchConsultationNotes(clinicId: string, doctorId?: string): Promise<ConsultationNoteView[]> {
@@ -664,14 +676,15 @@ export interface TimeSlotView {
 
 interface TimeSlotRaw {
   id: string;
-  doctor_id: string;
   clinic_id: string;
+  doctor_id: string;
   day_of_week: number;
   start_time: string;
   end_time: string;
-  is_available: boolean;
   max_capacity: number;
   buffer_minutes: number;
+  buffer_min: number;
+  is_active: boolean;
 }
 
 export async function fetchTimeSlots(clinicId: string, doctorId?: string): Promise<TimeSlotView[]> {
@@ -691,7 +704,7 @@ export async function fetchTimeSlots(clinicId: string, doctorId?: string): Promi
     endTime: r.end_time,
     maxCapacity: r.max_capacity,
     bufferMinutes: r.buffer_minutes,
-    isAvailable: r.is_available,
+    isAvailable: r.is_active,
   }));
 }
 

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -189,7 +189,7 @@ export async function getPublicServices(): Promise<PublicService[]> {
 
   const { data, error } = await supabase
     .from("services")
-    .select("id, name, description, duration_min, price, is_active, category")
+    .select("id, name, description, duration_minutes, duration_min, price, is_active, category")
     .eq("clinic_id", clinicId)
     .order("name", { ascending: true });
 
@@ -198,12 +198,12 @@ export async function getPublicServices(): Promise<PublicService[]> {
   return data.map((s) => ({
     id: s.id,
     name: s.name,
-    description: (s as Record<string, unknown>).description as string ?? "",
-    duration: (s as Record<string, unknown>).duration_min as number ?? 30,
+    description: (s.description as string) ?? "",
+    duration: (s.duration_minutes as number) ?? (s.duration_min as number) ?? 30,
     price: s.price ?? 0,
     currency: clinicConfig.currency,
-    active: (s as Record<string, unknown>).is_active as boolean ?? true,
-    category: (s as Record<string, unknown>).category as string ?? "General",
+    active: (s.is_active as boolean) ?? true,
+    category: (s.category as string) ?? "General",
   }));
 }
 
@@ -278,9 +278,9 @@ export async function getPublicTimeSlots(
 
   let q = supabase
     .from("time_slots")
-    .select("id, doctor_id, day_of_week, start_time, end_time, is_available, max_capacity, buffer_minutes")
+    .select("id, doctor_id, day_of_week, start_time, end_time, is_active, max_capacity, buffer_minutes")
     .eq("clinic_id", clinicId)
-    .eq("is_available", true);
+    .eq("is_active", true);
 
   if (doctorId) {
     q = q.eq("doctor_id", doctorId);
@@ -298,7 +298,7 @@ export async function getPublicTimeSlots(
     endTime: ts.end_time,
     maxCapacity: ts.max_capacity ?? 1,
     bufferMinutes: ts.buffer_minutes ?? 10,
-    isAvailable: ts.is_available ?? true,
+    isAvailable: (ts.is_active as boolean) ?? true,
   }));
 }
 
@@ -425,7 +425,7 @@ export async function getPublicPharmacyProducts(): Promise<PublicPharmacyProduct
   if (!products) return [];
 
   const stockMap = new Map(
-    ((stockRows ?? []) as { product_id: string; quantity: number; min_threshold: number; expiry_date: string | null; supplier_id: string | null }[])
+    ((stockRows ?? []) as { product_id: string; quantity: number; min_threshold: number; expiry_date: string | null; batch_number: string | null }[])
       .map((s) => [s.product_id, s]),
   );
 

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -109,10 +109,20 @@ export interface ClinicRow {
   id: string;
   name: string;
   type: string;
-  config: Record<string, unknown> | null;
-  tier: string | null;
-  status: string | null;
-  created_at: string | null;
+  tier: string;
+  subdomain: string | null;
+  domain: string | null;
+  clinic_type_key: string | null;
+  config: Record<string, unknown>;
+  status: string;
+  is_active: boolean;
+  owner_name: string | null;
+  owner_email: string | null;
+  owner_phone: string | null;
+  city: string | null;
+  features: Record<string, boolean>;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getClinics(): Promise<ClinicRow[]> {
@@ -180,7 +190,11 @@ export interface UserRow {
   phone: string | null;
   email: string | null;
   clinic_id: string | null;
-  created_at: string | null;
+  avatar_url: string | null;
+  is_active: boolean;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getClinicUsers(clinicId: string, role?: string): Promise<UserRow[]> {
@@ -216,9 +230,13 @@ export interface ServiceRow {
   id: string;
   clinic_id: string;
   name: string;
-  price: number | null;
+  description: string | null;
   duration_minutes: number;
+  duration_min: number;
+  price: number | null;
   category: string | null;
+  is_active: boolean;
+  created_at: string;
 }
 
 export async function getServices(clinicId: string): Promise<ServiceRow[]> {
@@ -233,18 +251,30 @@ export async function getServices(clinicId: string): Promise<ServiceRow[]> {
 
 export interface AppointmentRow {
   id: string;
+  clinic_id: string;
   patient_id: string;
   doctor_id: string;
-  clinic_id: string;
   service_id: string | null;
   slot_start: string;
   slot_end: string;
+  appointment_date: string;
+  start_time: string;
+  end_time: string;
   status: string;
   is_first_visit: boolean;
+  is_walk_in: boolean;
   insurance_flag: boolean;
-  source: string | null;
+  booking_source: string;
   notes: string | null;
-  created_at: string | null;
+  cancelled_at: string | null;
+  cancellation_reason: string | null;
+  rescheduled_from: string | null;
+  is_emergency: boolean;
+  recurrence_group_id: string | null;
+  recurrence_pattern: string | null;
+  recurrence_index: number | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getAppointments(clinicId: string): Promise<AppointmentRow[]> {
@@ -300,14 +330,15 @@ export async function getTodayAppointments(clinicId: string, doctorId?: string):
 
 export interface TimeSlotRow {
   id: string;
-  doctor_id: string;
   clinic_id: string;
+  doctor_id: string;
   day_of_week: number;
   start_time: string;
   end_time: string;
-  is_available: boolean;
   max_capacity: number;
   buffer_minutes: number;
+  buffer_min: number;
+  is_active: boolean;
 }
 
 export async function getTimeSlots(clinicId: string, doctorId?: string): Promise<TimeSlotRow[]> {
@@ -326,13 +357,16 @@ export async function getTimeSlots(clinicId: string, doctorId?: string): Promise
 export interface PaymentRow {
   id: string;
   clinic_id: string;
-  patient_id: string;
   appointment_id: string | null;
+  patient_id: string;
   amount: number;
   method: string | null;
   status: string;
-  ref: string | null;
-  created_at: string | null;
+  reference: string | null;
+  payment_type: string;
+  gateway_session_id: string | null;
+  refunded_amount: number;
+  created_at: string;
 }
 
 export async function getPayments(clinicId: string): Promise<PaymentRow[]> {
@@ -355,12 +389,14 @@ export async function getPaymentsByPatient(clinicId: string, patientId: string):
 
 export interface ReviewRow {
   id: string;
-  patient_id: string;
   clinic_id: string;
+  patient_id: string;
+  doctor_id: string | null;
   stars: number;
   comment: string | null;
   response: string | null;
-  created_at: string | null;
+  is_visible: boolean;
+  created_at: string;
 }
 
 export async function getReviews(clinicId: string): Promise<ReviewRow[]> {
@@ -376,12 +412,14 @@ export async function getReviews(clinicId: string): Promise<ReviewRow[]> {
 
 export interface NotificationRow {
   id: string;
+  clinic_id: string;
   user_id: string;
   type: string;
   channel: string;
-  message: string | null;
-  sent_at: string | null;
-  read_at: string | null;
+  title: string | null;
+  body: string | null;
+  is_read: boolean;
+  sent_at: string;
 }
 
 export async function getNotifications(userId: string): Promise<NotificationRow[]> {
@@ -397,11 +435,13 @@ export async function getNotifications(userId: string): Promise<NotificationRow[
 
 export interface DocumentRow {
   id: string;
-  user_id: string;
   clinic_id: string;
+  user_id: string;
   type: string;
   file_url: string;
-  uploaded_at: string | null;
+  file_name: string | null;
+  file_size: number | null;
+  created_at: string;
 }
 
 export async function getDocuments(clinicId: string, userId?: string): Promise<DocumentRow[]> {
@@ -419,12 +459,14 @@ export async function getDocuments(clinicId: string, userId?: string): Promise<D
 
 export interface PrescriptionRow {
   id: string;
-  patient_id: string;
-  doctor_id: string;
+  clinic_id: string;
   appointment_id: string | null;
-  content: unknown;
+  doctor_id: string;
+  patient_id: string;
+  items: { name: string; dosage: string; duration: string }[];
+  notes: string | null;
   pdf_url: string | null;
-  created_at: string | null;
+  created_at: string;
 }
 
 export async function getPrescriptions(clinicId: string, doctorId?: string): Promise<PrescriptionRow[]> {
@@ -460,12 +502,14 @@ export async function getPatientPrescriptions(patientId: string): Promise<Prescr
 
 export interface ConsultationNoteRow {
   id: string;
-  patient_id: string;
-  doctor_id: string;
+  clinic_id: string;
   appointment_id: string;
+  doctor_id: string;
+  patient_id: string;
   notes: string | null;
-  private: boolean;
-  created_at: string | null;
+  diagnosis: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getConsultationNotes(doctorId: string): Promise<ConsultationNoteRow[]> {
@@ -481,13 +525,15 @@ export async function getConsultationNotes(doctorId: string): Promise<Consultati
 
 export interface WaitingListRow {
   id: string;
+  clinic_id: string;
   patient_id: string;
   doctor_id: string;
-  clinic_id: string;
-  service_id: string | null;
   preferred_date: string | null;
+  preferred_time: string | null;
+  service_id: string | null;
   status: string;
-  created_at: string | null;
+  notified_at: string | null;
+  created_at: string;
 }
 
 export async function getWaitingList(clinicId: string): Promise<WaitingListRow[]> {
@@ -504,10 +550,9 @@ export async function getWaitingList(clinicId: string): Promise<WaitingListRow[]
 export interface FamilyMemberRow {
   id: string;
   primary_user_id: string;
-  name: string;
-  phone: string | null;
+  member_user_id: string;
   relationship: string;
-  created_at: string | null;
+  created_at: string;
 }
 
 export async function getFamilyMembers(userId: string): Promise<FamilyMemberRow[]> {
@@ -522,11 +567,12 @@ export async function getFamilyMembers(userId: string): Promise<FamilyMemberRow[
 
 export interface OdontogramRow {
   id: string;
+  clinic_id: string;
   patient_id: string;
   tooth_number: number;
   status: string;
   notes: string | null;
-  updated_at: string | null;
+  updated_at: string;
 }
 
 export async function getOdontogram(patientId: string): Promise<OdontogramRow[]> {
@@ -542,12 +588,15 @@ export async function getOdontogram(patientId: string): Promise<OdontogramRow[]>
 
 export interface TreatmentPlanRow {
   id: string;
+  clinic_id: string;
   patient_id: string;
   doctor_id: string;
-  steps: unknown;
-  status: string;
+  title: string;
+  steps: { step: number; description: string; status: string; date: string | null }[];
   total_cost: number | null;
-  created_at: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getTreatmentPlans(clinicId: string, doctorId?: string): Promise<TreatmentPlanRow[]> {
@@ -572,12 +621,15 @@ export async function getPatientTreatmentPlans(patientId: string): Promise<Treat
 
 export interface LabOrderRow {
   id: string;
-  doctor_id: string;
-  patient_id: string;
   clinic_id: string;
-  details: string;
+  patient_id: string;
+  doctor_id: string;
+  lab_name: string | null;
+  description: string;
   status: string;
-  created_at: string | null;
+  due_date: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getLabOrders(clinicId: string): Promise<LabOrderRow[]> {
@@ -593,6 +645,7 @@ export async function getLabOrders(clinicId: string): Promise<LabOrderRow[]> {
 
 export interface InstallmentRow {
   id: string;
+  clinic_id: string;
   treatment_plan_id: string;
   patient_id: string;
   amount: number;
@@ -600,6 +653,7 @@ export interface InstallmentRow {
   paid_date: string | null;
   status: string;
   receipt_url: string | null;
+  created_at: string;
 }
 
 export async function getInstallments(treatmentPlanId: string): Promise<InstallmentRow[]> {
@@ -624,8 +678,12 @@ export interface SterilizationLogRow {
   id: string;
   clinic_id: string;
   tool_name: string;
+  sterilized_by: string | null;
   sterilized_at: string;
   next_due: string | null;
+  method: string;
+  notes: string | null;
+  created_at: string;
 }
 
 export async function getSterilizationLog(clinicId: string): Promise<SterilizationLogRow[]> {
@@ -643,10 +701,19 @@ export interface ProductRow {
   id: string;
   clinic_id: string;
   name: string;
+  generic_name: string | null;
   category: string | null;
+  description: string | null;
   price: number | null;
+  currency: string;
   requires_prescription: boolean;
+  manufacturer: string | null;
   barcode: string | null;
+  dosage_form: string | null;
+  strength: string | null;
+  image_url: string | null;
+  is_active: boolean;
+  created_at: string;
 }
 
 export async function getProducts(clinicId: string): Promise<ProductRow[]> {
@@ -661,12 +728,13 @@ export async function getProducts(clinicId: string): Promise<ProductRow[]> {
 
 export interface StockRow {
   id: string;
-  product_id: string;
   clinic_id: string;
+  product_id: string;
   quantity: number;
   min_threshold: number;
   expiry_date: string | null;
-  supplier_id: string | null;
+  batch_number: string | null;
+  updated_at: string;
 }
 
 export async function getStock(clinicId: string): Promise<StockRow[]> {
@@ -683,9 +751,17 @@ export interface SupplierRow {
   id: string;
   clinic_id: string;
   name: string;
-  phone: string | null;
-  email: string | null;
-  products: unknown;
+  contact_phone: string | null;
+  contact_email: string | null;
+  contact_person: string | null;
+  address: string | null;
+  city: string | null;
+  categories: string[];
+  rating: number;
+  payment_terms: string | null;
+  delivery_days: number;
+  is_active: boolean;
+  created_at: string;
 }
 
 export async function getSuppliers(clinicId: string): Promise<SupplierRow[]> {
@@ -700,12 +776,14 @@ export async function getSuppliers(clinicId: string): Promise<SupplierRow[]> {
 
 export interface PrescriptionRequestRow {
   id: string;
-  patient_id: string;
   clinic_id: string;
+  patient_id: string;
   image_url: string;
   status: string;
   notes: string | null;
-  ready_at: string | null;
+  delivery_requested: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getPrescriptionRequests(clinicId: string): Promise<PrescriptionRequestRow[]> {
@@ -721,10 +799,21 @@ export async function getPrescriptionRequests(clinicId: string): Promise<Prescri
 
 export interface LoyaltyPointsRow {
   id: string;
-  patient_id: string;
   clinic_id: string;
+  patient_id: string;
   points: number;
-  last_updated: string | null;
+  available_points: number;
+  redeemed_points: number;
+  tier: string;
+  referral_code: string | null;
+  referred_by: string | null;
+  total_purchases: number;
+  date_of_birth: string | null;
+  birthday_reward_claimed: boolean;
+  birthday_reward_year: number | null;
+  last_earned: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export async function getLoyaltyPoints(clinicId: string): Promise<LoyaltyPointsRow[]> {
@@ -929,7 +1018,7 @@ export async function markNotificationRead(notificationId: string): Promise<bool
   const supabase = await createClient();
   const { error } = await supabase
     .from("notifications")
-    .update({ read_at: new Date().toISOString() })
+    .update({ is_read: true })
     .eq("id", notificationId);
   if (error) return false;
   return true;

--- a/src/lib/data/specialists.ts
+++ b/src/lib/data/specialists.ts
@@ -56,9 +56,9 @@ export async function fetchSkinPhotos(clinicId: string, patientId?: string): Pro
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; doctor_id: string; body_region: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; body_region: string;
     description: string | null; image_url: string | null; photo_date: string;
-    tags: string[] | null; created_at: string;
+    tags: string[] | null; created_at: string; updated_at: string;
   }>("skin_photos", { eq, order: ["photo_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -102,9 +102,10 @@ export async function fetchSkinConditions(clinicId: string, patientId?: string):
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; condition_name: string; body_region: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; condition_name: string; body_region: string;
     severity: string | null; status: string; diagnosis_date: string; notes: string | null;
     treatments: { name: string; startDate: string; endDate?: string; notes?: string }[] | null;
+    created_at: string; updated_at: string;
   }>("skin_conditions", { eq, order: ["diagnosis_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -164,9 +165,9 @@ export async function fetchECGRecords(clinicId: string, patientId?: string): Pro
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; record_date: string; file_url: string | null;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; record_date: string; file_url: string | null;
     heart_rate: number | null; rhythm: string | null; interpretation: string | null;
-    notes: string | null; is_abnormal: boolean;
+    notes: string | null; is_abnormal: boolean; created_at: string;
   }>("ecg_records", { eq, order: ["record_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -210,9 +211,9 @@ export async function fetchBloodPressureReadings(clinicId: string, patientId?: s
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; systolic: number; diastolic: number;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; systolic: number; diastolic: number;
     heart_rate: number | null; reading_date: string; position: string | null;
-    arm: string | null; notes: string | null;
+    arm: string | null; notes: string | null; created_at: string;
   }>("blood_pressure_readings", { eq, order: ["reading_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -254,8 +255,8 @@ export async function fetchHeartMonitoringNotes(clinicId: string, patientId?: st
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; note_date: string; category: string;
-    title: string; content: string | null; severity: string; is_alert: boolean;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; note_date: string; category: string;
+    title: string; content: string | null; severity: string; is_alert: boolean; created_at: string;
   }>("heart_monitoring_notes", { eq, order: ["note_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -303,10 +304,10 @@ export async function fetchHearingTests(clinicId: string, patientId?: string): P
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; test_date: string; test_type: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; test_date: string; test_type: string;
     left_ear_data: Record<string, number> | null; right_ear_data: Record<string, number> | null;
     interpretation: string | null; hearing_loss_type: string | null;
-    hearing_loss_degree: string | null; notes: string | null;
+    hearing_loss_degree: string | null; notes: string | null; created_at: string;
   }>("hearing_tests", { eq, order: ["test_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -351,8 +352,8 @@ export async function fetchENTExams(clinicId: string, patientId?: string): Promi
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; exam_date: string; template_type: string;
-    findings: Record<string, string> | null; diagnosis: string | null; plan: string | null;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; exam_date: string; template_type: string;
+    findings: Record<string, string> | null; diagnosis: string | null; plan: string | null; created_at: string;
   }>("ent_exam_records", { eq, order: ["exam_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -398,9 +399,9 @@ export async function fetchXRayRecords(clinicId: string, patientId?: string): Pr
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; record_date: string; body_part: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; record_date: string; body_part: string;
     image_url: string | null; annotations: { x: number; y: number; label: string }[] | null;
-    findings: string | null; diagnosis: string | null;
+    findings: string | null; diagnosis: string | null; created_at: string;
   }>("xray_records", { eq, order: ["record_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -446,10 +447,10 @@ export async function fetchFractureRecords(clinicId: string, patientId?: string)
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; location: string; fracture_type: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; location: string; fracture_type: string;
     severity: string; status: string; injury_date: string; diagnosis_date: string;
     expected_healing_date: string | null; notes: string | null;
-    xray_record_id: string | null;
+    xray_record_id: string | null; created_at: string; updated_at: string;
   }>("fracture_records", { eq, order: ["diagnosis_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -508,10 +509,10 @@ export async function fetchRehabPlans(clinicId: string, patientId?: string): Pro
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; title: string; condition: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; title: string; condition: string;
     start_date: string; target_end_date: string | null; status: string;
     milestones: { title: string; targetDate: string; completed: boolean; notes?: string }[] | null;
-    notes: string | null;
+    notes: string | null; created_at: string; updated_at: string;
   }>("rehab_plans", { eq, order: ["start_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -573,10 +574,10 @@ export async function fetchPsychSessionNotes(clinicId: string, doctorId: string,
   const eq: [string, unknown][] = [["clinic_id", clinicId], ["doctor_id", doctorId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; session_date: string; session_number: number;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; session_date: string; session_number: number;
     session_type: string; mood_rating: number | null; content: string | null;
     observations: string | null; plan: string | null; is_confidential: boolean;
-    access_level: string;
+    access_level: string; created_at: string;
   }>("psych_session_notes", { eq, order: ["session_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -627,10 +628,11 @@ export async function fetchPsychMedications(clinicId: string, patientId?: string
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; medication_name: string; dosage: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; medication_name: string; dosage: string;
     frequency: string; start_date: string; end_date: string | null; status: string;
     reason: string | null; side_effects: string | null; notes: string | null;
     dosage_history: { date: string; dosage: string; reason?: string }[] | null;
+    created_at: string; updated_at: string;
   }>("psych_medications", { eq, order: ["start_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -693,9 +695,9 @@ export async function fetchEEGRecords(clinicId: string, patientId?: string): Pro
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; record_date: string; file_url: string | null;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; record_date: string; file_url: string | null;
     duration_minutes: number | null; findings: string | null;
-    interpretation: string | null; is_abnormal: boolean; notes: string | null;
+    interpretation: string | null; is_abnormal: boolean; notes: string | null; created_at: string;
   }>("eeg_records", { eq, order: ["record_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -744,12 +746,12 @@ export async function fetchNeuroExams(clinicId: string, patientId?: string): Pro
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; exam_date: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; exam_date: string;
     mental_status: Record<string, string> | null; cranial_nerves: Record<string, string> | null;
     motor_function: Record<string, string> | null; sensory_function: Record<string, string> | null;
     reflexes: Record<string, string> | null; coordination: Record<string, string> | null;
     gait: Record<string, string> | null; diagnosis: string | null;
-    plan: string | null; notes: string | null;
+    plan: string | null; notes: string | null; created_at: string;
   }>("neuro_exam_records", { eq, order: ["exam_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -805,9 +807,9 @@ export async function fetchUrologyExams(clinicId: string, patientId?: string): P
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; exam_date: string; template_type: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; exam_date: string; template_type: string;
     findings: Record<string, string> | null; lab_results: Record<string, string> | null;
-    diagnosis: string | null; plan: string | null;
+    diagnosis: string | null; plan: string | null; created_at: string;
   }>("urology_exams", { eq, order: ["exam_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -854,10 +856,10 @@ export async function fetchSpirometryRecords(clinicId: string, patientId?: strin
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; test_date: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; test_date: string;
     fvc: number | null; fev1: number | null; fev1_fvc_ratio: number | null;
     pef: number | null; interpretation: string | null;
-    test_quality: string; notes: string | null;
+    test_quality: string; notes: string | null; created_at: string;
   }>("spirometry_records", { eq, order: ["test_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -900,8 +902,8 @@ export async function fetchRespiratoryTests(clinicId: string, patientId?: string
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; test_date: string; test_type: string;
-    results: Record<string, unknown> | null; interpretation: string | null; notes: string | null;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; test_date: string; test_type: string;
+    results: Record<string, unknown> | null; interpretation: string | null; notes: string | null; created_at: string;
   }>("respiratory_tests", { eq, order: ["test_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -942,8 +944,8 @@ export async function fetchBloodSugarReadings(clinicId: string, patientId?: stri
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; reading_date: string;
-    glucose_level: number; reading_type: string; unit: string; notes: string | null;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; reading_date: string;
+    glucose_level: number; reading_type: string; unit: string; notes: string | null; created_at: string;
   }>("blood_sugar_readings", { eq, order: ["reading_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -983,9 +985,9 @@ export async function fetchHormoneLevels(clinicId: string, patientId?: string): 
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; test_date: string; hormone_name: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; test_date: string; hormone_name: string;
     value: number; unit: string; reference_range: string | null;
-    is_abnormal: boolean; notes: string | null;
+    is_abnormal: boolean; notes: string | null; created_at: string;
   }>("hormone_levels", { eq, order: ["test_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -1032,11 +1034,12 @@ export async function fetchDiabetesManagement(clinicId: string, patientId?: stri
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; diabetes_type: string; diagnosis_date: string | null;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; diabetes_type: string; diagnosis_date: string | null;
     current_hba1c: number | null; target_hba1c: number;
     medications: { name: string; dosage: string; frequency: string }[] | null;
     diet_plan: string | null; exercise_plan: string | null;
     monitoring_frequency: string; notes: string | null; last_review_date: string | null;
+    created_at: string; updated_at: string;
   }>("diabetes_management", { eq, order: ["created_at", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -1101,11 +1104,12 @@ export async function fetchJointAssessments(clinicId: string, patientId?: string
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; assessment_date: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; assessment_date: string;
     joints_data: Record<string, { swollen: boolean; tender: boolean; notes?: string }> | null;
     vas_pain_score: number | null; morning_stiffness_minutes: number | null;
     swollen_joint_count: number; tender_joint_count: number;
     das28_score: number | null; functional_status: string | null; notes: string | null;
+    created_at: string;
   }>("joint_assessments", { eq, order: ["assessment_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,
@@ -1153,9 +1157,9 @@ export async function fetchMobilityTests(clinicId: string, patientId?: string): 
   const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (patientId) eq.push(["patient_id", patientId]);
   const rows = await fetchRows<{
-    id: string; patient_id: string; test_date: string; test_type: string;
+    id: string; clinic_id: string; patient_id: string; doctor_id: string; test_date: string; test_type: string;
     joint: string; range_of_motion: Record<string, number> | null;
-    strength_score: number | null; pain_during_test: number | null; notes: string | null;
+    strength_score: number | null; pain_during_test: number | null; notes: string | null; created_at: string;
   }>("mobility_tests", { eq, order: ["test_date", { ascending: false }] });
   return rows.map((r) => ({
     id: r.id,


### PR DESCRIPTION
## Summary

Fixes data layer type mismatches across `client.ts`, `server.ts`, `public.ts`, and `specialists.ts` to align with canonical DB types in `database.ts`.

### Changes

**server.ts** - Updated all 23 Row types to match database.ts schema:
- Added missing fields (e.g. `subdomain`, `is_active`, `avatar_url`, `updated_at`)
- Fixed field name mismatches (`ref` → `reference`, `content` → `items`, `message` → `body`, `uploaded_at` → `created_at`, `read_at` → `is_read`, `source` → `booking_source`)
- Fixed `markNotificationRead` to use `is_read: true` instead of `read_at`
- Removed incorrect fields (`private` from ConsultationNoteRow, `name`/`phone` from FamilyMemberRow)
- Added proper typing for `steps` in TreatmentPlanRow and `items` in PrescriptionRow

**client.ts** - Updated Raw types:
- Added `slot_start`, `slot_end`, `is_walk_in`, `recurrence_index`, `updated_at`, `clinic_id` to AppointmentRaw
- Fixed UserRaw `metadata` to non-nullable `Record<string, unknown>`
- Added `duration_minutes`, `created_at` to ServiceRaw
- Added `gateway_session_id` to PaymentRaw
- Fixed TimeSlotRaw `is_available` → `is_active`, added `buffer_min`
- Added missing timestamp fields throughout

**public.ts** - Fixed query-level mismatches:
- Updated time slot queries from `is_available` → `is_active`
- Added `duration_minutes` to services select
- Fixed stock inline type `supplier_id` → `batch_number`

**specialists.ts** - Added missing DB fields to all inline raw types:
- Added `clinic_id`, `doctor_id`, and timestamp fields across all 23 specialist fetch functions