### PR TITLE
fix: implement notifications GET, fix cron NULL dates, fix notify-booking schema

### DIFF
--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -35,7 +35,9 @@ export async function GET(request: NextRequest) {
     const todayStr = now.toISOString().split("T")[0];
     const tomorrowStr = twentyFourHoursFromNow.toISOString().split("T")[0];
 
-    // Fetch upcoming appointments that need reminders
+    // Fetch upcoming appointments that need reminders.
+    // Select both appointment_date/start_time and slot_start/slot_end
+    // since older records may only have slot_start/slot_end populated.
     const { data: appointments, error } = await supabase
       .from("appointments")
       .select(`
@@ -45,15 +47,17 @@ export async function GET(request: NextRequest) {
         doctor_id,
         appointment_date,
         start_time,
+        slot_start,
+        slot_end,
         status,
         patients:patient_id (id, name, phone),
         doctors:doctor_id (id, name),
         services:service_id (name)
       `)
-      .in("appointment_date", [todayStr, tomorrowStr])
       .in("status", ["confirmed", "pending"])
-      .order("appointment_date")
-      .order("start_time");
+      .or(
+        `appointment_date.in.(${todayStr},${tomorrowStr}),and(appointment_date.is.null,slot_start.gte.${now.toISOString()},slot_start.lte.${twentyFourHoursFromNow.toISOString()})`,
+      );
 
     if (error) {
       console.error("[Cron/Reminders] Query error:", error.message);
@@ -67,8 +71,21 @@ export async function GET(request: NextRequest) {
     const results: { appointmentId: string; type: string; success: boolean }[] = [];
 
     for (const appt of appointments) {
-      // Parse appointment datetime
-      const apptDatetime = new Date(`${appt.appointment_date}T${appt.start_time}`);
+      // Parse appointment datetime, falling back to slot_start when
+      // appointment_date or start_time are NULL.
+      let apptDatetime: Date;
+      const slotStart = appt.slot_start as string | null;
+
+      if (appt.appointment_date && appt.start_time) {
+        apptDatetime = new Date(`${appt.appointment_date}T${appt.start_time}`);
+      } else if (slotStart) {
+        apptDatetime = new Date(slotStart);
+      } else {
+        // Neither field is available — skip this appointment
+        continue;
+      }
+
+      if (isNaN(apptDatetime.getTime())) continue;
 
       // Determine which reminder to send
       const hoursUntil = (apptDatetime.getTime() - now.getTime()) / (1000 * 60 * 60);
@@ -83,6 +100,12 @@ export async function GET(request: NextRequest) {
 
       if (!trigger) continue;
 
+      // Discard appointments beyond 25 hours (twoHoursFromNow is used
+      // as the lower bound for 2h reminders above; twentyFourHoursFromNow
+      // caps the query window).
+      if (apptDatetime.getTime() > twentyFourHoursFromNow.getTime()) continue;
+      if (apptDatetime.getTime() < twoHoursFromNow.getTime() && trigger === "reminder_2h") continue;
+
       // Type-safe access to joined data
       const patient = appt.patients as unknown as { id: string; name: string; phone: string } | null;
       const doctor = appt.doctors as unknown as { id: string; name: string } | null;
@@ -90,14 +113,18 @@ export async function GET(request: NextRequest) {
 
       if (!patient) continue;
 
+      // Derive display date/time from the resolved datetime
+      const displayDate = appt.appointment_date ?? apptDatetime.toISOString().split("T")[0];
+      const displayTime = appt.start_time ?? apptDatetime.toISOString().split("T")[1]?.slice(0, 5) ?? "";
+
       const dispatchResults = await dispatchNotification(
         trigger,
         {
           patientName: patient.name,
           doctorName: doctor?.name ?? "Doctor",
           clinicName: "",
-          date: appt.appointment_date,
-          time: appt.start_time,
+          date: displayDate,
+          time: displayTime,
           serviceName: service?.name ?? "Appointment",
         },
         patient.id,

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -5,6 +5,8 @@ import {
   type NotificationChannel,
   type TemplateVariables,
 } from "@/lib/notifications";
+import type { NotificationChannel as DBNotificationChannel } from "@/lib/types/database";
+import { createClient } from "@/lib/supabase-server";
 
 export const runtime = "edge";
 
@@ -57,7 +59,7 @@ export async function POST(request: NextRequest) {
  * GET /api/notifications
  *
  * Returns notification history for a user.
- * Query params: userId, channel, trigger, status, limit
+ * Query params: userId, channel, type, limit, offset
  */
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
@@ -70,7 +72,49 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // TODO: Fetch from Supabase notifications table
-  // For now, return empty array (demo data is rendered client-side)
-  return NextResponse.json({ notifications: [], total: 0 });
+  try {
+    const supabase = await createClient();
+
+    const channel = searchParams.get("channel");
+    const type = searchParams.get("type");
+    const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 100);
+    const offset = parseInt(searchParams.get("offset") ?? "0", 10) || 0;
+
+    let query = supabase
+      .from("notifications")
+      .select("*", { count: "exact" })
+      .eq("user_id", userId);
+
+    if (channel) {
+      query = query.eq("channel", channel as DBNotificationChannel);
+    }
+
+    if (type) {
+      query = query.eq("type", type);
+    }
+
+    query = query
+      .order("sent_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    const { data: notifications, error, count } = await query;
+
+    if (error) {
+      console.error("[GET /api/notifications] Query error:", error.message);
+      return NextResponse.json(
+        { error: "Failed to fetch notifications" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      notifications: notifications ?? [],
+      total: count ?? 0,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to fetch notifications" },
+      { status: 500 },
+    );
+  }
 }

--- a/supabase/functions/notify-booking/index.ts
+++ b/supabase/functions/notify-booking/index.ts
@@ -23,8 +23,10 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 interface AppointmentRow {
   id: string;
-  appointment_date: string;
-  start_time: string;
+  appointment_date: string | null;
+  start_time: string | null;
+  slot_start: string | null;
+  slot_end: string | null;
   status: string;
   patient: { name: string; phone: string | null } | null;
   doctor: { name: string; phone: string | null } | null;
@@ -100,11 +102,11 @@ serve(async (req: Request) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
 
-    // Fetch appointment with related data
+    // Fetch appointment with related data (include slot_start/slot_end as fallback)
     const { data: appointment, error } = await supabase
       .from("appointments")
       .select(
-        "id, appointment_date, start_time, status, patient:users!patient_id(name, phone), doctor:users!doctor_id(name, phone), service:services(name), clinic:clinics(id, name, owner_phone)",
+        "id, appointment_date, start_time, slot_start, slot_end, status, patient:users!patient_id(name, phone), doctor:users!doctor_id(name, phone), service:services(name), clinic:clinics(id, name, owner_phone)",
       )
       .eq("id", appointmentId)
       .single();
@@ -119,16 +121,32 @@ serve(async (req: Request) => {
     const apt = appointment as unknown as AppointmentRow;
     const results: { recipient: string; sent: boolean }[] = [];
 
+    // Derive display date/time, falling back to slot_start when
+    // appointment_date or start_time are NULL.
+    let displayDate = apt.appointment_date;
+    let displayTime = apt.start_time;
+
+    if ((!displayDate || !displayTime) && apt.slot_start) {
+      const slotDt = new Date(apt.slot_start);
+      if (!isNaN(slotDt.getTime())) {
+        displayDate = displayDate ?? slotDt.toISOString().split("T")[0];
+        displayTime = displayTime ?? slotDt.toISOString().split("T")[1]?.slice(0, 5) ?? null;
+      }
+    }
+
+    const dateStr = displayDate ?? "TBD";
+    const timeStr = displayTime ?? "TBD";
+
     // Send confirmation to patient
     if (apt.patient?.phone) {
-      const body = `Hello ${apt.patient.name}, your appointment with ${apt.doctor?.name ?? "our doctor"} is confirmed for ${apt.appointment_date} at ${apt.start_time}. Service: ${apt.service?.name ?? "N/A"}. — ${apt.clinic?.name ?? ""}`;
+      const body = `Hello ${apt.patient.name}, your appointment with ${apt.doctor?.name ?? "our doctor"} is confirmed for ${dateStr} at ${timeStr}. Service: ${apt.service?.name ?? "N/A"}. — ${apt.clinic?.name ?? ""}`;
       const sent = await sendWhatsApp(apt.patient.phone, body);
       results.push({ recipient: "patient", sent });
     }
 
     // Notify doctor
     if (apt.doctor?.phone) {
-      const body = `New appointment: ${apt.patient?.name ?? "A patient"} on ${apt.appointment_date} at ${apt.start_time}. Service: ${apt.service?.name ?? "N/A"}.`;
+      const body = `New appointment: ${apt.patient?.name ?? "A patient"} on ${dateStr} at ${timeStr}. Service: ${apt.service?.name ?? "N/A"}.`;
       const sent = await sendWhatsApp(apt.doctor.phone, body);
       results.push({ recipient: "doctor", sent });
     }
@@ -136,7 +154,7 @@ serve(async (req: Request) => {
     // Notify clinic via in-app notification
     if (apt.clinic?.id) {
       // Look up the clinic admin to use as the notification recipient
-      const { data: clinicAdmin } = await supabase
+      const { data: clinicAdmin, error: adminError } = await supabase
         .from("users")
         .select("id")
         .eq("clinic_id", apt.clinic.id)
@@ -144,17 +162,27 @@ serve(async (req: Request) => {
         .limit(1)
         .single();
 
-      if (clinicAdmin?.id) {
-        await supabase.from("notifications").insert({
+      if (adminError || !clinicAdmin?.id) {
+        console.error(
+          `[notify-booking] No clinic_admin found for clinic ${apt.clinic.id}:`,
+          adminError?.message ?? "no matching user",
+        );
+      } else {
+        const { error: insertError } = await supabase.from("notifications").insert({
           user_id: clinicAdmin.id,
           clinic_id: apt.clinic.id,
           type: "new_booking",
           channel: "in_app",
           title: "New Appointment Booked",
-          message: `${apt.patient?.name ?? "A patient"} booked with ${apt.doctor?.name ?? "a doctor"} on ${apt.appointment_date} at ${apt.start_time}.`,
+          body: `${apt.patient?.name ?? "A patient"} booked with ${apt.doctor?.name ?? "a doctor"} on ${dateStr} at ${timeStr}.`,
           is_read: false,
         });
-        results.push({ recipient: "clinic_notification", sent: true });
+
+        if (insertError) {
+          console.error("[notify-booking] Failed to insert notification:", insertError.message);
+        } else {
+          results.push({ recipient: "clinic_notification", sent: true });
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes three critical runtime issues across notifications, cron reminders, and the notify-booking edge function.

### Task 1: Implement /api/notifications GET endpoint
- Replaced stub (always returned empty array) with actual Supabase query
- Queries `notifications` table filtered by `userId`
- Supports optional `channel`, `type`, `limit`, and `offset` query params for filtering and pagination
- Returns `{ notifications, total }` with exact count

### Task 2: Fix cron reminders NULL appointment_date/start_time
- Added `slot_start`/`slot_end` to the SELECT query as fallback fields
- Updated query filter to also match appointments where `appointment_date` is NULL but `slot_start` falls in the reminder window
- Added fallback logic: uses `slot_start` to derive datetime when `appointment_date`/`start_time` are NULL
- `twoHoursFromNow` variable is now used in the filter logic (was previously computed but unused)
- Derives display date/time from resolved datetime for notification messages
- Note: The booking API route (`/api/booking`) already correctly sets `appointment_date` and `start_time` on insert

### Task 3: Fix notify-booking edge function schema mismatch
- Added `slot_start`/`slot_end` to the appointment SELECT and `AppointmentRow` interface
- Added fallback logic for NULL `appointment_date`/`start_time` in WhatsApp message templates
- Changed notification insert to use `body` column instead of `message` for consistency with `notification-persist.ts` and the app's `Notification` type
- Added proper error handling: logs when no clinic_admin is found, and when notification insert fails
- Only reports `clinic_notification` as sent when insert actually succeeds