### PR TITLE
fix: resolve last ESLint warning in chatbot settings (set-state-in-effect)

### DIFF
--- a/src/app/(admin)/admin/settings/chatbot/page.tsx
+++ b/src/app/(admin)/admin/settings/chatbot/page.tsx
@@ -87,58 +87,56 @@ export default function ChatbotSettingsPage() {
   const [saving, setSaving] = useState(false);
   const [savedMessage, setSavedMessage] = useState<string | null>(null);
 
-  async function loadData() {
-    const supabase = getSupabase();
-
-    // Get current user's clinic
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) return;
-
-    const { data: profile } = await supabase
-      .from("users")
-      .select("clinic_id")
-      .eq("auth_id", user.id)
-      .single();
-
-    if (!profile?.clinic_id) return;
-    setClinicId(profile.clinic_id as string);
-
-    // Load chatbot config
-    const { data: configData } = await supabase
-      .from("chatbot_config")
-      .select("enabled, intelligence, greeting, language")
-      .eq("clinic_id", profile.clinic_id)
-      .single();
-
-    if (configData) {
-      const row = configData as Record<string, unknown>;
-      setConfig({
-        enabled: row.enabled as boolean,
-        intelligence: row.intelligence as ChatbotConfig["intelligence"],
-        greeting:
-          (row.greeting as string) || "Bonjour ! Comment puis-je vous aider ?",
-        language: (row.language as string) || "fr",
-      });
-    }
-
-    // Load FAQs
-    const { data: faqData } = await supabase
-      .from("chatbot_faqs")
-      .select("id, question, answer, keywords, sort_order, is_active")
-      .eq("clinic_id", profile.clinic_id)
-      .order("sort_order", { ascending: true });
-
-    if (faqData) {
-      setFaqs(faqData as FaqEntry[]);
-    }
-
-    setLoading(false);
-  }
-
   useEffect(() => {
-    loadData();
+    (async () => {
+      const supabase = getSupabase();
+
+      // Get current user's clinic
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: profile } = await supabase
+        .from("users")
+        .select("clinic_id")
+        .eq("auth_id", user.id)
+        .single();
+
+      if (!profile?.clinic_id) return;
+      setClinicId(profile.clinic_id as string);
+
+      // Load chatbot config
+      const { data: configData } = await supabase
+        .from("chatbot_config")
+        .select("enabled, intelligence, greeting, language")
+        .eq("clinic_id", profile.clinic_id)
+        .single();
+
+      if (configData) {
+        const row = configData as Record<string, unknown>;
+        setConfig({
+          enabled: row.enabled as boolean,
+          intelligence: row.intelligence as ChatbotConfig["intelligence"],
+          greeting:
+            (row.greeting as string) || "Bonjour ! Comment puis-je vous aider ?",
+          language: (row.language as string) || "fr",
+        });
+      }
+
+      // Load FAQs
+      const { data: faqData } = await supabase
+        .from("chatbot_faqs")
+        .select("id, question, answer, keywords, sort_order, is_active")
+        .eq("clinic_id", profile.clinic_id)
+        .order("sort_order", { ascending: true });
+
+      if (faqData) {
+        setFaqs(faqData as FaqEntry[]);
+      }
+
+      setLoading(false);
+    })();
   }, []);
 
   async function saveConfig() {
@@ -211,7 +209,16 @@ export default function ChatbotSettingsPage() {
     setSaving(false);
     setSavedMessage("Paramètres sauvegardés !");
     setTimeout(() => setSavedMessage(null), 3000);
-    loadData();
+
+    // Refresh FAQs after save to get server-assigned IDs
+    const { data: refreshedFaqs } = await supabase
+      .from("chatbot_faqs")
+      .select("id, question, answer, keywords, sort_order, is_active")
+      .eq("clinic_id", clinicId)
+      .order("sort_order", { ascending: true });
+    if (refreshedFaqs) {
+      setFaqs(refreshedFaqs as FaqEntry[]);
+    }
   }
 
   function addFaq() {


### PR DESCRIPTION
## Summary

Fixes the last remaining ESLint warning in the codebase — `react-hooks/set-state-in-effect` in `chatbot/page.tsx`.

### Problem
The `loadData()` function was defined outside the `useEffect` and called inside it, which triggers a `set-state-in-effect` warning because the linter detects setState calls from within an effect body.

### Fix
- Inlined the async data-fetching logic directly inside `useEffect` as an async IIFE
- Replaced the `loadData()` call in `saveConfig` with an inline FAQ refresh query
- Result: `npm run lint` now shows **0 warnings, 0 errors**