### PR TITLE
fix: convert CommonJS require() to ES module imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "postinstall": "node scripts/patch-opennext.js",
-    "build:cf": "opennextjs-cloudflare build && node scripts/post-build-patch.js",
+    "postinstall": "node scripts/patch-opennext.mjs",
+    "build:cf": "opennextjs-cloudflare build && node scripts/post-build-patch.mjs",
     "deploy": "npm run build:cf && wrangler deploy"
   },
   "dependencies": {

--- a/scripts/patch-opennext.mjs
+++ b/scripts/patch-opennext.mjs
@@ -11,8 +11,11 @@
  *    instead of throwing (e.g. subresource-integrity-manifest.json)
  */
 
-const fs = require("fs");
-const path = require("path");
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const LOAD_MANIFEST_PATH = path.join(
   __dirname,

--- a/scripts/post-build-patch.mjs
+++ b/scripts/post-build-patch.mjs
@@ -12,8 +12,11 @@
  * undefined for optional/missing manifests instead of throwing.
  */
 
-const fs = require("fs");
-const path = require("path");
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const HANDLER_PATH = path.join(
   __dirname,


### PR DESCRIPTION
## Task 20: Fix CommonJS require() imports (4 warnings)

Converted 4 `require()` calls in `scripts/patch-opennext` and `scripts/post-build-patch` from CommonJS to ES module `import` syntax.

### Changes
- Replaced `require("fs")` and `require("path")` with `import fs from "node:fs"` and `import path from "node:path"`
- Added `import.meta.url`-based `__dirname` replacement for ESM compatibility
- Renamed `.js` → `.mjs` since the project has no `"type": "module"` in package.json
- Updated `package.json` script references to use `.mjs` extensions

Fixes all 4 `@typescript-eslint/no-require-imports` ESLint warnings. Improves tree-shaking and avoids potential edge runtime issues.