### PR TITLE
feat: add loading spinner and skeleton to 101 data-fetching pages

### DIFF
--- a/src/app/(admin)/admin/branding/page.tsx
+++ b/src/app/(admin)/admin/branding/page.tsx
@@ -24,6 +24,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface BrandingState {
   name: string;
@@ -171,12 +172,7 @@ export default function BrandingPage() {
     };
 
   if (loading) {
-    return (
-      <div>
-        <h1 className="text-2xl font-bold mb-6">Branding</h1>
-        <p className="text-muted-foreground">Loading branding settings...</p>
-      </div>
-    );
+    return <PageLoader message="Loading branding settings..." />;
   }
 
   return (

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -12,6 +12,7 @@ import {
 import { LabDashboardKPIsComponent } from "@/components/admin/lab-dashboard-kpis";
 import { ClinicCenterDashboardKPIsComponent } from "@/components/admin/clinic-center-dashboard-kpis";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const activityVariant: Record<string, "default" | "success" | "warning" | "destructive"> = {
   booking: "default",
@@ -36,11 +37,7 @@ export default function AdminDashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading dashboard...</p>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   const totalPatients = stats?.totalPatients ?? 0;

--- a/src/app/(admin)/admin/patients/page.tsx
+++ b/src/app/(admin)/admin/patients/page.tsx
@@ -24,6 +24,7 @@ import {
   type PrescriptionView,
 } from "@/lib/data/client";
 import { exportPatients } from "@/lib/export-data";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type Patient = PatientView;
 
@@ -64,11 +65,7 @@ export default function AdminPatientDatabasePage() {
   );
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading patients...</p>
-      </div>
-    );
+    return <PageLoader message="Loading patients..." />;
   }
 
   const getPatientAppts = (patientId: string) =>

--- a/src/app/(admin)/admin/reviews/page.tsx
+++ b/src/app/(admin)/admin/reviews/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { getCurrentUser, fetchReviews, type ReviewView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function StarRating({ rating }: { rating: number }) {
   return (
@@ -37,11 +38,7 @@ export default function ReviewManagementPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading reviews...</p>
-      </div>
-    );
+    return <PageLoader message="Loading reviews..." />;
   }
 
   const avgRating = reviews.length > 0 ? reviews.reduce((s, r) => s + r.rating, 0) / reviews.length : 0;

--- a/src/app/(admin)/admin/settings/chatbot/page.tsx
+++ b/src/app/(admin)/admin/settings/chatbot/page.tsx
@@ -21,6 +21,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { createBrowserClient } from "@supabase/ssr";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface ChatbotConfig {
   enabled: boolean;
@@ -238,11 +239,7 @@ export default function ChatbotSettingsPage() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   return (

--- a/src/app/(doctor)/doctor/before-after/page.tsx
+++ b/src/app/(doctor)/doctor/before-after/page.tsx
@@ -8,6 +8,7 @@ import {
   createBeforeAfterPhoto,
   type BeforeAfterPhotoView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorBeforeAfterPage() {
   const [photos, setPhotos] = useState<BeforeAfterPhotoView[]>([]);
@@ -25,11 +26,7 @@ export default function DoctorBeforeAfterPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading photos...</p>
-      </div>
-    );
+    return <PageLoader message="Loading photos..." />;
   }
 
   const handleAddPhoto = async (photo: Omit<BeforeAfterPhotoView, "id">) => {

--- a/src/app/(doctor)/doctor/cardiology/page.tsx
+++ b/src/app/(doctor)/doctor/cardiology/page.tsx
@@ -21,6 +21,7 @@ import {
   fetchHeartMonitoringNotes, createHeartMonitoringNote,
   type ECGRecordView, type BloodPressureView, type HeartMonitoringNoteView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function bpCategory(systolic: number, diastolic: number): { label: string; color: string } {
   if (systolic < 120 && diastolic < 80) return { label: "Normal", color: "text-green-600" };
@@ -67,11 +68,7 @@ export default function CardiologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading cardiology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading cardiology records..." />;
   }
 
   const handleAddEcg = async () => {

--- a/src/app/(doctor)/doctor/certificates/page.tsx
+++ b/src/app/(doctor)/doctor/certificates/page.tsx
@@ -10,6 +10,7 @@ import {
   type MedicalCertificateView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorCertificatesPage() {
   const [certificates, setCertificates] = useState<MedicalCertificateView[]>([]);
@@ -32,11 +33,7 @@ export default function DoctorCertificatesPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading certificates...</p>
-      </div>
-    );
+    return <PageLoader message="Loading certificates..." />;
   }
 
   const handleCreateCertificate = async (data: {

--- a/src/app/(doctor)/doctor/child-info/page.tsx
+++ b/src/app/(doctor)/doctor/child-info/page.tsx
@@ -31,6 +31,7 @@ import {
   type MilestoneView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const MILESTONE_TEMPLATES: Record<string, { milestone: string; expectedAgeMonths: number }[]> = {
   motor: [
@@ -154,11 +155,7 @@ export default function ChildInfoPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading child development data...</p>
-      </div>
-    );
+    return <PageLoader message="Loading child development data..." />;
   }
 
   const categories: MilestoneView["category"][] = ["motor", "language", "social", "cognitive"];

--- a/src/app/(doctor)/doctor/consultation/page.tsx
+++ b/src/app/(doctor)/doctor/consultation/page.tsx
@@ -20,6 +20,7 @@ import {
   type AppointmentView,
   type ConsultationNoteView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface ConsultationNote {
   id: string;
@@ -84,11 +85,7 @@ export default function ConsultationNotesPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading consultation notes...</p>
-      </div>
-    );
+    return <PageLoader message="Loading consultation notes..." />;
   }
 
   const recentAppts = apptList

--- a/src/app/(doctor)/doctor/dashboard/page.tsx
+++ b/src/app/(doctor)/doctor/dashboard/page.tsx
@@ -24,6 +24,7 @@ import {
   type WaitingRoomEntry,
   type InvoiceView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 // ── Date helpers ──
 
@@ -151,11 +152,7 @@ export default function DoctorDashboardPage() {
   ];
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading dashboard...</p>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   const handleMarkDone = async (appointmentId: string) => {

--- a/src/app/(doctor)/doctor/dermatology/page.tsx
+++ b/src/app/(doctor)/doctor/dermatology/page.tsx
@@ -20,6 +20,7 @@ import {
   fetchSkinConditions, createSkinCondition, updateSkinCondition,
   type SkinPhotoView, type SkinConditionView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const BODY_REGIONS = [
   "Face", "Scalp", "Neck", "Chest", "Back", "Abdomen",
@@ -71,11 +72,7 @@ export default function DermatologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading dermatology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading dermatology records..." />;
   }
 
   const handleAddPhoto = async () => {

--- a/src/app/(doctor)/doctor/endocrinology/page.tsx
+++ b/src/app/(doctor)/doctor/endocrinology/page.tsx
@@ -21,6 +21,7 @@ import {
   fetchDiabetesManagement, createDiabetesManagement,
   type BloodSugarReadingView, type HormoneLevelView, type DiabetesManagementView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function glucoseCategory(level: number, type: string): { label: string; color: string } {
   if (type === "fasting") {
@@ -73,11 +74,7 @@ export default function EndocrinologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading endocrinology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading endocrinology records..." />;
   }
 
   const handleAddSugar = async () => {

--- a/src/app/(doctor)/doctor/ent/page.tsx
+++ b/src/app/(doctor)/doctor/ent/page.tsx
@@ -19,6 +19,7 @@ import {
   fetchENTExams, createENTExam,
   type HearingTestView, type ENTExamView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const AUDIOGRAM_FREQUENCIES = ["250", "500", "1000", "2000", "4000", "8000"];
 
@@ -81,11 +82,7 @@ export default function ENTPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading ENT records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading ENT records..." />;
   }
 
   const handleAddTest = async () => {

--- a/src/app/(doctor)/doctor/growth-charts/page.tsx
+++ b/src/app/(doctor)/doctor/growth-charts/page.tsx
@@ -29,6 +29,7 @@ import {
   type GrowthMeasurementView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 // WHO Weight-for-age reference data (boys, simplified percentiles: 3rd, 50th, 97th)
 const WHO_WEIGHT_BOYS: Record<number, [number, number, number]> = {
@@ -112,11 +113,7 @@ export default function GrowthChartsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading growth data...</p>
-      </div>
-    );
+    return <PageLoader message="Loading growth data..." />;
   }
 
   // Group by patient

--- a/src/app/(doctor)/doctor/installments/page.tsx
+++ b/src/app/(doctor)/doctor/installments/page.tsx
@@ -9,6 +9,7 @@ import {
   fetchInstallmentPlans,
   type InstallmentPlanView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorInstallmentsPage() {
   const [plans, setPlans] = useState<InstallmentPlanView[]>([]);
@@ -26,11 +27,7 @@ export default function DoctorInstallmentsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading installment plans...</p>
-      </div>
-    );
+    return <PageLoader message="Loading installment plans..." />;
   }
 
   const handleMarkPaid = (planId: string, installmentId: string) => {

--- a/src/app/(doctor)/doctor/iop-tracking/page.tsx
+++ b/src/app/(doctor)/doctor/iop-tracking/page.tsx
@@ -29,6 +29,7 @@ import {
   type IopMeasurementView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const METHODS = [
   { value: "goldmann", label: "Goldmann Applanation" },
@@ -94,11 +95,7 @@ export default function IopTrackingPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading IOP measurements...</p>
-      </div>
-    );
+    return <PageLoader message="Loading IOP measurements..." />;
   }
 
   // Group by patient for history chart

--- a/src/app/(doctor)/doctor/lab-orders/page.tsx
+++ b/src/app/(doctor)/doctor/lab-orders/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { LabOrdersPanel } from "@/components/dental/lab-orders-panel";
 import { getCurrentUser, fetchLabOrders } from "@/lib/data/client";
 import type { LabOrder } from "@/lib/types/dental";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorLabOrdersPage() {
   const [orders, setOrders] = useState<LabOrder[]>([]);
@@ -21,11 +22,7 @@ export default function DoctorLabOrdersPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading lab orders...</p>
-      </div>
-    );
+    return <PageLoader message="Loading lab orders..." />;
   }
 
   const handleUpdateStatus = (orderId: string, status: LabOrder["status"]) => {

--- a/src/app/(doctor)/doctor/neurology/page.tsx
+++ b/src/app/(doctor)/doctor/neurology/page.tsx
@@ -19,6 +19,7 @@ import {
   fetchNeuroExams, createNeuroExam,
   type EEGRecordView, type NeuroExamView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const NEURO_EXAM_SECTIONS = [
   { key: "mentalStatus", label: "Mental Status", fields: ["Orientation", "Attention", "Memory", "Language", "Calculation"] },
@@ -62,11 +63,7 @@ export default function NeurologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading neurology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading neurology records..." />;
   }
 
   const handleAddEeg = async () => {

--- a/src/app/(doctor)/doctor/odontogram/page.tsx
+++ b/src/app/(doctor)/doctor/odontogram/page.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { OdontogramChart } from "@/components/dental/odontogram-chart";
 import { getCurrentUser, fetchPatients, fetchOdontogram, upsertOdontogramEntry, type PatientView, type OdontogramView } from "@/lib/data/client";
 import type { ToothStatus, OdontogramEntry } from "@/lib/types/dental";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorOdontogramPage() {
   const [patients, setPatients] = useState<PatientView[]>([]);
@@ -41,11 +42,7 @@ export default function DoctorOdontogramPage() {
   }, [selectedPatient]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading odontogram...</p>
-      </div>
-    );
+    return <PageLoader message="Loading odontogram..." />;
   }
 
   const handleUpdateEntry = async (toothNumber: number, status: ToothStatus, notes: string) => {

--- a/src/app/(doctor)/doctor/orthopedics/page.tsx
+++ b/src/app/(doctor)/doctor/orthopedics/page.tsx
@@ -21,6 +21,7 @@ import {
   fetchRehabPlans, createRehabPlan,
   type XRayRecordView, type FractureRecordView, type RehabPlanView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const FRACTURE_STATUSES: Record<string, { label: string; variant: "default" | "warning" | "success" | "destructive" }> = {
   diagnosed: { label: "Diagnosed", variant: "destructive" },
@@ -65,11 +66,7 @@ export default function OrthopedicsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading orthopedics records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading orthopedics records..." />;
   }
 
   const handleAddXray = async () => {

--- a/src/app/(doctor)/doctor/patients/page.tsx
+++ b/src/app/(doctor)/doctor/patients/page.tsx
@@ -19,6 +19,7 @@ import {
   type PrescriptionView,
   type ConsultationNoteView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type Patient = PatientView;
 
@@ -52,11 +53,7 @@ export default function DoctorPatientsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading patients...</p>
-      </div>
-    );
+    return <PageLoader message="Loading patients..." />;
   }
 
   const filteredPatients = patients.filter(

--- a/src/app/(doctor)/doctor/pregnancies/page.tsx
+++ b/src/app/(doctor)/doctor/pregnancies/page.tsx
@@ -30,6 +30,7 @@ import {
   type PregnancyView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function addDays(date: string, days: number): string {
   const d = new Date(date);
@@ -119,11 +120,7 @@ export default function PregnanciesPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading pregnancy records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading pregnancy records..." />;
   }
 
   const active = pregnancies.filter((p) => p.status === "active");

--- a/src/app/(doctor)/doctor/prescriptions/page.tsx
+++ b/src/app/(doctor)/doctor/prescriptions/page.tsx
@@ -16,6 +16,7 @@ import {
   type PrescriptionView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type Prescription = PrescriptionView;
 
@@ -122,11 +123,7 @@ export default function DoctorPrescriptionsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading prescriptions...</p>
-      </div>
-    );
+    return <PageLoader message="Loading prescriptions..." />;
   }
 
   const addMedication = () => {

--- a/src/app/(doctor)/doctor/psychiatry/page.tsx
+++ b/src/app/(doctor)/doctor/psychiatry/page.tsx
@@ -20,6 +20,7 @@ import {
   fetchPsychMedications, createPsychMedication, updatePsychMedication,
   type PsychSessionNoteView, type PsychMedicationView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const MOOD_LABELS = ["", "Very Low", "Low", "Below Average", "Slightly Low", "Neutral", "Slightly Good", "Good", "Very Good", "Excellent", "Outstanding"];
 
@@ -55,11 +56,7 @@ export default function PsychiatryPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading psychiatry records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading psychiatry records..." />;
   }
 
   const toggleReveal = (id: string) => {

--- a/src/app/(doctor)/doctor/pulmonology/page.tsx
+++ b/src/app/(doctor)/doctor/pulmonology/page.tsx
@@ -19,6 +19,7 @@ import {
   fetchRespiratoryTests, createRespiratoryTest,
   type SpirometryRecordView, type RespiratoryTestView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function spirometryInterpretation(fev1FvcRatio: number | null): string {
   if (fev1FvcRatio === null) return "Insufficient data";
@@ -59,11 +60,7 @@ export default function PulmonologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading pulmonology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading pulmonology records..." />;
   }
 
   const handleAddSpiro = async () => {

--- a/src/app/(doctor)/doctor/rheumatology/page.tsx
+++ b/src/app/(doctor)/doctor/rheumatology/page.tsx
@@ -19,6 +19,7 @@ import {
   fetchMobilityTests, createMobilityTest,
   type JointAssessmentView, type MobilityTestView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const JOINTS = [
   "Left Shoulder", "Right Shoulder", "Left Elbow", "Right Elbow",
@@ -73,11 +74,7 @@ export default function RheumatologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading rheumatology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading rheumatology records..." />;
   }
 
   const handleAddAssessment = async () => {

--- a/src/app/(doctor)/doctor/schedule/page.tsx
+++ b/src/app/(doctor)/doctor/schedule/page.tsx
@@ -9,6 +9,7 @@ import {
   fetchDoctorAppointments,
   type AppointmentView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
@@ -37,11 +38,7 @@ export default function DoctorSchedulePage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading schedule...</p>
-      </div>
-    );
+    return <PageLoader message="Loading schedule..." />;
   }
 
   return (

--- a/src/app/(doctor)/doctor/slots/page.tsx
+++ b/src/app/(doctor)/doctor/slots/page.tsx
@@ -10,6 +10,7 @@ import {
   fetchTimeSlots,
   type TimeSlotView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 const monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
@@ -49,11 +50,7 @@ export default function NextAvailableSlotsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading slots...</p>
-      </div>
-    );
+    return <PageLoader message="Loading slots..." />;
   }
 
   const availableSlots = computeAvailableSlots(timeSlots, daysAhead);

--- a/src/app/(doctor)/doctor/sterilization/page.tsx
+++ b/src/app/(doctor)/doctor/sterilization/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { SterilizationLogPanel } from "@/components/dental/sterilization-log-panel";
 import { getCurrentUser, fetchSterilizationLog, createSterilizationEntry } from "@/lib/data/client";
 import type { SterilizationEntry } from "@/lib/types/dental";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorSterilizationPage() {
   const [log, setLog] = useState<SterilizationEntry[]>([]);
@@ -21,11 +22,7 @@ export default function DoctorSterilizationPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading sterilization log...</p>
-      </div>
-    );
+    return <PageLoader message="Loading sterilization log..." />;
   }
 
   const handleAddEntry = async (entry: Omit<SterilizationEntry, "id" | "sterilizedAt">) => {

--- a/src/app/(doctor)/doctor/stock/page.tsx
+++ b/src/app/(doctor)/doctor/stock/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { MaterialStockAlert } from "@/components/dental/material-stock-alert";
 import { getCurrentUser, fetchProducts, type ProductView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorStockPage() {
   const [stock, setStock] = useState<ProductView[]>([]);
@@ -20,11 +21,7 @@ export default function DoctorStockPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading stock...</p>
-      </div>
-    );
+    return <PageLoader message="Loading stock..." />;
   }
 
   return (

--- a/src/app/(doctor)/doctor/treatment-plans/page.tsx
+++ b/src/app/(doctor)/doctor/treatment-plans/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { TreatmentPlanBuilder } from "@/components/dental/treatment-plan-builder";
 import { getCurrentUser, fetchTreatmentPlans, updateTreatmentPlan } from "@/lib/data/client";
 import type { TreatmentPlan, TreatmentStep } from "@/lib/types/dental";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function DoctorTreatmentPlansPage() {
   const [plans, setPlans] = useState<TreatmentPlan[]>([]);
@@ -24,11 +25,7 @@ export default function DoctorTreatmentPlansPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading treatment plans...</p>
-      </div>
-    );
+    return <PageLoader message="Loading treatment plans..." />;
   }
 
   const handleUpdateStep = async (planId: string, stepIndex: number, status: TreatmentStep["status"]) => {

--- a/src/app/(doctor)/doctor/ultrasounds/page.tsx
+++ b/src/app/(doctor)/doctor/ultrasounds/page.tsx
@@ -29,6 +29,7 @@ import {
   type UltrasoundView,
   type PregnancyView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function UltrasoundsPage() {
   const [ultrasounds, setUltrasounds] = useState<UltrasoundView[]>([]);
@@ -101,11 +102,7 @@ export default function UltrasoundsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading ultrasound records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading ultrasound records..." />;
   }
 
   const activePregnancies = pregnancies.filter((p) => p.status === "active");

--- a/src/app/(doctor)/doctor/urology/page.tsx
+++ b/src/app/(doctor)/doctor/urology/page.tsx
@@ -17,6 +17,7 @@ import {
   fetchUrologyExams, createUrologyExam,
   type UrologyExamView,
 } from "@/lib/data/specialists";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const UROLOGY_TEMPLATES = [
   { value: "general", label: "General Urology Exam" },
@@ -60,11 +61,7 @@ export default function UrologyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading urology records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading urology records..." />;
   }
 
   const handleAdd = async () => {

--- a/src/app/(doctor)/doctor/vaccinations/page.tsx
+++ b/src/app/(doctor)/doctor/vaccinations/page.tsx
@@ -30,6 +30,7 @@ import {
   type VaccinationView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const COMMON_VACCINES = [
   "BCG", "Hepatitis B", "DTP (Diphtheria-Tetanus-Pertussis)",
@@ -113,11 +114,7 @@ export default function VaccinationsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading vaccination records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading vaccination records..." />;
   }
 
   const overdue = vaccinations.filter((v) => v.status === "overdue");

--- a/src/app/(doctor)/doctor/vision-tests/page.tsx
+++ b/src/app/(doctor)/doctor/vision-tests/page.tsx
@@ -29,6 +29,7 @@ import {
   type VisionTestView,
   type PatientView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function formatRx(sphere: number | null, cylinder: number | null, axis: number | null): string {
   if (sphere === null && cylinder === null) return "—";
@@ -104,11 +105,7 @@ export default function VisionTestsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading vision test records...</p>
-      </div>
-    );
+    return <PageLoader message="Loading vision test records..." />;
   }
 
   return (

--- a/src/app/(doctor)/doctor/waiting-room/page.tsx
+++ b/src/app/(doctor)/doctor/waiting-room/page.tsx
@@ -11,6 +11,7 @@ import {
   fetchWaitingRoom,
   type WaitingRoomEntry,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function WaitingRoomPage() {
   const [entries, setEntries] = useState<WaitingRoomEntry[]>([]);
@@ -28,11 +29,7 @@ export default function WaitingRoomPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading waiting room...</p>
-      </div>
-    );
+    return <PageLoader message="Loading waiting room..." />;
   }
 
   const waitingEntries = entries.filter((e) => e.status === "waiting");

--- a/src/app/(equipment)/equipment/dashboard/page.tsx
+++ b/src/app/(equipment)/equipment/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { fetchEquipmentInventory, fetchEquipmentRentals, fetchEquipmentMaintenan
 import type { EquipmentItemView, EquipmentRentalView, EquipmentMaintenanceView } from "@/lib/data/client";
 import { useEquipmentLocale } from "../../layout";
 import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function EquipmentDashboardPage() {
   const { locale } = useEquipmentLocale();
@@ -38,11 +39,7 @@ export default function EquipmentDashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">{t("loading")}</div>
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   const available = inventory.filter((i) => i.isAvailable);

--- a/src/app/(equipment)/equipment/inventory/page.tsx
+++ b/src/app/(equipment)/equipment/inventory/page.tsx
@@ -21,6 +21,7 @@ import {
 import type { EquipmentItemView } from "@/lib/data/client";
 import { useEquipmentLocale } from "../../layout";
 import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const conditionColors: Record<string, string> = {
   new: "bg-emerald-100 text-emerald-700 border-0",
@@ -184,11 +185,7 @@ export default function EquipmentInventoryPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">{t("loading")}</div>
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   const filtered = items.filter((item) => {

--- a/src/app/(equipment)/equipment/maintenance/page.tsx
+++ b/src/app/(equipment)/equipment/maintenance/page.tsx
@@ -18,6 +18,7 @@ import {
 import type { EquipmentMaintenanceView, EquipmentItemView } from "@/lib/data/client";
 import { useEquipmentLocale } from "../../layout";
 import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const STATUS_OPTIONS = ["all", "scheduled", "in_progress", "completed", "cancelled"] as const;
 const TYPE_OPTIONS = ["routine", "repair", "calibration", "inspection", "cleaning"] as const;
@@ -176,11 +177,7 @@ export default function EquipmentMaintenancePage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">{t("loading")}</div>
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   const filtered = records.filter((r) => {

--- a/src/app/(equipment)/equipment/rentals/page.tsx
+++ b/src/app/(equipment)/equipment/rentals/page.tsx
@@ -18,6 +18,7 @@ import {
 import type { EquipmentRentalView, EquipmentItemView } from "@/lib/data/client";
 import { useEquipmentLocale } from "../../layout";
 import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const STATUS_OPTIONS = ["all", "reserved", "active", "returned", "overdue", "cancelled"] as const;
 const PAYMENT_OPTIONS = ["pending", "partial", "paid", "refunded"] as const;
@@ -198,11 +199,7 @@ export default function EquipmentRentalsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">{t("loading")}</div>
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   const filtered = rentals.filter((r) => {

--- a/src/app/(lab)/lab-panel/dashboard/page.tsx
+++ b/src/app/(lab)/lab-panel/dashboard/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchLabTestOrders } from "@/lib/data/client";
 import type { LabTestOrderView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function LabDashboardPage() {
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
@@ -23,11 +24,7 @@ export default function LabDashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   const pending = orders.filter((o) => o.status === "pending");

--- a/src/app/(lab)/lab-panel/patient-history/page.tsx
+++ b/src/app/(lab)/lab-panel/patient-history/page.tsx
@@ -8,6 +8,7 @@ import { Search, History, FlaskConical, TrendingUp, TrendingDown, Minus } from "
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchPatients, fetchPatientLabOrders, fetchLabTestResults } from "@/lib/data/client";
 import type { PatientView, LabTestOrderView, LabTestResultView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function FlagBadge({ flag }: { flag: string }) {
   const color =
@@ -66,11 +67,7 @@ export default function PatientHistoryPage() {
   }, [selectedOrderId]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading patients...</div>
-      </div>
-    );
+    return <PageLoader message="Loading patients..." />;
   }
 
   const filteredPatients = patients.filter((p) => {

--- a/src/app/(lab)/lab-panel/reports/page.tsx
+++ b/src/app/(lab)/lab-panel/reports/page.tsx
@@ -9,6 +9,7 @@ import { Search, FileText, Download } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchLabTestOrders } from "@/lib/data/client";
 import type { LabTestOrderView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function LabReportsPage() {
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
@@ -24,11 +25,7 @@ export default function LabReportsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading reports...</div>
-      </div>
-    );
+    return <PageLoader message="Loading reports..." />;
   }
 
   const filtered = orders.filter((o) => {

--- a/src/app/(lab)/lab-panel/results/page.tsx
+++ b/src/app/(lab)/lab-panel/results/page.tsx
@@ -17,6 +17,7 @@ import { Search, FlaskConical, ArrowUpDown, TrendingUp, TrendingDown, Minus, Plu
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchLabTestOrders, fetchLabTestResults, saveLabTestResult } from "@/lib/data/client";
 import type { LabTestOrderView, LabTestResultView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 function FlagIcon({ flag }: { flag: string }) {
   if (flag === "high" || flag === "critical_high") return <TrendingUp className="h-3 w-3" />;
@@ -142,11 +143,7 @@ export default function ResultsPage() {
   const selectedOrder = orders.find((o) => o.id === selectedOrderId);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading...</div>
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   const filtered = orders.filter((o) => {

--- a/src/app/(lab)/lab-panel/test-orders/page.tsx
+++ b/src/app/(lab)/lab-panel/test-orders/page.tsx
@@ -24,6 +24,7 @@ import {
   createLabTestOrder, updateLabOrderStatus, assignLabTechnician,
 } from "@/lib/data/client";
 import type { LabTestOrderView, LabTestCatalogView, PatientView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const statusOptions = ["all", "pending", "sample_collected", "in_progress", "completed", "validated", "cancelled"] as const;
 const priorityOptions = ["normal", "urgent", "stat"] as const;
@@ -128,11 +129,7 @@ export default function TestOrdersPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading test orders...</div>
-      </div>
-    );
+    return <PageLoader message="Loading test orders..." />;
   }
 
   const filtered = orders.filter((o) => {

--- a/src/app/(nutritionist)/nutritionist/meal-plans/page.tsx
+++ b/src/app/(nutritionist)/nutritionist/meal-plans/page.tsx
@@ -5,6 +5,7 @@ import { Apple } from "lucide-react";
 import { MealPlanBuilder } from "@/components/para-medical/meal-plan-builder";
 import { getCurrentUser } from "@/lib/data/client";
 import type { MealPlan } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function MealPlansPage() {
   const [plans, setPlans] = useState<MealPlan[]>([]);
@@ -21,11 +22,7 @@ export default function MealPlansPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading meal plans...</p>
-      </div>
-    );
+    return <PageLoader message="Loading meal plans..." />;
   }
 
   return (

--- a/src/app/(nutritionist)/nutritionist/measurements/page.tsx
+++ b/src/app/(nutritionist)/nutritionist/measurements/page.tsx
@@ -5,6 +5,7 @@ import { Scale } from "lucide-react";
 import { BodyMeasurementTracker } from "@/components/para-medical/body-measurement-tracker";
 import { getCurrentUser } from "@/lib/data/client";
 import type { BodyMeasurement } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function MeasurementsPage() {
   const [measurements, setMeasurements] = useState<BodyMeasurement[]>([]);
@@ -21,11 +22,7 @@ export default function MeasurementsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading measurements...</p>
-      </div>
-    );
+    return <PageLoader message="Loading measurements..." />;
   }
 
   return (

--- a/src/app/(optician)/optician/frame-catalog/page.tsx
+++ b/src/app/(optician)/optician/frame-catalog/page.tsx
@@ -5,6 +5,7 @@ import { Glasses } from "lucide-react";
 import { FrameCatalog } from "@/components/para-medical/frame-catalog";
 import { getCurrentUser } from "@/lib/data/client";
 import type { FrameCatalogItem } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function FrameCatalogPage() {
   const [frames, setFrames] = useState<FrameCatalogItem[]>([]);
@@ -21,11 +22,7 @@ export default function FrameCatalogPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading frame catalog...</p>
-      </div>
-    );
+    return <PageLoader message="Loading frame catalog..." />;
   }
 
   return (

--- a/src/app/(optician)/optician/lens-inventory/page.tsx
+++ b/src/app/(optician)/optician/lens-inventory/page.tsx
@@ -5,6 +5,7 @@ import { Package } from "lucide-react";
 import { LensInventoryManager } from "@/components/para-medical/lens-inventory-manager";
 import { getCurrentUser } from "@/lib/data/client";
 import type { LensInventoryItem } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function LensInventoryPage() {
   const [items, setItems] = useState<LensInventoryItem[]>([]);
@@ -21,11 +22,7 @@ export default function LensInventoryPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading lens inventory...</p>
-      </div>
-    );
+    return <PageLoader message="Loading lens inventory..." />;
   }
 
   return (

--- a/src/app/(optician)/optician/prescriptions/page.tsx
+++ b/src/app/(optician)/optician/prescriptions/page.tsx
@@ -5,6 +5,7 @@ import { FileText } from "lucide-react";
 import { OpticalPrescriptionTracker } from "@/components/para-medical/optical-prescription-tracker";
 import { getCurrentUser } from "@/lib/data/client";
 import type { OpticalPrescription } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function OpticalPrescriptionsPage() {
   const [prescriptions, setPrescriptions] = useState<OpticalPrescription[]>([]);
@@ -21,11 +22,7 @@ export default function OpticalPrescriptionsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading prescriptions...</p>
-      </div>
-    );
+    return <PageLoader message="Loading prescriptions..." />;
   }
 
   return (

--- a/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
@@ -20,6 +20,7 @@ import {
   createParapharmacyProduct, updateParapharmacyProduct, deleteParapharmacyProduct,
 } from "@/lib/data/client";
 import type { ProductView, ParapharmacyCategoryView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const defaultForm = {
   name: "",
@@ -133,11 +134,7 @@ export default function ParapharmacyCatalogPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading catalog...</div>
-      </div>
-    );
+    return <PageLoader message="Loading catalog..." />;
   }
 
   const filtered = products.filter((p) => {

--- a/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
@@ -16,6 +16,7 @@ import {
   getOutOfStockProducts,
 } from "@/lib/data/client";
 import type { ProductView, ParapharmacyCategoryView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ParapharmacyDashboardPage() {
   const [products, setProducts] = useState<ProductView[]>([]);
@@ -36,11 +37,7 @@ export default function ParapharmacyDashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   const activeProducts = products.filter((p) => p.active);

--- a/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
@@ -8,6 +8,7 @@ import { Search, Package, AlertTriangle } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchParapharmacyProducts, getStockStatus, getExpiryStatus } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ParapharmacyInventoryPage() {
   const [products, setProducts] = useState<ProductView[]>([]);
@@ -22,11 +23,7 @@ export default function ParapharmacyInventoryPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading inventory...</div>
-      </div>
-    );
+    return <PageLoader message="Loading inventory..." />;
   }
 
   const filtered = products.filter((p) => {

--- a/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
@@ -17,6 +17,7 @@ import { Search, Receipt, DollarSign, Plus, Minus, ShoppingCart, Loader2, Trash2
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchDailySales, fetchParapharmacyProducts, createParapharmacySale } from "@/lib/data/client";
 import type { DailySaleView, ProductView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface CartItem {
   productId: string;
@@ -122,11 +123,7 @@ export default function ParapharmacySalesPage() {
   });
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading sales...</div>
-      </div>
-    );
+    return <PageLoader message="Loading sales..." />;
   }
 
   const filtered = sales.filter((s) => {

--- a/src/app/(patient)/patient/appointments/page.tsx
+++ b/src/app/(patient)/patient/appointments/page.tsx
@@ -13,6 +13,7 @@ import {
   type AppointmentView,
 } from "@/lib/data/client";
 import { RescheduleDialog } from "@/components/patient/reschedule-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const statusColors: Record<string, string> = {
   scheduled: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
@@ -46,11 +47,7 @@ export default function PatientAppointmentsPage() {
   }, [refreshKey]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading appointments...</p>
-      </div>
-    );
+    return <PageLoader message="Loading appointments..." />;
   }
   const upcoming = patientAppointments.filter(
     (a) => a.status === "scheduled" || a.status === "confirmed" || a.status === "in-progress"

--- a/src/app/(patient)/patient/before-after/page.tsx
+++ b/src/app/(patient)/patient/before-after/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchBeforeAfterPhotos,
   type BeforeAfterPhotoView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function PatientBeforeAfterPage() {
   const [myPhotos, setMyPhotos] = useState<BeforeAfterPhotoView[]>([]);
@@ -24,11 +25,7 @@ export default function PatientBeforeAfterPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading photos...</p>
-      </div>
-    );
+    return <PageLoader message="Loading photos..." />;
   }
 
   return (

--- a/src/app/(patient)/patient/dashboard/page.tsx
+++ b/src/app/(patient)/patient/dashboard/page.tsx
@@ -18,6 +18,7 @@ import {
   type NotificationView,
 } from "@/lib/data/client";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const quickLinks = [
   { icon: Calendar, label: "My Appointments", description: "View & manage bookings", href: "/patient/appointments" },
@@ -59,11 +60,7 @@ export default function PatientDashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading dashboard...</p>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   const upcoming = appointmentsList.filter((a) => a.status === "scheduled" || a.status === "confirmed");

--- a/src/app/(patient)/patient/invoices/page.tsx
+++ b/src/app/(patient)/patient/invoices/page.tsx
@@ -10,6 +10,7 @@ import {
   fetchInvoices,
   type InvoiceView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const statusVariant: Record<string, "success" | "warning" | "destructive"> = {
   paid: "success",
@@ -34,11 +35,7 @@ export default function PatientInvoicesPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading invoices...</p>
-      </div>
-    );
+    return <PageLoader message="Loading invoices..." />;
   }
 
   const totalPaid = invoices.filter((i) => i.status === "paid").reduce((sum, i) => sum + i.amount, 0);

--- a/src/app/(patient)/patient/medical-history/page.tsx
+++ b/src/app/(patient)/patient/medical-history/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Activity, Pill, FileText, Stethoscope, AlertTriangle, TrendingUp } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { PageLoader } from "@/components/ui/page-loader";
 import {
   getCurrentUser,
   fetchPatientAppointments,
@@ -54,11 +55,7 @@ export default function MedicalHistoryPage() {
   }, []);
 
   if (loading || !patient) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading medical history...</p>
-      </div>
-    );
+    return <PageLoader message="Loading medical history..." />;
   }
 
   const diagnoses = consultNotes.map(n => ({

--- a/src/app/(patient)/patient/payment-plan/page.tsx
+++ b/src/app/(patient)/patient/payment-plan/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchInstallmentPlans,
   type InstallmentPlanView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function PatientPaymentPlanPage() {
   const [myPlans, setMyPlans] = useState<InstallmentPlanView[]>([]);
@@ -24,11 +25,7 @@ export default function PatientPaymentPlanPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading payment plans...</p>
-      </div>
-    );
+    return <PageLoader message="Loading payment plans..." />;
   }
 
   const handleGenerateReceipt = (planId: string, installmentId: string) => {

--- a/src/app/(patient)/patient/prescriptions/page.tsx
+++ b/src/app/(patient)/patient/prescriptions/page.tsx
@@ -10,6 +10,7 @@ import {
   fetchPrescriptions,
   type PrescriptionView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function PatientPrescriptionsPage() {
   const [downloading, setDownloading] = useState<string | null>(null);
@@ -28,11 +29,7 @@ export default function PatientPrescriptionsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading prescriptions...</p>
-      </div>
-    );
+    return <PageLoader message="Loading prescriptions..." />;
   }
 
   const handleDownload = (rxId: string) => {

--- a/src/app/(patient)/patient/tooth-map/page.tsx
+++ b/src/app/(patient)/patient/tooth-map/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchOdontogram,
   type OdontogramView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function PatientToothMapPage() {
   const [entries, setEntries] = useState<OdontogramView[]>([]);
@@ -24,11 +25,7 @@ export default function PatientToothMapPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading tooth map...</p>
-      </div>
-    );
+    return <PageLoader message="Loading tooth map..." />;
   }
 
   return (

--- a/src/app/(patient)/patient/treatment-plan/page.tsx
+++ b/src/app/(patient)/patient/treatment-plan/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchTreatmentPlans,
   type TreatmentPlanView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function PatientTreatmentPlanPage() {
   const [myPlans, setMyPlans] = useState<TreatmentPlanView[]>([]);
@@ -24,11 +25,7 @@ export default function PatientTreatmentPlanPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading treatment plans...</p>
-      </div>
-    );
+    return <PageLoader message="Loading treatment plans..." />;
   }
 
   return (

--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -23,13 +23,13 @@ import {
   getOutOfStockProducts,
 } from "@/lib/data/client";
 import type {
-import { PageLoader } from "@/components/ui/page-loader";
   ProductView,
   PharmacyPrescriptionView,
   DailySaleView,
   PurchaseOrderView,
   LoyaltyMemberView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 // ── Date helpers ──
 

--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -23,6 +23,7 @@ import {
   getOutOfStockProducts,
 } from "@/lib/data/client";
 import type {
+import { PageLoader } from "@/components/ui/page-loader";
   ProductView,
   PharmacyPrescriptionView,
   DailySaleView,
@@ -116,11 +117,7 @@ export default function PharmacistDashboardPage() {
   );
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   // ── Prescription fill rate ──

--- a/src/app/(pharmacist)/pharmacist/expiry/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/expiry/page.tsx
@@ -7,6 +7,7 @@ import { AlertTriangle, Check, Clock, X } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchProducts, getExpiryStatus } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ExpiryTrackerPage() {
   const [allProducts, setAllProducts] = useState<ProductView[]>([]);
@@ -32,11 +33,7 @@ export default function ExpiryTrackerPage() {
   }, [allProducts]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading expiry data...</div>
-      </div>
-    );
+    return <PageLoader message="Loading expiry data..." />;
   }
 
   const expired = products.filter((p) => p.expiryStatus === "red");

--- a/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
@@ -13,6 +13,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchLoyaltyMembers, fetchLoyaltyTransactions, getPointsValue } from "@/lib/data/client";
 import type { LoyaltyMemberView, LoyaltyTransactionView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type LoyaltyTier = "bronze" | "silver" | "gold" | "platinum";
 type TransactionType = "earned" | "redeemed" | "birthday_bonus" | "referral_bonus" | "expired";
@@ -48,11 +49,7 @@ export default function LoyaltyPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading loyalty data...</div>
-      </div>
-    );
+    return <PageLoader message="Loading loyalty data..." />;
   }
 
   const filteredMembers = allMembers.filter(

--- a/src/app/(pharmacist)/pharmacist/orders/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/orders/page.tsx
@@ -11,6 +11,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchPurchaseOrders, fetchSuppliers } from "@/lib/data/client";
 import type { PurchaseOrderView, SupplierView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type OrderStatus = "draft" | "sent" | "confirmed" | "shipped" | "delivered" | "cancelled";
 
@@ -37,11 +38,7 @@ export default function OrdersPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading orders...</div>
-      </div>
-    );
+    return <PageLoader message="Loading orders..." />;
   }
 
   const filtered = filterStatus === "all"

--- a/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
@@ -12,6 +12,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchPrescriptionRequests } from "@/lib/data/client";
 import type { PharmacyPrescriptionView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type PrescriptionStatus = "pending" | "reviewing" | "partially-ready" | "ready" | "picked-up" | "delivered" | "rejected";
 
@@ -40,11 +41,7 @@ export default function PrescriptionsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading prescriptions...</div>
-      </div>
-    );
+    return <PageLoader message="Loading prescriptions..." />;
   }
 
   const filtered = allPrescriptions.filter((rx) => {

--- a/src/app/(pharmacist)/pharmacist/sales/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/sales/page.tsx
@@ -11,6 +11,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchDailySales } from "@/lib/data/client";
 import type { DailySaleView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SalesPage() {
   const [allSales, setAllSales] = useState<DailySaleView[]>([]);
@@ -41,11 +42,7 @@ export default function SalesPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading sales data...</div>
-      </div>
-    );
+    return <PageLoader message="Loading sales data..." />;
   }
 
   return (

--- a/src/app/(pharmacist)/pharmacist/stock/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/stock/page.tsx
@@ -17,6 +17,7 @@ import {
   getExpiryStatus,
 } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const categories = [
   { value: "all", label: "All" },
@@ -73,11 +74,7 @@ export default function StockPage() {
   const totalValue = filtered.reduce((sum, p) => sum + p.price * p.stockQuantity, 0);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading stock data...</div>
-      </div>
-    );
+    return <PageLoader message="Loading stock data..." />;
   }
 
   return (

--- a/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
@@ -11,6 +11,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchSuppliers, fetchPurchaseOrders } from "@/lib/data/client";
 import type { SupplierView, PurchaseOrderView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SuppliersPage() {
   const [allSuppliers, setAllSuppliers] = useState<SupplierView[]>([]);
@@ -25,11 +26,7 @@ export default function SuppliersPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading suppliers...</div>
-      </div>
-    );
+    return <PageLoader message="Loading suppliers..." />;
   }
 
   return (

--- a/src/app/(physiotherapist)/physiotherapist/exercise-programs/page.tsx
+++ b/src/app/(physiotherapist)/physiotherapist/exercise-programs/page.tsx
@@ -5,6 +5,7 @@ import { Dumbbell } from "lucide-react";
 import { ExerciseProgramBuilder } from "@/components/para-medical/exercise-program-builder";
 import { getCurrentUser } from "@/lib/data/client";
 import type { ExerciseProgram } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ExerciseProgramsPage() {
   const [programs, setPrograms] = useState<ExerciseProgram[]>([]);
@@ -22,11 +23,7 @@ export default function ExerciseProgramsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading exercise programs...</p>
-      </div>
-    );
+    return <PageLoader message="Loading exercise programs..." />;
   }
 
   return (

--- a/src/app/(physiotherapist)/physiotherapist/progress-photos/page.tsx
+++ b/src/app/(physiotherapist)/physiotherapist/progress-photos/page.tsx
@@ -5,6 +5,7 @@ import { Camera } from "lucide-react";
 import { ProgressPhotoGallery } from "@/components/para-medical/progress-photo-gallery";
 import { getCurrentUser } from "@/lib/data/client";
 import type { ProgressPhoto } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ProgressPhotosPage() {
   const [photos, setPhotos] = useState<ProgressPhoto[]>([]);
@@ -21,11 +22,7 @@ export default function ProgressPhotosPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading photos...</p>
-      </div>
-    );
+    return <PageLoader message="Loading photos..." />;
   }
 
   return (

--- a/src/app/(physiotherapist)/physiotherapist/sessions/page.tsx
+++ b/src/app/(physiotherapist)/physiotherapist/sessions/page.tsx
@@ -5,6 +5,7 @@ import { ClipboardList } from "lucide-react";
 import { PhysioSessionTracker } from "@/components/para-medical/physio-session-tracker";
 import { getCurrentUser } from "@/lib/data/client";
 import type { PhysioSession } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function PhysioSessionsPage() {
   const [sessions, setSessions] = useState<PhysioSession[]>([]);
@@ -21,11 +22,7 @@ export default function PhysioSessionsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading sessions...</p>
-      </div>
-    );
+    return <PageLoader message="Loading sessions..." />;
   }
 
   return (

--- a/src/app/(psychologist)/psychologist/progress/page.tsx
+++ b/src/app/(psychologist)/psychologist/progress/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "recharts";
 import { getCurrentUser } from "@/lib/data/client";
 import type { TherapySessionNote } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ProgressTrackingPage() {
   const [sessions, setSessions] = useState<TherapySessionNote[]>([]);
@@ -25,11 +26,7 @@ export default function ProgressTrackingPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading progress data...</p>
-      </div>
-    );
+    return <PageLoader message="Loading progress data..." />;
   }
 
   const moodData = sessions

--- a/src/app/(psychologist)/psychologist/session-notes/page.tsx
+++ b/src/app/(psychologist)/psychologist/session-notes/page.tsx
@@ -5,6 +5,7 @@ import { Brain } from "lucide-react";
 import { TherapySessionNotes } from "@/components/para-medical/therapy-session-notes";
 import { getCurrentUser } from "@/lib/data/client";
 import type { TherapySessionNote } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SessionNotesPage() {
   const [sessions, setSessions] = useState<TherapySessionNote[]>([]);
@@ -21,11 +22,7 @@ export default function SessionNotesPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading session notes...</p>
-      </div>
-    );
+    return <PageLoader message="Loading session notes..." />;
   }
 
   return (

--- a/src/app/(psychologist)/psychologist/therapy-plans/page.tsx
+++ b/src/app/(psychologist)/psychologist/therapy-plans/page.tsx
@@ -5,6 +5,7 @@ import { Target } from "lucide-react";
 import { TherapyPlanView } from "@/components/para-medical/therapy-plan-view";
 import { getCurrentUser } from "@/lib/data/client";
 import type { TherapyPlan } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function TherapyPlansPage() {
   const [plans, setPlans] = useState<TherapyPlan[]>([]);
@@ -21,11 +22,7 @@ export default function TherapyPlansPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading therapy plans...</p>
-      </div>
-    );
+    return <PageLoader message="Loading therapy plans..." />;
   }
 
   return (

--- a/src/app/(radiology)/radiology/dashboard/page.tsx
+++ b/src/app/(radiology)/radiology/dashboard/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyDashboardPage() {
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
@@ -23,11 +24,7 @@ export default function RadiologyDashboardPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading dashboard...</div>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   const pending = orders.filter((o) => o.status === "pending" || o.status === "scheduled");

--- a/src/app/(radiology)/radiology/images/page.tsx
+++ b/src/app/(radiology)/radiology/images/page.tsx
@@ -27,6 +27,7 @@ import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyImagesPage() {
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
@@ -99,11 +100,7 @@ export default function RadiologyImagesPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading images...</div>
-      </div>
-    );
+    return <PageLoader message="Loading images..." />;
   }
 
   const filtered = orders.filter((o) => {

--- a/src/app/(radiology)/radiology/orders/page.tsx
+++ b/src/app/(radiology)/radiology/orders/page.tsx
@@ -30,6 +30,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders, fetchRadiologyTemplates } from "@/lib/data/client";
 import type { RadiologyOrderView, RadiologyTemplateView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const statusOptions = ["all", "pending", "scheduled", "in_progress", "images_ready", "reported", "validated", "cancelled"] as const;
 const modalityOptions = ["xray", "ct", "mri", "ultrasound", "mammography", "pet", "fluoroscopy", "other"] as const;
@@ -191,11 +192,7 @@ export default function RadiologyOrdersPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading orders...</div>
-      </div>
-    );
+    return <PageLoader message="Loading orders..." />;
   }
 
   const filtered = orders.filter((o) => {

--- a/src/app/(radiology)/radiology/reports/page.tsx
+++ b/src/app/(radiology)/radiology/reports/page.tsx
@@ -9,6 +9,7 @@ import { Search, FileText, Download, Scan, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyReportsPage() {
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
@@ -56,11 +57,7 @@ export default function RadiologyReportsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading reports...</div>
-      </div>
-    );
+    return <PageLoader message="Loading reports..." />;
   }
 
   const filtered = orders.filter((o) => {

--- a/src/app/(radiology)/radiology/templates/page.tsx
+++ b/src/app/(radiology)/radiology/templates/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { clinicConfig } from "@/config/clinic.config";
 import { fetchRadiologyTemplates } from "@/lib/data/client";
 import type { RadiologyTemplateView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyTemplatesPage() {
   const [templates, setTemplates] = useState<RadiologyTemplateView[]>([]);
@@ -23,11 +24,7 @@ export default function RadiologyTemplatesPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[50vh]">
-        <div className="animate-pulse text-muted-foreground">Loading templates...</div>
-      </div>
-    );
+    return <PageLoader message="Loading templates..." />;
   }
 
   const filtered = templates.filter((t) => {

--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -17,6 +17,7 @@ import {
 import { ManualBookingDialog } from "@/components/receptionist/manual-booking-dialog";
 import { WalkInDialog } from "@/components/receptionist/walk-in-dialog";
 import { PaymentDialog } from "@/components/receptionist/payment-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const statusVariant: Record<string, "default" | "success" | "warning" | "destructive" | "secondary" | "outline"> = {
   scheduled: "outline",
@@ -77,11 +78,7 @@ export default function ReceptionistDashboardPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Loading dashboard...</p>
-      </div>
-    );
+    return <PageLoader message="Loading dashboard..." />;
   }
 
   return (

--- a/src/app/(receptionist)/receptionist/patients/page.tsx
+++ b/src/app/(receptionist)/receptionist/patients/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { getCurrentUser, fetchPatients, type PatientView } from "@/lib/data/client";
 import { PatientRegistrationDialog } from "@/components/receptionist/patient-registration-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ReceptionistPatientsPage() {
   const [patients, setPatients] = useState<PatientView[]>([]);
@@ -49,11 +50,7 @@ export default function ReceptionistPatientsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Loading patients...</p>
-      </div>
-    );
+    return <PageLoader message="Loading patients..." />;
   }
 
   return (

--- a/src/app/(receptionist)/receptionist/payments/page.tsx
+++ b/src/app/(receptionist)/receptionist/payments/page.tsx
@@ -14,6 +14,7 @@ import {
   type InvoiceView,
 } from "@/lib/data/client";
 import { PaymentDialog } from "@/components/receptionist/payment-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface PaymentEntry {
   id: string;
@@ -81,11 +82,7 @@ export default function PaymentsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Loading payments...</p>
-      </div>
-    );
+    return <PageLoader message="Loading payments..." />;
   }
 
   return (

--- a/src/app/(speech-therapist)/speech-therapist/exercise-library/page.tsx
+++ b/src/app/(speech-therapist)/speech-therapist/exercise-library/page.tsx
@@ -5,6 +5,7 @@ import { BookOpen } from "lucide-react";
 import { SpeechExerciseLibrary } from "@/components/para-medical/speech-exercise-library";
 import { getCurrentUser } from "@/lib/data/client";
 import type { SpeechExercise } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ExerciseLibraryPage() {
   const [exercises, setExercises] = useState<SpeechExercise[]>([]);
@@ -21,11 +22,7 @@ export default function ExerciseLibraryPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading exercise library...</p>
-      </div>
-    );
+    return <PageLoader message="Loading exercise library..." />;
   }
 
   return (

--- a/src/app/(speech-therapist)/speech-therapist/reports/page.tsx
+++ b/src/app/(speech-therapist)/speech-therapist/reports/page.tsx
@@ -5,6 +5,7 @@ import { FileText } from "lucide-react";
 import { SpeechProgressReports } from "@/components/para-medical/speech-progress-reports";
 import { getCurrentUser } from "@/lib/data/client";
 import type { SpeechProgressReport } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SpeechReportsPage() {
   const [reports, setReports] = useState<SpeechProgressReport[]>([]);
@@ -21,11 +22,7 @@ export default function SpeechReportsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading reports...</p>
-      </div>
-    );
+    return <PageLoader message="Loading reports..." />;
   }
 
   return (

--- a/src/app/(speech-therapist)/speech-therapist/sessions/page.tsx
+++ b/src/app/(speech-therapist)/speech-therapist/sessions/page.tsx
@@ -5,6 +5,7 @@ import { ClipboardList } from "lucide-react";
 import { SpeechSessionTracker } from "@/components/para-medical/speech-session-tracker";
 import { getCurrentUser } from "@/lib/data/client";
 import type { SpeechSession } from "@/lib/types/para-medical";
+import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SpeechSessionsPage() {
   const [sessions, setSessions] = useState<SpeechSession[]>([]);
@@ -21,11 +22,7 @@ export default function SpeechSessionsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading sessions...</p>
-      </div>
-    );
+    return <PageLoader message="Loading sessions..." />;
   }
 
   return (

--- a/src/components/admin/clinic-center-dashboard-kpis.tsx
+++ b/src/components/admin/clinic-center-dashboard-kpis.tsx
@@ -17,6 +17,7 @@ import {
   type ClinicCenterDashboardKPIs,
 } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { PageLoader } from "@/components/ui/page-loader";
 
 /**
  * ClinicCenterDashboardKPIs
@@ -48,11 +49,7 @@ export function ClinicCenterDashboardKPIsComponent() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-10">
-        <p className="text-sm text-muted-foreground">Loading clinic/center KPIs...</p>
-      </div>
-    );
+    return <PageLoader message="Loading clinic/center KPIs..." />;
   }
 
   const totalBeds = data?.totalBeds ?? 0;

--- a/src/components/admin/lab-dashboard-kpis.tsx
+++ b/src/components/admin/lab-dashboard-kpis.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { fetchLabDashboardKPIs, type LabDashboardKPIs } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { PageLoader } from "@/components/ui/page-loader";
 
 /**
  * LabDashboardKPIs
@@ -45,11 +46,7 @@ export function LabDashboardKPIsComponent() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-10">
-        <p className="text-sm text-muted-foreground">Loading lab KPIs...</p>
-      </div>
-    );
+    return <PageLoader message="Loading lab KPIs..." />;
   }
 
   const pending = data?.pendingTestOrders ?? 0;

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -20,6 +20,7 @@ import {
   type AnalyticsData,
 } from "@/lib/data/client";
 import { exportToCSV } from "@/lib/export-data";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const COLORS = [
   "#2563eb", "#7c3aed", "#db2777", "#ea580c",
@@ -43,11 +44,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading analytics...</p>
-      </div>
-    );
+    return <PageLoader message="Loading analytics..." />;
   }
 
   if (!analytics) {

--- a/src/components/doctor/patient-card.tsx
+++ b/src/components/doctor/patient-card.tsx
@@ -14,6 +14,7 @@ import {
   type PrescriptionView,
   type AppointmentView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type TabKey = "overview" | "history" | "prescriptions" | "notes";
 
@@ -50,11 +51,7 @@ export function PatientCard({ patientId }: { patientId?: string }) {
   }, [patientId]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading patient...</p>
-      </div>
-    );
+    return <PageLoader message="Loading patient..." />;
   }
 
   if (!patient) {

--- a/src/components/doctor/prescription-writer.tsx
+++ b/src/components/doctor/prescription-writer.tsx
@@ -13,6 +13,7 @@ import {
   type PatientView,
 } from "@/lib/data/client";
 import { downloadPrescriptionPDF } from "@/lib/prescription-pdf";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface Medication {
   name: string;
@@ -51,11 +52,7 @@ export function PrescriptionWriter() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading...</p>
-      </div>
-    );
+    return <PageLoader message="Loading..." />;
   }
 
   const patient = patients.find((p) => p.id === selectedPatient) ?? patients[0];

--- a/src/components/doctor/schedule-view.tsx
+++ b/src/components/doctor/schedule-view.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
 import { EmergencySlotCreator } from "./emergency-slot-creator";
+import { PageLoader } from "@/components/ui/page-loader";
 
 type ViewMode = "timeline" | "list";
 
@@ -48,11 +49,7 @@ export function ScheduleView() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading schedule...</p>
-      </div>
-    );
+    return <PageLoader message="Loading schedule..." />;
   }
 
   const timeSlots = [

--- a/src/components/patient/appointment-list.tsx
+++ b/src/components/patient/appointment-list.tsx
@@ -11,6 +11,7 @@ import {
   type AppointmentView,
 } from "@/lib/data/client";
 import { RescheduleDialog } from "./reschedule-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const CANCELLATION_WINDOW_HOURS = 24;
 
@@ -110,11 +111,7 @@ export function AppointmentList({ patientId }: { patientId?: string }) {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading appointments...</p>
-      </div>
-    );
+    return <PageLoader message="Loading appointments..." />;
   }
 
   const apptToReschedule = rescheduleAppt

--- a/src/components/patient/medical-record.tsx
+++ b/src/components/patient/medical-record.tsx
@@ -13,6 +13,7 @@ import {
   type AppointmentView,
   type PrescriptionView,
 } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 /**
  * MedicalRecord
@@ -51,11 +52,7 @@ export function MedicalRecord({ patientId }: { patientId?: string }) {
   }, [patientId]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-sm text-muted-foreground">Loading medical record...</p>
-      </div>
-    );
+    return <PageLoader message="Loading medical record..." />;
   }
 
   if (!patient) {

--- a/src/components/patient/waiting-list-status.tsx
+++ b/src/components/patient/waiting-list-status.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { WaitingListView } from "@/lib/data/client";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface WaitingListStatusProps {
   patientId: string;
@@ -58,13 +59,7 @@ export function WaitingListStatus({ patientId }: WaitingListStatusProps) {
   };
 
   if (loading) {
-    return (
-      <Card>
-        <CardContent className="py-4">
-          <p className="text-sm text-muted-foreground">Loading waiting list...</p>
-        </CardContent>
-      </Card>
-    );
+    return <PageLoader message="Loading waiting list..." />;
   }
 
   if (entries.length === 0) {

--- a/src/components/receptionist/booking-calendar.tsx
+++ b/src/components/receptionist/booking-calendar.tsx
@@ -15,6 +15,7 @@ import {
 import { clinicConfig } from "@/config/clinic.config";
 import { ManualBookingDialog } from "./manual-booking-dialog";
 import { WalkInDialog } from "./walk-in-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 // Local appointment type that supports drag-and-drop rescheduling
 interface LocalAppointment extends AppointmentView {
@@ -174,11 +175,7 @@ export function ReceptionistBookingCalendar() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Loading calendar...</p>
-      </div>
-    );
+    return <PageLoader message="Loading calendar..." />;
   }
 
   return (

--- a/src/components/receptionist/daily-report.tsx
+++ b/src/components/receptionist/daily-report.tsx
@@ -17,6 +17,7 @@ import {
   type InvoiceView,
 } from "@/lib/data/client";
 import { exportAppointments, exportInvoices } from "@/lib/export-data";
+import { PageLoader } from "@/components/ui/page-loader";
 
 const statusVariant: Record<string, "default" | "success" | "warning" | "destructive" | "secondary" | "outline"> = {
   scheduled: "outline",
@@ -112,11 +113,7 @@ export function DailyReport() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Loading report...</p>
-      </div>
-    );
+    return <PageLoader message="Loading report..." />;
   }
 
   return (

--- a/src/components/receptionist/waiting-room-manager.tsx
+++ b/src/components/receptionist/waiting-room-manager.tsx
@@ -14,6 +14,7 @@ import {
   fetchPatients,
 } from "@/lib/data/client";
 import { WalkInDialog } from "./walk-in-dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 
 interface WaitingPatient {
   id: string;
@@ -153,11 +154,7 @@ export function WaitingRoomManager() {
     : 0;
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Loading waiting room...</p>
-      </div>
-    );
+    return <PageLoader message="Loading waiting room..." />;
   }
 
   return (

--- a/src/components/ui/page-loader.tsx
+++ b/src/components/ui/page-loader.tsx
@@ -1,0 +1,27 @@
+import { Loader2 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface PageLoaderProps {
+  message?: string;
+}
+
+export function PageLoader({ message = "Loading..." }: PageLoaderProps) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Loader2 className="h-5 w-5 animate-spin text-primary" />
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-1/3" />
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+          <Skeleton className="h-24 rounded-xl" />
+        </div>
+        <Skeleton className="h-64 rounded-xl" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Task 23: Add loading states to data-fetching pages

Replaces text-only "Loading..." messages and blank `return null` blocks with a proper `PageLoader` component across **101 pages/components**.

### Changes

- **New `Skeleton` component** (`src/components/ui/skeleton.tsx`) — shadcn-style `animate-pulse` placeholder
- **New `PageLoader` component** (`src/components/ui/page-loader.tsx`) — `Loader2` spinner + skeleton card placeholders
- **Updated 101 files** that had unused `loading` state variables — each now renders `<PageLoader message="Loading ..." />` during data fetching

### Before / After

**Before:** Users see a blank page or a tiny text-only message while data loads

**After:** Users see an animated spinner with skeleton placeholders, providing immediate visual feedback

### Files affected

- `src/app/(doctor)/doctor/*` — 46 pages
- `src/app/(patient)/patient/*` — 9 pages
- `src/app/(admin)/admin/*` — 5 pages
- `src/app/(pharmacist)/pharmacist/*` — 8 pages
- `src/app/(lab)/lab-panel/*` — 5 pages
- `src/app/(radiology)/radiology/*` — 5 pages
- `src/app/(parapharmacy)/parapharmacy/*` — 4 pages
- `src/app/(equipment)/equipment/*` — 4 pages
- `src/app/(receptionist)/receptionist/*` — 3 pages
- `src/components/*` — 12 components

### CI Note

The Lint & Type Check CI job fails due to **pre-existing TypeScript errors** on `main` (in `client.ts`, `server.ts`, `specialists.ts`, and scoping issues with `load` functions in several pages). These are not regressions from this PR — the same errors exist on the `main` branch. The Cloudflare Pages build also fails on `main`.

---

[Devin session](https://app.devin.ai/sessions/291fb2eb877b40e183c5dffa9110d3ed)