### PR TITLE
fix: address 5 critical issues from security audit

### DIFF
--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
+import { withAuth } from "@/lib/with-auth";
 
 /** Build a timezone-aware Date for a date + time string using the clinic's timezone. */
 function clinicDateTime(dateStr: string, timeStr: string): Date {
@@ -23,15 +23,13 @@ export const runtime = "edge";
  *
  * Cancel an appointment if within the cancellation window.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
     const body = (await request.json()) as { appointmentId: string; reason?: string };
 
     if (!body.appointmentId) {
       return NextResponse.json({ error: "appointmentId is required" }, { status: 400 });
     }
-
-    const supabase = await createClient();
 
     // Fetch the appointment
     const { data: appt, error: fetchError } = await supabase
@@ -103,21 +101,19 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to cancel appointment" }, { status: 500 });
   }
-}
+}, null);
 
 /**
  * GET /api/booking/cancel?appointmentId=...
  *
  * Check if an appointment can be cancelled.
  */
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (request, { supabase }) => {
   const appointmentId = request.nextUrl.searchParams.get("appointmentId");
 
   if (!appointmentId) {
     return NextResponse.json({ error: "appointmentId is required" }, { status: 400 });
   }
-
-  const supabase = await createClient();
 
   const { data: appt, error } = await supabase
     .from("appointments")
@@ -150,4 +146,4 @@ export async function GET(request: NextRequest) {
   }
 
   return NextResponse.json({ canCancel: true, hoursRemaining: hoursUntilAppt });
-}
+}, null);

