### PR TITLE
fix: 5 more issues — waiting-list constants, shared patient utility, audit logging, booking-source constants

### DIFF
--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import { withAuth } from "@/lib/with-auth";
-import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import { APPOINTMENT_STATUS, WAITING_LIST_STATUS } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
 
 /**
@@ -135,7 +135,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       .eq("clinic_id", clinicConfig.clinicId)
       .eq("doctor_id", appt.doctor_id)
       .eq("preferred_date", appt.appointment_date)
-      .eq("status", "waiting")
+      .eq("status", WAITING_LIST_STATUS.WAITING)
       .order("created_at", { ascending: true })
       .limit(1)
       .single();
@@ -143,7 +143,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     if (candidate) {
       await supabase
         .from("waiting_list")
-        .update({ status: "notified", notified_at: new Date().toISOString() })
+        .update({ status: WAITING_LIST_STATUS.NOTIFIED, notified_at: new Date().toISOString() })
         .eq("id", candidate.id);
     }
 

--- a/src/app/api/booking/emergency-slot/route.ts
+++ b/src/app/api/booking/emergency-slot/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import { withAuth } from "@/lib/with-auth";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
-import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
+import { logAuditEvent } from "@/lib/audit-log";
 
 export const runtime = "edge";
 
@@ -149,7 +150,7 @@ export const POST = withAuth(async (request, { supabase }) => {
           status: APPOINTMENT_STATUS.CONFIRMED,
           is_first_visit: false,
           insurance_flag: false,
-          booking_source: "online",
+          booking_source: BOOKING_SOURCE.ONLINE,
           is_emergency: true,
         })
         .select("id")
@@ -164,6 +165,15 @@ export const POST = withAuth(async (request, { supabase }) => {
 
         return NextResponse.json({ error: "Failed to create appointment" }, { status: 500 });
       }
+
+      // Audit log for healthcare compliance
+      await logAuditEvent({
+        supabase,
+        action: "appointment.emergency_booked",
+        type: "booking",
+        clinicId: clinicConfig.clinicId,
+        description: `Emergency appointment ${appointment.id} created for patient ${patientId} with doctor ${claimedSlot.doctor_id} on ${claimedSlot.slot_date}`,
+      });
 
       return NextResponse.json({
         status: "booked",

--- a/src/app/api/booking/recurring/route.ts
+++ b/src/app/api/booking/recurring/route.ts
@@ -3,7 +3,7 @@ import { clinicConfig } from "@/config/clinic.config";
 import { getPublicServices } from "@/lib/data/public";
 import { withAuth } from "@/lib/with-auth";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
-import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
 import type { TablesInsert } from "@/lib/types/database";
 
 export const runtime = "edge";
@@ -118,7 +118,7 @@ export const POST = withAuth(async (request, { supabase }) => {
           status: APPOINTMENT_STATUS.SCHEDULED,
           is_first_visit: insertIndex === 0 ? (body.isFirstVisit ?? false) : false,
           insurance_flag: body.hasInsurance ?? false,
-          booking_source: "online",
+          booking_source: BOOKING_SOURCE.ONLINE,
           recurrence_group_id: groupId,
           notes: `Recurring: ${body.pattern} (${insertIndex + 1}/${body.occurrences})`,
           is_emergency: false,

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -9,8 +9,9 @@ import {
   getPublicSpecialties,
 } from "@/lib/data/public";
 import { createClient } from "@/lib/supabase-server";
-import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
+import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 
 export const runtime = "edge";
 
@@ -135,35 +136,14 @@ export async function POST(request: NextRequest) {
 
     const supabase = await createClient();
 
-    // Find or create a patient record
-    let patientId: string;
-    const { data: existingPatient } = await supabase
-      .from("users")
-      .select("id")
-      .eq("clinic_id", clinicConfig.clinicId)
-      .eq("phone", body.patient.phone)
-      .eq("role", "patient")
-      .single();
-
-    if (existingPatient) {
-      patientId = existingPatient.id;
-    } else {
-      const { data: newPatient, error: patientError } = await supabase
-        .from("users")
-        .insert({
-          clinic_id: clinicConfig.clinicId,
-          name: body.patient.name,
-          phone: body.patient.phone,
-          email: body.patient.email ?? null,
-          role: "patient",
-        })
-        .select("id")
-        .single();
-
-      if (patientError || !newPatient) {
-        return NextResponse.json({ error: "Failed to create patient record" }, { status: 500 });
-      }
-      patientId = newPatient.id;
+    // Find or create a patient record using the shared utility
+    // (prefers phone-based lookup to avoid name collisions)
+    const patientId = await findOrCreatePatient(
+      supabase, clinicConfig.clinicId, "patient-new", body.patient.name,
+      { phone: body.patient.phone, email: body.patient.email },
+    );
+    if (!patientId) {
+      return NextResponse.json({ error: "Failed to create patient record" }, { status: 500 });
     }
 
     // Calculate end time
@@ -191,7 +171,7 @@ export async function POST(request: NextRequest) {
         status: APPOINTMENT_STATUS.CONFIRMED,
         is_first_visit: body.isFirstVisit,
         insurance_flag: body.hasInsurance,
-        booking_source: "online",
+        booking_source: BOOKING_SOURCE.ONLINE,
         notes: body.patient.reason ?? null,
         is_emergency: false,
       })

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { clinicConfig } from "@/config/clinic.config";
 import { withAuth } from "@/lib/with-auth";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
+import { logAuditEvent } from "@/lib/audit-log";
+import { WAITING_LIST_STATUS } from "@/lib/types/database";
 
 export const runtime = "edge";
 
@@ -52,7 +54,7 @@ export const POST = withAuth(async (request, { supabase }) => {
         preferred_date: body.preferredDate,
         preferred_time: body.preferredTime ?? null,
         service_id: body.serviceId ?? null,
-        status: "waiting",
+        status: WAITING_LIST_STATUS.WAITING,
       })
       .select("id")
       .single();
@@ -61,6 +63,15 @@ export const POST = withAuth(async (request, { supabase }) => {
       console.error("[POST /api/booking/waiting-list] Error:", error?.message);
       return NextResponse.json({ error: "Failed to add to waiting list" }, { status: 400 });
     }
+
+    // Audit log for healthcare compliance
+    await logAuditEvent({
+      supabase,
+      action: "waiting_list.added",
+      type: "booking",
+      clinicId: clinicConfig.clinicId,
+      description: `Patient ${patientId} added to waiting list (entry ${entry.id}) for doctor ${body.doctorId} on ${body.preferredDate}`,
+    });
 
     return NextResponse.json({
       status: "added",
@@ -142,6 +153,15 @@ export const DELETE = withAuth(async (request, { supabase }) => {
       console.error("[DELETE /api/booking/waiting-list] Error:", error.message);
       return NextResponse.json({ error: "Failed to remove from waiting list" }, { status: 400 });
     }
+
+    // Audit log for healthcare compliance
+    await logAuditEvent({
+      supabase,
+      action: "waiting_list.removed",
+      type: "booking",
+      clinicId: clinicConfig.clinicId,
+      description: `Waiting list entry ${body.entryId} removed`,
+    });
 
     return NextResponse.json({ status: "removed", message: "Removed from waiting list" });
   } catch (err) {

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -8514,6 +8514,22 @@ export type DocumentType =
 
 export type WaitingListStatus = "waiting" | "notified" | "booked" | "expired";
 
+/** Runtime constants for WaitingListStatus to eliminate magic strings. */
+export const WAITING_LIST_STATUS = {
+  WAITING: "waiting",
+  NOTIFIED: "notified",
+  BOOKED: "booked",
+  EXPIRED: "expired",
+} as const satisfies Record<string, WaitingListStatus>;
+
+/** Runtime constants for BookingSource to eliminate magic strings. */
+export const BOOKING_SOURCE = {
+  ONLINE: "online",
+  PHONE: "phone",
+  WALK_IN: "walk_in",
+  WHATSAPP: "whatsapp",
+} as const satisfies Record<string, BookingSource>;
+
 export type ToothStatus =
   | "healthy"
   | "decayed"


