### PR TITLE
fix: consolidate cron system and standardize auth

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -20,6 +20,11 @@ OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-4o-mini
 
+# Cron Authentication
+# Used by the Cloudflare Worker scheduled handler to authenticate
+# calls to /api/cron/* routes. Generate with: openssl rand -hex 32
+CRON_SECRET=
+
 # Subdomain routing
 # Set to your root domain (e.g., "yourdomain.com") to enable
 # clinic subdomains like clinicname.yourdomain.com

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -6,28 +6,21 @@ import { dispatchNotification } from "@/lib/notifications";
  * GET /api/cron/reminders
  *
  * Automated appointment reminder endpoint.
- * Designed to be called by a cron job (e.g., Vercel Cron, GitHub Actions, or external scheduler).
+ * Called by the Cloudflare Worker scheduled handler (see worker-cron-handler.ts)
+ * every 30 minutes via the cron triggers defined in wrangler.toml.
  *
  * Sends two types of reminders:
  * - reminder_24h: For appointments happening in the next 24 hours
  * - reminder_2h: For appointments happening in the next 2 hours
  *
- * Protected by CRON_SECRET environment variable to prevent unauthorized access.
- *
- * Setup:
- * - Set CRON_SECRET env var on your deployment
- * - Configure a cron job to call: GET /api/cron/reminders?secret=YOUR_CRON_SECRET
- *   every 30 minutes (or as frequently as desired)
- *
- * For Vercel Cron, add to vercel.json:
- * { "crons": [{ "path": "/api/cron/reminders", "schedule": "0,30 * * * *" }] }
+ * Protected by CRON_SECRET via Authorization: Bearer header.
  */
 export async function GET(request: NextRequest) {
-  // Verify cron secret
-  const secret = request.nextUrl.searchParams.get("secret");
+  // Verify cron secret (Authorization: Bearer <CRON_SECRET>)
+  const authHeader = request.headers.get("authorization");
   const cronSecret = process.env.CRON_SECRET;
 
-  if (cronSecret && secret !== cronSecret) {
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/supabase/functions/reminder-24h/index.ts
+++ b/supabase/functions/reminder-24h/index.ts
@@ -1,21 +1,39 @@
 /**
+ * @deprecated — DO NOT ENABLE THIS FUNCTION
+ *
  * Supabase Edge Function: reminder-24h
  *
- * Scheduled function (cron) that runs daily.
- * Finds all appointments happening in the next 24 hours
- * and sends WhatsApp reminders to patients.
+ * This function is DEPRECATED. The primary reminder system is the Next.js
+ * API route at /api/cron/reminders, which is more complete:
+ *   - Handles both 24-hour AND 2-hour reminders
+ *   - Uses the shared notification engine (dispatchNotification)
+ *   - Triggered by Cloudflare Cron via the Worker scheduled handler
  *
- * Invoke via Supabase cron or manual call:
- *   POST /functions/v1/reminder-24h
+ * If both systems are active, patients will receive DUPLICATE reminders.
  *
- * Required env vars (set in Supabase Dashboard > Edge Functions):
- *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
- *   WHATSAPP_PROVIDER (meta | twilio)
- *   WHATSAPP_PHONE_NUMBER_ID + WHATSAPP_ACCESS_TOKEN (for Meta)
- *   TWILIO_ACCOUNT_SID + TWILIO_AUTH_TOKEN + TWILIO_WHATSAPP_FROM (for Twilio)
+ * This file is kept for reference only. If you need to re-enable it,
+ * first disable the Cloudflare Cron trigger for reminders in wrangler.toml.
  */
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+// ---------- DISABLED ----------
+// This function immediately returns a deprecation notice.
+// The original implementation is preserved below for reference.
+
+serve(async () => {
+  return new Response(
+    JSON.stringify({
+      error: "DEPRECATED — use /api/cron/reminders instead",
+      docs: "This Supabase Edge Function is disabled. The Next.js API route at /api/cron/reminders handles both 24h and 2h reminders via the Cloudflare Worker scheduled handler.",
+    }),
+    { status: 410, headers: { "Content-Type": "application/json" } },
+  );
+});
+
+/*
+// ---------- ORIGINAL IMPLEMENTATION (for reference) ----------
+
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 interface AppointmentRow {
@@ -120,7 +138,7 @@ serve(async () => {
         recipient_name: row.patient.name,
         body,
         status: sent ? "sent" : "failed",
-      }).then(() => {/* ignore log errors */});
+      }).then(() => {/* ignore log errors * /});
     }
 
     return new Response(
@@ -139,3 +157,4 @@ serve(async () => {
     });
   }
 });
+*/

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -1,0 +1,68 @@
+/**
+ * Custom Cloudflare Worker entry point.
+ *
+ * Re-exports the OpenNext fetch handler and adds a scheduled() handler
+ * so that Cloudflare Cron Triggers (defined in wrangler.toml) can invoke
+ * the Next.js cron API routes with the correct CRON_SECRET auth.
+ *
+ * Cron schedule (from wrangler.toml):
+ *   - Every 30 min  →  /api/cron/reminders  (appointment reminders)
+ *   - Daily at 2 AM →  /api/cron/billing    (subscription renewals)
+ *
+ * @see https://opennext.js.org/cloudflare/howtos/custom-worker
+ */
+
+// @ts-expect-error — .open-next/worker.js is generated at build time
+import { default as handler } from "./.open-next/worker.js";
+
+/**
+ * Map cron expressions to their corresponding API routes.
+ * The cron value comes from controller.cron and matches wrangler.toml.
+ */
+const CRON_ROUTES: Record<string, string> = {
+  "*/30 * * * *": "/api/cron/reminders",
+  "0 2 * * *": "/api/cron/billing",
+};
+
+export default {
+  fetch: handler.fetch,
+
+  async scheduled(
+    controller: ScheduledController,
+    env: Record<string, string>,
+    ctx: ExecutionContext,
+  ) {
+    const route = CRON_ROUTES[controller.cron] ?? null;
+
+    if (!route) {
+      console.error(`[Cron] Unknown cron expression: ${controller.cron}`);
+      return;
+    }
+
+    console.log(`[Cron] Firing ${controller.cron} → ${route}`);
+
+    // Build a request to the Next.js API route via the same Worker fetch handler.
+    // Use Authorization: Bearer header — both cron routes expect this format.
+    const url = new URL(route, "http://localhost");
+    const headers: HeadersInit = {};
+
+    const cronSecret = env.CRON_SECRET;
+    if (cronSecret) {
+      headers["Authorization"] = `Bearer ${cronSecret}`;
+    }
+
+    const request = new Request(url.toString(), { headers });
+
+    ctx.waitUntil(
+      handler
+        .fetch(request, env, ctx)
+        .then(async (res: Response) => {
+          const body = await res.text();
+          console.log(`[Cron] ${route} responded ${res.status}: ${body}`);
+        })
+        .catch((err: unknown) => {
+          console.error(`[Cron] ${route} failed:`, err);
+        }),
+    );
+  },
+} satisfies ExportedHandler;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 #:schema node_modules/wrangler/config-schema.json
 name = "webs-alots"
-main = ".open-next/worker.js"
+main = "worker-cron-handler.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
@@ -27,7 +27,7 @@ crons = ["*/30 * * * *", "0 2 * * *"]
 # Uses separate Supabase project for data isolation
 [env.staging]
 name = "webs-alots-staging"
-main = ".open-next/worker.js"
+main = "worker-cron-handler.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
## Problem

Two independent reminder systems doing the same thing:
1. **Supabase Edge Function** (`reminder-24h/index.ts`) - runs as Supabase scheduled function
2. **Next.js API Route** (`/api/cron/reminders/route.ts`) - triggered by Cloudflare Cron every 30 min

If both are active, patients get **duplicate WhatsApp reminders**.

Additionally, the two cron routes use **different auth methods**:
- `/api/cron/reminders` checks `?secret=CRON_SECRET` (query param)
- `/api/cron/billing` checks `Authorization: Bearer CRON_SECRET` (header)

And Cloudflare Cron Triggers call the worker's `scheduled()` handler directly - they don't make HTTP requests with query params. There was no `scheduled()` handler wired up.

## Changes

### Deprecated `reminder-24h` Edge Function
The function now returns `410 Gone` with a deprecation notice. The original implementation is preserved in a comment block for reference. The Next.js route is the primary system (handles both 24h AND 2h reminders, uses the notification engine).

### Standardized Cron Auth
Both `/api/cron/reminders` and `/api/cron/billing` now use the same auth method: `Authorization: Bearer CRON_SECRET` header.

### Created `worker-cron-handler.ts`
Custom Cloudflare Worker entry point that:
- Re-exports the OpenNext fetch handler for normal requests
- Adds a `scheduled()` handler that maps cron expressions to API routes
- Calls the routes with `Authorization: Bearer CRON_SECRET` header
- Based on the [OpenNext custom worker pattern](https://opennext.js.org/cloudflare/howtos/custom-worker)

Cron mapping:
- `*/30 * * * *` -> `/api/cron/reminders`
- `0 2 * * *` -> `/api/cron/billing`

### Updated `wrangler.toml`
Changed `main` entry point from `.open-next/worker.js` to `worker-cron-handler.ts` (both production and staging).

### Added `CRON_SECRET` to `.env.local.example`
With a note on how to generate it (`openssl rand -hex 32`).

## Setup Required

After deploying, set `CRON_SECRET` as a Cloudflare Worker secret:
```bash
wrangler secret put CRON_SECRET
```