### PR TITLE
feat: add Worker env vars, routes, and wildcard subdomain support for groupsmix.com

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,17 +21,17 @@ ROOT_DOMAIN = "groupsmix.com"
 NEXT_PUBLIC_SITE_URL = "https://groupsmix.com"
 R2_BUCKET_NAME = "webs-alots-uploads"
 
-# ---- Cron Triggers ----
-# Appointment reminders: every 30 minutes
-# Subscription renewal check: daily at 2am UTC
-[triggers]
-crons = ["*/30 * * * *", "0 2 * * *"]
-
 # ---- Workers Routes (custom domain + wildcard subdomains) ----
 routes = [
   { pattern = "groupsmix.com/*", zone_name = "groupsmix.com" },
   { pattern = "*.groupsmix.com/*", zone_name = "groupsmix.com" },
 ]
+
+# ---- Cron Triggers ----
+# Appointment reminders: every 30 minutes
+# Subscription renewal check: daily at 2am UTC
+[triggers]
+crons = ["*/30 * * * *", "0 2 * * *"]
 
 # ---- Staging Environment ----
 # Deploy with: wrangler deploy --env staging

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,15 +15,27 @@ binding = "ASSETS"
 binding = "R2_BUCKET"
 bucket_name = "webs-alots-uploads"
 
+# ---- Non-Sensitive Environment Variables ----
+[vars]
+ROOT_DOMAIN = "groupsmix.com"
+NEXT_PUBLIC_SITE_URL = "https://groupsmix.com"
+R2_BUCKET_NAME = "webs-alots-uploads"
+
 # ---- Cron Triggers ----
 # Appointment reminders: every 30 minutes
 # Subscription renewal check: daily at 2am UTC
 [triggers]
 crons = ["*/30 * * * *", "0 2 * * *"]
 
+# ---- Workers Routes (custom domain + wildcard subdomains) ----
+routes = [
+  { pattern = "groupsmix.com/*", zone_name = "groupsmix.com" },
+  { pattern = "*.groupsmix.com/*", zone_name = "groupsmix.com" },
+]
+
 # ---- Staging Environment ----
 # Deploy with: wrangler deploy --env staging
-# URL: staging.yourdomain.com
+# URL: staging.groupsmix.com
 # Uses separate Supabase project for data isolation
 [env.staging]
 name = "webs-alots-staging"
@@ -38,6 +50,11 @@ binding = "ASSETS"
 [[env.staging.r2_buckets]]
 binding = "R2_BUCKET"
 bucket_name = "webs-alots-uploads"
+
+[env.staging.vars]
+ROOT_DOMAIN = "groupsmix.com"
+NEXT_PUBLIC_SITE_URL = "https://staging.groupsmix.com"
+R2_BUCKET_NAME = "webs-alots-uploads"
 
 # ---- Staging Cron Triggers ----
 # Same schedule as production

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -42,6 +42,9 @@ name = "webs-alots-staging"
 main = "worker-cron-handler.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
+routes = [
+  { pattern = "staging.groupsmix.com/*", zone_name = "groupsmix.com" },
+]
 
 [env.staging.assets]
 directory = ".open-next/assets"


### PR DESCRIPTION
## Changes

### wrangler.toml updates:
- Added `[vars]` block with `ROOT_DOMAIN`, `NEXT_PUBLIC_SITE_URL`, `R2_BUCKET_NAME`
- Added Workers routes for `groupsmix.com/*` and `*.groupsmix.com/*` (subdomain routing)
- Added staging env vars with staging-specific `NEXT_PUBLIC_SITE_URL`

### Infrastructure changes done outside this PR:
- **Worker secrets set** via `wrangler secret put`: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `CRON_SECRET`, `R2_ACCOUNT_ID`
- **Wildcard DNS** created: `*.groupsmix.com` CNAME -> `groupsmix.com` (proxied)
- **R2 backup bucket** created: `webs-alots-backups`
- **GitHub secrets** added: `R2_ACCOUNT_ID`, `R2_BUCKET_NAME`, `R2_BACKUP_BUCKET`, `SUPABASE_SERVICE_ROLE_KEY`, `CRON_SECRET`