### PR TITLE
fix: remove Supabase type casts, add booking double-submit prevention, add loading indicators

### DIFF
--- a/src/app/(admin)/admin/doctors/page.tsx
+++ b/src/app/(admin)/admin/doctors/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Plus, Edit, Trash2 } from "lucide-react";
+import { Plus, Edit, Trash2, Loader2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -94,6 +94,14 @@ export default function ManageDoctorsPage() {
     setDoctorsList(doctorsList.filter((d) => d.id !== id));
     setDeleteConfirm(null);
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/app/(admin)/admin/services/page.tsx
+++ b/src/app/(admin)/admin/services/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Plus, Edit, Trash2, Clock, CreditCard } from "lucide-react";
+import { Plus, Edit, Trash2, Clock, CreditCard, Loader2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -95,6 +95,14 @@ export default function ManageServicesPage() {
   const toggleActive = (id: string) => {
     setServicesList(servicesList.map((s) => (s.id === id ? { ...s, active: !s.active } : s)));
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/app/(admin)/admin/working-hours/page.tsx
+++ b/src/app/(admin)/admin/working-hours/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Clock, Save } from "lucide-react";
+import { Clock, Save, Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -64,6 +64,14 @@ export default function WorkingHoursPage() {
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/app/(super-admin)/super-admin/announcements/page.tsx
+++ b/src/app/(super-admin)/super-admin/announcements/page.tsx
@@ -133,6 +133,14 @@ export default function AnnouncementsPage() {
     setList((prev) => prev.map((a) => a.id === item.id ? { ...a, active: !a.active } : a));
   }
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">

--- a/src/app/(super-admin)/super-admin/features/page.tsx
+++ b/src/app/(super-admin)/super-admin/features/page.tsx
@@ -106,6 +106,14 @@ export default function FeatureTogglesPage() {
   const enabledCount = features.filter((f) => f.globalEnabled).length;
   const totalClinics = totalClinicsCount;
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex items-center justify-between mb-6">

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -124,6 +124,14 @@ export default function PricingPage() {
     }
   };
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">

--- a/src/app/(super-admin)/super-admin/subscriptions/page.tsx
+++ b/src/app/(super-admin)/super-admin/subscriptions/page.tsx
@@ -104,6 +104,14 @@ export default function SubscriptionsPage() {
     return labels[status];
   };
 
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -96,8 +96,7 @@ export async function POST(request: NextRequest) {
   }
 
   const supabase = await createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data, error } = await (supabase.from as any)("users")
+  const { data, error } = await supabase.from("users")
     .insert({
       clinic_id: auth.clinicId,
       role: "patient",

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import { ChevronLeft, ChevronRight, Check, Stethoscope, User, ShieldCheck, Repeat, Users } from "lucide-react";
+import { ChevronLeft, ChevronRight, Check, Stethoscope, User, ShieldCheck, Repeat, Users, Loader2 } from "lucide-react";
 import { fetchDoctors, fetchServices, type DoctorView, type ServiceView } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -221,7 +221,11 @@ export function BookingForm() {
     }
   };
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const handleConfirm = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     try {
       if (isRecurring && clinicConfig.features.recurringBookings) {
         const res = await fetch("/api/booking/recurring", {
@@ -273,6 +277,8 @@ export function BookingForm() {
       setSubmitted(true);
     } catch {
       setSubmitted(true);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -700,8 +706,13 @@ export function BookingForm() {
               <ChevronRight className="h-4 w-4 ml-1" />
             </Button>
           ) : (
-            <Button onClick={handleConfirm}>
-              {isRecurring ? "Confirm Recurring Booking" : "Confirm Booking"}
+            <Button onClick={handleConfirm} disabled={isSubmitting}>
+              {isSubmitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {isSubmitting
+                ? "Submitting…"
+                : isRecurring
+                  ? "Confirm Recurring Booking"
+                  : "Confirm Booking"}
             </Button>
           )}
         </div>

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -59,8 +59,7 @@ export async function createBackup(
   let totalRecords = 0;
 
   for (const table of BACKUP_TABLES) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { data: rows, error } = await (supabase.from as any)(table)
+    const { data: rows, error } = await supabase.from(table)
       .select("*")
       .eq("clinic_id", clinicId)
       .order("created_at", { ascending: false });
@@ -168,8 +167,7 @@ export async function restoreBackup(
       clinic_id: targetClinicId,
     }));
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { error } = await (supabase.from as any)(table)
+    const { error } = await supabase.from(table)
       .upsert(mappedRows, { onConflict: "id" });
 
     if (error) {

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -13,6 +13,9 @@
 
 import { createClient } from "@/lib/supabase-client";
 import { clinicConfig } from "@/config/clinic.config";
+import type { Database } from "@/lib/types/database";
+
+type TableName = keyof Database["public"]["Tables"];
 
 // ── re-export the browser client for direct use ──
 export { createClient };
@@ -57,7 +60,7 @@ export function clearUserCache() {
 // ── Generic fetch helper ──
 
 async function fetchRows<T>(
-  table: string,
+  table: TableName,
   opts?: {
     select?: string;
     eq?: [string, unknown][];
@@ -69,9 +72,7 @@ async function fetchRows<T>(
   },
 ): Promise<T[]> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let q = (supabase.from as any)(table).select(opts?.select ?? "*");
+  let q = supabase.from(table).select(opts?.select ?? "*");
   if (opts?.eq) {
     for (const [col, val] of opts.eq) {
       q = q.eq(col, val);
@@ -154,8 +155,8 @@ async function ensureLookups(clinicId: string) {
   if (_userMap && _serviceMap) return;
   const supabase = createClient();
   const [usersRes, servicesRes] = await Promise.all([
-    supabase.from("users").select("id, name, phone, email").eq("clinic_id", clinicId),
-    supabase.from("services").select("id, name, price").eq("clinic_id", clinicId),
+  supabase.from("users").select("id, name, phone, email").eq("clinic_id", clinicId),
+  supabase.from("services").select("id, name, price").eq("clinic_id", clinicId),
   ]);
   _userMap = new Map(
     ((usersRes.data ?? []) as { id: string; name: string; phone: string; email: string }[]).map((u) => [
@@ -860,11 +861,11 @@ export interface DashboardStats {
 export async function fetchDashboardStats(clinicId: string): Promise<DashboardStats> {
   const supabase = createClient();
   const [patientsRes, appointmentsRes, paymentsRes, reviewsRes, doctorsRes] = await Promise.all([
-    supabase.from("users").select("id, metadata").eq("clinic_id", clinicId).eq("role", "patient"),
-    supabase.from("appointments").select("id, status").eq("clinic_id", clinicId),
-    supabase.from("payments").select("id, amount").eq("clinic_id", clinicId).eq("status", "completed"),
-    supabase.from("reviews").select("id, stars").eq("clinic_id", clinicId),
-    supabase.from("users").select("id").eq("clinic_id", clinicId).eq("role", "doctor"),
+  supabase.from("users").select("id, metadata").eq("clinic_id", clinicId).eq("role", "patient"),
+  supabase.from("appointments").select("id, status").eq("clinic_id", clinicId),
+  supabase.from("payments").select("id, amount").eq("clinic_id", clinicId).eq("status", "completed"),
+  supabase.from("reviews").select("id, stars").eq("clinic_id", clinicId),
+  supabase.from("users").select("id").eq("clinic_id", clinicId).eq("role", "doctor"),
   ]);
   const patients = (patientsRes.data ?? []) as { id: string; metadata: Record<string, unknown> | null }[];
   const appts = (appointmentsRes.data ?? []) as { id: string; status: string }[];
@@ -919,8 +920,7 @@ export async function createPayment(data: {
   status?: string;
 }): Promise<boolean> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase.from as any)("payments").insert({
+  const { error } = await supabase.from("payments").insert({
     ...data,
     status: data.status ?? "completed",
     payment_type: "full",
@@ -1058,8 +1058,7 @@ export async function upsertOdontogramEntry(data: {
   dentition?: "adult" | "child";
 }): Promise<boolean> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase.from as any)("odontogram").upsert(data, {
+  const { error } = await supabase.from("odontogram").upsert(data, {
     onConflict: "clinic_id,patient_id,tooth_number",
   });
   if (error) {
@@ -1102,8 +1101,7 @@ export async function createTreatmentPlan(data: {
   status?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("treatment_plans")
+  const { data: result, error } = await supabase.from("treatment_plans")
     .insert({ ...data, status: data.status ?? "planned" })
     .select("id")
     .single();
@@ -1150,8 +1148,7 @@ export async function createSterilizationEntry(data: {
   cycle_number?: number;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("sterilization_log")
+  const { data: result, error } = await supabase.from("sterilization_log")
     .insert({ ...data, sterilized_at: new Date().toISOString() })
     .select("id")
     .single();
@@ -2262,10 +2259,10 @@ export async function fetchAnalytics(clinicId: string): Promise<AnalyticsData> {
   const supabase = createClient();
 
   const [apptsRes, paymentsRes, reviewsRes, patientsRes] = await Promise.all([
-    supabase.from("appointments").select("*").eq("clinic_id", clinicId),
-    supabase.from("payments").select("*").eq("clinic_id", clinicId).eq("status", "completed"),
-    supabase.from("reviews").select("*").eq("clinic_id", clinicId),
-    supabase.from("users").select("id, created_at").eq("clinic_id", clinicId).eq("role", "patient"),
+  supabase.from("appointments").select("*").eq("clinic_id", clinicId),
+  supabase.from("payments").select("*").eq("clinic_id", clinicId).eq("status", "completed"),
+  supabase.from("reviews").select("*").eq("clinic_id", clinicId),
+  supabase.from("users").select("id, created_at").eq("clinic_id", clinicId).eq("role", "patient"),
   ]);
 
   type ApptRow = { id: string; appointment_date: string; start_time: string; status: string; patient_id: string; service_id: string | null; booking_source: string | null };
@@ -2552,8 +2549,7 @@ export async function createAppointment(data: {
   is_emergency?: boolean;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: appt, error } = await (supabase.from as any)("appointments")
+  const { data: appt, error } = await supabase.from("appointments")
     .insert({
       ...data,
       status: "confirmed",
@@ -3113,8 +3109,7 @@ export async function createLabTestOrder(data: {
 }): Promise<string | null> {
   const supabase = createClient();
   const orderNumber = `LAB-${Date.now().toString(36).toUpperCase()}`;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("lab_test_orders")
+  const { data: result, error } = await supabase.from("lab_test_orders")
     .insert({
       clinic_id: data.clinic_id,
       patient_id: data.patient_id,
@@ -3143,8 +3138,7 @@ export async function createLabTestOrder(data: {
       test_name: catalogMap.get(testId) ?? "Test",
       status: "pending",
     }));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    await (supabase.from as any)("lab_test_items").insert(items);
+    await supabase.from("lab_test_items").insert(items);
   }
   return orderId;
 }
@@ -3205,8 +3199,7 @@ export async function saveLabTestResult(data: {
   entered_by?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("lab_test_results")
+  const { data: result, error } = await supabase.from("lab_test_results")
     .insert({
       order_id: data.order_id,
       test_item_id: data.test_item_id,
@@ -3285,8 +3278,7 @@ export async function createParapharmacyProduct(data: {
   is_active?: boolean;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("products")
+  const { data: result, error } = await supabase.from("products")
     .insert({
       clinic_id: data.clinic_id,
       name: data.name,
@@ -3355,8 +3347,7 @@ export async function createParapharmacySale(data: {
   const supabase = createClient();
   const total = data.items.reduce((sum, item) => sum + item.quantity * item.unit_price, 0);
   const now = new Date();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("sales")
+  const { data: result, error } = await supabase.from("sales")
     .insert({
       clinic_id: data.clinic_id,
       patient_name: data.patient_name,
@@ -3413,8 +3404,7 @@ export async function adjustParapharmacyStock(
     .eq("product_id", productId);
   if (error) {
     // Try insert if no stock row exists
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { error: insertError } = await (supabase.from as any)("stock")
+    const { error: insertError } = await supabase.from("stock")
       .insert({ product_id: productId, quantity: newQuantity });
     if (insertError) {
       console.error("[data] adjust stock:", insertError.message);
@@ -3874,8 +3864,7 @@ export async function createEquipmentItem(data: {
   notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("equipment_inventory")
+  const { data: result, error } = await supabase.from("equipment_inventory")
     .insert({
       ...data,
       currency: data.currency ?? "MAD",
@@ -4315,8 +4304,7 @@ export async function createVaccination(data: {
   notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: row, error } = await (supabase.from as any)("vaccinations")
+  const { data: row, error } = await supabase.from("vaccinations")
     .insert(data)
     .select("id")
     .single();
@@ -4393,8 +4381,7 @@ export async function createMilestone(data: {
   notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: row, error } = await (supabase.from as any)("developmental_milestones")
+  const { data: row, error } = await supabase.from("developmental_milestones")
     .insert(data)
     .select("id")
     .single();
@@ -4613,8 +4600,7 @@ export async function createUltrasound(data: {
   notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: row, error } = await (supabase.from as any)("ultrasound_records")
+  const { data: row, error } = await supabase.from("ultrasound_records")
     .insert(data)
     .select("id")
     .single();
@@ -4957,10 +4943,10 @@ export async function fetchClinicCenterDashboardKPIs(clinicId: string): Promise<
   const supabase = createClient();
 
   const [deptRes, bedRes, admissionRes, paymentsRes] = await Promise.all([
-    supabase.from("departments").select("id, clinic_id, name, code, is_active").eq("clinic_id", clinicId).eq("is_active", true),
-    supabase.from("beds").select("id, clinic_id, department_id, bed_number, status, patient_id").eq("clinic_id", clinicId),
-    supabase.from("admissions").select("id, clinic_id, patient_id, doctor_id, department_id, bed_id, admission_date, discharge_date, status").eq("clinic_id", clinicId),
-    supabase.from("payments").select("id, amount, created_at, appointment_id").eq("clinic_id", clinicId).eq("status", "completed"),
+  supabase.from("departments").select("id, clinic_id, name, code, is_active").eq("clinic_id", clinicId).eq("is_active", true),
+  supabase.from("beds").select("id, clinic_id, department_id, bed_number, status, patient_id").eq("clinic_id", clinicId),
+  supabase.from("admissions").select("id, clinic_id, patient_id, doctor_id, department_id, bed_id, admission_date, discharge_date, status").eq("clinic_id", clinicId),
+  supabase.from("payments").select("id, amount, created_at, appointment_id").eq("clinic_id", clinicId).eq("status", "completed"),
   ]);
 
   const departments = (deptRes.data ?? []) as DepartmentRaw[];

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -10,13 +10,16 @@
  */
 
 import { createClient } from "@/lib/supabase-server";
+import type { Database } from "@/lib/types/database";
+
+type TableName = keyof Database["public"]["Tables"];
 
 // ────────────────────────────────────────────
 // Helpers
 // ────────────────────────────────────────────
 
 async function query<T>(
-  table: string,
+  table: TableName,
   opts?: {
     select?: string;
     filters?: Record<string, unknown>;
@@ -27,8 +30,7 @@ async function query<T>(
   },
 ): Promise<T[]> {
   const supabase = await createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let q = (supabase.from as any)(table).select(opts?.select ?? "*");
+  let q = supabase.from(table).select(opts?.select ?? "*");
 
   if (opts?.eq) {
     for (const [col, val] of opts.eq) {
@@ -54,15 +56,14 @@ async function query<T>(
 }
 
 async function queryOne<T>(
-  table: string,
+  table: TableName,
   opts?: {
     select?: string;
     eq?: [string, unknown][];
   },
 ): Promise<T | null> {
   const supabase = await createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let q = (supabase.from as any)(table).select(opts?.select ?? "*");
+  let q = supabase.from(table).select(opts?.select ?? "*");
   if (opts?.eq) {
     for (const [col, val] of opts.eq) {
       q = q.eq(col, val);
@@ -1042,8 +1043,7 @@ export async function createRadiologyOrder(data: {
 }): Promise<{ id: string; order_number: string } | null> {
   const supabase = await createClient();
   const orderNumber = `RAD-${Date.now().toString(36).toUpperCase()}`;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: row, error } = await (supabase.from as any)("radiology_orders")
+  const { data: row, error } = await supabase.from("radiology_orders")
     .insert({
       ...data,
       order_number: orderNumber,

--- a/src/lib/data/specialists.ts
+++ b/src/lib/data/specialists.ts
@@ -7,11 +7,14 @@
  */
 
 import { createClient } from "@/lib/supabase-client";
+import type { Database } from "@/lib/types/database";
+
+type TableName = keyof Database["public"]["Tables"];
 
 // ── Generic fetch helper (mirrors client.ts) ──
 
 async function fetchRows<T>(
-  table: string,
+  table: TableName,
   opts?: {
     select?: string;
     eq?: [string, unknown][];
@@ -20,8 +23,7 @@ async function fetchRows<T>(
   },
 ): Promise<T[]> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let q = (supabase.from as any)(table).select(opts?.select ?? "*");
+  let q = supabase.from(table).select(opts?.select ?? "*");
   if (opts?.eq) {
     for (const [col, val] of opts.eq) {
       q = q.eq(col, val);
@@ -128,8 +130,7 @@ export async function createSkinCondition(data: {
   notes?: string; treatments?: unknown[];
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("skin_conditions").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("skin_conditions").insert(data).select("id").single();
   if (error) { console.error("[specialists] create skin condition:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -139,8 +140,7 @@ export async function updateSkinCondition(
   data: { status?: string; severity?: string; notes?: string; treatments?: unknown[] },
 ): Promise<boolean> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { error } = await (supabase.from as any)("skin_conditions")
+  const { error } = await supabase.from("skin_conditions")
     .update({ ...data, updated_at: new Date().toISOString() }).eq("id", id);
   if (error) { console.error("[specialists] update skin condition:", error.message); return false; }
   return true;
@@ -278,8 +278,7 @@ export async function createHeartMonitoringNote(data: {
   severity?: string; is_alert?: boolean;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("heart_monitoring_notes").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("heart_monitoring_notes").insert(data).select("id").single();
   if (error) { console.error("[specialists] create heart note:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -333,8 +332,7 @@ export async function createHearingTest(data: {
   hearing_loss_type?: string; hearing_loss_degree?: string; notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("hearing_tests").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("hearing_tests").insert(data).select("id").single();
   if (error) { console.error("[specialists] create hearing test:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -375,8 +373,7 @@ export async function createENTExam(data: {
   diagnosis?: string; plan?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("ent_exam_records").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("ent_exam_records").insert(data).select("id").single();
   if (error) { console.error("[specialists] create ENT exam:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -477,8 +474,7 @@ export async function createFractureRecord(data: {
   xray_record_id?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("fracture_records").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("fracture_records").insert(data).select("id").single();
   if (error) { console.error("[specialists] create fracture record:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -604,8 +600,7 @@ export async function createPsychSessionNote(data: {
   is_confidential?: boolean; access_level?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("psych_session_notes").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("psych_session_notes").insert(data).select("id").single();
   if (error) { console.error("[specialists] create psych note:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -659,8 +654,7 @@ export async function createPsychMedication(data: {
   reason?: string; notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("psych_medications").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("psych_medications").insert(data).select("id").single();
   if (error) { console.error("[specialists] create psych medication:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -781,8 +775,7 @@ export async function createNeuroExam(data: {
   gait?: Record<string, string>; diagnosis?: string; plan?: string; notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("neuro_exam_records").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("neuro_exam_records").insert(data).select("id").single();
   if (error) { console.error("[specialists] create neuro exam:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -832,8 +825,7 @@ export async function createUrologyExam(data: {
   lab_results?: Record<string, string>; diagnosis?: string; plan?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("urology_exams").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("urology_exams").insert(data).select("id").single();
   if (error) { console.error("[specialists] create urology exam:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -1137,8 +1129,7 @@ export async function createJointAssessment(data: {
   functional_status?: string; notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("joint_assessments").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("joint_assessments").insert(data).select("id").single();
   if (error) { console.error("[specialists] create joint assessment:", error.message); return null; }
   return result?.id ?? null;
 }
@@ -1182,8 +1173,7 @@ export async function createMobilityTest(data: {
   strength_score?: number; pain_during_test?: number; notes?: string;
 }): Promise<string | null> {
   const supabase = createClient();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const { data: result, error } = await (supabase.from as any)("mobility_tests").insert(data).select("id").single();
+  const { data: result, error } = await supabase.from("mobility_tests").insert(data).select("id").single();
   if (error) { console.error("[specialists] create mobility test:", error.message); return null; }
   return result?.id ?? null;
 }


### PR DESCRIPTION
## Summary

This PR addresses three tasks:

### Task 21: Remove Supabase Type Casts
- Added `Database` type import and `TableName` type alias to `server.ts`, `client.ts`, `specialists.ts`
- Typed helper function `table` parameters as `keyof Database["public"]["Tables"]`
- Replaced all `(supabase.from as any)` calls with properly typed `supabase.from()` calls
- Fixed in: `client.ts`, `specialists.ts`, `backup.ts`, `api/v1/patients/route.ts`, `server.ts`

### Task 22: Double-Submit Prevention on Booking Form
- Added `isSubmitting` state variable to `booking-form.tsx`
- Guard clause in `handleConfirm` prevents concurrent submissions
- Submit button is disabled during submission with a `Loader2` spinner
- Button text changes to "Submitting…" during submission

### Task 23: Loading Indicators for Data-Fetching Pages
- Added `Loader2` spinner loading states to 7 pages that declared `loading` state but never rendered loading UI:
  - `admin/doctors/page.tsx`
  - `admin/services/page.tsx`
  - `admin/working-hours/page.tsx`
  - `super-admin/announcements/page.tsx`
  - `super-admin/features/page.tsx`
  - `super-admin/pricing/page.tsx`
  - `super-admin/subscriptions/page.tsx`

## Files Changed (13)
- `src/lib/data/client.ts`
- `src/lib/data/server.ts`
- `src/lib/data/specialists.ts`
- `src/lib/backup.ts`
- `src/app/api/v1/patients/route.ts`
- `src/components/booking/booking-form.tsx`
- 7 page files with loading indicator additions