### PR TITLE
fix(M2): Add error logging to bare catch blocks in API routes

### DIFF
--- a/src/app/api/booking/payment/confirm/route.ts
+++ b/src/app/api/booking/payment/confirm/route.ts
@@ -57,7 +57,8 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ status: "confirmed", message: "Payment confirmed" });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/booking/payment/confirm] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json({ error: "Failed to confirm payment" }, { status: 500 });
   }
 }, STAFF_ROLES);

--- a/src/app/api/booking/payment/initiate/route.ts
+++ b/src/app/api/booking/payment/initiate/route.ts
@@ -133,7 +133,8 @@ export const POST = withAuth(async (request, { supabase }) => {
       paymentId: payment.id,
       gatewaySessionId,
     });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/booking/payment/initiate] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json({ error: "Failed to initiate payment" }, { status: 500 });
   }
 }, STAFF_ROLES);

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -71,7 +71,8 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ status: "refunded", message: "Payment refunded" });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/booking/payment/refund] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json({ error: "Failed to refund payment" }, { status: 500 });
   }
 }, ADMIN_ROLES);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -248,7 +248,8 @@ export async function POST(request: NextRequest) {
         Connection: "keep-alive",
       },
     });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/chat] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Failed to process chat message" },
       { status: 500 },

--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -108,7 +108,8 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ definition: data }, { status: 201 });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/custom-fields] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Invalid request body" },
       { status: 400 },
@@ -164,7 +165,8 @@ export const PATCH = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ definition: data });
-  } catch {
+  } catch (err) {
+    console.error("[PATCH /api/custom-fields] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Invalid request body" },
       { status: 400 },

--- a/src/app/api/custom-fields/values/route.ts
+++ b/src/app/api/custom-fields/values/route.ts
@@ -135,7 +135,8 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ values: data });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/custom-fields/values] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Invalid request body" },
       { status: 400 },
@@ -245,7 +246,8 @@ export const PATCH = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ values: data });
-  } catch {
+  } catch (err) {
+    console.error("[PATCH /api/custom-fields/values] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Invalid request body" },
       { status: 400 },

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -66,7 +66,8 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     );
 
     return NextResponse.json({ results });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/notifications] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Failed to dispatch notification" },
       { status: 500 },
@@ -126,7 +127,8 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
       notifications: notifications ?? [],
       total: count ?? 0,
     });
-  } catch {
+  } catch (err) {
+    console.error("[GET /api/notifications] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Failed to fetch notifications" },
       { status: 500 },

--- a/src/app/api/notifications/trigger/route.ts
+++ b/src/app/api/notifications/trigger/route.ts
@@ -115,7 +115,8 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       template: template.name,
       dispatched: allResults,
     });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/notifications/trigger] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Failed to trigger notification" },
       { status: 500 },

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -141,7 +141,8 @@ export const POST = withAuth(async (request, { supabase, user }) => {
       message: "Clinic registered successfully",
       clinic_id: clinic.id,
     });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/onboarding] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Failed to process onboarding" },
       { status: 500 },

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -152,7 +152,8 @@ async function verifyStripeSignature(
     const expectedSignature = await hmacSha256Hex(secret, signedPayload);
 
     return timingSafeEqual(expectedSignature, signature);
-  } catch {
+  } catch (err) {
+    console.error("[Stripe Webhook] Signature verification error:", err instanceof Error ? err.message : "Unknown error");
     return false;
   }
 }

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -143,7 +143,8 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ status: "ok" });
-  } catch {
+  } catch (err) {
+    console.error("[POST /api/webhooks] Error:", err instanceof Error ? err.message : "Unknown error");
     return NextResponse.json(
       { error: "Failed to process webhook" },
       { status: 500 },


### PR DESCRIPTION
## Summary

Fixes issue M2 from the deep analysis report: bare `catch {}` blocks in API routes that swallow errors without logging.

### Changes

Replaced all bare `catch {}` blocks with `catch (err)` and added `console.error` logging following the established pattern from `impersonate/route.ts`:

```ts
} catch (err) {
  console.error("[METHOD /api/endpoint] Error:", err instanceof Error ? err.message : "Unknown error");
  return NextResponse.json({ error: "..." }, { status: 500 });
}
```

### Files Modified (11 files)

- `src/app/api/custom-fields/values/route.ts` (POST, PATCH)
- `src/app/api/custom-fields/route.ts` (POST, PATCH)
- `src/app/api/onboarding/route.ts` (POST)
- `src/app/api/notifications/route.ts` (POST, GET)
- `src/app/api/notifications/trigger/route.ts` (POST)
- `src/app/api/webhooks/route.ts` (POST)
- `src/app/api/booking/payment/refund/route.ts` (POST)
- `src/app/api/booking/payment/confirm/route.ts` (POST)
- `src/app/api/booking/payment/initiate/route.ts` (POST)
- `src/app/api/payments/webhook/route.ts` (verifyStripeSignature)
- `src/app/api/chat/route.ts` (POST)

### Verification

- ✅ ESLint passes
- ✅ TypeScript typecheck passes
- ✅ No new dependencies added

---

[Devin session](https://app.devin.ai/sessions/1e4f80bdb8834b9a9f84e6a544492812)