### PR TITLE
feat: Add write operations for Task 21 (Lab) and Task 23 (Parapharmacy)

### DIFF
--- a/src/app/(lab)/lab-panel/results/page.tsx
+++ b/src/app/(lab)/lab-panel/results/page.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, FlaskConical, ArrowUpDown, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { Search, FlaskConical, ArrowUpDown, TrendingUp, TrendingDown, Minus, Plus, Loader2, FileText } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
-import { fetchLabTestOrders, fetchLabTestResults } from "@/lib/data/client";
+import { fetchLabTestOrders, fetchLabTestResults, saveLabTestResult } from "@/lib/data/client";
 import type { LabTestOrderView, LabTestResultView } from "@/lib/data/client";
 
 function FlagIcon({ flag }: { flag: string }) {
@@ -30,6 +39,30 @@ export default function ResultsPage() {
   const [resultsLoading, setResultsLoading] = useState(false);
   const [search, setSearch] = useState("");
 
+  // Result entry dialog
+  const [entryOpen, setEntryOpen] = useState(false);
+  const [entrySaving, setEntrySaving] = useState(false);
+  const [entryForm, setEntryForm] = useState({
+    testItemId: "",
+    parameterName: "",
+    value: "",
+    unit: "",
+    referenceMin: "",
+    referenceMax: "",
+    flag: "normal",
+    notes: "",
+  });
+
+  const [pdfGenerating, setPdfGenerating] = useState(false);
+
+  const refreshResults = useCallback(() => {
+    if (!selectedOrderId) return;
+    setResultsLoading(true);
+    fetchLabTestResults(selectedOrderId)
+      .then(setResults)
+      .finally(() => setResultsLoading(false));
+  }, [selectedOrderId]);
+
   useEffect(() => {
     fetchLabTestOrders(clinicConfig.clinicId)
       .then((all) => {
@@ -49,6 +82,64 @@ export default function ResultsPage() {
       .then(setResults)
       .finally(() => setResultsLoading(false));
   }, [selectedOrderId]);
+
+  const handleAddResult = async () => {
+    if (!selectedOrderId || !entryForm.parameterName || !entryForm.value) return;
+    setEntrySaving(true);
+    try {
+      await saveLabTestResult({
+        order_id: selectedOrderId,
+        test_item_id: entryForm.testItemId || selectedOrderId,
+        parameter_name: entryForm.parameterName,
+        value: entryForm.value,
+        unit: entryForm.unit || undefined,
+        reference_min: entryForm.referenceMin ? parseFloat(entryForm.referenceMin) : undefined,
+        reference_max: entryForm.referenceMax ? parseFloat(entryForm.referenceMax) : undefined,
+        flag: entryForm.flag || "normal",
+        notes: entryForm.notes || undefined,
+      });
+      setEntryOpen(false);
+      setEntryForm({ testItemId: "", parameterName: "", value: "", unit: "", referenceMin: "", referenceMax: "", flag: "normal", notes: "" });
+      refreshResults();
+    } finally {
+      setEntrySaving(false);
+    }
+  };
+
+  const handleGeneratePdf = async () => {
+    if (!selectedOrderId) return;
+    const order = orders.find((o) => o.id === selectedOrderId);
+    if (!order) return;
+    setPdfGenerating(true);
+    try {
+      const res = await fetch("/api/lab/report-pdf", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orderId: selectedOrderId,
+          clinicId: clinicConfig.clinicId,
+          patientName: order.patientName,
+          orderNumber: order.orderNumber,
+          results: results.map((r) => ({
+            testName: r.testName,
+            value: r.value,
+            unit: r.unit,
+            referenceMin: r.referenceMin,
+            referenceMax: r.referenceMax,
+            flag: r.flag,
+          })),
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        if (data.pdfUrl) window.open(data.pdfUrl, "_blank");
+      }
+    } finally {
+      setPdfGenerating(false);
+    }
+  };
+
+  const selectedOrder = orders.find((o) => o.id === selectedOrderId);
 
   if (loading) {
     return (
@@ -139,7 +230,18 @@ export default function ResultsPage() {
                     <ArrowUpDown className="h-4 w-4" />
                     Test Results
                   </h2>
-                  <Badge variant="outline">{results.length} result{results.length !== 1 ? "s" : ""}</Badge>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">{results.length} result{results.length !== 1 ? "s" : ""}</Badge>
+                    <Button size="sm" variant="outline" onClick={() => setEntryOpen(true)}>
+                      <Plus className="h-3 w-3 mr-1" /> Add Result
+                    </Button>
+                    {results.length > 0 && (
+                      <Button size="sm" variant="outline" onClick={handleGeneratePdf} disabled={pdfGenerating}>
+                        {pdfGenerating ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <FileText className="h-3 w-3 mr-1" />}
+                        Generate PDF
+                      </Button>
+                    )}
+                  </div>
                 </div>
 
                 {results.length === 0 ? (
@@ -190,6 +292,81 @@ export default function ResultsPage() {
           )}
         </div>
       </div>
+
+      {/* Result Entry Dialog */}
+      <Dialog open={entryOpen} onOpenChange={setEntryOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Test Result</DialogTitle>
+            <DialogDescription>
+              Enter a test result for {selectedOrder?.patientName ?? "this order"}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            {selectedOrder && selectedOrder.tests.length > 0 && (
+              <div className="grid gap-2">
+                <Label>Test</Label>
+                <Select value={entryForm.testItemId} onValueChange={(v) => setEntryForm((p) => ({ ...p, testItemId: v }))}>
+                  <SelectTrigger><SelectValue placeholder="Select test..." /></SelectTrigger>
+                  <SelectContent>
+                    {selectedOrder.tests.map((t) => (
+                      <SelectItem key={t.id} value={t.id}>{t.testName}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            <div className="grid gap-2">
+              <Label>Parameter Name</Label>
+              <Input placeholder="e.g., Glucose, Hemoglobin..." value={entryForm.parameterName} onChange={(e) => setEntryForm((p) => ({ ...p, parameterName: e.target.value }))} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label>Value</Label>
+                <Input placeholder="e.g., 5.2" value={entryForm.value} onChange={(e) => setEntryForm((p) => ({ ...p, value: e.target.value }))} />
+              </div>
+              <div className="grid gap-2">
+                <Label>Unit</Label>
+                <Input placeholder="e.g., g/dL" value={entryForm.unit} onChange={(e) => setEntryForm((p) => ({ ...p, unit: e.target.value }))} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label>Reference Min</Label>
+                <Input type="number" placeholder="Min" value={entryForm.referenceMin} onChange={(e) => setEntryForm((p) => ({ ...p, referenceMin: e.target.value }))} />
+              </div>
+              <div className="grid gap-2">
+                <Label>Reference Max</Label>
+                <Input type="number" placeholder="Max" value={entryForm.referenceMax} onChange={(e) => setEntryForm((p) => ({ ...p, referenceMax: e.target.value }))} />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label>Flag</Label>
+              <Select value={entryForm.flag} onValueChange={(v) => setEntryForm((p) => ({ ...p, flag: v }))}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="normal">Normal</SelectItem>
+                  <SelectItem value="low">Low</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                  <SelectItem value="critical_low">Critical Low</SelectItem>
+                  <SelectItem value="critical_high">Critical High</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-2">
+              <Label>Notes (optional)</Label>
+              <Input placeholder="Additional notes..." value={entryForm.notes} onChange={(e) => setEntryForm((p) => ({ ...p, notes: e.target.value }))} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEntryOpen(false)}>Cancel</Button>
+            <Button onClick={handleAddResult} disabled={entrySaving || !entryForm.parameterName || !entryForm.value}>
+              {entrySaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Save Result
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(lab)/lab-panel/test-orders/page.tsx
+++ b/src/app/(lab)/lab-panel/test-orders/page.tsx
@@ -1,32 +1,131 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
-  Search, Filter, AlertTriangle, Clock, CheckCircle,
-  FlaskConical, ChevronDown,
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle, DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import {
+  Search, Filter, ChevronDown, FlaskConical, Plus,
+  Clock, CheckCircle, Loader2, UserPlus, ArrowRight,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
-import { fetchLabTestOrders } from "@/lib/data/client";
-import type { LabTestOrderView } from "@/lib/data/client";
+import {
+  fetchLabTestOrders, fetchLabTestCatalog, fetchPatients,
+  createLabTestOrder, updateLabOrderStatus, assignLabTechnician,
+} from "@/lib/data/client";
+import type { LabTestOrderView, LabTestCatalogView, PatientView } from "@/lib/data/client";
 
 const statusOptions = ["all", "pending", "sample_collected", "in_progress", "completed", "validated", "cancelled"] as const;
+const priorityOptions = ["normal", "urgent", "stat"] as const;
 
 export default function TestOrdersPage() {
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
+  const [catalog, setCatalog] = useState<LabTestCatalogView[]>([]);
+  const [patients, setPatients] = useState<PatientView[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchLabTestOrders(clinicConfig.clinicId)
-      .then(setOrders)
-      .finally(() => setLoading(false));
+  const [newOrderOpen, setNewOrderOpen] = useState(false);
+  const [newOrderSaving, setNewOrderSaving] = useState(false);
+  const [newOrder, setNewOrder] = useState({
+    patientId: "",
+    priority: "normal" as string,
+    clinicalNotes: "",
+    fastingRequired: false,
+    selectedTests: [] as string[],
+  });
+
+  const [techDialogOpen, setTechDialogOpen] = useState(false);
+  const [techOrderId, setTechOrderId] = useState<string | null>(null);
+  const [techId, setTechId] = useState("");
+  const [techSaving, setTechSaving] = useState(false);
+  const [updatingStatusId, setUpdatingStatusId] = useState<string | null>(null);
+
+  const refreshOrders = useCallback(() => {
+    fetchLabTestOrders(clinicConfig.clinicId).then(setOrders);
   }, []);
+
+  useEffect(() => {
+    Promise.all([
+      fetchLabTestOrders(clinicConfig.clinicId),
+      fetchLabTestCatalog(clinicConfig.clinicId),
+      fetchPatients(clinicConfig.clinicId),
+    ]).then(([o, c, p]) => {
+      setOrders(o);
+      setCatalog(c);
+      setPatients(p);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleCreateOrder = async () => {
+    if (!newOrder.patientId) return;
+    setNewOrderSaving(true);
+    try {
+      await createLabTestOrder({
+        clinic_id: clinicConfig.clinicId,
+        patient_id: newOrder.patientId,
+        priority: newOrder.priority,
+        clinical_notes: newOrder.clinicalNotes || undefined,
+        fasting_required: newOrder.fastingRequired,
+        test_ids: newOrder.selectedTests.length > 0 ? newOrder.selectedTests : undefined,
+      });
+      setNewOrderOpen(false);
+      setNewOrder({ patientId: "", priority: "normal", clinicalNotes: "", fastingRequired: false, selectedTests: [] });
+      refreshOrders();
+    } finally {
+      setNewOrderSaving(false);
+    }
+  };
+
+  const handleStatusUpdate = async (orderId: string, newStatus: string) => {
+    setUpdatingStatusId(orderId);
+    try {
+      await updateLabOrderStatus(orderId, newStatus);
+      refreshOrders();
+    } finally {
+      setUpdatingStatusId(null);
+    }
+  };
+
+  const openTechDialog = (orderId: string) => {
+    setTechOrderId(orderId);
+    setTechId("");
+    setTechDialogOpen(true);
+  };
+
+  const handleAssignTech = async () => {
+    if (!techOrderId) return;
+    setTechSaving(true);
+    try {
+      await assignLabTechnician(techOrderId, techId || null);
+      setTechDialogOpen(false);
+      refreshOrders();
+    } finally {
+      setTechSaving(false);
+    }
+  };
+
+  const toggleTest = (testId: string) => {
+    setNewOrder((prev) => ({
+      ...prev,
+      selectedTests: prev.selectedTests.includes(testId)
+        ? prev.selectedTests.filter((id) => id !== testId)
+        : [...prev.selectedTests, testId],
+    }));
+  };
 
   if (loading) {
     return (
@@ -49,6 +148,16 @@ export default function TestOrdersPage() {
     return true;
   });
 
+  const getNextStatus = (current: string): string | null => {
+    const flow: Record<string, string> = {
+      pending: "sample_collected",
+      sample_collected: "in_progress",
+      in_progress: "completed",
+      completed: "validated",
+    };
+    return flow[current] ?? null;
+  };
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
@@ -56,6 +165,85 @@ export default function TestOrdersPage() {
           <h1 className="text-2xl font-bold">Test Orders</h1>
           <p className="text-muted-foreground text-sm">{orders.length} total orders</p>
         </div>
+        <Dialog open={newOrderOpen} onOpenChange={setNewOrderOpen}>
+          <DialogTrigger asChild>
+            <Button><Plus className="h-4 w-4 mr-2" /> New Order</Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>Create Lab Test Order</DialogTitle>
+              <DialogDescription>Request lab tests for a patient.</DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label>Patient</Label>
+                <Select value={newOrder.patientId} onValueChange={(v) => setNewOrder((p) => ({ ...p, patientId: v }))}>
+                  <SelectTrigger><SelectValue placeholder="Select a patient..." /></SelectTrigger>
+                  <SelectContent>
+                    {patients.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>{p.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label>Priority</Label>
+                <Select value={newOrder.priority} onValueChange={(v) => setNewOrder((p) => ({ ...p, priority: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {priorityOptions.map((pr) => (
+                      <SelectItem key={pr} value={pr} className="capitalize">{pr}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {catalog.length > 0 && (
+                <div className="grid gap-2">
+                  <Label>Tests ({newOrder.selectedTests.length} selected)</Label>
+                  <div className="max-h-48 overflow-y-auto border rounded-md p-2 space-y-1">
+                    {catalog.map((test) => (
+                      <label key={test.id} className="flex items-center gap-2 text-sm p-1 hover:bg-muted/50 rounded cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={newOrder.selectedTests.includes(test.id)}
+                          onChange={() => toggleTest(test.id)}
+                          className="rounded"
+                        />
+                        <span>{test.name}</span>
+                        {test.category && <Badge variant="outline" className="text-xs ml-auto">{test.category}</Badge>}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <div className="grid gap-2">
+                <Label>Clinical Notes</Label>
+                <Textarea
+                  placeholder="Relevant clinical information..."
+                  value={newOrder.clinicalNotes}
+                  onChange={(e) => setNewOrder((p) => ({ ...p, clinicalNotes: e.target.value }))}
+                  rows={2}
+                />
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={newOrder.fastingRequired}
+                  onChange={(e) => setNewOrder((p) => ({ ...p, fastingRequired: e.target.checked }))}
+                  className="rounded"
+                />
+                Fasting Required
+              </label>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setNewOrderOpen(false)}>Cancel</Button>
+              <Button onClick={handleCreateOrder} disabled={newOrderSaving || !newOrder.patientId}>
+                {newOrderSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Create Order
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-3 mb-6">
@@ -158,6 +346,36 @@ export default function TestOrdersPage() {
                       ))}
                     </div>
                   </div>
+
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    {getNextStatus(order.status) && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={(e) => { e.stopPropagation(); handleStatusUpdate(order.id, getNextStatus(order.status)!); }}
+                        disabled={updatingStatusId === order.id}
+                      >
+                        {updatingStatusId === order.id ? <Loader2 className="h-3 w-3 mr-1 animate-spin" /> : <ArrowRight className="h-3 w-3 mr-1" />}
+                        Move to {getNextStatus(order.status)!.replace("_", " ")}
+                      </Button>
+                    )}
+                    {order.status !== "cancelled" && order.status !== "validated" && (
+                      <Button size="sm" variant="outline" onClick={(e) => { e.stopPropagation(); openTechDialog(order.id); }}>
+                        <UserPlus className="h-3 w-3 mr-1" /> Assign Technician
+                      </Button>
+                    )}
+                    {order.status !== "cancelled" && order.status !== "validated" && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-red-600 hover:text-red-700"
+                        onClick={(e) => { e.stopPropagation(); handleStatusUpdate(order.id, "cancelled"); }}
+                        disabled={updatingStatusId === order.id}
+                      >
+                        Cancel Order
+                      </Button>
+                    )}
+                  </div>
                 </div>
               )}
             </CardContent>
@@ -171,6 +389,26 @@ export default function TestOrdersPage() {
           </div>
         )}
       </div>
+
+      <Dialog open={techDialogOpen} onOpenChange={setTechDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Assign Technician</DialogTitle>
+            <DialogDescription>Select a technician for this order.</DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <Label>Technician ID</Label>
+            <Input placeholder="Enter technician user ID..." value={techId} onChange={(e) => setTechId(e.target.value)} />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setTechDialogOpen(false)}>Cancel</Button>
+            <Button onClick={handleAssignTech} disabled={techSaving}>
+              {techSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Assign
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
@@ -1,14 +1,36 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Search, ShoppingBag, Filter } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { Search, ShoppingBag, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
-import { fetchParapharmacyProducts, fetchParapharmacyCategories, getStockStatus } from "@/lib/data/client";
+import {
+  fetchParapharmacyProducts, fetchParapharmacyCategories, getStockStatus,
+  createParapharmacyProduct, updateParapharmacyProduct, deleteParapharmacyProduct,
+} from "@/lib/data/client";
 import type { ProductView, ParapharmacyCategoryView } from "@/lib/data/client";
+
+const defaultForm = {
+  name: "",
+  genericName: "",
+  category: "General",
+  description: "",
+  price: "",
+  manufacturer: "",
+  dosageForm: "",
+  strength: "",
+};
 
 export default function ParapharmacyCatalogPage() {
   const [products, setProducts] = useState<ProductView[]>([]);
@@ -16,6 +38,18 @@ export default function ParapharmacyCatalogPage() {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("all");
+
+  // CRUD state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({ ...defaultForm });
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const refreshProducts = useCallback(() => {
+    fetchParapharmacyProducts(clinicConfig.clinicId).then(setProducts);
+  }, []);
 
   useEffect(() => {
     const cId = clinicConfig.clinicId;
@@ -29,6 +63,74 @@ export default function ParapharmacyCatalogPage() {
       })
       .finally(() => setLoading(false));
   }, []);
+
+  const openCreate = () => {
+    setEditingId(null);
+    setForm({ ...defaultForm });
+    setDialogOpen(true);
+  };
+
+  const openEdit = (p: ProductView) => {
+    setEditingId(p.id);
+    setForm({
+      name: p.name,
+      genericName: p.genericName ?? "",
+      category: p.category,
+      description: p.description ?? "",
+      price: String(p.price),
+      manufacturer: p.manufacturer ?? "",
+      dosageForm: p.dosageForm ?? "",
+      strength: p.strength ?? "",
+    });
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!form.name) return;
+    setSaving(true);
+    try {
+      if (editingId) {
+        await updateParapharmacyProduct(editingId, {
+          name: form.name,
+          generic_name: form.genericName || null,
+          category: form.category,
+          description: form.description || null,
+          price: parseFloat(form.price) || 0,
+          manufacturer: form.manufacturer || null,
+          dosage_form: form.dosageForm || null,
+          strength: form.strength || null,
+        });
+      } else {
+        await createParapharmacyProduct({
+          clinic_id: clinicConfig.clinicId,
+          name: form.name,
+          generic_name: form.genericName || undefined,
+          category: form.category || undefined,
+          description: form.description || undefined,
+          price: parseFloat(form.price) || 0,
+          manufacturer: form.manufacturer || undefined,
+          dosage_form: form.dosageForm || undefined,
+          strength: form.strength || undefined,
+        });
+      }
+      setDialogOpen(false);
+      refreshProducts();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    setDeleting(true);
+    try {
+      await deleteParapharmacyProduct(deleteId);
+      setDeleteId(null);
+      refreshProducts();
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -57,6 +159,9 @@ export default function ParapharmacyCatalogPage() {
           <h1 className="text-2xl font-bold">Product Catalog</h1>
           <p className="text-muted-foreground text-sm">{products.filter((p) => p.active).length} active products</p>
         </div>
+        <Button onClick={openCreate}>
+          <Plus className="h-4 w-4 mr-2" /> Add Product
+        </Button>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-3 mb-6">
@@ -109,6 +214,14 @@ export default function ParapharmacyCatalogPage() {
                 {product.manufacturer && (
                   <p className="text-xs text-muted-foreground mt-2">By {product.manufacturer}</p>
                 )}
+                <div className="flex gap-1 mt-3 pt-3 border-t">
+                  <Button size="sm" variant="ghost" onClick={() => openEdit(product)}>
+                    <Pencil className="h-3 w-3 mr-1" /> Edit
+                  </Button>
+                  <Button size="sm" variant="ghost" className="text-red-600 hover:text-red-700" onClick={() => setDeleteId(product.id)}>
+                    <Trash2 className="h-3 w-3 mr-1" /> Delete
+                  </Button>
+                </div>
               </CardContent>
             </Card>
           );
@@ -121,6 +234,95 @@ export default function ParapharmacyCatalogPage() {
           <p className="text-muted-foreground">No products match your search</p>
         </div>
       )}
+
+      {/* Add / Edit Product Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{editingId ? "Edit Product" : "Add Product"}</DialogTitle>
+            <DialogDescription>
+              {editingId ? "Update product details." : "Add a new product to the catalog."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label>Name *</Label>
+                <Input value={form.name} onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))} placeholder="Product name" />
+              </div>
+              <div className="grid gap-2">
+                <Label>Generic Name</Label>
+                <Input value={form.genericName} onChange={(e) => setForm((p) => ({ ...p, genericName: e.target.value }))} placeholder="Generic name" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label>Category</Label>
+                <Select value={form.category} onValueChange={(v) => setForm((p) => ({ ...p, category: v }))}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {categories.map((c) => (
+                      <SelectItem key={c.id} value={c.name}>{c.name}</SelectItem>
+                    ))}
+                    <SelectItem value="General">General</SelectItem>
+                    <SelectItem value="Cosmetics">Cosmetics</SelectItem>
+                    <SelectItem value="Supplements">Supplements</SelectItem>
+                    <SelectItem value="Baby Care">Baby Care</SelectItem>
+                    <SelectItem value="Hygiene">Hygiene</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label>Price (MAD)</Label>
+                <Input type="number" value={form.price} onChange={(e) => setForm((p) => ({ ...p, price: e.target.value }))} placeholder="0" />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label>Description</Label>
+              <Input value={form.description} onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))} placeholder="Product description" />
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="grid gap-2">
+                <Label>Manufacturer</Label>
+                <Input value={form.manufacturer} onChange={(e) => setForm((p) => ({ ...p, manufacturer: e.target.value }))} placeholder="Brand" />
+              </div>
+              <div className="grid gap-2">
+                <Label>Dosage Form</Label>
+                <Input value={form.dosageForm} onChange={(e) => setForm((p) => ({ ...p, dosageForm: e.target.value }))} placeholder="e.g., Cream" />
+              </div>
+              <div className="grid gap-2">
+                <Label>Strength</Label>
+                <Input value={form.strength} onChange={(e) => setForm((p) => ({ ...p, strength: e.target.value }))} placeholder="e.g., 50mg" />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+            <Button onClick={handleSave} disabled={saving || !form.name}>
+              {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {editingId ? "Update" : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <Dialog open={!!deleteId} onOpenChange={(open: boolean) => { if (!open) setDeleteId(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Product</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete this product? This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteId(null)}>Cancel</Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
@@ -1,24 +1,125 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search, Receipt, DollarSign } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog, DialogContent, DialogDescription, DialogFooter,
+  DialogHeader, DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { Search, Receipt, DollarSign, Plus, Minus, ShoppingCart, Loader2, Trash2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
-import { fetchDailySales } from "@/lib/data/client";
-import type { DailySaleView } from "@/lib/data/client";
+import { fetchDailySales, fetchParapharmacyProducts, createParapharmacySale } from "@/lib/data/client";
+import type { DailySaleView, ProductView } from "@/lib/data/client";
+
+interface CartItem {
+  productId: string;
+  productName: string;
+  unitPrice: number;
+  quantity: number;
+}
 
 export default function ParapharmacySalesPage() {
   const [sales, setSales] = useState<DailySaleView[]>([]);
+  const [products, setProducts] = useState<ProductView[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
 
+  // POS state
+  const [posOpen, setPosOpen] = useState(false);
+  const [cart, setCart] = useState<CartItem[]>([]);
+  const [customerName, setCustomerName] = useState("");
+  const [paymentMethod, setPaymentMethod] = useState("cash");
+  const [productSearch, setProductSearch] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const refreshSales = useCallback(() => {
+    fetchDailySales(clinicConfig.clinicId).then(setSales);
+  }, []);
+
   useEffect(() => {
-    fetchDailySales(clinicConfig.clinicId)
-      .then(setSales)
+    Promise.all([
+      fetchDailySales(clinicConfig.clinicId),
+      fetchParapharmacyProducts(clinicConfig.clinicId),
+    ])
+      .then(([s, p]) => {
+        setSales(s);
+        setProducts(p);
+      })
       .finally(() => setLoading(false));
   }, []);
+
+  const addToCart = (product: ProductView) => {
+    setCart((prev) => {
+      const existing = prev.find((c) => c.productId === product.id);
+      if (existing) {
+        return prev.map((c) =>
+          c.productId === product.id ? { ...c, quantity: c.quantity + 1 } : c,
+        );
+      }
+      return [...prev, {
+        productId: product.id,
+        productName: product.name,
+        unitPrice: product.price,
+        quantity: 1,
+      }];
+    });
+  };
+
+  const updateCartQty = (productId: string, delta: number) => {
+    setCart((prev) =>
+      prev
+        .map((c) =>
+          c.productId === productId ? { ...c, quantity: Math.max(0, c.quantity + delta) } : c,
+        )
+        .filter((c) => c.quantity > 0),
+    );
+  };
+
+  const removeFromCart = (productId: string) => {
+    setCart((prev) => prev.filter((c) => c.productId !== productId));
+  };
+
+  const cartTotal = cart.reduce((sum, c) => sum + c.quantity * c.unitPrice, 0);
+
+  const handleCreateSale = async () => {
+    if (cart.length === 0 || !customerName) return;
+    setSaving(true);
+    try {
+      await createParapharmacySale({
+        clinic_id: clinicConfig.clinicId,
+        patient_name: customerName,
+        payment_method: paymentMethod,
+        items: cart.map((c) => ({
+          product_id: c.productId,
+          product_name: c.productName,
+          quantity: c.quantity,
+          unit_price: c.unitPrice,
+        })),
+      });
+      setPosOpen(false);
+      setCart([]);
+      setCustomerName("");
+      setPaymentMethod("cash");
+      setProductSearch("");
+      refreshSales();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const filteredProducts = products.filter((p) => {
+    if (!p.active) return false;
+    if (!productSearch) return true;
+    const q = productSearch.toLowerCase();
+    return p.name.toLowerCase().includes(q) || p.category.toLowerCase().includes(q);
+  });
 
   if (loading) {
     return (
@@ -45,6 +146,9 @@ export default function ParapharmacySalesPage() {
           <h1 className="text-2xl font-bold">Sales</h1>
           <p className="text-muted-foreground text-sm">Parapharmacy sales records</p>
         </div>
+        <Button onClick={() => setPosOpen(true)}>
+          <ShoppingCart className="h-4 w-4 mr-2" /> New Sale
+        </Button>
         <Card className="p-3">
           <div className="flex items-center gap-2">
             <DollarSign className="h-4 w-4 text-emerald-600" />
@@ -100,6 +204,103 @@ export default function ParapharmacySalesPage() {
           </div>
         )}
       </div>
+
+      {/* POS Dialog */}
+      <Dialog open={posOpen} onOpenChange={setPosOpen}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>New Sale</DialogTitle>
+            <DialogDescription>Create a new parapharmacy sale.</DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="grid gap-2">
+                <Label>Customer Name *</Label>
+                <Input value={customerName} onChange={(e) => setCustomerName(e.target.value)} placeholder="Customer name" />
+              </div>
+              <div className="grid gap-2">
+                <Label>Payment Method</Label>
+                <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="cash">Cash</SelectItem>
+                    <SelectItem value="card">Card</SelectItem>
+                    <SelectItem value="mobile">Mobile Payment</SelectItem>
+                    <SelectItem value="insurance">Insurance</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {/* Product Search */}
+            <div className="grid gap-2">
+              <Label>Add Products</Label>
+              <Input
+                value={productSearch}
+                onChange={(e) => setProductSearch(e.target.value)}
+                placeholder="Search products to add..."
+              />
+              {productSearch && (
+                <div className="border rounded-md max-h-32 overflow-y-auto">
+                  {filteredProducts.slice(0, 8).map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      className="w-full text-left px-3 py-2 hover:bg-muted text-sm flex justify-between"
+                      onClick={() => { addToCart(p); setProductSearch(""); }}
+                    >
+                      <span>{p.name}</span>
+                      <span className="text-muted-foreground">{p.price} MAD</span>
+                    </button>
+                  ))}
+                  {filteredProducts.length === 0 && (
+                    <p className="px-3 py-2 text-sm text-muted-foreground">No products found</p>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Cart */}
+            {cart.length > 0 && (
+              <div className="border rounded-md">
+                <div className="px-3 py-2 bg-muted/50 text-sm font-medium">Cart ({cart.length} items)</div>
+                {cart.map((item) => (
+                  <div key={item.productId} className="flex items-center justify-between px-3 py-2 border-t text-sm">
+                    <div className="flex-1">
+                      <p className="font-medium">{item.productName}</p>
+                      <p className="text-xs text-muted-foreground">{item.unitPrice} MAD each</p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button size="icon" variant="outline" className="h-6 w-6" onClick={() => updateCartQty(item.productId, -1)}>
+                        <Minus className="h-3 w-3" />
+                      </Button>
+                      <span className="w-6 text-center">{item.quantity}</span>
+                      <Button size="icon" variant="outline" className="h-6 w-6" onClick={() => updateCartQty(item.productId, 1)}>
+                        <Plus className="h-3 w-3" />
+                      </Button>
+                      <Button size="icon" variant="ghost" className="h-6 w-6 text-red-500" onClick={() => removeFromCart(item.productId)}>
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                      <span className="w-16 text-right font-medium">{(item.quantity * item.unitPrice).toFixed(2)}</span>
+                    </div>
+                  </div>
+                ))}
+                <div className="flex items-center justify-between px-3 py-2 border-t bg-muted/50 font-semibold">
+                  <span>Total</span>
+                  <span>{cartTotal.toFixed(2)} MAD</span>
+                </div>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPosOpen(false)}>Cancel</Button>
+            <Button onClick={handleCreateSale} disabled={saving || cart.length === 0 || !customerName}>
+              {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              Complete Sale ({cartTotal.toFixed(2)} MAD)
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/api/lab/report-pdf/route.ts
+++ b/src/app/api/lab/report-pdf/route.ts
@@ -1,0 +1,177 @@
+/**
+ * POST /api/lab/report-pdf — Generate a PDF report for a lab test order
+ *
+ * Body: { orderId, clinicId, patientName, orderNumber, results }
+ *
+ * Generates an HTML report, uploads to R2, and updates the order's pdf_url.
+ * Returns: { pdfUrl }
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
+import { updateLabOrderPdfUrl } from "@/lib/data/server";
+
+interface LabResultItem {
+  testName: string;
+  value: string | null;
+  unit: string | null;
+  referenceMin: number | null;
+  referenceMax: number | null;
+  flag: string | null;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function flagLabel(flag: string | null): string {
+  if (!flag || flag === "normal") return "";
+  return flag.replace("_", " ").toUpperCase();
+}
+
+function flagColor(flag: string | null): string {
+  if (flag === "critical_high" || flag === "critical_low") return "#dc2626";
+  if (flag === "high") return "#ea580c";
+  if (flag === "low") return "#ca8a04";
+  return "#16a34a";
+}
+
+function generateLabReportHtml(data: {
+  patientName: string;
+  orderNumber: string;
+  results: LabResultItem[];
+  generatedAt: string;
+}): string {
+  const resultRows = data.results
+    .map((r) => {
+      const ref =
+        r.referenceMin != null && r.referenceMax != null
+          ? `${r.referenceMin} - ${r.referenceMax}`
+          : r.referenceMin != null
+            ? `>= ${r.referenceMin}`
+            : r.referenceMax != null
+              ? `<= ${r.referenceMax}`
+              : "&mdash;";
+
+      const fl = flagLabel(r.flag);
+      const flStyle = fl ? `color: ${flagColor(r.flag)}; font-weight: bold;` : "";
+
+      return `<tr>
+        <td>${escapeHtml(r.testName)}</td>
+        <td>${r.value ? escapeHtml(r.value) : "&mdash;"}</td>
+        <td>${r.unit ? escapeHtml(r.unit) : ""}</td>
+        <td>${ref}</td>
+        <td style="${flStyle}">${fl || "Normal"}</td>
+      </tr>`;
+    })
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Lab Report — ${escapeHtml(data.orderNumber)}</title>
+<style>
+  body { font-family: Arial, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; color: #333; }
+  h1 { color: #0d9488; border-bottom: 2px solid #0d9488; padding-bottom: 10px; }
+  .meta { background: #f5f5f5; padding: 15px; border-radius: 8px; margin: 20px 0; }
+  .meta p { margin: 5px 0; }
+  .meta strong { color: #555; }
+  table { width: 100%; border-collapse: collapse; margin: 20px 0; }
+  th { background: #f0fdfa; color: #0d9488; text-align: left; padding: 10px 8px; border-bottom: 2px solid #0d9488; font-size: 13px; }
+  td { padding: 8px; border-bottom: 1px solid #e5e7eb; font-size: 13px; }
+  tr:last-child td { border-bottom: none; }
+  .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #888; }
+</style>
+</head>
+<body>
+  <h1>Laboratory Report</h1>
+  <div class="meta">
+    <p><strong>Patient:</strong> ${escapeHtml(data.patientName)}</p>
+    <p><strong>Order:</strong> ${escapeHtml(data.orderNumber)}</p>
+    <p><strong>Date:</strong> ${escapeHtml(data.generatedAt)}</p>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Test</th>
+        <th>Value</th>
+        <th>Unit</th>
+        <th>Reference Range</th>
+        <th>Flag</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${resultRows}
+    </tbody>
+  </table>
+
+  <div class="footer">
+    <p>Generated on ${escapeHtml(data.generatedAt)}</p>
+  </div>
+</body>
+</html>`;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { orderId, clinicId, patientName, orderNumber, results } = body;
+
+    if (!orderId || !clinicId || !patientName || !orderNumber) {
+      return NextResponse.json(
+        { error: "orderId, clinicId, patientName, and orderNumber are required" },
+        { status: 400 },
+      );
+    }
+
+    if (!results || !Array.isArray(results) || results.length === 0) {
+      return NextResponse.json(
+        { error: "At least one result is required" },
+        { status: 400 },
+      );
+    }
+
+    const generatedAt = new Date().toLocaleString("en-US", {
+      dateStyle: "long",
+      timeStyle: "short",
+    });
+
+    const html = generateLabReportHtml({
+      patientName,
+      orderNumber,
+      results: results as LabResultItem[],
+      generatedAt,
+    });
+
+    const fileName = `lab-report-${orderId.slice(0, 8)}-${Date.now()}.html`;
+    const key = buildUploadKey(clinicId, "lab-reports", fileName);
+
+    if (!isR2Configured()) {
+      const dataUrl = `data:text/html;base64,${Buffer.from(html).toString("base64")}`;
+      return NextResponse.json({ pdfUrl: dataUrl, fallback: true });
+    }
+
+    const buffer = Buffer.from(html, "utf-8");
+    const url = await uploadToR2(key, buffer, "text/html");
+
+    if (!url) {
+      return NextResponse.json(
+        { error: "Failed to upload report" },
+        { status: 500 },
+      );
+    }
+
+    await updateLabOrderPdfUrl(orderId, url);
+
+    return NextResponse.json({ pdfUrl: url });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -3097,6 +3097,333 @@ export async function fetchLabTestResults(orderId: string): Promise<LabTestResul
 }
 
 // ─────────────────────────────────────────────
+// Analysis Lab — Mutations
+// ─────────────────────────────────────────────
+
+export async function createLabTestOrder(data: {
+  clinic_id: string;
+  patient_id: string;
+  ordering_doctor_id?: string;
+  assigned_technician_id?: string;
+  priority?: string;
+  clinical_notes?: string;
+  fasting_required?: boolean;
+  test_ids?: string[];
+}): Promise<string | null> {
+  const supabase = createClient();
+  const orderNumber = `LAB-${Date.now().toString(36).toUpperCase()}`;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: result, error } = await (supabase.from as any)("lab_test_orders")
+    .insert({
+      clinic_id: data.clinic_id,
+      patient_id: data.patient_id,
+      ordering_doctor_id: data.ordering_doctor_id ?? null,
+      assigned_technician_id: data.assigned_technician_id ?? null,
+      order_number: orderNumber,
+      status: "pending",
+      priority: data.priority ?? "normal",
+      clinical_notes: data.clinical_notes ?? null,
+      fasting_required: data.fasting_required ?? false,
+    })
+    .select("id")
+    .single();
+  if (error) {
+    console.error("[data] create lab test order:", error.message);
+    return null;
+  }
+  const orderId = result?.id as string;
+  // Insert test items if provided
+  if (data.test_ids && data.test_ids.length > 0 && orderId) {
+    const catalog = await fetchLabTestCatalog(data.clinic_id);
+    const catalogMap = new Map(catalog.map((c) => [c.id, c.name]));
+    const items = data.test_ids.map((testId) => ({
+      order_id: orderId,
+      test_id: testId,
+      test_name: catalogMap.get(testId) ?? "Test",
+      status: "pending",
+    }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabase.from as any)("lab_test_items").insert(items);
+  }
+  return orderId;
+}
+
+export async function updateLabOrderStatus(
+  orderId: string,
+  status: string,
+): Promise<boolean> {
+  const supabase = createClient();
+  const updateData: Record<string, unknown> = { status, updated_at: new Date().toISOString() };
+  if (status === "sample_collected") {
+    updateData.sample_collected_at = new Date().toISOString();
+  } else if (status === "completed") {
+    updateData.completed_at = new Date().toISOString();
+  } else if (status === "validated") {
+    updateData.validated_at = new Date().toISOString();
+  }
+  const { error } = await supabase
+    .from("lab_test_orders")
+    .update(updateData)
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] update lab order status:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function assignLabTechnician(
+  orderId: string,
+  technicianId: string | null,
+): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("lab_test_orders")
+    .update({
+      assigned_technician_id: technicianId,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] assign lab technician:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function saveLabTestResult(data: {
+  order_id: string;
+  test_item_id: string;
+  parameter_name: string;
+  value: string;
+  unit?: string;
+  reference_min?: number;
+  reference_max?: number;
+  flag?: string;
+  notes?: string;
+  entered_by?: string;
+}): Promise<string | null> {
+  const supabase = createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: result, error } = await (supabase.from as any)("lab_test_results")
+    .insert({
+      order_id: data.order_id,
+      test_item_id: data.test_item_id,
+      parameter_name: data.parameter_name,
+      value: data.value,
+      unit: data.unit ?? null,
+      reference_min: data.reference_min ?? null,
+      reference_max: data.reference_max ?? null,
+      flag: data.flag ?? "normal",
+      notes: data.notes ?? null,
+      entered_by: data.entered_by ?? null,
+      entered_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  if (error) {
+    console.error("[data] save lab test result:", error.message);
+    return null;
+  }
+  return result?.id ?? null;
+}
+
+export async function updateLabTestResult(
+  resultId: string,
+  data: Partial<{
+    value: string;
+    unit: string;
+    reference_min: number | null;
+    reference_max: number | null;
+    flag: string;
+    notes: string | null;
+  }>,
+): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("lab_test_results")
+    .update(data as never)
+    .eq("id", resultId);
+  if (error) {
+    console.error("[data] update lab test result:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function updateLabOrderPdfUrl(
+  orderId: string,
+  pdfUrl: string,
+): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("lab_test_orders")
+    .update({ pdf_url: pdfUrl, updated_at: new Date().toISOString() })
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] update lab order pdf url:", error.message);
+    return false;
+  }
+  return true;
+}
+
+// ─────────────────────────────────────────────
+// Parapharmacy — Mutations
+// ─────────────────────────────────────────────
+
+export async function createParapharmacyProduct(data: {
+  clinic_id: string;
+  name: string;
+  generic_name?: string;
+  category?: string;
+  description?: string;
+  price?: number;
+  manufacturer?: string;
+  dosage_form?: string;
+  strength?: string;
+  is_active?: boolean;
+}): Promise<string | null> {
+  const supabase = createClient();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: result, error } = await (supabase.from as any)("products")
+    .insert({
+      clinic_id: data.clinic_id,
+      name: data.name,
+      generic_name: data.generic_name ?? null,
+      category: data.category ?? "General",
+      description: data.description ?? null,
+      price: data.price ?? 0,
+      manufacturer: data.manufacturer ?? null,
+      dosage_form: data.dosage_form ?? null,
+      strength: data.strength ?? null,
+      is_active: data.is_active ?? true,
+      is_parapharmacy: true,
+      requires_prescription: false,
+    })
+    .select("id")
+    .single();
+  if (error) {
+    console.error("[data] create parapharmacy product:", error.message);
+    return null;
+  }
+  return result?.id ?? null;
+}
+
+export async function updateParapharmacyProduct(
+  id: string,
+  data: Partial<{
+    name: string;
+    generic_name: string | null;
+    category: string;
+    description: string | null;
+    price: number;
+    manufacturer: string | null;
+    dosage_form: string | null;
+    strength: string | null;
+    is_active: boolean;
+  }>,
+): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("products")
+    .update({ ...data, updated_at: new Date().toISOString() } as never)
+    .eq("id", id);
+  if (error) {
+    console.error("[data] update parapharmacy product:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function deleteParapharmacyProduct(id: string): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase.from("products").delete().eq("id", id);
+  if (error) {
+    console.error("[data] delete parapharmacy product:", error.message);
+    return false;
+  }
+  return true;
+}
+
+export async function createParapharmacySale(data: {
+  clinic_id: string;
+  patient_name: string;
+  payment_method: string;
+  items: { product_id: string; product_name: string; quantity: number; unit_price: number }[];
+}): Promise<string | null> {
+  const supabase = createClient();
+  const total = data.items.reduce((sum, item) => sum + item.quantity * item.unit_price, 0);
+  const now = new Date();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: result, error } = await (supabase.from as any)("sales")
+    .insert({
+      clinic_id: data.clinic_id,
+      patient_name: data.patient_name,
+      payment_method: data.payment_method,
+      total,
+      date: now.toISOString().split("T")[0],
+      time: now.toTimeString().slice(0, 5),
+      items: data.items,
+      is_parapharmacy: true,
+    })
+    .select("id")
+    .single();
+  if (error) {
+    console.error("[data] create parapharmacy sale:", error.message);
+    return null;
+  }
+  // Update stock quantities
+  for (const item of data.items) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (supabase.rpc as any)("decrement_stock", {
+      p_product_id: item.product_id,
+      p_quantity: item.quantity,
+    }).then(({ error: rpcErr }: { error: { message: string } | null }) => {
+      if (rpcErr) {
+        // Fallback: manually update stock
+        supabase
+          .from("stock")
+          .select("quantity")
+          .eq("product_id", item.product_id)
+          .single()
+          .then(({ data: stockRow }) => {
+            if (stockRow) {
+              const newQty = Math.max(0, (stockRow as { quantity: number }).quantity - item.quantity);
+              supabase
+                .from("stock")
+                .update({ quantity: newQty } as never)
+                .eq("product_id", item.product_id);
+            }
+          });
+      }
+    });
+  }
+  return result?.id ?? null;
+}
+
+export async function adjustParapharmacyStock(
+  productId: string,
+  newQuantity: number,
+): Promise<boolean> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("stock")
+    .update({ quantity: newQuantity, updated_at: new Date().toISOString() } as never)
+    .eq("product_id", productId);
+  if (error) {
+    // Try insert if no stock row exists
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error: insertError } = await (supabase.from as any)("stock")
+      .insert({ product_id: productId, quantity: newQuantity });
+    if (insertError) {
+      console.error("[data] adjust stock:", insertError.message);
+      return false;
+    }
+  }
+  return true;
+}
+
+// ─────────────────────────────────────────────
 // Radiology — Orders
 // ─────────────────────────────────────────────
 

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -1156,3 +1156,23 @@ export async function updateRadiologyOrderPdfUrl(
   }
   return true;
 }
+
+// ────────────────────────────────────────────
+// Lab — Mutations (server-side)
+// ────────────────────────────────────────────
+
+export async function updateLabOrderPdfUrl(
+  orderId: string,
+  pdfUrl: string,
+): Promise<boolean> {
+  const supabase = await createClient();
+  const { error } = await supabase
+    .from("lab_test_orders")
+    .update({ pdf_url: pdfUrl, updated_at: new Date().toISOString() })
+    .eq("id", orderId);
+  if (error) {
+    console.error("[data] Error updating lab order PDF URL:", error.message);
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

Implements all missing write operations for **Task 21 (Analysis Lab)** and **Task 23 (Parapharmacy)**, bringing both modules from read-only to full CRUD capability.

### Task 21 — Analysis Lab

**Data Layer** (`client.ts`):
- `createLabTestOrder()` — creates orders with auto-generated order numbers and optional test items
- `updateLabOrderStatus()` — status workflow with timestamp tracking (pending → sample_collected → in_progress → completed → validated)
- `assignLabTechnician()` — assigns technician to order
- `saveLabTestResult()` — saves individual test results with parameters, values, units, reference ranges, flags
- `updateLabTestResult()` — updates existing results
- `updateLabOrderPdfUrl()` — stores PDF URL for reports

**Server Data Layer** (`server.ts`):
- `updateLabOrderPdfUrl()` — server-side function for API route

**Test Orders Page** (`test-orders/page.tsx`):
- Create order dialog (patient selection, test selection, priority, clinical notes, fasting required)
- Status workflow buttons (pending → sample_collected → in_progress → completed → validated)
- Technician assignment dialog
- Order cancellation

**Results Page** (`results/page.tsx`):
- Result entry form with parameter name, value, unit, reference range (min/max), flag selection
- Test item selection from order
- PDF report generation button

**Lab PDF API** (`/api/lab/report-pdf/route.ts`):
- Generates HTML lab report with patient info, results table, reference ranges, flags
- Uploads to R2 storage (with data URL fallback)
- Updates order pdf_url

### Task 23 — Parapharmacy

**Data Layer** (`client.ts`):
- `createParapharmacyProduct()` — creates products with name, category, price, manufacturer, dosage form, strength
- `updateParapharmacyProduct()` — updates product details
- `deleteParapharmacyProduct()` — deletes products
- `createParapharmacySale()` — creates sales with automatic stock decrement via RPC or fallback
- `adjustParapharmacyStock()` — adjusts stock quantities

**Catalog Page** (`catalog/page.tsx`):
- Add Product button and dialog with full form fields
- Edit product dialog (pre-populated)
- Delete product with confirmation dialog
- Category selection with preset options

**Sales Page** (`sales/page.tsx`):
- New Sale (POS) button and dialog
- Customer name and payment method selection
- Product search with autocomplete dropdown
- Cart management (add, remove, quantity +/- controls)
- Running total display
- Complete Sale button

### Verification
- ✅ `npm run lint` — 0 errors (152 pre-existing warnings)
- ✅ `npx tsc --noEmit` — 0 errors

**7 files changed, 1363 lines added**