### PR TITLE
fix: remove 25 unused variables/imports across 20 files

### DIFF
--- a/src/app/(doctor)/doctor/endocrinology/page.tsx
+++ b/src/app/(doctor)/doctor/endocrinology/page.tsx
@@ -18,7 +18,7 @@ import { getCurrentUser } from "@/lib/data/client";
 import {
   fetchBloodSugarReadings, createBloodSugarReading,
   fetchHormoneLevels, createHormoneLevel,
-  fetchDiabetesManagement, createDiabetesManagement, updateDiabetesManagement,
+  fetchDiabetesManagement, createDiabetesManagement,
   type BloodSugarReadingView, type HormoneLevelView, type DiabetesManagementView,
 } from "@/lib/data/specialists";
 

--- a/src/app/(doctor)/doctor/iop-tracking/page.tsx
+++ b/src/app/(doctor)/doctor/iop-tracking/page.tsx
@@ -198,7 +198,7 @@ export default function IopTrackingPage() {
 
                         {/* Data points */}
                         <div className="flex items-end gap-1 h-32 pt-4 pb-2">
-                          {data.map((m, i) => {
+                          {data.map((m) => {
                             const maxP = 35;
                             const odH = Math.min((m.odPressure / maxP) * 100, 100);
                             const osH = Math.min((m.osPressure / maxP) * 100, 100);

--- a/src/app/(doctor)/doctor/lab-orders/page.tsx
+++ b/src/app/(doctor)/doctor/lab-orders/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { LabOrdersPanel } from "@/components/dental/lab-orders-panel";
-import { getCurrentUser, fetchLabOrders, type LabOrderView } from "@/lib/data/client";
+import { getCurrentUser, fetchLabOrders } from "@/lib/data/client";
 import type { LabOrder } from "@/lib/types/dental";
 
 export default function DoctorLabOrdersPage() {

--- a/src/app/(doctor)/doctor/patients/page.tsx
+++ b/src/app/(doctor)/doctor/patients/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Search, User, Phone, Calendar, FileText, Pill, ClipboardList, AlertCircle } from "lucide-react";
+import { Search, User, Phone, Calendar, FileText, Pill, AlertCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/app/(patient)/patient/medical-history/page.tsx
+++ b/src/app/(patient)/patient/medical-history/page.tsx
@@ -9,7 +9,6 @@ import {
   fetchPatientAppointments,
   fetchPrescriptions,
   fetchConsultationNotes,
-  type PatientView,
   type AppointmentView,
   type PrescriptionView,
   type ConsultationNoteView,

--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   ClipboardList, AlertTriangle,
-  Clock, Users, DollarSign, ArrowRight,
+  Clock, DollarSign, ArrowRight,
   Check, Eye, AlertCircle, TrendingUp,
   Package, Pill, BarChart3,
 } from "lucide-react";

--- a/src/app/(radiology)/radiology/dashboard/page.tsx
+++ b/src/app/(radiology)/radiology/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
-  ClipboardList, Clock, Image, FileText,
+  ClipboardList, Clock, Image,
   ArrowRight, CheckCircle, Hourglass, AlertTriangle,
 } from "lucide-react";
 import Link from "next/link";

--- a/src/app/(radiology)/radiology/viewer/page.tsx
+++ b/src/app/(radiology)/radiology/viewer/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ExternalLink, Monitor, Info, FileImage, Scan } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";

--- a/src/components/booking/payment-step.tsx
+++ b/src/components/booking/payment-step.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { clinicConfig } from "@/config/clinic.config";
-import { formatMAD, type MoroccanPaymentMethod } from "@/lib/morocco";
+import { type MoroccanPaymentMethod } from "@/lib/morocco";
 
 interface PaymentStepProps {
   appointmentId: string;

--- a/src/components/custom-fields/custom-field-renderer.tsx
+++ b/src/components/custom-fields/custom-field-renderer.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,

--- a/src/components/morocco/doctor-directory.tsx
+++ b/src/components/morocco/doctor-directory.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { MOROCCAN_CITIES, formatMoroccanPhone, phoneToWhatsApp } from "@/lib/morocco";
+import { phoneToWhatsApp } from "@/lib/morocco";
 
 // ---- Types ----
 

--- a/src/components/morocco/fisc-export.tsx
+++ b/src/components/morocco/fisc-export.tsx
@@ -17,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { formatMAD, formatMADFormal, calculateTVA } from "@/lib/morocco";
+import { formatMAD, formatMADFormal } from "@/lib/morocco";
 
 // ---- Types ----
 

--- a/src/components/morocco/payment-methods.tsx
+++ b/src/components/morocco/payment-methods.tsx
@@ -7,7 +7,6 @@ import {
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -10,11 +10,11 @@ interface DialogProps {
   children: React.ReactNode
 }
 
-function Dialog({ open, onOpenChange, children }: DialogProps) {
+function Dialog({ open, children }: DialogProps) {
   return <>{open ? children : null}</>
 }
 
-function DialogTrigger({ children, asChild, onClick, ...props }: React.ComponentProps<"button"> & { asChild?: boolean }) {
+function DialogTrigger({ children, onClick, ...props }: React.ComponentProps<"button"> & { asChild?: boolean }) {
   return <button type="button" onClick={onClick} {...props}>{children}</button>
 }
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ interface DropdownMenuTriggerProps extends React.ComponentProps<"button"> {
   asChild?: boolean
 }
 
-function DropdownMenuTrigger({ className, children, asChild, ...props }: DropdownMenuTriggerProps) {
+function DropdownMenuTrigger({ className, children, ...props }: DropdownMenuTriggerProps) {
   return (
     <button type="button" className={cn("outline-none", className)} {...props}>
       {children}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -10,7 +10,7 @@ interface SheetProps {
   children: React.ReactNode
 }
 
-function Sheet({ open, onOpenChange, children }: SheetProps) {
+function Sheet({ open, children }: SheetProps) {
   if (!open) return null
   return <>{children}</>
 }

--- a/src/components/video-consultation.tsx
+++ b/src/components/video-consultation.tsx
@@ -51,7 +51,6 @@ const ICE_SERVERS: RTCConfiguration = {
 
 export function VideoConsultation({
   roomId,
-  userId: _userId,
   userName,
   onEnd,
 }: VideoConsultationProps) {

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -2030,6 +2030,7 @@ export interface BlogPostView {
 
 // Blog posts aren't in the DB schema — they may be stored in clinic config
 // For now we return empty; pages will fall back to demo data if empty
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function fetchBlogPosts(_clinicId: string): Promise<BlogPostView[]> {
   return [];
 }
@@ -4966,8 +4967,6 @@ export async function fetchClinicCenterDashboardKPIs(clinicId: string): Promise<
   const dischargesToday = admissions.filter(
     (a) => a.status === "discharged" && a.discharge_date && a.discharge_date.startsWith(todayStr),
   ).length;
-
-  const deptMap = new Map(departments.map((d) => [d.id, d.name]));
 
   const departmentPatientLoad: DepartmentPatientLoad[] = departments.map((dept) => {
     const deptBeds = beds.filter((b) => b.department_id === dept.id);

--- a/src/lib/morocco.ts
+++ b/src/lib/morocco.ts
@@ -11,9 +11,6 @@
 
 // ---- Phone Number Formatting ----
 
-/** Valid Moroccan mobile prefixes */
-const MOROCCO_MOBILE_PREFIXES = ["06", "07", "05"];
-const MOROCCO_LANDLINE_PREFIXES = ["05"];
 const MOROCCO_COUNTRY_CODE = "+212";
 
 /**


### PR DESCRIPTION
## Summary

Remove all 25 ESLint `@typescript-eslint/no-unused-vars` warnings across 20 files.

### Changes

**Unused imports removed:**
- `updateDiabetesManagement` from endocrinology page
- `LabOrderView` type from lab-orders page
- `ClipboardList` from patients page
- `Card`/`CardContent` from parapharmacy inventory page
- `PatientView` type from medical-history page
- `Users` from pharmacist dashboard
- `FileText` from radiology dashboard
- `Button` from radiology viewer
- `formatMAD` from booking payment-step
- `Textarea` from custom-field-renderer
- `MOROCCAN_CITIES`/`formatMoroccanPhone` from doctor-directory
- `calculateTVA` from fisc-export
- `Input` from payment-methods

**Unused parameters removed:**
- `i` (map index) in iop-tracking page
- `onOpenChange` in Dialog and Sheet components
- `asChild` in DialogTrigger and DropdownMenuTrigger
- `_userId` in VideoConsultation

**Unused variables removed:**
- `deptMap` in client.ts
- `MOROCCO_MOBILE_PREFIXES` and `MOROCCO_LANDLINE_PREFIXES` in morocco.ts

**eslint-disable added:**
- `_clinicId` param in `fetchBlogPosts` stub (intentionally unused)

[Devin session](https://app.devin.ai/sessions/066321d8066d423b9c958b2f4343a862)