### PR TITLE
fix: remove CI push trigger duplication and no-op migration backup check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, staging]
-  push:
-    branches: [main, staging]
 
 jobs:
   lint:

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'supabase/migrations/**'
-      - 'full_backup.sql'
 
 jobs:
   validate-migrations:
@@ -66,23 +65,3 @@ jobs:
           done
 
           echo "Basic SQL validation complete."
-
-      - name: Check backup is up to date
-        run: |
-          echo "Checking if full_backup.sql exists..."
-          if [ ! -f full_backup.sql ]; then
-            echo "WARNING: full_backup.sql not found"
-            exit 0
-          fi
-
-          migration_count=$(ls supabase/migrations/*.sql | wc -l)
-          backup_refs=$(grep -c '>>>>>>>>>>.*<<<<<<<<<<' full_backup.sql || true)
-
-          echo "Migration files: $migration_count"
-          echo "Backup references: $backup_refs"
-
-          if [ "$backup_refs" != "$migration_count" ]; then
-            echo "WARNING: full_backup.sql may be out of date (has $backup_refs migration refs, expected $migration_count)"
-          else
-            echo "OK: full_backup.sql references all $migration_count migrations"
-          fi


### PR DESCRIPTION
## Changes

### Task 27: Fix CI workflow duplication
- Removed `push` trigger from `.github/workflows/ci.yml` so CI only runs on `pull_request`
- The deploy workflow already handles post-merge checks, eliminating duplicate lint runs on push to main/staging

### Task 28: Fix no-op migration-check step
- Removed the "Check backup is up to date" step from `.github/workflows/migration-check.yml` since `full_backup.sql` is gitignored and never present in CI (the step always printed a warning and exited 0)
- Removed `full_backup.sql` from the workflow `paths` trigger since the file can never appear in a PR diff