### PR TITLE
fix: remove insecure getSession() export from auth.ts

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -132,18 +132,6 @@ export async function signOut(): Promise<void> {
 // ============================================================
 
 /**
- * Get the current authenticated user's session.
- * Returns null if not authenticated.
- */
-export async function getSession() {
-  const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  return session;
-}
-
-/**
  * Get the current user's profile from the users table.
  * Returns null if not authenticated or profile not found.
  */


### PR DESCRIPTION
## Problem

`getSession()` in `src/lib/auth.ts` uses `supabase.auth.getSession()` which reads from cookies and can be tampered with. The middleware already has a comment warning against this pattern (line 158-159) and correctly uses `getUser()` instead.

## Changes

- Removed the `getSession()` function and its export from `src/lib/auth.ts`
- No call sites needed updating — no files import `getSession` from `auth.ts`
- The existing `getUserProfile()` and `requireAuth()` already use the secure `supabase.auth.getUser()` which validates against the Supabase server

## Verification

- Searched all files under `src/` — zero imports of `getSession` from `@/lib/auth`
- Middleware already uses `getUser()` correctly
- Lint passes cleanly