### PR DESCRIPTION
## Summary

Second batch of 5 fixes from the deep analysis report.

### Changes

1. **WAITING_LIST_STATUS runtime constants** — Added `WAITING_LIST_STATUS` constants (`WAITING`, `NOTIFIED`, `BOOKED`, `EXPIRED`) to `types/database.ts` and replaced magic strings in `cancel/route.ts` and `waiting-list/route.ts`

2. **Replaced inline patient find-or-create with shared utility** — `booking/route.ts` had duplicated patient lookup/creation logic. Now uses the shared `findOrCreatePatient` utility (prefers phone-based lookup to avoid name collisions)

3. **Added audit logging to emergency-slot booking** — Emergency appointment creation now logs to `activity_logs` for healthcare compliance, matching the pattern used by regular booking, cancel, and reschedule endpoints

4. **BOOKING_SOURCE runtime constants** — Added `BOOKING_SOURCE` constants (`ONLINE`, `PHONE`, `WALK_IN`, `WHATSAPP`) and replaced magic strings in booking, emergency-slot, and recurring routes

5. **Added audit logging to waiting-list operations** — Waiting-list POST (add) and DELETE (remove) now log audit events for healthcare compliance

### Files Changed
- `src/lib/types/database.ts` — Added `WAITING_LIST_STATUS` and `BOOKING_SOURCE` constants
- `src/app/api/booking/route.ts` — Use `findOrCreatePatient` utility + `BOOKING_SOURCE.ONLINE`
- `src/app/api/booking/cancel/route.ts` — Use `WAITING_LIST_STATUS` constants
- `src/app/api/booking/emergency-slot/route.ts` — Add audit logging + `BOOKING_SOURCE.ONLINE`
- `src/app/api/booking/recurring/route.ts` — Use `BOOKING_SOURCE.ONLINE`
- `src/app/api/booking/waiting-list/route.ts` — Use `WAITING_LIST_STATUS.WAITING` + add audit logging

[Devin session](https://app.devin.ai/sessions/e1c393ea6fa84b4986658c540399d058)