--- a/src/app/api/booking/emergency-slot/route.ts
+++ b/src/app/api/booking/emergency-slot/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { clinicConfig } from "@/config/clinic.config";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -9,7 +10,7 @@ export const runtime = "edge";
  *
  * Create an emergency slot (doctor only) or book an existing one.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
     const body = (await request.json()) as {
       action: "create" | "book";
@@ -25,8 +26,6 @@ export async function POST(request: NextRequest) {
       patientName?: string;
       serviceId?: string;
     };
-
-    const supabase = await createClient();
 
     if (body.action === "create") {
       if (!body.doctorId || !body.date || !body.startTime || !body.durationMin) {
@@ -87,20 +86,22 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // Fetch the emergency slot
-      const { data: slot, error: slotError } = await supabase
+      // ATOMIC: Claim the slot only if it is currently unbooked.
+      // This eliminates the TOCTOU race condition by combining check + update.
+      const { data: claimedSlot, error: claimError } = await supabase
         .from("emergency_slots")
-        .select("id, doctor_id, slot_date, start_time, end_time, is_booked")
+        .update({ is_booked: true })
         .eq("id", body.slotId)
         .eq("clinic_id", clinicConfig.clinicId)
+        .eq("is_booked", false)
+        .select("id, doctor_id, slot_date, start_time, end_time")
         .single();
 
-      if (slotError || !slot) {
-        return NextResponse.json({ error: "Emergency slot not found" }, { status: 404 });
-      }
-
-      if (slot.is_booked) {
-        return NextResponse.json({ error: "Emergency slot is already booked" }, { status: 400 });
+      if (claimError || !claimedSlot) {
+        return NextResponse.json(
+          { error: "Emergency slot is unavailable or already booked" },
+          { status: 409 },
+        );
       }
 
       // Find or create patient
@@ -131,17 +132,17 @@ export async function POST(request: NextRequest) {
         }
       }
 
-      // Create appointment from emergency slot
+      // Slot is now atomically claimed. Create the appointment.
       const { data: appointment, error: apptError } = await supabase
         .from("appointments")
         .insert({
           clinic_id: clinicConfig.clinicId,
           patient_id: patientId,
-          doctor_id: slot.doctor_id,
+          doctor_id: claimedSlot.doctor_id,
           service_id: body.serviceId ?? null,
-          appointment_date: slot.slot_date,
-          start_time: slot.start_time,
-          end_time: slot.end_time,
+          appointment_date: claimedSlot.slot_date,
+          start_time: claimedSlot.start_time,
+          end_time: claimedSlot.end_time,
           status: "confirmed",
           is_first_visit: false,
           insurance_flag: false,
@@ -152,21 +153,14 @@ export async function POST(request: NextRequest) {
         .single();
 
       if (apptError || !appointment) {
-        // Handle unique constraint violation (double-booking race condition)
-        if (apptError?.code === "23505") {
-          return NextResponse.json(
-            { error: "This slot has already been booked. Please choose another time." },
-            { status: 409 },
-          );
-        }
+        // Rollback: release the slot claim if appointment creation fails
+        await supabase
+          .from("emergency_slots")
+          .update({ is_booked: false })
+          .eq("id", body.slotId);
+
         return NextResponse.json({ error: "Failed to create appointment" }, { status: 500 });
       }
-
-      // Mark slot as booked
-      await supabase
-        .from("emergency_slots")
-        .update({ is_booked: true })
-        .eq("id", body.slotId);
 
       return NextResponse.json({
         status: "booked",
@@ -179,7 +173,7 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to process emergency slot request" }, { status: 500 });
   }
-}
+}, null);
 
 /**
  * GET /api/booking/emergency-slot?doctorId=...&date=...

--- a/src/app/api/booking/recurring/route.ts
+++ b/src/app/api/booking/recurring/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import { getPublicServices } from "@/lib/data/public";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -18,7 +18,7 @@ function addInterval(date: Date, pattern: "weekly" | "biweekly" | "monthly"): Da
  *
  * Create a recurring booking series or cancel one.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
     const body = (await request.json()) as {
       action: "create" | "cancel";
@@ -38,8 +38,6 @@ export async function POST(request: NextRequest) {
       cancelAll?: boolean;
       appointmentId?: string;
     };
-
-    const supabase = await createClient();
 
     if (body.action === "create") {
       if (!body.patientId || !body.patientName || !body.doctorId || !body.date || !body.time || !body.pattern || !body.occurrences) {
@@ -114,7 +112,8 @@ export async function POST(request: NextRequest) {
             is_first_visit: i === 0 ? (body.isFirstVisit ?? false) : false,
             insurance_flag: body.hasInsurance ?? false,
             booking_source: "online",
-            notes: `Recurring: ${body.pattern} (${i + 1}/${body.occurrences}) group:${groupId}`,
+            recurrence_group_id: groupId,
+            notes: `Recurring: ${body.pattern} (${i + 1}/${body.occurrences})`,
             is_emergency: false,
           } as never)
           .select("id")
@@ -184,4 +183,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to process recurring booking" }, { status: 500 });
   }
-}
+}, null);

--- a/src/app/api/booking/reschedule/route.ts
+++ b/src/app/api/booking/reschedule/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/with-auth";
+import { clinicConfig } from "@/config/clinic.config";
 
 export const runtime = "edge";
 
@@ -8,7 +9,7 @@ export const runtime = "edge";
  *
  * Reschedule an existing appointment to a new date/time.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
     const body = (await request.json()) as {
       appointmentId: string;
@@ -31,17 +32,24 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid time format (expected HH:MM)" }, { status: 400 });
     }
 
-    const supabase = await createClient();
-
     // Get the existing appointment
     const { data: existing, error: fetchError } = await supabase
       .from("appointments")
-      .select("*")
+      .select("id, status, clinic_id")
       .eq("id", body.appointmentId)
+      .eq("clinic_id", clinicConfig.clinicId)
       .single();
 
     if (fetchError || !existing) {
       return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
+    }
+
+    // Only allow rescheduling appointments in a valid state
+    if (existing.status === "cancelled" || existing.status === "completed" || existing.status === "rescheduled") {
+      return NextResponse.json(
+        { error: "Appointment cannot be rescheduled in its current state" },
+        { status: 400 },
+      );
     }
 
     // Update the existing appointment with new date/time
@@ -50,7 +58,7 @@ export async function POST(request: NextRequest) {
       .update({
         appointment_date: body.newDate,
         start_time: body.newTime,
-        status: "confirmed",
+        status: "rescheduled",
       })
       .eq("id", body.appointmentId);
 
@@ -66,4 +74,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to reschedule appointment" }, { status: 500 });
   }
-}
+}, null);

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
+import { withAuth } from "@/lib/with-auth";
 
 export const runtime = "edge";
 
@@ -9,7 +9,7 @@ export const runtime = "edge";
  *
  * Add a patient to the waiting list.
  */
-export async function POST(request: NextRequest) {
+export const POST = withAuth(async (request, { supabase }) => {
   try {
     const body = (await request.json()) as {
       patientId: string;
@@ -26,8 +26,6 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
-
-    const supabase = await createClient();
 
     // If patientId looks like a temp ID, try to find or create the patient
     let patientId = body.patientId;
@@ -87,20 +85,19 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to add to waiting list" }, { status: 500 });
   }
-}
+}, null);
 
 /**
  * GET /api/booking/waiting-list?patientId=...  OR  ?doctorId=...&date=...
  *
  * Get waiting list entries.
  */
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (request, { supabase }) => {
   const patientId = request.nextUrl.searchParams.get("patientId");
   const doctorId = request.nextUrl.searchParams.get("doctorId");
   const date = request.nextUrl.searchParams.get("date");
   const time = request.nextUrl.searchParams.get("time");
 
-  const supabase = await createClient();
   const clinicId = clinicConfig.clinicId;
 
   if (patientId) {
@@ -134,14 +131,14 @@ export async function GET(request: NextRequest) {
     { error: "patientId, or doctorId and date are required" },
     { status: 400 },
   );
-}
+}, null);
 
 /**
  * DELETE /api/booking/waiting-list
  *
  * Remove a patient from the waiting list.
  */
-export async function DELETE(request: NextRequest) {
+export const DELETE = withAuth(async (request, { supabase }) => {
   try {
     const body = (await request.json()) as { entryId: string };
 
@@ -149,7 +146,6 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: "entryId is required" }, { status: 400 });
     }
 
-    const supabase = await createClient();
     const { error } = await supabase
       .from("waiting_list")
       .delete()
@@ -164,4 +160,4 @@ export async function DELETE(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Failed to remove from waiting list" }, { status: 500 });
   }
-}
+}, null);

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -28,14 +28,15 @@ export async function POST(request: NextRequest) {
     const supabase = await createClient();
 
     if (callbackData.status === "approved") {
-      // Find and update the payment by order ID (stored as gateway_session_id)
+      // Find the payment by order ID (stored as gateway_session_id)
+      // Only process if not already completed (idempotency check)
       const { data: payment } = await supabase
         .from("payments")
-        .select("id, appointment_id")
+        .select("id, appointment_id, status")
         .eq("gateway_session_id", callbackData.orderId)
         .single();
 
-      if (payment) {
+      if (payment && payment.status !== "completed") {
         // Mark payment as completed
         await supabase
           .from("payments")

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -74,18 +74,21 @@ export async function POST(request: NextRequest) {
         const patientId = session.metadata?.patient_id;
         const clinicId = session.metadata?.clinic_id;
 
-        // Record payment in Supabase
+        // Record payment in Supabase (idempotent via upsert on reference)
         if (clinicId && patientId) {
-          await supabase.from("payments").insert({
-            clinic_id: clinicId,
-            patient_id: patientId,
-            appointment_id: appointmentId || null,
-            amount: (session.amount_total || 0) / 100, // Convert from centimes
-            method: "online",
-            status: "completed",
-            reference: session.id,
-            payment_type: "full",
-          });
+          await supabase.from("payments").upsert(
+            {
+              clinic_id: clinicId,
+              patient_id: patientId,
+              appointment_id: appointmentId || null,
+              amount: (session.amount_total || 0) / 100, // Convert from centimes
+              method: "online",
+              status: "completed",
+              reference: session.id,
+              payment_type: "full",
+            },
+            { onConflict: "reference" },
+          );
         }
 
         // Update appointment payment status if applicable

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -15,6 +15,16 @@
 
 const RESEND_API_URL = "https://api.resend.com/emails";
 
+/** Escape HTML special characters to prevent injection in email templates. */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export interface EmailSendResult {
   success: boolean;
   messageId?: string;
@@ -156,7 +166,9 @@ export async function sendNotificationEmail(
   body: string,
   clinicName?: string,
 ): Promise<EmailSendResult> {
-  const brandName = clinicName || "Health SaaS Platform";
+  const safeBrandName = escapeHtml(clinicName || "Health SaaS Platform");
+  const safeSubject = escapeHtml(subject);
+  const safeBody = escapeHtml(body);
 
   const html = `
 <!DOCTYPE html>
@@ -166,21 +178,21 @@ export async function sendNotificationEmail(
   <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;background:#ffffff;">
     <tr>
       <td style="padding:24px 32px;background:#0f172a;color:#ffffff;">
-        <h1 style="margin:0;font-size:20px;font-weight:600;">${brandName}</h1>
+        <h1 style="margin:0;font-size:20px;font-weight:600;">${safeBrandName}</h1>
       </td>
     </tr>
     <tr>
       <td style="padding:32px;">
-        <h2 style="margin:0 0 16px;font-size:18px;color:#1e293b;">${subject}</h2>
+        <h2 style="margin:0 0 16px;font-size:18px;color:#1e293b;">${safeSubject}</h2>
         <div style="font-size:14px;line-height:1.6;color:#475569;">
-          ${body}
+          ${safeBody}
         </div>
       </td>
     </tr>
     <tr>
       <td style="padding:16px 32px;background:#f8fafc;border-top:1px solid #e2e8f0;text-align:center;">
         <p style="margin:0;font-size:12px;color:#94a3b8;">
-          ${brandName} &mdash; Plateforme de gestion m&eacute;dicale
+          ${safeBrandName} &mdash; Plateforme de gestion m&eacute;dicale
         </p>
       </td>
     </tr>


### PR DESCRIPTION
## Summary

Addresses 5 critical issues identified in the deep analysis security audit.

### Changes

1. **Add authentication to booking endpoints** (S1 - CRITICAL)
   - Wrapped `cancel`, `reschedule`, `recurring`, `emergency-slot`, and `waiting-list` endpoints with `withAuth()` — all mutation and query endpoints now require authentication.

2. **Add idempotency to payment webhooks** (S3/S4 - HIGH)
   - Stripe webhook: Changed `insert` to `upsert` with `onConflict: "reference"` to prevent duplicate payment records on webhook retries.
   - CMI callback: Added status check — skips processing if payment is already `completed`.

3. **Fix recurring booking `recurrence_group_id`** (L2 - HIGH)
   - Store `groupId` in the `recurrence_group_id` column during appointment creation instead of only embedding it in free-text notes. This fixes group cancellation which was completely broken.

4. **Fix emergency slot booking race condition** (L1 - HIGH)
   - Replaced TOCTOU check-then-act pattern with an atomic `UPDATE ... WHERE is_booked = false`. If the slot is already booked, the update returns no rows and the request is rejected with 409.
   - Added rollback: if appointment creation fails after claiming the slot, the slot is released.

5. **HTML-escape email template variables** (S5 - HIGH)
   - Added `escapeHtml()` utility that escapes `&`, `<`, `>`, `"`, `'` in `brandName`, `subject`, and `body` before interpolation into the HTML email template. Prevents stored XSS via email.

### Bonus fixes included
- **Reschedule status validation** (L3): Added check to reject rescheduling of `cancelled`, `completed`, or already `rescheduled` appointments. Status is now set to `rescheduled` instead of `confirmed`.
- **Clinic-scoped queries**: Added `clinic_id` filter to reschedule endpoint queries.
- **Cleaned up unused imports**: Removed `createClient` and `NextRequest` imports that are no longer needed after `withAuth` refactor.