### PR TITLE
fix: address 5 more issues from deep analysis report (batch 2)

### DIFF
--- a/src/app/api/booking/payment/confirm/route.ts
+++ b/src/app/api/booking/payment/confirm/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { logAuditEvent } from "@/lib/audit-log";
 import { clinicConfig } from "@/config/clinic.config";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import type { UserRole } from "@/lib/types/database";
@@ -56,6 +57,14 @@ export const POST = withAuth(async (request, { supabase }) => {
         .eq("id", payment.appointment_id)
         .in("status", [APPOINTMENT_STATUS.PENDING, APPOINTMENT_STATUS.SCHEDULED]);
     }
+
+    await logAuditEvent({
+      supabase,
+      action: "payment_confirmed",
+      type: "payment",
+      clinicId: clinicConfig.clinicId,
+      description: `Payment ${body.paymentId} confirmed`,
+    });
 
     return NextResponse.json({ status: "confirmed", message: "Payment confirmed" });
   } catch (err) {

--- a/src/app/api/booking/payment/initiate/route.ts
+++ b/src/app/api/booking/payment/initiate/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
+import { logAuditEvent } from "@/lib/audit-log";
 import { clinicConfig } from "@/config/clinic.config";
+import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 import type { UserRole } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
 
@@ -28,6 +30,11 @@ export const POST = withAuth(async (request, { supabase }) => {
         { error: "appointmentId, patientId, patientName, amount, and paymentType are required" },
         { status: 400 },
       );
+    }
+
+    // Input length validation to prevent DoS via oversized payloads
+    if (body.patientName.length > 200) {
+      return NextResponse.json({ error: "Patient name exceeds maximum allowed length" }, { status: 400 });
     }
 
     // Validate payment amount is a positive finite number
@@ -68,32 +75,13 @@ export const POST = withAuth(async (request, { supabase }) => {
       return NextResponse.json({ error: "A payment already exists for this appointment" }, { status: 400 });
     }
 
-    // Find or create patient
-    let patientId = body.patientId;
-    if (patientId.startsWith("patient-")) {
-      const { data: existing } = await supabase
-        .from("users")
-        .select("id")
-        .eq("clinic_id", clinicConfig.clinicId)
-        .eq("name", body.patientName)
-        .eq("role", "patient")
-        .limit(1)
-        .single();
-
-      if (existing) {
-        patientId = existing.id;
-      } else {
-        const { data: newPatient } = await supabase
-          .from("users")
-          .insert({
-            clinic_id: clinicConfig.clinicId,
-            name: body.patientName,
-            role: "patient",
-          })
-          .select("id")
-          .single();
-        if (newPatient) patientId = newPatient.id;
-      }
+    // Find or create patient using shared utility (prefers phone-based lookup
+    // over name-based to avoid assigning payments to the wrong patient).
+    const patientId = await findOrCreatePatient(
+      supabase, clinicConfig.clinicId, body.patientId, body.patientName,
+    );
+    if (!patientId) {
+      return NextResponse.json({ error: "Failed to resolve patient" }, { status: 500 });
     }
 
     const method = body.method ?? "online";
@@ -126,6 +114,14 @@ export const POST = withAuth(async (request, { supabase }) => {
       console.error("[POST /api/booking/payment/initiate] Insert error:", insertError?.message);
       return NextResponse.json({ error: "Failed to initiate payment" }, { status: 500 });
     }
+
+    await logAuditEvent({
+      supabase,
+      action: "payment_initiated",
+      type: "payment",
+      clinicId: clinicConfig.clinicId,
+      description: `Payment initiated: ${body.paymentType} ${body.amount} via ${method} for appointment ${body.appointmentId}`,
+    });
 
     return NextResponse.json({
       status: "initiated",

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { logAuditEvent } from "@/lib/audit-log";
 import { clinicConfig } from "@/config/clinic.config";
 import type { UserRole } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
@@ -20,10 +21,10 @@ export const POST = withAuth(async (request, { supabase }) => {
       return NextResponse.json({ error: "paymentId is required" }, { status: 400 });
     }
 
-    // Fetch the payment
+    // Fetch the payment (include refunded_amount to track cumulative refunds)
     const { data: payment, error: fetchError } = await supabase
       .from("payments")
-      .select("id, status, amount")
+      .select("id, status, amount, refunded_amount")
       .eq("id", body.paymentId)
       .eq("clinic_id", clinicConfig.clinicId)
       .single();
@@ -32,8 +33,8 @@ export const POST = withAuth(async (request, { supabase }) => {
       return NextResponse.json({ error: "Payment not found" }, { status: 404 });
     }
 
-    if (payment.status !== "completed") {
-      return NextResponse.json({ error: "Only completed payments can be refunded" }, { status: 400 });
+    if (payment.status !== "completed" && payment.status !== "partially_refunded") {
+      return NextResponse.json({ error: "Only completed or partially refunded payments can be refunded" }, { status: 400 });
     }
 
     const refundAmount = body.amount ?? payment.amount;
@@ -50,18 +51,24 @@ export const POST = withAuth(async (request, { supabase }) => {
       );
     }
 
-    if (refundAmount > payment.amount) {
+    const alreadyRefunded = (payment.refunded_amount as number) ?? 0;
+    const remaining = payment.amount - alreadyRefunded;
+
+    if (refundAmount > remaining) {
       return NextResponse.json(
-        { error: `Refund amount cannot exceed original payment amount (${payment.amount})` },
+        { error: `Refund amount (${refundAmount}) exceeds remaining refundable amount (${remaining})` },
         { status: 400 },
       );
     }
 
+    const newRefundedTotal = alreadyRefunded + refundAmount;
+    const isFullyRefunded = newRefundedTotal >= payment.amount;
+
     const { error: updateError } = await supabase
       .from("payments")
       .update({
-        status: "refunded",
-        refunded_amount: refundAmount,
+        status: isFullyRefunded ? "refunded" : "partially_refunded",
+        refunded_amount: newRefundedTotal,
       })
       .eq("id", body.paymentId);
 
@@ -69,6 +76,14 @@ export const POST = withAuth(async (request, { supabase }) => {
       console.error("[POST /api/booking/payment/refund] Update error:", updateError.message);
       return NextResponse.json({ error: "Failed to refund payment" }, { status: 500 });
     }
+
+    await logAuditEvent({
+      supabase,
+      action: "payment_refunded",
+      type: "payment",
+      clinicId: clinicConfig.clinicId,
+      description: `Payment ${body.paymentId} refunded: ${refundAmount} of ${payment.amount}`,
+    });
 
     return NextResponse.json({ status: "refunded", message: "Payment refunded" });
   } catch (err) {

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { verifyCmiCallback } from "@/lib/cmi";
+import { APPOINTMENT_STATUS } from "@/lib/types/database";
 
 /**
  * POST /api/payments/cmi/callback
@@ -50,9 +51,9 @@ export async function POST(request: NextRequest) {
         if (payment.appointment_id) {
           await supabase
             .from("appointments")
-            .update({ status: "confirmed" })
+            .update({ status: APPOINTMENT_STATUS.CONFIRMED })
             .eq("id", payment.appointment_id)
-            .in("status", ["pending", "scheduled"]);
+            .in("status", [APPOINTMENT_STATUS.PENDING, APPOINTMENT_STATUS.SCHEDULED]);
         }
       }
 

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
+import { APPOINTMENT_STATUS } from "@/lib/types/database";
 
 /**
  * POST /api/payments/webhook
@@ -95,9 +96,9 @@ export async function POST(request: NextRequest) {
         if (appointmentId) {
           await supabase
             .from("appointments")
-            .update({ status: "confirmed" })
+            .update({ status: APPOINTMENT_STATUS.CONFIRMED })
             .eq("id", appointmentId)
-            .eq("status", "pending");
+            .eq("status", APPOINTMENT_STATUS.PENDING);
         }
 
         console.log(`[Stripe Webhook] Payment completed: ${session.id}`);


### PR DESCRIPTION
## 5 More Fixes from Deep Analysis Report (Batch 2)

Continuation of PR #121 — addresses 5 additional issues identified in the deep analysis report.

### Changes

1. **Fix 6 (M4/L4/5.2): Replace inline patient find-or-create in `payment/initiate`**
   - Replaced duplicated name-based patient lookup with shared `findOrCreatePatient` utility
   - Prefers phone-based lookup to avoid wrong-patient association from name collisions
   - Added input length validation on `patientName` (max 200 chars)

2. **Fix 7 (M3): APPOINTMENT_STATUS constants in Stripe webhook**
   - Replaced magic strings `"confirmed"` / `"pending"` with `APPOINTMENT_STATUS.CONFIRMED` / `.PENDING`

3. **Fix 8 (M3): APPOINTMENT_STATUS constants in CMI callback**
   - Replaced magic strings `"confirmed"` / `"pending"` / `"scheduled"` with type-safe constants

4. **Fix 9 (Healthcare Compliance): Audit logging for payment mutations**
   - Added `logAuditEvent()` calls to `payment/initiate`, `payment/confirm`, and `payment/refund`
   - Logs payment type, amount, method, and appointment association

5. **Fix 10 (Partial Refund Bug): Cumulative refund tracking**
   - Now fetches `refunded_amount` to validate against cumulative total
   - Prevents over-refund: validates `refundAmount <= remaining refundable`
   - Supports `partially_refunded` status for partial refunds
   - Allows further refunds on partially-refunded payments

### Files Changed
- `src/app/api/booking/payment/initiate/route.ts`
- `src/app/api/booking/payment/confirm/route.ts`
- `src/app/api/booking/payment/refund/route.ts`
- `src/app/api/payments/webhook/route.ts`
- `src/app/api/payments/cmi/callback/route.ts`