### PR TITLE
fix: address remaining audit findings (chat auth, cache invalidation, pagination guards)

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchChatbotContext, buildSystemPrompt, getBasicResponse } from "@/lib/chatbot-data";
 import { TENANT_HEADERS } from "@/lib/tenant";
+import { createClient } from "@/lib/supabase-server";
 
 export const runtime = "edge";
 
@@ -154,6 +155,17 @@ export async function POST(request: NextRequest) {
     }
 
     // --- ADVANCED: OpenAI-compatible API (paid) ---
+    // The advanced tier consumes paid API credits. Require authentication
+    // to prevent unauthenticated abuse.
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json(
+        { error: "Authentication required for advanced AI chat" },
+        { status: 401 },
+      );
+    }
+
     const apiKey = process.env.OPENAI_API_KEY;
     const baseUrl = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
     const model = process.env.OPENAI_MODEL || "gpt-4o-mini";

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -90,7 +90,9 @@ async function fetchRows<T>(
   if (opts?.gte) q = q.gte(opts.gte[0] as string, opts.gte[1]);
   if (opts?.lte) q = q.lte(opts.lte[0] as string, opts.lte[1]);
   if (opts?.order) q = q.order(opts.order[0], opts.order[1]);
-  if (opts?.limit) q = q.limit(opts.limit);
+  // Apply an upper-bound limit to prevent unbounded result sets.
+  // Callers can override with a smaller value via opts.limit.
+  q = q.limit(opts?.limit ?? 1000);
   const { data, error } = await q;
   if (error) {
     console.error(`[data] ${table}:`, error.message);
@@ -956,12 +958,14 @@ export async function upsertReview(data: {
     console.error("[data] create review:", error.message);
     return false;
   }
+  clearLookupCache();
   return true;
 }
 
 export async function updateReviewResponse(reviewId: string, response: string): Promise<boolean> {
   const supabase = createClient();
   const { error } = await supabase.from("reviews").update({ response }).eq("id", reviewId);
+  if (!error) clearLookupCache();
   return !error;
 }
 
@@ -2539,6 +2543,7 @@ export async function addToWaitingList(data: {
     console.error("[data] addToWaitingList:", error.message);
     return { success: false, error: error.message };
   }
+  clearLookupCache();
   return { success: true, entryId: entry?.id };
 }
 
@@ -2573,6 +2578,7 @@ export async function createAppointment(data: {
     console.error("[data] createAppointment:", error.message);
     return { success: false, error: error.message };
   }
+  clearLookupCache();
   return { success: true, id: appt?.id };
 }
 

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -169,12 +169,15 @@ export async function getPublicAverageRating(): Promise<number> {
 
   // Fetch just the stars column (lightweight) since Supabase JS doesn't
   // support aggregate functions like AVG() directly.
-  // TODO: Replace with a Postgres function or materialized view for clinics
-  // with large review counts to avoid fetching all rows.
+  // Limit to the most recent 500 reviews to avoid fetching unbounded rows.
+  // For clinics with >500 reviews, consider a Postgres function or
+  // materialized view for exact averages.
   const { data } = await supabase
     .from("reviews")
     .select("stars")
-    .eq("clinic_id", clinicId);
+    .eq("clinic_id", clinicId)
+    .order("created_at", { ascending: false })
+    .limit(500);
 
   if (!data || data.length === 0) return 0;
   const sum = data.reduce((s, r) => s + r.stars, 0);


### PR DESCRIPTION
## Summary

Addresses remaining findings from the deep analysis audit report that were not yet fixed.

### Changes

**1.5 — Chat endpoint authentication (Security, Medium)**
- Advanced (paid) AI tier now requires authentication via `supabase.auth.getUser()`
- Prevents unauthenticated users from consuming paid OpenAI API credits
- Basic and Smart tiers remain publicly accessible (no cost to clinic)

**3.1 — Client cache invalidation (Data Integrity, Medium)**
- Added `clearLookupCache()` calls after mutations: `upsertReview`, `updateReviewResponse`, `addToWaitingList`, `createAppointment`
- Ensures stale cached data is cleared when users/appointments/reviews change

**3.5 — getPublicAverageRating unbounded fetch (Data Integrity, Low)**
- Added `.order(created_at, desc).limit(500)` to prevent fetching all review rows
- Caps at most recent 500 reviews; suggests Postgres function for clinics exceeding this

**4.3 — fetchRows pagination guard (Efficiency, Medium)**
- Added default upper-bound limit of 1000 rows to the generic `fetchRows` helper
- Callers can still override with a smaller limit; prevents unbounded result sets

### Notes
- All other findings (1.1–1.4, 1.6–1.11, 2.1–2.9, 3.2–3.4, 3.6, 4.2, 5.4) were already addressed in #126
- Lint and TypeScript typecheck both pass clean

[Devin session](https://app.devin.ai/sessions/27871eacbbe94e0ab5fafe593f5eb0f4)