### PR TITLE
feat: Task 22 — Radiology & Medical Imaging features

### DIFF
--- a/src/app/(radiology)/radiology/images/page.tsx
+++ b/src/app/(radiology)/radiology/images/page.tsx
@@ -1,10 +1,28 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Image, ExternalLink, Eye, FileImage } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Search, Image, ExternalLink, Eye, FileImage, Upload, Loader2, X } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";
@@ -12,14 +30,73 @@ import type { RadiologyOrderView } from "@/lib/data/client";
 
 export default function RadiologyImagesPage() {
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [allOrders, setAllOrders] = useState<RadiologyOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
 
+  // Upload dialog state
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [uploadOrderId, setUploadOrderId] = useState("");
+  const [uploadFiles, setUploadFiles] = useState<File[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState("");
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshOrders = useCallback(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId).then((all) => {
+      setAllOrders(all);
+      setOrders(all.filter((o) => o.imageCount > 0));
+    });
+  }, []);
+
   useEffect(() => {
     fetchRadiologyOrders(clinicConfig.clinicId)
-      .then((all) => setOrders(all.filter((o) => o.imageCount > 0)))
+      .then((all) => {
+        setAllOrders(all);
+        setOrders(all.filter((o) => o.imageCount > 0));
+      })
       .finally(() => setLoading(false));
   }, []);
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const files = Array.from(e.dataTransfer.files);
+    setUploadFiles((prev) => [...prev, ...files]);
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setUploadFiles((prev) => [...prev, ...Array.from(e.target.files!)]);
+    }
+  };
+
+  const removeFile = (index: number) => {
+    setUploadFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleUpload = async () => {
+    if (!uploadOrderId || uploadFiles.length === 0) return;
+    setUploading(true);
+    try {
+      for (let i = 0; i < uploadFiles.length; i++) {
+        setUploadProgress(`Uploading ${i + 1} of ${uploadFiles.length}...`);
+        const formData = new FormData();
+        formData.append("file", uploadFiles[i]);
+        formData.append("orderId", uploadOrderId);
+        formData.append("clinicId", clinicConfig.clinicId);
+        await fetch("/api/radiology/upload", { method: "POST", body: formData });
+      }
+      setUploadOpen(false);
+      setUploadFiles([]);
+      setUploadOrderId("");
+      setUploadProgress("");
+      refreshOrders();
+    } finally {
+      setUploading(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -40,8 +117,83 @@ export default function RadiologyImagesPage() {
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold">Image Gallery</h1>
-          <p className="text-muted-foreground text-sm">Browse uploaded radiology images</p>
+          <p className="text-muted-foreground text-sm">Browse and upload radiology images</p>
         </div>
+        <Dialog open={uploadOpen} onOpenChange={setUploadOpen}>
+          <DialogTrigger asChild>
+            <Button><Upload className="h-4 w-4 mr-2" /> Upload Images</Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>Upload Radiology Images</DialogTitle>
+              <DialogDescription>Upload X-ray, MRI, CT, or DICOM images to a study order.</DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label>Study Order</Label>
+                <Select value={uploadOrderId} onValueChange={setUploadOrderId}>
+                  <SelectTrigger><SelectValue placeholder="Select an order..." /></SelectTrigger>
+                  <SelectContent>
+                    {allOrders.map((o) => (
+                      <SelectItem key={o.id} value={o.id}>
+                        {o.orderNumber} - {o.patientName} ({o.modality.toUpperCase()})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div
+                className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors ${dragOver ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/20" : "border-muted-foreground/25 hover:border-muted-foreground/50"}`}
+                onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+                <p className="text-sm text-muted-foreground">
+                  Drag & drop files here, or click to browse
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  JPEG, PNG, TIFF, DICOM, PDF (max 50 MB)
+                </p>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  accept="image/*,application/dicom,.dcm,application/pdf"
+                  onChange={handleFileSelect}
+                  className="hidden"
+                />
+              </div>
+
+              {uploadFiles.length > 0 && (
+                <div className="space-y-2">
+                  <Label>Selected Files ({uploadFiles.length})</Label>
+                  {uploadFiles.map((file, i) => (
+                    <div key={i} className="flex items-center justify-between text-sm bg-muted/50 rounded px-3 py-2">
+                      <span className="truncate mr-2">{file.name} ({(file.size / 1024 / 1024).toFixed(1)} MB)</span>
+                      <Button variant="ghost" size="sm" onClick={() => removeFile(i)} className="h-6 w-6 p-0">
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {uploadProgress && (
+                <p className="text-sm text-muted-foreground">{uploadProgress}</p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setUploadOpen(false)}>Cancel</Button>
+              <Button onClick={handleUpload} disabled={uploading || !uploadOrderId || uploadFiles.length === 0}>
+                {uploading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Upload {uploadFiles.length} File{uploadFiles.length !== 1 ? "s" : ""}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       <div className="relative mb-6 max-w-md">
@@ -55,6 +207,8 @@ export default function RadiologyImagesPage() {
             <div className="aspect-video bg-muted flex items-center justify-center">
               {order.images.length > 0 && order.images[0].thumbnailUrl ? (
                 <img src={order.images[0].thumbnailUrl} alt={`${order.modality} - ${order.bodyPart}`} className="w-full h-full object-cover" />
+              ) : order.images.length > 0 && order.images[0].fileUrl ? (
+                <img src={order.images[0].fileUrl} alt={`${order.modality} - ${order.bodyPart}`} className="w-full h-full object-cover" />
               ) : (
                 <FileImage className="h-16 w-16 text-muted-foreground/30" />
               )}
@@ -78,9 +232,9 @@ export default function RadiologyImagesPage() {
                     <Eye className="h-3 w-3 mr-1" /> View
                   </a>
                 )}
-                {order.images.some((img) => img.dicomStudyUid) && (
+                {order.images.some((img) => img.isDicom) && (
                   <Link
-                    href={`/radiology/viewer?study=${order.images[0].dicomStudyUid ?? ""}`}
+                    href={`/radiology/viewer?study=${order.images.find((img) => img.dicomStudyUid)?.dicomStudyUid ?? ""}&order=${order.id}`}
                     className="inline-flex items-center rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted transition-colors"
                   >
                     <ExternalLink className="h-3 w-3 mr-1" /> DICOM
@@ -96,6 +250,9 @@ export default function RadiologyImagesPage() {
         <div className="text-center py-12">
           <Image className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
           <p className="text-muted-foreground">No images found</p>
+          <Button variant="outline" className="mt-4" onClick={() => setUploadOpen(true)}>
+            <Upload className="h-4 w-4 mr-2" /> Upload your first images
+          </Button>
         </div>
       )}
     </div>

--- a/src/app/(radiology)/radiology/orders/page.tsx
+++ b/src/app/(radiology)/radiology/orders/page.tsx
@@ -1,32 +1,194 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
-  Search, Filter, AlertTriangle, Clock, CheckCircle,
-  Scan, ChevronDown, Image,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Search, Filter, ChevronDown, Scan, Plus,
+  FileText, Loader2,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
-import { fetchRadiologyOrders } from "@/lib/data/client";
-import type { RadiologyOrderView } from "@/lib/data/client";
+import { fetchRadiologyOrders, fetchRadiologyTemplates } from "@/lib/data/client";
+import type { RadiologyOrderView, RadiologyTemplateView } from "@/lib/data/client";
 
 const statusOptions = ["all", "pending", "scheduled", "in_progress", "images_ready", "reported", "validated", "cancelled"] as const;
+const modalityOptions = ["xray", "ct", "mri", "ultrasound", "mammography", "pet", "fluoroscopy", "other"] as const;
+const priorityOptions = ["normal", "urgent", "stat"] as const;
 
 export default function RadiologyOrdersPage() {
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [templates, setTemplates] = useState<RadiologyTemplateView[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchRadiologyOrders(clinicConfig.clinicId)
-      .then(setOrders)
-      .finally(() => setLoading(false));
+  const [newOrderOpen, setNewOrderOpen] = useState(false);
+  const [newOrderSaving, setNewOrderSaving] = useState(false);
+  const [newOrder, setNewOrder] = useState({
+    patientId: "",
+    modality: "xray" as string,
+    bodyPart: "",
+    clinicalIndication: "",
+    priority: "normal" as string,
+    scheduledAt: "",
+  });
+
+  const [reportDialogOpen, setReportDialogOpen] = useState(false);
+  const [reportOrderId, setReportOrderId] = useState<string | null>(null);
+  const [reportSaving, setReportSaving] = useState(false);
+  const [reportData, setReportData] = useState({
+    findings: "",
+    impression: "",
+    reportText: "",
+    templateId: "",
+  });
+
+  const [updatingStatusId, setUpdatingStatusId] = useState<string | null>(null);
+
+  const refreshOrders = useCallback(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId).then(setOrders);
   }, []);
+
+  useEffect(() => {
+    Promise.all([
+      fetchRadiologyOrders(clinicConfig.clinicId),
+      fetchRadiologyTemplates(clinicConfig.clinicId),
+    ]).then(([o, t]) => {
+      setOrders(o);
+      setTemplates(t);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleCreateOrder = async () => {
+    if (!newOrder.patientId || !newOrder.modality) return;
+    setNewOrderSaving(true);
+    try {
+      const res = await fetch("/api/radiology/orders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clinicId: clinicConfig.clinicId,
+          patientId: newOrder.patientId,
+          modality: newOrder.modality,
+          bodyPart: newOrder.bodyPart || undefined,
+          clinicalIndication: newOrder.clinicalIndication || undefined,
+          priority: newOrder.priority,
+          scheduledAt: newOrder.scheduledAt || undefined,
+        }),
+      });
+      if (res.ok) {
+        setNewOrderOpen(false);
+        setNewOrder({ patientId: "", modality: "xray", bodyPart: "", clinicalIndication: "", priority: "normal", scheduledAt: "" });
+        refreshOrders();
+      }
+    } finally {
+      setNewOrderSaving(false);
+    }
+  };
+
+  const handleStatusUpdate = async (orderId: string, newStatus: string) => {
+    setUpdatingStatusId(orderId);
+    try {
+      const res = await fetch("/api/radiology/orders", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orderId, action: "status", status: newStatus }),
+      });
+      if (res.ok) refreshOrders();
+    } finally {
+      setUpdatingStatusId(null);
+    }
+  };
+
+  const openReportDialog = (order: RadiologyOrderView) => {
+    setReportOrderId(order.id);
+    setReportData({
+      findings: order.findings ?? "",
+      impression: order.impression ?? "",
+      reportText: order.reportText ?? "",
+      templateId: "",
+    });
+    setReportDialogOpen(true);
+  };
+
+  const handleApplyTemplate = (templateId: string) => {
+    const tpl = templates.find((t) => t.id === templateId);
+    if (!tpl) return;
+    const text = tpl.sections.map((s) => `## ${s.title}\n${s.content}`).join("\n\n");
+    setReportData((prev) => ({ ...prev, reportText: text, templateId }));
+  };
+
+  const handleSaveReport = async () => {
+    if (!reportOrderId) return;
+    setReportSaving(true);
+    try {
+      const res = await fetch("/api/radiology/orders", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orderId: reportOrderId,
+          action: "report",
+          findings: reportData.findings,
+          impression: reportData.impression,
+          reportText: reportData.reportText,
+          templateId: reportData.templateId || undefined,
+        }),
+      });
+      if (res.ok) {
+        setReportDialogOpen(false);
+        refreshOrders();
+      }
+    } finally {
+      setReportSaving(false);
+    }
+  };
+
+  const handleGeneratePdf = async (order: RadiologyOrderView) => {
+    const res = await fetch("/api/radiology/report-pdf", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        orderId: order.id,
+        clinicId: clinicConfig.clinicId,
+        patientName: order.patientName,
+        modality: order.modality,
+        bodyPart: order.bodyPart,
+        findings: order.findings,
+        impression: order.impression,
+        reportText: order.reportText,
+        radiologistName: order.radiologistName,
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.pdfUrl) {
+        window.open(data.pdfUrl, "_blank");
+        refreshOrders();
+      }
+    }
+  };
 
   if (loading) {
     return (
@@ -45,6 +207,16 @@ export default function RadiologyOrdersPage() {
     return true;
   });
 
+  const getNextStatus = (current: string): string | null => {
+    const flow: Record<string, string> = {
+      pending: "scheduled",
+      scheduled: "in_progress",
+      in_progress: "images_ready",
+      images_ready: "reported",
+    };
+    return flow[current] ?? null;
+  };
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -52,6 +224,66 @@ export default function RadiologyOrdersPage() {
           <h1 className="text-2xl font-bold">Study Orders</h1>
           <p className="text-muted-foreground text-sm">{orders.length} total orders</p>
         </div>
+        <Dialog open={newOrderOpen} onOpenChange={setNewOrderOpen}>
+          <DialogTrigger asChild>
+            <Button><Plus className="h-4 w-4 mr-2" /> New Order</Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>Create Radiology Order</DialogTitle>
+              <DialogDescription>Request a new imaging study for a patient.</DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="patientId">Patient ID</Label>
+                <Input id="patientId" placeholder="Patient UUID" value={newOrder.patientId} onChange={(e) => setNewOrder((p) => ({ ...p, patientId: e.target.value }))} />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="grid gap-2">
+                  <Label>Modality</Label>
+                  <Select value={newOrder.modality} onValueChange={(v) => setNewOrder((p) => ({ ...p, modality: v }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {modalityOptions.map((m) => (
+                        <SelectItem key={m} value={m}>{m.toUpperCase()}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label>Priority</Label>
+                  <Select value={newOrder.priority} onValueChange={(v) => setNewOrder((p) => ({ ...p, priority: v }))}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {priorityOptions.map((pr) => (
+                        <SelectItem key={pr} value={pr} className="capitalize">{pr}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="bodyPart">Body Part</Label>
+                <Input id="bodyPart" placeholder="e.g., Chest, Knee, Brain" value={newOrder.bodyPart} onChange={(e) => setNewOrder((p) => ({ ...p, bodyPart: e.target.value }))} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="indication">Clinical Indication</Label>
+                <Textarea id="indication" placeholder="Reason for imaging..." value={newOrder.clinicalIndication} onChange={(e) => setNewOrder((p) => ({ ...p, clinicalIndication: e.target.value }))} rows={2} />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="scheduledAt">Scheduled Date/Time</Label>
+                <Input id="scheduledAt" type="datetime-local" value={newOrder.scheduledAt} onChange={(e) => setNewOrder((p) => ({ ...p, scheduledAt: e.target.value }))} />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setNewOrderOpen(false)}>Cancel</Button>
+              <Button onClick={handleCreateOrder} disabled={newOrderSaving || !newOrder.patientId}>
+                {newOrderSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Create Order
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-3 mb-6">
@@ -108,7 +340,7 @@ export default function RadiologyOrdersPage() {
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                     <div>
                       <p className="text-muted-foreground text-xs">Ordering Doctor</p>
-                      <p className="font-medium">{order.orderingDoctorName ?? "—"}</p>
+                      <p className="font-medium">{order.orderingDoctorName ?? "\u2014"}</p>
                     </div>
                     <div>
                       <p className="text-muted-foreground text-xs">Radiologist</p>
@@ -116,7 +348,7 @@ export default function RadiologyOrdersPage() {
                     </div>
                     <div>
                       <p className="text-muted-foreground text-xs">Scheduled</p>
-                      <p className="font-medium">{order.scheduledAt ? new Date(order.scheduledAt).toLocaleString() : "—"}</p>
+                      <p className="font-medium">{order.scheduledAt ? new Date(order.scheduledAt).toLocaleString() : "\u2014"}</p>
                     </div>
                     <div>
                       <p className="text-muted-foreground text-xs">Images</p>
@@ -141,6 +373,49 @@ export default function RadiologyOrdersPage() {
                       <p className="font-medium">{order.impression}</p>
                     </div>
                   )}
+
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    {getNextStatus(order.status) && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={(e) => { e.stopPropagation(); handleStatusUpdate(order.id, getNextStatus(order.status)!); }}
+                        disabled={updatingStatusId === order.id}
+                      >
+                        {updatingStatusId === order.id && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                        Move to {getNextStatus(order.status)!.replace("_", " ")}
+                      </Button>
+                    )}
+                    {order.status !== "cancelled" && order.status !== "validated" && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={(e) => { e.stopPropagation(); openReportDialog(order); }}
+                      >
+                        <FileText className="h-3 w-3 mr-1" /> Write Report
+                      </Button>
+                    )}
+                    {(order.status === "reported" || order.status === "validated") && order.findings && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={(e) => { e.stopPropagation(); handleGeneratePdf(order); }}
+                      >
+                        Generate PDF
+                      </Button>
+                    )}
+                    {order.status !== "cancelled" && order.status !== "validated" && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-red-600 hover:text-red-700"
+                        onClick={(e) => { e.stopPropagation(); handleStatusUpdate(order.id, "cancelled"); }}
+                        disabled={updatingStatusId === order.id}
+                      >
+                        Cancel Order
+                      </Button>
+                    )}
+                  </div>
                 </div>
               )}
             </CardContent>
@@ -154,6 +429,49 @@ export default function RadiologyOrdersPage() {
           </div>
         )}
       </div>
+
+      <Dialog open={reportDialogOpen} onOpenChange={setReportDialogOpen}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Write Radiology Report</DialogTitle>
+            <DialogDescription>Enter findings and impression for this study.</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            {templates.length > 0 && (
+              <div className="grid gap-2">
+                <Label>Load from Template</Label>
+                <Select value={reportData.templateId} onValueChange={handleApplyTemplate}>
+                  <SelectTrigger><SelectValue placeholder="Select a template..." /></SelectTrigger>
+                  <SelectContent>
+                    {templates.map((t) => (
+                      <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="grid gap-2">
+              <Label htmlFor="findings">Findings</Label>
+              <Textarea id="findings" placeholder="Describe the findings..." value={reportData.findings} onChange={(e) => setReportData((p) => ({ ...p, findings: e.target.value }))} rows={4} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="impression">Impression</Label>
+              <Textarea id="impression" placeholder="Summary / Impression..." value={reportData.impression} onChange={(e) => setReportData((p) => ({ ...p, impression: e.target.value }))} rows={3} />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="reportText">Full Report</Label>
+              <Textarea id="reportText" placeholder="Complete report text..." value={reportData.reportText} onChange={(e) => setReportData((p) => ({ ...p, reportText: e.target.value }))} rows={6} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReportDialogOpen(false)}>Cancel</Button>
+            <Button onClick={handleSaveReport} disabled={reportSaving || (!reportData.findings && !reportData.impression && !reportData.reportText)}>
+              {reportSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Save Report
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(radiology)/radiology/reports/page.tsx
+++ b/src/app/(radiology)/radiology/reports/page.tsx
@@ -3,8 +3,9 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, FileText, Download, Scan } from "lucide-react";
+import { Search, FileText, Download, Scan, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
@@ -14,12 +15,45 @@ export default function RadiologyReportsPage() {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [generatingPdf, setGeneratingPdf] = useState<string | null>(null);
 
   useEffect(() => {
     fetchRadiologyOrders(clinicConfig.clinicId)
       .then((all) => setOrders(all.filter((o) => o.status === "reported" || o.status === "validated")))
       .finally(() => setLoading(false));
   }, []);
+
+  const handleGeneratePdf = async (order: RadiologyOrderView) => {
+    setGeneratingPdf(order.id);
+    try {
+      const res = await fetch("/api/radiology/report-pdf", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orderId: order.id,
+          clinicId: clinicConfig.clinicId,
+          patientName: order.patientName,
+          modality: order.modality,
+          bodyPart: order.bodyPart,
+          findings: order.findings,
+          impression: order.impression,
+          reportText: order.reportText,
+          radiologistName: order.radiologistName,
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.pdfUrl) {
+          window.open(data.pdfUrl, "_blank");
+          // Refresh to get updated pdfUrl
+          fetchRadiologyOrders(clinicConfig.clinicId)
+            .then((all) => setOrders(all.filter((o) => o.status === "reported" || o.status === "validated")));
+        }
+      }
+    } finally {
+      setGeneratingPdf(null);
+    }
+  };
 
   if (loading) {
     return (
@@ -69,15 +103,26 @@ export default function RadiologyReportsPage() {
                   <Badge className={order.status === "validated" ? "bg-green-100 text-green-700 border-0" : "bg-emerald-100 text-emerald-700 border-0"}>
                     {order.status}
                   </Badge>
-                  {order.pdfUrl && (
+                  {order.pdfUrl ? (
                     <a
                       href={order.pdfUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex items-center rounded-md border px-3 py-1 text-xs font-medium hover:bg-muted transition-colors"
+                      onClick={(e) => e.stopPropagation()}
                     >
                       <Download className="h-3 w-3 mr-1" /> PDF
                     </a>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={(e) => { e.stopPropagation(); handleGeneratePdf(order); }}
+                      disabled={generatingPdf === order.id}
+                    >
+                      {generatingPdf === order.id ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <Download className="h-3 w-3 mr-1" />}
+                      Generate PDF
+                    </Button>
                   )}
                 </div>
               </div>
@@ -103,7 +148,7 @@ export default function RadiologyReportsPage() {
                     </div>
                   )}
                   <div className="text-sm text-muted-foreground">
-                    <p>Radiologist: {order.radiologistName ?? "—"} &middot; Reported: {order.reportedAt ? new Date(order.reportedAt).toLocaleString() : "—"}</p>
+                    <p>Radiologist: {order.radiologistName ?? "\u2014"} &middot; Reported: {order.reportedAt ? new Date(order.reportedAt).toLocaleString() : "\u2014"}</p>
                   </div>
                 </div>
               )}

--- a/src/app/(radiology)/radiology/viewer/page.tsx
+++ b/src/app/(radiology)/radiology/viewer/page.tsx
@@ -1,9 +1,31 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
-import { ExternalLink, Monitor, Info } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ExternalLink, Monitor, Info, FileImage, Scan } from "lucide-react";
+import { clinicConfig } from "@/config/clinic.config";
+import { fetchRadiologyOrders } from "@/lib/data/client";
+import type { RadiologyOrderView } from "@/lib/data/client";
 
 export default function DicomViewerPage() {
+  const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchRadiologyOrders(clinicConfig.clinicId)
+      .then((all) => setOrders(all.filter((o) => o.imageCount > 0)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const dicomOrders = orders.filter((o) =>
+    o.images.some((img) => img.isDicom || img.dicomStudyUid)
+  );
+  const nonDicomOrders = orders.filter(
+    (o) => !o.images.some((img) => img.isDicom || img.dicomStudyUid)
+  );
+
   return (
     <div>
       <div className="mb-6">
@@ -11,16 +33,15 @@ export default function DicomViewerPage() {
         <p className="text-muted-foreground text-sm">View medical images in DICOM format</p>
       </div>
 
-      <Card>
+      <Card className="mb-6">
         <CardContent className="pt-6">
-          <div className="text-center py-12 space-y-4">
+          <div className="text-center py-8 space-y-4">
             <Monitor className="h-16 w-16 text-indigo-600 mx-auto" />
             <h2 className="text-xl font-semibold">DICOM Viewer Integration</h2>
             <p className="text-muted-foreground max-w-md mx-auto">
               Connect to an external DICOM viewer such as OHIF Viewer or Cornerstone.js
               to view medical images with full diagnostic tools.
             </p>
-
             <div className="flex items-center justify-center gap-3 pt-4">
               <a
                 href="https://viewer.ohif.org/"
@@ -32,24 +53,117 @@ export default function DicomViewerPage() {
                 Open OHIF Viewer
               </a>
             </div>
-
-            <div className="mt-8 p-4 bg-muted/50 rounded-lg text-left max-w-lg mx-auto">
-              <div className="flex items-start gap-3">
-                <Info className="h-5 w-5 text-blue-600 mt-0.5" />
-                <div>
-                  <h3 className="font-medium text-sm mb-1">Integration Notes</h3>
-                  <ul className="text-xs text-muted-foreground space-y-1">
-                    <li>&bull; Upload DICOM files via the Image Gallery</li>
-                    <li>&bull; DICOM Study UIDs are stored with each image</li>
-                    <li>&bull; Configure your PACS/DICOMweb endpoint in clinic settings</li>
-                    <li>&bull; Supported viewers: OHIF, Cornerstone.js, Horos</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
           </div>
         </CardContent>
       </Card>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-pulse text-muted-foreground">Loading studies...</div>
+        </div>
+      ) : (
+        <>
+          {dicomOrders.length > 0 && (
+            <div className="mb-6">
+              <h3 className="text-lg font-semibold mb-3">DICOM Studies</h3>
+              <div className="space-y-3">
+                {dicomOrders.map((order) => (
+                  <Card key={order.id}>
+                    <CardContent className="pt-4 pb-4">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-4">
+                          <div className="h-10 w-10 rounded-full bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center">
+                            <Scan className="h-5 w-5 text-indigo-600" />
+                          </div>
+                          <div>
+                            <p className="font-medium">{order.patientName}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {order.orderNumber} &middot; {order.modality.toUpperCase()} &middot; {order.bodyPart ?? "N/A"}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline" className="text-xs">{order.imageCount} image{order.imageCount !== 1 ? "s" : ""}</Badge>
+                          {order.images.find((img) => img.dicomStudyUid) && (
+                            <a
+                              href={`https://viewer.ohif.org/viewer?StudyInstanceUIDs=${order.images.find((img) => img.dicomStudyUid)?.dicomStudyUid}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-flex items-center rounded-md bg-indigo-600 text-white px-3 py-1.5 text-xs font-medium hover:bg-indigo-700 transition-colors"
+                            >
+                              <ExternalLink className="h-3 w-3 mr-1" /> Open in OHIF
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {nonDicomOrders.length > 0 && (
+            <div className="mb-6">
+              <h3 className="text-lg font-semibold mb-3">Standard Images</h3>
+              <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+                {nonDicomOrders.map((order) => (
+                  <Card key={order.id}>
+                    <CardContent className="pt-4 pb-4">
+                      <div className="flex items-center gap-3">
+                        <FileImage className="h-8 w-8 text-muted-foreground" />
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-sm truncate">{order.patientName}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {order.modality.toUpperCase()} &middot; {order.imageCount} image{order.imageCount !== 1 ? "s" : ""}
+                          </p>
+                        </div>
+                        {order.images[0]?.fileUrl && (
+                          <a
+                            href={order.images[0].fileUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center rounded-md border px-2 py-1 text-xs hover:bg-muted transition-colors"
+                          >
+                            View
+                          </a>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {orders.length === 0 && (
+            <Card>
+              <CardContent className="pt-6">
+                <div className="text-center py-8">
+                  <FileImage className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+                  <p className="text-muted-foreground">No studies with images found</p>
+                  <p className="text-xs text-muted-foreground mt-1">Upload images via the Image Gallery page</p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+
+      <div className="mt-6 p-4 bg-muted/50 rounded-lg text-left max-w-lg">
+        <div className="flex items-start gap-3">
+          <Info className="h-5 w-5 text-blue-600 mt-0.5" />
+          <div>
+            <h3 className="font-medium text-sm mb-1">Integration Notes</h3>
+            <ul className="text-xs text-muted-foreground space-y-1">
+              <li>&bull; Upload DICOM files via the Image Gallery</li>
+              <li>&bull; DICOM Study UIDs are stored with each image</li>
+              <li>&bull; Configure your PACS/DICOMweb endpoint in clinic settings</li>
+              <li>&bull; Supported viewers: OHIF, Cornerstone.js, Horos</li>
+            </ul>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/api/radiology/orders/route.ts
+++ b/src/app/api/radiology/orders/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/radiology/orders — Create a new radiology order
+ * PATCH /api/radiology/orders — Update order status or save report
+ *
+ * POST body: { clinicId, patientId, modality, bodyPart?, clinicalIndication?, priority?, scheduledAt?, orderingDoctorId? }
+ * PATCH body (status update): { orderId, action: "status", status }
+ * PATCH body (save report): { orderId, action: "report", findings, impression, reportText, templateId?, radiologistId? }
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import {
+  createRadiologyOrder,
+  updateRadiologyOrderStatus,
+  saveRadiologyReport,
+} from "@/lib/data/server";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { clinicId, patientId, modality, bodyPart, clinicalIndication, priority, scheduledAt, orderingDoctorId } = body;
+
+    if (!clinicId || !patientId || !modality) {
+      return NextResponse.json(
+        { error: "clinicId, patientId, and modality are required" },
+        { status: 400 },
+      );
+    }
+
+    const result = await createRadiologyOrder({
+      clinic_id: clinicId,
+      patient_id: patientId,
+      ordering_doctor_id: orderingDoctorId,
+      modality,
+      body_part: bodyPart,
+      clinical_indication: clinicalIndication,
+      priority,
+      scheduled_at: scheduledAt,
+    });
+
+    if (!result) {
+      return NextResponse.json(
+        { error: "Failed to create order" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { orderId, action } = body;
+
+    if (!orderId || !action) {
+      return NextResponse.json(
+        { error: "orderId and action are required" },
+        { status: 400 },
+      );
+    }
+
+    if (action === "status") {
+      const { status } = body;
+      if (!status) {
+        return NextResponse.json(
+          { error: "status is required for status update" },
+          { status: 400 },
+        );
+      }
+      const success = await updateRadiologyOrderStatus(orderId, status);
+      if (!success) {
+        return NextResponse.json(
+          { error: "Failed to update status" },
+          { status: 500 },
+        );
+      }
+      return NextResponse.json({ success: true });
+    }
+
+    if (action === "report") {
+      const { findings, impression, reportText, templateId, radiologistId } = body;
+      if (!findings && !impression && !reportText) {
+        return NextResponse.json(
+          { error: "At least one of findings, impression, or reportText is required" },
+          { status: 400 },
+        );
+      }
+      const success = await saveRadiologyReport(orderId, {
+        findings: findings ?? "",
+        impression: impression ?? "",
+        report_text: reportText ?? "",
+        report_template_id: templateId,
+        radiologist_id: radiologistId,
+      });
+      if (!success) {
+        return NextResponse.json(
+          { error: "Failed to save report" },
+          { status: 500 },
+        );
+      }
+      return NextResponse.json({ success: true });
+    }
+
+    return NextResponse.json(
+      { error: `Unknown action: ${action}` },
+      { status: 400 },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/radiology/report-pdf/route.ts
+++ b/src/app/api/radiology/report-pdf/route.ts
@@ -1,0 +1,143 @@
+/**
+ * POST /api/radiology/report-pdf — Generate a PDF report for a radiology order
+ *
+ * Body: { orderId, clinicId, patientName, modality, bodyPart?, findings, impression, reportText, radiologistName? }
+ *
+ * Generates a simple PDF, uploads to R2, and updates the order's pdf_url.
+ * Returns: { pdfUrl }
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
+import { updateRadiologyOrderPdfUrl } from "@/lib/data/server";
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function generateReportHtml(data: {
+  patientName: string;
+  modality: string;
+  bodyPart?: string;
+  findings: string;
+  impression: string;
+  reportText: string;
+  radiologistName?: string;
+  generatedAt: string;
+}): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Radiology Report</title>
+<style>
+  body { font-family: Arial, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; color: #333; }
+  h1 { color: #4338ca; border-bottom: 2px solid #4338ca; padding-bottom: 10px; }
+  .meta { background: #f5f5f5; padding: 15px; border-radius: 8px; margin: 20px 0; }
+  .meta p { margin: 5px 0; }
+  .meta strong { color: #555; }
+  .section { margin: 20px 0; }
+  .section h2 { color: #4338ca; font-size: 16px; margin-bottom: 8px; }
+  .section p { line-height: 1.6; white-space: pre-wrap; }
+  .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #888; }
+</style>
+</head>
+<body>
+  <h1>Radiology Report</h1>
+  <div class="meta">
+    <p><strong>Patient:</strong> ${escapeHtml(data.patientName)}</p>
+    <p><strong>Modality:</strong> ${escapeHtml(data.modality.toUpperCase())}</p>
+    ${data.bodyPart ? `<p><strong>Body Part:</strong> ${escapeHtml(data.bodyPart)}</p>` : ""}
+    <p><strong>Date:</strong> ${escapeHtml(data.generatedAt)}</p>
+    ${data.radiologistName ? `<p><strong>Radiologist:</strong> ${escapeHtml(data.radiologistName)}</p>` : ""}
+  </div>
+
+  ${data.findings ? `<div class="section"><h2>Findings</h2><p>${escapeHtml(data.findings)}</p></div>` : ""}
+  ${data.impression ? `<div class="section"><h2>Impression</h2><p>${escapeHtml(data.impression)}</p></div>` : ""}
+  ${data.reportText ? `<div class="section"><h2>Full Report</h2><p>${escapeHtml(data.reportText)}</p></div>` : ""}
+
+  <div class="footer">
+    <p>Generated on ${escapeHtml(data.generatedAt)}</p>
+  </div>
+</body>
+</html>`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const {
+      orderId,
+      clinicId,
+      patientName,
+      modality,
+      bodyPart,
+      findings,
+      impression,
+      reportText,
+      radiologistName,
+    } = body;
+
+    if (!orderId || !clinicId || !patientName || !modality) {
+      return NextResponse.json(
+        { error: "orderId, clinicId, patientName, and modality are required" },
+        { status: 400 },
+      );
+    }
+
+    if (!findings && !impression && !reportText) {
+      return NextResponse.json(
+        { error: "Report content is required (findings, impression, or reportText)" },
+        { status: 400 },
+      );
+    }
+
+    const generatedAt = new Date().toLocaleString("en-US", {
+      dateStyle: "long",
+      timeStyle: "short",
+    });
+
+    const html = generateReportHtml({
+      patientName,
+      modality,
+      bodyPart,
+      findings: findings ?? "",
+      impression: impression ?? "",
+      reportText: reportText ?? "",
+      radiologistName,
+      generatedAt,
+    });
+
+    // Store as HTML report (PDF generation would require a headless browser)
+    const fileName = `report-${orderId.slice(0, 8)}-${Date.now()}.html`;
+    const key = buildUploadKey(clinicId, "radiology-reports", fileName);
+
+    if (!isR2Configured()) {
+      // Return the HTML content as a data URL fallback
+      const dataUrl = `data:text/html;base64,${Buffer.from(html).toString("base64")}`;
+      return NextResponse.json({ pdfUrl: dataUrl, fallback: true });
+    }
+
+    const buffer = Buffer.from(html, "utf-8");
+    const url = await uploadToR2(key, buffer, "text/html");
+
+    if (!url) {
+      return NextResponse.json(
+        { error: "Failed to upload report" },
+        { status: 500 },
+      );
+    }
+
+    // Update the order's pdf_url
+    await updateRadiologyOrderPdfUrl(orderId, url);
+
+    return NextResponse.json({ pdfUrl: url });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/radiology/upload/route.ts
+++ b/src/app/api/radiology/upload/route.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/radiology/upload — Upload radiology images to R2 + record in DB
+ *
+ * Accepts multipart/form-data with:
+ *   - file: The image file (X-ray, MRI, CT, DICOM, etc.)
+ *   - orderId: Radiology order UUID
+ *   - clinicId: Clinic UUID
+ *   - modality: (optional) Imaging modality
+ *   - description: (optional) Image description
+ *
+ * Returns: { id, url, key }
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
+import { createRadiologyImage } from "@/lib/data/server";
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB for medical images
+
+const ALLOWED_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/tiff",
+  "image/bmp",
+  "application/pdf",
+  "application/dicom",
+  "application/octet-stream", // DICOM files often have this type
+]);
+
+export async function POST(request: NextRequest) {
+  if (!isR2Configured()) {
+    return NextResponse.json(
+      { error: "File storage is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+  const orderId = formData.get("orderId") as string;
+  const clinicId = formData.get("clinicId") as string;
+  const modality = (formData.get("modality") as string) || undefined;
+  const description = (formData.get("description") as string) || undefined;
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  if (!orderId || !clinicId) {
+    return NextResponse.json(
+      { error: "orderId and clinicId are required" },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: "File too large (max 50 MB)" },
+      { status: 400 },
+    );
+  }
+
+  if (!ALLOWED_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: `File type not allowed: ${file.type}` },
+      { status: 400 },
+    );
+  }
+
+  const isDicom =
+    file.type === "application/dicom" ||
+    file.name.toLowerCase().endsWith(".dcm");
+
+  const key = buildUploadKey(clinicId, "radiology", file.name);
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  const url = await uploadToR2(key, buffer, file.type);
+  if (!url) {
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+
+  const imageRecord = await createRadiologyImage({
+    order_id: orderId,
+    clinic_id: clinicId,
+    file_url: url,
+    file_name: file.name,
+    file_size: file.size,
+    content_type: file.type,
+    modality,
+    is_dicom: isDicom,
+    description,
+  });
+
+  if (!imageRecord) {
+    return NextResponse.json(
+      { error: "Failed to save image record" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ id: imageRecord.id, url, key });
+}

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -1023,3 +1023,134 @@ export async function markNotificationRead(notificationId: string): Promise<bool
   if (error) return false;
   return true;
 }
+
+// ────────────────────────────────────────────
+// Radiology — Mutations
+// ────────────────────────────────────────────
+
+export async function createRadiologyOrder(data: {
+  clinic_id: string;
+  patient_id: string;
+  ordering_doctor_id?: string;
+  modality: string;
+  body_part?: string;
+  clinical_indication?: string;
+  priority?: string;
+  scheduled_at?: string;
+}): Promise<{ id: string; order_number: string } | null> {
+  const supabase = await createClient();
+  const orderNumber = `RAD-${Date.now().toString(36).toUpperCase()}`;
+  const { data: row, error } = await supabase
+    .from("radiology_orders")
+    .insert({
+      ...data,
+      order_number: orderNumber,
+      status: "pending",
+      priority: data.priority ?? "normal",
+    })
+    .select("id, order_number")
+    .single();
+  if (error) {
+    console.error("[data] Error creating radiology order:", error.message);
+    return null;
+  }
+  return row as { id: string; order_number: string };
+}
+
+export async function updateRadiologyOrderStatus(
+  orderId: string,
+  status: string,
+): Promise<boolean> {
+  const supabase = await createClient();
+  const updateData: Record<string, unknown> = { status, updated_at: new Date().toISOString() };
+  if (status === "in_progress") {
+    updateData.performed_at = new Date().toISOString();
+  }
+  const { error } = await supabase
+    .from("radiology_orders")
+    .update(updateData)
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] Error updating radiology order status:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function saveRadiologyReport(
+  orderId: string,
+  report: {
+    findings: string;
+    impression: string;
+    report_text: string;
+    report_template_id?: string;
+    radiologist_id?: string;
+  },
+): Promise<boolean> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("radiology_orders")
+    .update({
+      findings: report.findings,
+      impression: report.impression,
+      report_text: report.report_text,
+      report_template_id: report.report_template_id ?? null,
+      radiologist_id: report.radiologist_id ?? null,
+      reported_at: new Date().toISOString(),
+      status: "reported",
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] Error saving radiology report:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function createRadiologyImage(data: {
+  order_id: string;
+  clinic_id: string;
+  file_url: string;
+  file_name?: string;
+  file_size?: number;
+  content_type?: string;
+  modality?: string;
+  is_dicom?: boolean;
+  dicom_metadata?: Record<string, unknown>;
+  thumbnail_url?: string;
+  description?: string;
+  uploaded_by?: string;
+}): Promise<{ id: string } | null> {
+  const supabase = await createClient();
+  const { data: row, error } = await supabase
+    .from("radiology_images")
+    .insert({
+      ...data,
+      is_dicom: data.is_dicom ?? false,
+      dicom_metadata: data.dicom_metadata ?? {},
+    })
+    .select("id")
+    .single();
+  if (error) {
+    console.error("[data] Error creating radiology image:", error.message);
+    return null;
+  }
+  return row as { id: string };
+}
+
+export async function updateRadiologyOrderPdfUrl(
+  orderId: string,
+  pdfUrl: string,
+): Promise<boolean> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("radiology_orders")
+    .update({ pdf_url: pdfUrl, updated_at: new Date().toISOString() })
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] Error updating radiology PDF URL:", error.message);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Task 22 — Radiology & Medical Imaging

### Backend
- **Image Upload API** (`POST /api/radiology/upload`): Upload X-ray, MRI, scanner images to R2 cloud storage with DICOM detection
- **Orders API** (`POST/PATCH /api/radiology/orders`): Create orders, update status, save reports
- **PDF Report API** (`POST /api/radiology/report-pdf`): Generate HTML-based radiology reports
- **Server mutations**: createRadiologyOrder, updateRadiologyOrderStatus, saveRadiologyReport, createRadiologyImage, updateRadiologyOrderPdfUrl

### Frontend
- **Orders page**: New Order dialog, status workflow buttons (pending→scheduled→in_progress→images_ready→reported), Write Report dialog with template loading, Generate PDF, Cancel Order
- **Images page**: Drag-and-drop upload UI with order selection, progress tracking, image gallery grid
- **Reports page**: Report list with expandable details, Generate PDF button, PDF download links
- **DICOM Viewer page**: Study list from database, OHIF viewer links with Study UIDs, standard image viewer

### Supported file types
JPEG, PNG, WebP, TIFF, BMP, PDF, DICOM (up to 50MB)

### Storage
Files stored in R2 at `clinics/{clinicId}/radiology/{timestamp}-{filename}`