### PR TITLE
Replace <img> tags with Next.js <Image /> for automatic optimization

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(doctor)/doctor/dermatology/page.tsx
+++ b/src/app/(doctor)/doctor/dermatology/page.tsx
@@ -5,6 +5,7 @@ import {
   Camera, Plus, MapPin, Calendar, Tag, Eye,
   AlertTriangle, CheckCircle, Search, Save,
 } from "lucide-react";
+import Image from "next/image";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -179,9 +180,9 @@ export default function DermatologyPage() {
               {filteredPhotos.map((photo) => (
                 <Card key={photo.id}>
                   <CardContent className="p-4">
-                    <div className="aspect-square rounded-lg bg-muted flex items-center justify-center mb-3">
+                    <div className="relative aspect-square rounded-lg bg-muted flex items-center justify-center mb-3">
                       {photo.imageUrl ? (
-                        <img src={photo.imageUrl} alt={photo.description} className="rounded-lg object-cover w-full h-full" />
+                        <Image src={photo.imageUrl} alt={photo.description} fill className="rounded-lg object-cover" />
                       ) : (
                         <div className="text-center">
                           <Camera className="h-8 w-8 mx-auto text-muted-foreground" />

--- a/src/app/(doctor)/doctor/orthopedics/page.tsx
+++ b/src/app/(doctor)/doctor/orthopedics/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useCallback } from "react";
 import {
-  Bone, Plus, Save, Calendar, Image,
+  Bone, Plus, Save, Calendar, Image as ImageIcon,
   Target, CheckCircle, Clock, AlertTriangle,
 } from "lucide-react";
+import NextImage from "next/image";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -162,7 +163,7 @@ export default function OrthopedicsPage() {
           </div>
           {xrays.length === 0 ? (
             <Card><CardContent className="py-8 text-center">
-              <Image className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
+              <ImageIcon className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
               <p className="text-sm text-muted-foreground">No X-ray records.</p>
             </CardContent></Card>
           ) : (
@@ -170,11 +171,11 @@ export default function OrthopedicsPage() {
               {xrays.map((xray) => (
                 <Card key={xray.id}>
                   <CardContent className="p-4">
-                    <div className="aspect-video rounded-lg bg-muted flex items-center justify-center mb-3">
+                    <div className="relative aspect-video rounded-lg bg-muted flex items-center justify-center mb-3">
                       {xray.imageUrl ? (
-                        <img src={xray.imageUrl} alt={xray.bodyPart} className="rounded-lg object-cover w-full h-full" />
+                        <NextImage src={xray.imageUrl} alt={xray.bodyPart} fill className="rounded-lg object-cover" />
                       ) : (
-                        <Image className="h-8 w-8 text-muted-foreground" />
+                        <ImageIcon className="h-8 w-8 text-muted-foreground" />
                       )}
                     </div>
                     <div className="flex items-center justify-between mb-2">
@@ -346,7 +347,7 @@ export default function OrthopedicsPage() {
                 onChange={(e) => setXrayForm((p) => ({ ...p, bodyPart: e.target.value }))} />
             </div>
             <div className="border-2 border-dashed rounded-lg p-4 text-center">
-              <Image className="h-6 w-6 mx-auto text-muted-foreground mb-1" />
+              <ImageIcon className="h-6 w-6 mx-auto text-muted-foreground mb-1" />
               <p className="text-xs text-muted-foreground">Attach X-Ray Image</p>
               <Button variant="outline" size="sm" className="mt-2 text-xs">Browse</Button>
             </div>

--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Image from "next/image";
 import { Award, Languages, GraduationCap, Briefcase } from "lucide-react";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -29,9 +30,11 @@ export default function AboutPage() {
       <div className="max-w-3xl mx-auto">
         <div className="text-center mb-12">
           {cfg.photoUrl ? (
-            <img
+            <Image
               src={cfg.photoUrl}
               alt={cfg.doctorName}
+              width={128}
+              height={128}
               className="h-32 w-32 rounded-full mx-auto mb-4 object-cover shadow-lg"
             />
           ) : (

--- a/src/app/(radiology)/radiology/images/page.tsx
+++ b/src/app/(radiology)/radiology/images/page.tsx
@@ -22,7 +22,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Search, Image, ExternalLink, Eye, FileImage, Upload, Loader2, X } from "lucide-react";
+import { Search, Image as ImageIcon, ExternalLink, Eye, FileImage, Upload, Loader2, X } from "lucide-react";
+import NextImage from "next/image";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";
@@ -204,11 +205,11 @@ export default function RadiologyImagesPage() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {filtered.map((order) => (
           <Card key={order.id} className="overflow-hidden">
-            <div className="aspect-video bg-muted flex items-center justify-center">
+            <div className="relative aspect-video bg-muted flex items-center justify-center">
               {order.images.length > 0 && order.images[0].thumbnailUrl ? (
-                <img src={order.images[0].thumbnailUrl} alt={`${order.modality} - ${order.bodyPart}`} className="w-full h-full object-cover" />
+                <NextImage src={order.images[0].thumbnailUrl} alt={`${order.modality} - ${order.bodyPart}`} fill className="object-cover" />
               ) : order.images.length > 0 && order.images[0].fileUrl ? (
-                <img src={order.images[0].fileUrl} alt={`${order.modality} - ${order.bodyPart}`} className="w-full h-full object-cover" />
+                <NextImage src={order.images[0].fileUrl} alt={`${order.modality} - ${order.bodyPart}`} fill className="object-cover" />
               ) : (
                 <FileImage className="h-16 w-16 text-muted-foreground/30" />
               )}
@@ -248,7 +249,7 @@ export default function RadiologyImagesPage() {
 
       {filtered.length === 0 && (
         <div className="text-center py-12">
-          <Image className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
+          <ImageIcon className="h-12 w-12 text-muted-foreground mx-auto mb-3" />
           <p className="text-muted-foreground">No images found</p>
           <Button variant="outline" className="mt-4" onClick={() => setUploadOpen(true)}>
             <Upload className="h-4 w-4 mr-2" /> Upload your first images

--- a/src/components/aesthetic/consultation-photos.tsx
+++ b/src/components/aesthetic/consultation-photos.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { Camera, Plus, MapPin, StickyNote } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -95,9 +96,9 @@ export function ConsultationPhotos({ photos, editable = false, onAddPhoto }: Con
             {photos.map((photo) => (
               <Card key={photo.id} className="cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all" onClick={() => setSelectedPhoto(photo)}>
                 <CardContent className="p-2">
-                  <div className="aspect-square bg-muted rounded-lg mb-2 flex items-center justify-center overflow-hidden">
+                  <div className="relative aspect-square bg-muted rounded-lg mb-2 flex items-center justify-center overflow-hidden">
                     {photo.thumbnailUrl || photo.photoUrl ? (
-                      <img src={photo.thumbnailUrl || photo.photoUrl} alt="Consultation" className="w-full h-full object-cover rounded-lg" />
+                      <Image src={photo.thumbnailUrl || photo.photoUrl} alt="Consultation" fill className="object-cover rounded-lg" />
                     ) : (
                       <Camera className="h-8 w-8 text-muted-foreground" />
                     )}
@@ -130,9 +131,9 @@ export function ConsultationPhotos({ photos, editable = false, onAddPhoto }: Con
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  <div className="aspect-video bg-muted rounded-lg flex items-center justify-center overflow-hidden relative">
+                  <div className="relative aspect-video bg-muted rounded-lg flex items-center justify-center overflow-hidden">
                     {selectedPhoto.photoUrl ? (
-                      <img src={selectedPhoto.photoUrl} alt="Consultation" className="w-full h-full object-contain" />
+                      <Image src={selectedPhoto.photoUrl} alt="Consultation" fill className="object-contain" />
                     ) : (
                       <Camera className="h-12 w-12 text-muted-foreground" />
                     )}

--- a/src/components/morocco/doctor-directory.tsx
+++ b/src/components/morocco/doctor-directory.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import Image from "next/image";
 import {
   Search, MapPin, Star, Phone, Calendar,
   Filter, Globe, MessageCircle, Stethoscope,
@@ -252,9 +253,11 @@ export function DoctorDirectory({
                 {/* Avatar */}
                 <div className="h-16 w-16 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
                   {doctor.avatar ? (
-                    <img
+                    <Image
                       src={doctor.avatar}
                       alt={doctor.name}
+                      width={64}
+                      height={64}
                       className="h-16 w-16 rounded-full object-cover"
                     />
                   ) : (

--- a/src/components/para-medical/frame-catalog.tsx
+++ b/src/components/para-medical/frame-catalog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import {
   Glasses, Search, AlertTriangle, Package,
 } from "lucide-react";
@@ -105,9 +106,9 @@ export function FrameCatalog({ frames }: FrameCatalogProps) {
         )}
         {filtered.map((frame) => (
           <Card key={frame.id} className={!frame.is_active ? "opacity-60" : ""}>
-            <div className="aspect-video bg-muted flex items-center justify-center overflow-hidden">
+            <div className="relative aspect-video bg-muted flex items-center justify-center overflow-hidden">
               {frame.photo_url ? (
-                <img src={frame.photo_url} alt={`${frame.brand} ${frame.model}`} className="w-full h-full object-cover" />
+                <Image src={frame.photo_url} alt={`${frame.brand} ${frame.model}`} fill className="object-cover" />
               ) : (
                 <Glasses className="h-12 w-12 text-muted-foreground" />
               )}

--- a/src/components/para-medical/progress-photo-gallery.tsx
+++ b/src/components/para-medical/progress-photo-gallery.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import { Camera, Calendar, ChevronLeft, ChevronRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -72,12 +73,13 @@ export function ProgressPhotoGallery({ photos }: ProgressPhotoGalleryProps) {
               <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
                 {datePhotos.map((photo) => (
                   <Card key={photo.id} className="overflow-hidden">
-                    <div className="aspect-square bg-muted flex items-center justify-center">
+                    <div className="relative aspect-square bg-muted flex items-center justify-center">
                       {photo.photo_url ? (
-                        <img
+                        <Image
                           src={photo.photo_url}
                           alt={photo.notes || "Progress photo"}
-                          className="w-full h-full object-cover"
+                          fill
+                          className="object-cover"
                         />
                       ) : (
                         <Camera className="h-8 w-8 text-muted-foreground" />
@@ -112,9 +114,9 @@ export function ProgressPhotoGallery({ photos }: ProgressPhotoGalleryProps) {
             <div className="grid grid-cols-2 gap-4">
               <div className="text-center">
                 <p className="text-xs text-muted-foreground mb-2">Earliest: {sortedPhotos[sortedPhotos.length - 1].photo_date}</p>
-                <div className="aspect-square bg-muted rounded-lg flex items-center justify-center overflow-hidden">
+                <div className="relative aspect-square bg-muted rounded-lg flex items-center justify-center overflow-hidden">
                   {sortedPhotos[sortedPhotos.length - 1].photo_url ? (
-                    <img src={sortedPhotos[sortedPhotos.length - 1].photo_url} alt="Before" className="w-full h-full object-cover" />
+                    <Image src={sortedPhotos[sortedPhotos.length - 1].photo_url} alt="Before" fill className="object-cover" />
                   ) : (
                     <Camera className="h-8 w-8 text-muted-foreground" />
                   )}
@@ -122,9 +124,9 @@ export function ProgressPhotoGallery({ photos }: ProgressPhotoGalleryProps) {
               </div>
               <div className="text-center">
                 <p className="text-xs text-muted-foreground mb-2">Latest: {sortedPhotos[0].photo_date}</p>
-                <div className="aspect-square bg-muted rounded-lg flex items-center justify-center overflow-hidden">
+                <div className="relative aspect-square bg-muted rounded-lg flex items-center justify-center overflow-hidden">
                   {sortedPhotos[0].photo_url ? (
-                    <img src={sortedPhotos[0].photo_url} alt="After" className="w-full h-full object-cover" />
+                    <Image src={sortedPhotos[0].photo_url} alt="After" fill className="object-cover" />
                   ) : (
                     <Camera className="h-8 w-8 text-muted-foreground" />
                   )}

--- a/src/components/public/header.tsx
+++ b/src/components/public/header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
 import { buttonVariants } from "@/components/ui/button";
@@ -30,8 +31,7 @@ export function PublicHeader({ logoUrl, clinicName }: PublicHeaderProps) {
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <Link href="/" className="flex items-center gap-2 text-xl font-bold">
           {logoUrl && (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img src={logoUrl} alt={displayName} className="h-8 w-auto" />
+            <Image src={logoUrl} alt={displayName} width={32} height={32} className="h-8 w-auto" />
           )}
           {displayName}
         </Link>

--- a/src/components/public/hero-section.tsx
+++ b/src/components/public/hero-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { buttonVariants } from "@/components/ui/button";
 import { clinicConfig } from "@/config/clinic.config";
 import { defaultWebsiteConfig } from "@/lib/website-config";
@@ -34,9 +35,11 @@ export function HeroSection() {
 
           <div className="hidden lg:flex justify-center">
             {cfg.imageUrl ? (
-              <img
+              <Image
                 src={cfg.imageUrl}
                 alt={clinicConfig.name}
+                width={500}
+                height={384}
                 className="rounded-2xl shadow-xl max-h-96 object-cover"
               />
             ) : (


### PR DESCRIPTION
## Summary

Replace all 14 raw `<img>` tags across 11 files with Next.js `<Image />` component for automatic image optimization (WebP conversion, lazy loading, responsive srcsets).

## Changes

### Image Component Replacements (11 files)
- **`src/app/(public)/about/page.tsx`** — Doctor photo (width=128, height=128)
- **`src/app/(radiology)/radiology/images/page.tsx`** — Radiology thumbnails (2 imgs, fill mode)
- **`src/components/aesthetic/consultation-photos.tsx`** — Consultation photos (2 imgs, fill mode)
- **`src/components/morocco/doctor-directory.tsx`** — Doctor avatar (width=64, height=64)
- **`src/components/para-medical/frame-catalog.tsx`** — Frame photo (fill mode)
- **`src/components/para-medical/progress-photo-gallery.tsx`** — Progress photos (3 imgs, fill mode)
- **`src/components/public/hero-section.tsx`** — Hero image (width=500, height=384)
- **`src/components/public/header.tsx`** — Clinic logo (width=32, height=32), removed eslint-disable comment
- **`src/app/(doctor)/doctor/orthopedics/page.tsx`** — X-ray images (fill mode)
- **`src/app/(doctor)/doctor/dermatology/page.tsx`** — Skin photos (fill mode)

### Config
- **`next.config.ts`** — Added `images.remotePatterns` allowing all HTTPS domains (needed since image URLs are dynamic/user-uploaded)

### Technical Details
- Used `fill` prop + `relative` parent for images that fill their container
- Used explicit `width`/`height` for fixed-size images
- Renamed lucide-react `Image` icon imports to `ImageIcon` to avoid naming conflicts
- All `@next/next/no-img-element` ESLint warnings resolved (was 13 warnings + 1 suppressed)

---
[Devin session](https://app.devin.ai/sessions/44f62c2f186d41c0a09f5c62a444030f)