### PR TITLE
refactor: extract auth middleware, fix N+1 query, sanitize errors, rename lab endpoint, fix webhook recipient

### DIFF
--- a/src/app/(lab)/lab-panel/results/page.tsx
+++ b/src/app/(lab)/lab-panel/results/page.tsx
@@ -113,7 +113,7 @@ export default function ResultsPage() {
     if (!order) return;
     setPdfGenerating(true);
     try {
-      const res = await fetch("/api/lab/report-pdf", {
+      const res = await fetch("/api/lab/report-html", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/app/api/booking/payment/confirm/route.ts
+++ b/src/app/api/booking/payment/confirm/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -12,22 +12,8 @@ const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", 
  *
  * Confirm a pending payment.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = (await request.json()) as { paymentId: string };
 
     if (!body.paymentId) {
@@ -57,7 +43,8 @@ export async function POST(request: NextRequest) {
       .eq("id", body.paymentId);
 
     if (updateError) {
-      return NextResponse.json({ error: updateError.message }, { status: 500 });
+      console.error("[POST /api/booking/payment/confirm] Update error:", updateError.message);
+      return NextResponse.json({ error: "Failed to confirm payment" }, { status: 500 });
     }
 
     // Also confirm the associated appointment if it is still scheduled
@@ -73,4 +60,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to confirm payment" }, { status: 500 });
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/booking/payment/initiate/route.ts
+++ b/src/app/api/booking/payment/initiate/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -12,22 +12,8 @@ const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", 
  *
  * Initiate a payment for an appointment.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = (await request.json()) as {
       appointmentId: string;
       patientId: string;
@@ -137,7 +123,8 @@ export async function POST(request: NextRequest) {
           { status: 409 },
         );
       }
-      return NextResponse.json({ error: insertError?.message ?? "Failed to initiate payment" }, { status: 500 });
+      console.error("[POST /api/booking/payment/initiate] Insert error:", insertError?.message);
+      return NextResponse.json({ error: "Failed to initiate payment" }, { status: 500 });
     }
 
     return NextResponse.json({
@@ -149,4 +136,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to initiate payment" }, { status: 500 });
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -12,22 +12,8 @@ const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
  *
  * Refund a completed payment (full or partial).
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !ADMIN_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 admin only" }, { status: 403 });
-    }
-
     const body = (await request.json()) as { paymentId: string; amount?: number };
 
     if (!body.paymentId) {
@@ -80,11 +66,12 @@ export async function POST(request: NextRequest) {
       .eq("id", body.paymentId);
 
     if (updateError) {
-      return NextResponse.json({ error: updateError.message }, { status: 500 });
+      console.error("[POST /api/booking/payment/refund] Update error:", updateError.message);
+      return NextResponse.json({ error: "Failed to refund payment" }, { status: 500 });
     }
 
     return NextResponse.json({ status: "refunded", message: "Payment refunded" });
   } catch {
     return NextResponse.json({ error: "Failed to refund payment" }, { status: 500 });
   }
-}
+}, ADMIN_ROLES);

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -75,7 +75,8 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (error || !entry) {
-      return NextResponse.json({ error: error?.message ?? "Failed to add to waiting list" }, { status: 400 });
+      console.error("[POST /api/booking/waiting-list] Error:", error?.message);
+      return NextResponse.json({ error: "Failed to add to waiting list" }, { status: 400 });
     }
 
     return NextResponse.json({
@@ -155,7 +156,8 @@ export async function DELETE(request: NextRequest) {
       .eq("id", body.entryId);
 
     if (error) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
+      console.error("[DELETE /api/booking/waiting-list] Error:", error.message);
+      return NextResponse.json({ error: "Failed to remove from waiting list" }, { status: 400 });
     }
 
     return NextResponse.json({ status: "removed", message: "Removed from waiting list" });

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -5,7 +5,7 @@
  *                              and persist the URL to the clinics table
  */
 
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import { createClient } from "@/lib/supabase-server";
 import {
@@ -14,6 +14,7 @@ import {
   buildUploadKey,
 } from "@/lib/r2";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
 
@@ -76,21 +77,7 @@ export async function GET() {
 
 // ── PUT — update text branding fields (colors, fonts) ──
 
-export async function PUT(request: NextRequest) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-  const { data: profile } = await supabase
-    .from("users")
-    .select("role")
-    .eq("auth_id", user.id)
-    .single();
-  if (!profile || !ADMIN_ROLES.includes(profile.role as UserRole)) {
-    return NextResponse.json({ error: "Forbidden \u2014 admin only" }, { status: 403 });
-  }
-
+export const PUT = withAuth(async (request, { supabase }) => {
   const clinicId = clinicConfig.clinicId;
   const body = await request.json();
 
@@ -130,6 +117,7 @@ export async function PUT(request: NextRequest) {
     .eq("id", clinicId);
 
   if (error) {
+    console.error("[PUT /api/branding] Update error:", error.message);
     return NextResponse.json(
       { error: "Failed to update branding" },
       { status: 500 },
@@ -137,25 +125,11 @@ export async function PUT(request: NextRequest) {
   }
 
   return NextResponse.json({ ok: true });
-}
+}, ADMIN_ROLES);
 
 // ── POST — upload a branding image and save URL ──
 
-export async function POST(request: NextRequest) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-  const { data: profile } = await supabase
-    .from("users")
-    .select("role")
-    .eq("auth_id", user.id)
-    .single();
-  if (!profile || !ADMIN_ROLES.includes(profile.role as UserRole)) {
-    return NextResponse.json({ error: "Forbidden \u2014 admin only" }, { status: 403 });
-  }
-
+export const POST = withAuth(async (request, { supabase }) => {
   const clinicId = clinicConfig.clinicId;
 
   if (!isR2Configured()) {
@@ -216,6 +190,7 @@ export async function POST(request: NextRequest) {
     .eq("id", clinicId);
 
   if (error) {
+    console.error("[POST /api/branding] Save URL error:", error.message);
     return NextResponse.json(
       { error: "Upload succeeded but failed to save URL" },
       { status: 500 },
@@ -223,4 +198,4 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ url, key });
-}
+}, ADMIN_ROLES);

--- a/src/app/api/cron/billing/route.ts
+++ b/src/app/api/cron/billing/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     return NextResponse.json(
-      { error: "Failed to fetch subscriptions", details: error.message },
+      { error: "Failed to fetch subscriptions" },
       { status: 500 },
     );
   }

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -57,11 +57,12 @@ export async function GET(request: NextRequest) {
       .in("status", ["confirmed", "pending"])
       .or(
         `appointment_date.in.(${todayStr},${tomorrowStr}),and(appointment_date.is.null,slot_start.gte.${now.toISOString()},slot_start.lte.${twentyFourHoursFromNow.toISOString()})`,
-      );
+      )
+      .limit(500);
 
     if (error) {
-      console.error("[Cron/Reminders] Query error:", error.message);
-      return NextResponse.json({ error: error.message }, { status: 500 });
+        console.error("[Cron/Reminders] Query error:", error.message);
+        return NextResponse.json({ error: "Failed to query appointments" }, { status: 500 });
     }
 
     if (!appointments || appointments.length === 0) {
@@ -141,8 +142,7 @@ export async function GET(request: NextRequest) {
       results,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("[Cron/Reminders] Error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[Cron/Reminders] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to process reminders" }, { status: 500 });
   }
 }

--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -36,7 +37,7 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     return NextResponse.json(
-      { error: error.message },
+      { error: "Failed to fetch custom field definitions" },
       { status: 500 },
     );
   }
@@ -50,30 +51,8 @@ export async function GET(request: NextRequest) {
  * Create a new custom field definition.
  * Only super admins can create definitions.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-
-    // Verify the caller is authenticated
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    // Only super_admin can create custom field definitions
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-
-    if (!profile || profile.role !== "super_admin") {
-      return NextResponse.json({ error: "Forbidden — super_admin only" }, { status: 403 });
-    }
-
     const body = await request.json();
 
     const {
@@ -121,8 +100,9 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (error) {
+      console.error("[POST /api/custom-fields] Insert error:", error.message);
       return NextResponse.json(
-        { error: error.message },
+        { error: "Failed to create custom field definition" },
         { status: 500 },
       );
     }
@@ -134,7 +114,7 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-}
+}, ["super_admin"]);
 
 /**
  * PATCH /api/custom-fields
@@ -142,30 +122,8 @@ export async function POST(request: NextRequest) {
  * Update an existing custom field definition.
  * Body must include `id` and any fields to update.
  */
-export async function PATCH(request: NextRequest) {
+export const PATCH = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-
-    // Verify the caller is authenticated
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    // Only super_admin can update custom field definitions
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-
-    if (!profile || profile.role !== "super_admin") {
-      return NextResponse.json({ error: "Forbidden — super_admin only" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { id, ...updates } = body;
 
@@ -198,8 +156,9 @@ export async function PATCH(request: NextRequest) {
       .single();
 
     if (error) {
+      console.error("[PATCH /api/custom-fields] Update error:", error.message);
       return NextResponse.json(
-        { error: error.message },
+        { error: "Failed to update custom field definition" },
         { status: 500 },
       );
     }
@@ -211,7 +170,7 @@ export async function PATCH(request: NextRequest) {
       { status: 400 },
     );
   }
-}
+}, ["super_admin"]);
 
 /**
  * DELETE /api/custom-fields?id=...
@@ -219,29 +178,7 @@ export async function PATCH(request: NextRequest) {
  * Soft-delete a custom field definition (sets is_active = false).
  * System fields cannot be deleted.
  */
-export async function DELETE(request: NextRequest) {
-  const supabase = await createClient();
-
-  // Verify the caller is authenticated
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
-  // Only super_admin can delete custom field definitions
-  const { data: profile } = await supabase
-    .from("users")
-    .select("role")
-    .eq("auth_id", user.id)
-    .single();
-
-  if (!profile || profile.role !== "super_admin") {
-    return NextResponse.json({ error: "Forbidden — super_admin only" }, { status: 403 });
-  }
-
+export const DELETE = withAuth(async (request, { supabase }) => {
   const id = request.nextUrl.searchParams.get("id");
 
   if (!id) {
@@ -271,11 +208,12 @@ export async function DELETE(request: NextRequest) {
     .eq("id", id);
 
   if (error) {
+    console.error("[DELETE /api/custom-fields] Update error:", error.message);
     return NextResponse.json(
-      { error: error.message },
+      { error: "Failed to delete custom field definition" },
       { status: 500 },
     );
   }
 
   return NextResponse.json({ success: true });
-}
+}, ["super_admin"]);

--- a/src/app/api/custom-fields/values/route.ts
+++ b/src/app/api/custom-fields/values/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -11,21 +11,7 @@ const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", 
  *
  * Returns custom field values for a specific entity instance.
  */
-export async function GET(request: NextRequest) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-  const { data: profile } = await supabase
-    .from("users")
-    .select("role")
-    .eq("auth_id", user.id)
-    .single();
-  if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-    return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-  }
-
+export const GET = withAuth(async (request, { supabase }) => {
   const clinicId = request.nextUrl.searchParams.get("clinic_id");
   const entityType = request.nextUrl.searchParams.get("entity_type");
   const entityId = request.nextUrl.searchParams.get("entity_id");
@@ -46,8 +32,9 @@ export async function GET(request: NextRequest) {
     .single();
 
   if (error && error.code !== "PGRST116") {
+    console.error("[GET /api/custom-fields/values] Query error:", error.message);
     return NextResponse.json(
-      { error: error.message },
+      { error: "Failed to fetch custom field values" },
       { status: 500 },
     );
   }
@@ -56,29 +43,15 @@ export async function GET(request: NextRequest) {
     values: data?.field_values ?? {},
     id: data?.id ?? null,
   });
-}
+}, STAFF_ROLES);
 
 /**
  * POST /api/custom-fields/values
  *
  * Save (upsert) custom field values for a specific entity instance.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { clinic_id, entity_type, entity_id, field_values } = body;
 
@@ -154,8 +127,9 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (error) {
+      console.error("[POST /api/custom-fields/values] Upsert error:", error.message);
       return NextResponse.json(
-        { error: error.message },
+        { error: "Failed to save custom field values" },
         { status: 500 },
       );
     }
@@ -167,29 +141,15 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-}
+}, STAFF_ROLES);
 
 /**
  * PATCH /api/custom-fields/values
  *
  * Partially update custom field values (merge with existing).
  */
-export async function PATCH(request: NextRequest) {
+export const PATCH = withAuth(async (request, { supabase }) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { clinic_id, entity_type, entity_id, field_values } = body;
 
@@ -277,8 +237,9 @@ export async function PATCH(request: NextRequest) {
       .single();
 
     if (error) {
+      console.error("[PATCH /api/custom-fields/values] Upsert error:", error.message);
       return NextResponse.json(
-        { error: error.message },
+        { error: "Failed to update custom field values" },
         { status: 500 },
       );
     }
@@ -290,4 +251,4 @@ export async function PATCH(request: NextRequest) {
       { status: 400 },
     );
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/with-auth";
 
 /**
  * POST /api/impersonate
@@ -13,29 +13,8 @@ import { createClient } from "@/lib/supabase-server";
  *
  * Ends the impersonation session by clearing the cookie.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase, user }) => {
   try {
-    const supabase = await createClient();
-
-    // Verify the current user is a super_admin
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-
-    if (!profile || profile.role !== "super_admin") {
-      return NextResponse.json({ error: "Forbidden — super_admin only" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { clinicId, clinicName } = body as { clinicId: string; clinicName: string };
 
@@ -93,19 +72,13 @@ export async function POST(request: NextRequest) {
 
     return response;
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[POST /api/impersonate] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to start impersonation" }, { status: 500 });
   }
-}
+}, ["super_admin"]);
 
-export async function DELETE() {
+export const DELETE = withAuth(async (_request, { supabase, user }) => {
   try {
-    const supabase = await createClient();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
     // Log the end of impersonation
     if (user) {
       try {
@@ -140,7 +113,7 @@ export async function DELETE() {
 
     return response;
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[DELETE /api/impersonate] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to end impersonation" }, { status: 500 });
   }
-}
+}, ["super_admin"]);

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/lab/report-pdf — Generate a PDF report for a lab test order
+ * POST /api/lab/report-html — Generate an HTML report for a lab test order
  *
  * Body: { orderId, clinicId, patientName, orderNumber, results }
  *
@@ -7,11 +7,11 @@
  * Returns: { pdfUrl }
  */
 
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
 import { updateLabOrderPdfUrl } from "@/lib/data/server";
-import { createClient } from "@/lib/supabase-server";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
 
@@ -122,22 +122,8 @@ function generateLabReportHtml(data: {
 </html>`;
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { orderId, clinicId, patientName, orderNumber, results } = body;
 
@@ -189,7 +175,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ pdfUrl: url });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[POST /api/lab/report-html] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to generate lab report" }, { status: 500 });
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import {
   dispatchNotification,
   type NotificationTrigger,
@@ -6,7 +6,7 @@ import {
   type TemplateVariables,
 } from "@/lib/notifications";
 import type { NotificationChannel as DBNotificationChannel, UserRole } from "@/lib/types/database";
-import { createClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -16,31 +16,10 @@ export const runtime = "edge";
  * Dispatches a notification across configured channels.
  * Body: { trigger, variables, recipientId, channels }
  */
-export async function POST(request: NextRequest) {
+const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
+
+export const POST = withAuth(async (request) => {
   try {
-    const supabase = await createClient();
-
-    // Verify the caller is authenticated
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    // Only admins and staff roles can dispatch notifications
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-
-    const allowedRoles: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
-    if (!profile || !allowedRoles.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden — insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
 
     const {
@@ -76,7 +55,7 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     );
   }
-}
+}, STAFF_ROLES);
 
 /**
  * GET /api/notifications
@@ -84,35 +63,12 @@ export async function POST(request: NextRequest) {
  * Returns notification history for a user.
  * Query params: userId, channel, type, limit, offset
  */
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (request, { supabase, profile }) => {
   const searchParams = request.nextUrl.searchParams;
   const requestedUserId = searchParams.get("userId");
 
   try {
-    const supabase = await createClient();
-
-    // Verify the caller is authenticated
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    // Resolve the caller's profile
-    const { data: profile } = await supabase
-      .from("users")
-      .select("id, role")
-      .eq("auth_id", user.id)
-      .single();
-
-    if (!profile) {
-      return NextResponse.json({ error: "User profile not found" }, { status: 404 });
-    }
-
-    const staffRoles: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
-    const isStaff = staffRoles.includes(profile.role as UserRole);
+    const isStaff = STAFF_ROLES.includes(profile.role);
 
     // Non-staff users can only read their own notifications
     const userId = isStaff && requestedUserId ? requestedUserId : profile.id;
@@ -159,4 +115,4 @@ export async function GET(request: NextRequest) {
       { status: 500 },
     );
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/notifications/trigger/route.ts
+++ b/src/app/api/notifications/trigger/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import {
   dispatchNotification,
   defaultNotificationTemplates,
@@ -6,7 +6,7 @@ import {
   type TemplateVariables,
 } from "@/lib/notifications";
 import type { UserRole } from "@/lib/types/database";
-import { createClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -37,30 +37,8 @@ const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", 
  * - payment_received: When a payment is confirmed
  * - new_patient_registered: When a new patient registers
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request) => {
   try {
-    const supabase = await createClient();
-
-    // Verify the caller is authenticated
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    // Only staff roles can trigger notifications
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
 
     const {
@@ -119,4 +97,4 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     );
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -20,19 +20,8 @@ interface OnboardingRequestBody {
  * Inserts a clinic row with the clinic_type_key FK and creates the
  * clinic_admin user record.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase, user }) => {
   try {
-    const supabase = await createClient();
-
-    // Verify the caller is authenticated
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
     // Require email verification before allowing clinic creation
     if (!user.email_confirmed_at) {
       return NextResponse.json(
@@ -149,4 +138,4 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     );
   }
-}
+}, null);

--- a/src/app/api/payments/cmi/route.ts
+++ b/src/app/api/payments/cmi/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { createCmiPayment, isCmiConfigured } from "@/lib/cmi";
+import { withAuth } from "@/lib/with-auth";
 
 /**
  * POST /api/payments/cmi
@@ -18,7 +18,7 @@ import { createCmiPayment, isCmiConfigured } from "@/lib/cmi";
  *
  * Requires: CMI_MERCHANT_ID, CMI_SECRET_KEY env vars
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { user }) => {
   if (!isCmiConfigured()) {
     return NextResponse.json(
       { error: "CMI payment gateway is not configured. Set CMI_MERCHANT_ID and CMI_SECRET_KEY." },
@@ -27,15 +27,6 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
     const body = await request.json();
     const {
       amount,
@@ -88,8 +79,7 @@ export async function POST(request: NextRequest) {
       formFields: result.formFields,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("[CMI] Error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[CMI] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to create CMI payment" }, { status: 500 });
   }
-}
+}, null);

--- a/src/app/api/payments/create-checkout/route.ts
+++ b/src/app/api/payments/create-checkout/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/with-auth";
 
 /**
  * POST /api/payments/create-checkout
@@ -19,7 +19,7 @@ import { createClient } from "@/lib/supabase-server";
  *
  * Requires: STRIPE_SECRET_KEY env var
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { user }) => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
 
   if (!stripeSecretKey) {
@@ -30,15 +30,6 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
     const body = await request.json();
     const {
       amount,
@@ -99,7 +90,7 @@ export async function POST(request: NextRequest) {
     if (!stripeResponse.ok) {
       console.error("[Stripe] Checkout session error:", session.error?.message);
       return NextResponse.json(
-        { error: session.error?.message || "Failed to create checkout session" },
+        { error: "Failed to create checkout session" },
         { status: 400 },
       );
     }
@@ -109,8 +100,7 @@ export async function POST(request: NextRequest) {
       url: session.url,
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    console.error("[Payments] Error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[Payments] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to process payment" }, { status: 500 });
   }
-}
+}, null);

--- a/src/app/api/radiology/orders/route.ts
+++ b/src/app/api/radiology/orders/route.ts
@@ -7,33 +7,19 @@
  * PATCH body (save report): { orderId, action: "report", findings, impression, reportText, templateId?, radiologistId? }
  */
 
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   createRadiologyOrder,
   updateRadiologyOrderStatus,
   saveRadiologyReport,
 } from "@/lib/data/server";
-import { createClient } from "@/lib/supabase-server";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden — insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { clinicId, patientId, modality, bodyPart, clinicalIndication, priority, scheduledAt, orderingDoctorId } = body;
 
@@ -64,27 +50,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(result, { status: 201 });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[POST /api/radiology/orders] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to create radiology order" }, { status: 500 });
   }
-}
+}, STAFF_ROLES);
 
-export async function PATCH(request: NextRequest) {
+export const PATCH = withAuth(async (request) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden — insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
     const { orderId, action } = body;
 
@@ -142,7 +114,7 @@ export async function PATCH(request: NextRequest) {
       { status: 400 },
     );
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[PATCH /api/radiology/orders] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to update radiology order" }, { status: 500 });
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/radiology/report-pdf/route.ts
+++ b/src/app/api/radiology/report-pdf/route.ts
@@ -7,11 +7,11 @@
  * Returns: { pdfUrl }
  */
 
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
 import { updateRadiologyOrderPdfUrl } from "@/lib/data/server";
-import { createClient } from "@/lib/supabase-server";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
 
@@ -71,22 +71,8 @@ function generateReportHtml(data: {
 </html>`;
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request) => {
   try {
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-    const { data: profile } = await supabase
-      .from("users")
-      .select("role")
-      .eq("auth_id", user.id)
-      .single();
-    if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-      return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-    }
-
     const body = await request.json();
     const {
       orderId,
@@ -155,7 +141,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ pdfUrl: url });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[POST /api/radiology/report-pdf] Error:", err instanceof Error ? err.message : "Unknown error");
+    return NextResponse.json({ error: "Failed to generate radiology report" }, { status: 500 });
   }
-}
+}, STAFF_ROLES);

--- a/src/app/api/radiology/upload/route.ts
+++ b/src/app/api/radiology/upload/route.ts
@@ -11,11 +11,11 @@
  * Returns: { id, url, key }
  */
 
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
 import { createRadiologyImage } from "@/lib/data/server";
-import { createClient } from "@/lib/supabase-server";
 import type { UserRole } from "@/lib/types/database";
+import { withAuth } from "@/lib/with-auth";
 
 const STAFF_ROLES: UserRole[] = ["super_admin", "clinic_admin", "receptionist", "doctor"];
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB for medical images
@@ -31,21 +31,7 @@ const ALLOWED_TYPES = new Set([
   "application/octet-stream", // DICOM files often have this type
 ]);
 
-export async function POST(request: NextRequest) {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-  const { data: profile } = await supabase
-    .from("users")
-    .select("role")
-    .eq("auth_id", user.id)
-    .single();
-  if (!profile || !STAFF_ROLES.includes(profile.role as UserRole)) {
-    return NextResponse.json({ error: "Forbidden \u2014 insufficient permissions" }, { status: 403 });
-  }
-
+export const POST = withAuth(async (request) => {
   if (!isR2Configured()) {
     return NextResponse.json(
       { error: "File storage is not configured" },
@@ -117,4 +103,4 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ id: imageRecord.id, url, key });
-}
+}, STAFF_ROLES);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -13,14 +13,14 @@
  *   Returns: { uploadUrl: string, publicUrl: string, key: string }
  */
 
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import {
   uploadToR2,
   isR2Configured,
   buildUploadKey,
   getPresignedUploadUrl,
 } from "@/lib/r2";
-import { createClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -33,17 +33,7 @@ const ALLOWED_TYPES = new Set([
   "application/pdf",
 ]);
 
-export async function POST(request: NextRequest) {
-  // Verify authentication before accepting uploads
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
+export const POST = withAuth(async (request) => {
   if (!isR2Configured()) {
     return NextResponse.json(
       { error: "File storage is not configured" },
@@ -89,19 +79,9 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ url, key });
-}
+}, null);
 
-export async function GET(request: NextRequest) {
-  // Verify authentication before generating presigned URLs
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
+export const GET = withAuth(async (request) => {
   if (!isR2Configured()) {
     return NextResponse.json(
       { error: "File storage is not configured" },
@@ -144,4 +124,4 @@ export async function GET(request: NextRequest) {
     : null;
 
   return NextResponse.json({ uploadUrl, publicUrl, key });
-}
+}, null);

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -44,7 +44,8 @@ export async function GET(request: NextRequest) {
   const { data, count, error } = await query;
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[GET /api/v1/appointments] Query error:", error.message);
+    return NextResponse.json({ error: "Failed to fetch appointments" }, { status: 500 });
   }
 
   return NextResponse.json({
@@ -99,7 +100,8 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[POST /api/v1/appointments] Insert error:", error.message);
+    return NextResponse.json({ error: "Failed to create appointment" }, { status: 500 });
   }
 
   return NextResponse.json({ data }, { status: 201 });

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -45,7 +45,8 @@ export async function GET(request: NextRequest) {
   const { data, count, error } = await query;
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[GET /api/v1/patients] Query error:", error.message);
+    return NextResponse.json({ error: "Failed to fetch patients" }, { status: 500 });
   }
 
   return NextResponse.json({
@@ -91,7 +92,8 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[POST /api/v1/patients] Insert error:", error.message);
+    return NextResponse.json({ error: "Failed to create patient" }, { status: 500 });
   }
 
   return NextResponse.json({ data }, { status: 201 });

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase-server";
 import {
   dispatchNotification,
   type TemplateVariables,
@@ -49,9 +50,9 @@ async function verifyWebhookSignature(
 }
 
 /**
- * Extracts the message text from a WhatsApp webhook payload.
+ * Extracts the message text and sender phone from a WhatsApp webhook payload.
  */
-function extractMessageText(entry: Record<string, unknown>): string | null {
+function extractMessageInfo(entry: Record<string, unknown>): { text: string; senderPhone: string } | null {
   const changes = entry.changes as Array<Record<string, unknown>> | undefined;
   if (!changes) return null;
   for (const change of changes) {
@@ -61,7 +62,10 @@ function extractMessageText(entry: Record<string, unknown>): string | null {
     if (!messages) continue;
     for (const msg of messages) {
       const text = msg.text as Record<string, unknown> | undefined;
-      if (text && typeof text.body === "string") return text.body;
+      const from = msg.from as string | undefined;
+      if (text && typeof text.body === "string" && from) {
+        return { text: text.body, senderPhone: from };
+      }
     }
   }
   return null;
@@ -93,28 +97,66 @@ export async function POST(request: NextRequest) {
     const body = JSON.parse(rawBody) as Record<string, unknown>;
     const entries = (body.entry || []) as Array<Record<string, unknown>>;
 
-    for (const entry of entries) {
-      const messageText = extractMessageText(entry);
-      if (!messageText) continue;
+    const supabase = await createClient();
 
-      const upperText = messageText.trim().toUpperCase();
+    for (const entry of entries) {
+      const msgInfo = extractMessageInfo(entry);
+      if (!msgInfo) continue;
+
+      const upperText = msgInfo.text.trim().toUpperCase();
+
+      // Resolve patient and upcoming appointment from the sender's phone number
+      const { data: patient } = await supabase
+        .from("users")
+        .select("id, name, clinic_id")
+        .eq("phone", msgInfo.senderPhone)
+        .eq("role", "patient")
+        .limit(1)
+        .single();
+
+      const patientName = patient?.name ?? "Patient";
+      const patientId = patient?.id ?? null;
+
+      // Find the next upcoming appointment for this patient
+      let recipientId = patientId;
+      if (patient) {
+        const { data: appt } = await supabase
+          .from("appointments")
+          .select("id, doctor_id, status")
+          .eq("patient_id", patient.id)
+          .in("status", ["confirmed", "pending", "scheduled"])
+          .order("appointment_date", { ascending: true })
+          .limit(1)
+          .single();
+
+        if (upperText === "CONFIRM" && appt) {
+          await supabase
+            .from("appointments")
+            .update({ status: "confirmed" })
+            .eq("id", appt.id);
+        } else if (upperText === "CANCEL" && appt) {
+          await supabase
+            .from("appointments")
+            .update({ status: "cancelled", cancellation_reason: "Cancelled via WhatsApp" })
+            .eq("id", appt.id);
+        }
+
+        // Notify the relevant staff member (doctor assigned to the appointment)
+        recipientId = appt?.doctor_id ?? patientId;
+      }
 
       if (upperText === "CONFIRM") {
-        // Patient confirmed appointment via WhatsApp reply
-        // In production: update appointment status in Supabase
         await dispatchNotification(
           "booking_confirmation",
-          { patient_name: "Patient", clinic_name: "Clinic" } as TemplateVariables,
-          "receptionist",
+          { patient_name: patientName, clinic_name: "Clinic" } as TemplateVariables,
+          recipientId ?? "receptionist",
           ["in_app"],
         );
       } else if (upperText === "CANCEL") {
-        // Patient requested cancellation via WhatsApp reply
-        // In production: update appointment status and notify staff
         await dispatchNotification(
           "cancellation",
-          { patient_name: "Patient", clinic_name: "Clinic" } as TemplateVariables,
-          "receptionist",
+          { patient_name: patientName, clinic_name: "Clinic" } as TemplateVariables,
+          recipientId ?? "receptionist",
           ["in_app"],
         );
       }

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -140,34 +140,26 @@ export async function getPublicReviews(): Promise<PublicReview[]> {
   const clinicId = getClinicId();
   const supabase = await createClient();
 
-  // Fetch reviews with patient names via join
+  // Fetch reviews with patient names via Supabase join (single query)
   const { data: reviews, error } = await supabase
     .from("reviews")
-    .select("id, patient_id, stars, comment, response, created_at")
+    .select("id, stars, comment, response, created_at, patients:patient_id(name)")
     .eq("clinic_id", clinicId)
     .order("created_at", { ascending: false });
 
   if (error || !reviews || reviews.length === 0) return [];
 
-  // Get patient names
-  const patientIds = [...new Set(reviews.map((r) => r.patient_id))];
-  const { data: users } = await supabase
-    .from("users")
-    .select("id, name")
-    .in("id", patientIds);
-
-  const nameMap = new Map(
-    (users ?? []).map((u: { id: string; name: string }) => [u.id, u.name]),
-  );
-
-  return reviews.map((r) => ({
-    id: r.id,
-    patientName: nameMap.get(r.patient_id) ?? "Patient",
-    rating: r.stars,
-    comment: r.comment ?? "",
-    date: r.created_at?.split("T")[0] ?? "",
-    replied: !!r.response,
-  }));
+  return reviews.map((r) => {
+    const patient = r.patients as unknown as { name: string } | null;
+    return {
+      id: r.id,
+      patientName: patient?.name ?? "Patient",
+      rating: r.stars,
+      comment: r.comment ?? "",
+      date: r.created_at?.split("T")[0] ?? "",
+      replied: !!r.response,
+    };
+  });
 }
 
 export async function getPublicAverageRating(): Promise<number> {

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -1,0 +1,102 @@
+/**
+ * Shared authentication middleware for API route handlers.
+ *
+ * Eliminates the repeated boilerplate of:
+ *   1. createClient()
+ *   2. supabase.auth.getUser()
+ *   3. Fetch user profile from `users` table
+ *   4. Check role against allowed roles
+ *
+ * Usage:
+ *   export const POST = withAuth(handler, ["super_admin", "clinic_admin"]);
+ *
+ * The wrapped handler receives the original request plus an `auth` object
+ * containing the authenticated Supabase client, user, and profile.
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase-server";
+import type { UserRole } from "@/lib/types/database";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database";
+import type { User } from "@supabase/supabase-js";
+
+export interface AuthContext {
+  supabase: SupabaseClient<Database>;
+  user: User;
+  profile: { id: string; role: UserRole };
+}
+
+type AuthenticatedHandler = (
+  request: NextRequest,
+  auth: AuthContext,
+) => Promise<NextResponse>;
+
+/**
+ * Wraps a Next.js API route handler with authentication and role checks.
+ *
+ * @param handler - The route handler that receives the request and auth context
+ * @param allowedRoles - Array of roles permitted to access this endpoint.
+ *                       Pass `null` to skip role checking (auth-only).
+ */
+export function withAuth(
+  handler: AuthenticatedHandler,
+  allowedRoles: UserRole[] | null,
+) {
+  return async (request: NextRequest): Promise<NextResponse> => {
+    try {
+      const supabase = await createClient();
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        return NextResponse.json(
+          { error: "Not authenticated" },
+          { status: 401 },
+        );
+      }
+
+      // If no role checking needed, skip profile lookup
+      if (allowedRoles === null) {
+        return handler(request, {
+          supabase,
+          user,
+          profile: { id: user.id, role: "patient" as UserRole },
+        });
+      }
+
+      const { data: profile } = await supabase
+        .from("users")
+        .select("id, role")
+        .eq("auth_id", user.id)
+        .single();
+
+      if (!profile) {
+        return NextResponse.json(
+          { error: "User profile not found" },
+          { status: 404 },
+        );
+      }
+
+      if (!allowedRoles.includes(profile.role as UserRole)) {
+        return NextResponse.json(
+          { error: "Forbidden — insufficient permissions" },
+          { status: 403 },
+        );
+      }
+
+      return handler(request, {
+        supabase,
+        user,
+        profile: { id: profile.id, role: profile.role as UserRole },
+      });
+    } catch {
+      return NextResponse.json(
+        { error: "Authentication failed" },
+        { status: 500 },
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary

This PR implements 6 refactoring and cleanup tasks:

### OPT-01: Extract Auth Middleware
- Created `withAuth(handler, allowedRoles)` wrapper in `src/lib/with-auth.ts`
- Refactored 20+ route handlers to use the shared wrapper
- Eliminated ~300 lines of duplicated auth boilerplate
- Supports both role-checked and auth-only endpoints

### OPT-04: Fix N+1 Query in Reviews
- Combined 2 separate queries (reviews + patient names) into a single Supabase join
- Uses `.select("id, stars, comment, response, created_at, patients:patient_id(name)")`

### OPT-05: Add Limit to Cron Reminders
- Added `.limit(500)` to the appointments query in cron reminders

### LOW-02: Rename Lab Report Endpoint
- Renamed `report-pdf` to `report-html` (it generates HTML, not PDF)
- Updated all frontend references

### LOW-04: Fix Webhook Hardcoded Recipient
- Resolves actual patient/appointment from sender phone number
- Updates appointment status on CONFIRM/CANCEL
- Notifies the assigned doctor instead of hardcoded "receptionist"

### LOW-05: Sanitize Error Messages
- Replaced raw `error.message` in responses with generic user-facing messages
- Added `console.error` for server-side detailed logging

### Changes: 26 files changed, 319 insertions(+), 556 deletions(-)