### PR TITLE
refactor: DRY extract shared crypto utils (timingSafeEqual, sha256Hex, hmacSha256Hex)

### DIFF
--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
+import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 
 /**
  * POST /api/payments/webhook
@@ -145,32 +146,9 @@ async function verifyStripeSignature(
     if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
 
     const signedPayload = `${timestamp}.${payload}`;
-    const encoder = new TextEncoder();
-    const key = await crypto.subtle.importKey(
-      "raw",
-      encoder.encode(secret),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign"],
-    );
+    const expectedSignature = await hmacSha256Hex(secret, signedPayload);
 
-    const signatureBytes = await crypto.subtle.sign(
-      "HMAC",
-      key,
-      encoder.encode(signedPayload),
-    );
-
-    const expectedSignature = Array.from(new Uint8Array(signatureBytes))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-
-    // Constant-time comparison to prevent timing attacks
-    if (expectedSignature.length !== signature.length) return false;
-    let mismatch = 0;
-    for (let i = 0; i < expectedSignature.length; i++) {
-      mismatch |= expectedSignature.charCodeAt(i) ^ signature.charCodeAt(i);
-    }
-    return mismatch === 0;
+    return timingSafeEqual(expectedSignature, signature);
   } catch {
     return false;
   }

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -4,6 +4,7 @@ import {
   dispatchNotification,
   type TemplateVariables,
 } from "@/lib/notifications";
+import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 
 export const runtime = "edge";
 
@@ -22,31 +23,9 @@ async function verifyWebhookSignature(
   if (!signatureHeader.startsWith(expectedPrefix)) return false;
 
   const receivedSignature = signatureHeader.slice(expectedPrefix.length);
+  const computedSignature = await hmacSha256Hex(appSecret, rawBody);
 
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(appSecret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const signatureBuffer = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    encoder.encode(rawBody),
-  );
-  const computedSignature = Array.from(new Uint8Array(signatureBuffer))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  // Constant-time comparison to prevent timing attacks
-  if (computedSignature.length !== receivedSignature.length) return false;
-  let mismatch = 0;
-  for (let i = 0; i < computedSignature.length; i++) {
-    mismatch |= computedSignature.charCodeAt(i) ^ receivedSignature.charCodeAt(i);
-  }
-  return mismatch === 0;
+  return timingSafeEqual(computedSignature, receivedSignature);
 }
 
 /**

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -14,31 +14,7 @@
 
 import { type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase-server";
-
-/**
- * Compute a hex-encoded SHA-256 hash of the given value.
- * Uses the Web Crypto API available in edge runtimes.
- */
-async function sha256(value: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(value);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-/**
- * Constant-time string comparison to prevent timing attacks.
- */
-function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let mismatch = 0;
-  for (let i = 0; i < a.length; i++) {
-    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return mismatch === 0;
-}
+import { sha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 
 export async function authenticateApiKey(
   request: NextRequest,
@@ -52,7 +28,7 @@ export async function authenticateApiKey(
   const supabase = await createClient();
 
   // Compute hash of the provided key for comparison
-  const keyHash = await sha256(apiKey);
+  const keyHash = await sha256Hex(apiKey);
   const keyPrefix = apiKey.slice(0, 8);
 
   // Try hash-based lookup first (new keys)

--- a/src/lib/cmi.ts
+++ b/src/lib/cmi.ts
@@ -16,6 +16,8 @@
  *   CMI_GATEWAY_URL  — CMI gateway URL (defaults to production)
  */
 
+import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
+
 // ---- Types ----
 
 export interface CmiPaymentRequest {
@@ -83,25 +85,7 @@ async function generateHash(
 ): Promise<string> {
   const sortedKeys = Object.keys(fields).sort();
   const hashInput = sortedKeys.map((k) => fields[k]).join("|");
-
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secretKey),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-
-  const signature = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    encoder.encode(hashInput),
-  );
-
-  return Array.from(new Uint8Array(signature))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return hmacSha256Hex(secretKey, hashInput);
 }
 
 // ---- Payment Creation ----
@@ -192,14 +176,7 @@ export async function verifyCmiCallback(
   const received = receivedHash.toLowerCase();
 
   // Constant-time comparison to prevent timing attacks
-  if (expectedHash.length !== received.length) {
-    return null;
-  }
-  let mismatch = 0;
-  for (let i = 0; i < expectedHash.length; i++) {
-    mismatch |= expectedHash.charCodeAt(i) ^ received.charCodeAt(i);
-  }
-  if (mismatch !== 0) {
+  if (!timingSafeEqual(expectedHash, received)) {
     return null; // Invalid hash — potential tampering
   }
 

--- a/src/lib/crypto-utils.ts
+++ b/src/lib/crypto-utils.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared cryptographic utilities for signature verification and hashing.
+ *
+ * Uses the Web Crypto API available in edge runtimes (Cloudflare Workers,
+ * Vercel Edge, Next.js middleware, etc.).
+ */
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Both strings must be hex-encoded and equal length.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+/**
+ * Compute hex-encoded SHA-256 hash using Web Crypto API.
+ */
+export async function sha256Hex(value: string): Promise<string> {
+  const data = new TextEncoder().encode(value);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Compute hex-encoded HMAC-SHA256 using Web Crypto API.
+ */
+export async function hmacSha256Hex(
+  secret: string,
+  message: string,
+): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return Array.from(new Uint8Array(signature))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}


### PR DESCRIPTION
## Summary

Extracts duplicated constant-time string comparison and crypto hashing logic into a shared `src/lib/crypto-utils.ts` module.

### Problem
The same constant-time comparison loop and HMAC-SHA256 / SHA-256 implementations were copy-pasted across 4 files:
- `src/lib/api-auth.ts`
- `src/lib/cmi.ts`
- `src/app/api/webhooks/route.ts`
- `src/app/api/payments/webhook/route.ts`

### Solution
Created `src/lib/crypto-utils.ts` exporting three utilities:
- **`timingSafeEqual(a, b)`** — constant-time string comparison to prevent timing attacks
- **`sha256Hex(value)`** — hex-encoded SHA-256 hash via Web Crypto API
- **`hmacSha256Hex(secret, message)`** — hex-encoded HMAC-SHA256 via Web Crypto API

All 4 consumer files now import from the shared module instead of inlining the logic.

### Changes
| File | Change |
|------|--------|
| `src/lib/crypto-utils.ts` | **New** — shared crypto utilities |
| `src/lib/api-auth.ts` | Removed inline `sha256()` and `timingSafeEqual()`, imports from crypto-utils |
| `src/lib/cmi.ts` | Removed inline HMAC logic in `generateHash()`, replaced inline comparison loop with `timingSafeEqual()` |
| `src/app/api/webhooks/route.ts` | Removed inline HMAC + comparison logic, imports `hmacSha256Hex` + `timingSafeEqual` |
| `src/app/api/payments/webhook/route.ts` | Removed inline HMAC + comparison logic, imports `hmacSha256Hex` + `timingSafeEqual` |

**Net result:** 5 files changed, +64 lines, -103 lines

### Testing
- ESLint: ✓ passes
- TypeScript: ✓ no type errors
- No behavioral changes — purely a refactor extracting identical logic