### PR TITLE
feat: add notification_log table migration

### DIFF
--- a/supabase/migrations/00020_notification_log.sql
+++ b/supabase/migrations/00020_notification_log.sql
@@ -1,0 +1,58 @@
+-- ============================================================
+-- Migration 00020: Add notification_log table
+--
+-- The reminder-24h edge function inserts into notification_log
+-- but the table was never created. This migration adds it with
+-- proper foreign keys, indexes, and RLS policies.
+-- ============================================================
+
+-- ============================================================
+-- 1. CREATE TABLE
+-- ============================================================
+
+CREATE TABLE notification_log (
+  id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  appointment_id   UUID REFERENCES appointments(id) ON DELETE SET NULL,
+  clinic_id        UUID REFERENCES clinics(id) ON DELETE CASCADE,
+  trigger          TEXT NOT NULL,
+  channel          TEXT NOT NULL CHECK (channel IN ('whatsapp', 'email', 'sms', 'in_app')),
+  recipient_phone  TEXT,
+  recipient_name   TEXT,
+  body             TEXT,
+  status           TEXT NOT NULL DEFAULT 'pending'
+                   CHECK (status IN ('pending', 'sent', 'failed', 'delivered', 'read')),
+  error_message    TEXT,
+  created_at       TIMESTAMPTZ DEFAULT now()
+);
+
+-- ============================================================
+-- 2. INDEXES
+-- ============================================================
+
+CREATE INDEX idx_notification_log_appointment ON notification_log(appointment_id);
+CREATE INDEX idx_notification_log_clinic ON notification_log(clinic_id);
+CREATE INDEX idx_notification_log_status ON notification_log(status);
+CREATE INDEX idx_notification_log_created ON notification_log(created_at);
+CREATE INDEX idx_notification_log_trigger ON notification_log(trigger);
+
+-- ============================================================
+-- 3. ROW LEVEL SECURITY
+-- ============================================================
+
+ALTER TABLE notification_log ENABLE ROW LEVEL SECURITY;
+
+-- Super admins: full access
+CREATE POLICY "sa_notification_log_all" ON notification_log
+  FOR ALL USING (is_super_admin()) WITH CHECK (is_super_admin());
+
+-- Clinic staff: read logs belonging to their clinic
+CREATE POLICY "staff_notification_log_read" ON notification_log
+  FOR SELECT USING (clinic_id = get_user_clinic_id() AND is_clinic_staff());
+
+-- Clinic admin: full access to their clinic's logs
+CREATE POLICY "admin_notification_log_all" ON notification_log
+  FOR ALL
+  USING (clinic_id = get_user_clinic_id() AND get_user_role() = 'clinic_admin')
+  WITH CHECK (clinic_id = get_user_clinic_id());
+
+-- Service role (edge functions) bypasses RLS automatically


### PR DESCRIPTION
## Summary

The `reminder-24h` Supabase edge function (`supabase/functions/reminder-24h/index.ts:116`) inserts into a `notification_log` table, but this table was never created in any migration.

This migration (`00020_notification_log.sql`) adds the missing table.

## Schema

| Column | Type | Notes |
|---|---|---|
| `id` | UUID PK | Auto-generated |
| `appointment_id` | UUID FK → appointments | Nullable, ON DELETE SET NULL |
| `clinic_id` | UUID FK → clinics | Nullable, ON DELETE CASCADE |
| `trigger` | TEXT NOT NULL | e.g. `reminder_24h` |
| `channel` | TEXT NOT NULL | Constrained: whatsapp, email, sms, in_app |
| `recipient_phone` | TEXT | |
| `recipient_name` | TEXT | |
| `body` | TEXT | Message content |
| `status` | TEXT NOT NULL | Constrained: pending, sent, failed, delivered, read |
| `error_message` | TEXT | For failure tracking |
| `created_at` | TIMESTAMPTZ | Defaults to now() |

## Includes

- **Foreign keys** to `appointments` and `clinics`
- **Indexes** on appointment_id, clinic_id, status, created_at, trigger
- **RLS policies**: super admin full access, clinic admin full access (scoped), clinic staff read (scoped)
- Edge functions use service role key which bypasses RLS automatically

---
[Devin session](https://app.devin.ai/sessions/e01031fa606b4b95b6d85f5cab6fa17c)