### PR TITLE
fix: address 10 additional issues from deep analysis audit

### DIFF
--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -80,10 +80,18 @@ async function validateBookingRequest(body: BookingRequestBody): Promise<Validat
     return fail("Cannot book an appointment in the past");
   }
 
-  // Parse day-of-week using noon to avoid DST edge cases.
-  // Date string "YYYY-MM-DD" parsed at noon is safe across all timezones.
+  // Determine day-of-week in the clinic's timezone so that midnight-
+  // boundary edge cases don't return the wrong day.  Intl.DateTimeFormat
+  // with the `weekday` option is timezone-aware, unlike Date.getDay().
+  const dayFormatter = new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    timeZone: tz,
+  });
+  const dayMap: Record<string, number> = {
+    Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6,
+  };
   const parsedDate = new Date(body.date + "T12:00:00");
-  const dayOfWeek = parsedDate.getDay();
+  const dayOfWeek = dayMap[dayFormatter.format(parsedDate)] ?? parsedDate.getDay();
   const hours = clinicConfig.workingHours[dayOfWeek];
   if (!hours?.enabled) {
     return fail("Selected date is not a working day");

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -30,17 +30,27 @@ const MAX_MESSAGE_LENGTH = 2000;
 
 /**
  * Sanitize user-supplied text before it reaches the LLM.
- * Strips common prompt-injection markers while keeping normal punctuation.
+ *
+ * Defence-in-depth: this is NOT a substitute for proper output
+ * filtering / guardrails on the LLM response, but it raises the
+ * bar against common injection patterns.
  */
 function sanitizeUserInput(text: string): string {
-  return text
-    // Strip attempts to impersonate system/assistant roles
-    .replace(/^\s*(system|assistant)\s*:/gi, "")
-    // Remove markdown-style "instruction" fences that could confuse the model
-    .replace(/```(system|instructions?)[\s\S]*?```/gi, "")
-    // Collapse excessive whitespace
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  return (
+    text
+      // Strip attempts to impersonate system/assistant roles
+      // (covers whitespace/zero-width tricks between characters)
+      .replace(/^\s*(s\s*y\s*s\s*t\s*e\s*m|a\s*s\s*s\s*i\s*s\s*t\s*a\s*n\s*t)\s*:/gi, "")
+      // Remove markdown-style "instruction" fences
+      .replace(/```(system|instructions?)[\s\S]*?```/gi, "")
+      // Strip ChatML-style markers (e.g. <|im_start|>system)
+      .replace(/<\|im_(start|end)\|>\s*(system|assistant)?/gi, "")
+      // Strip XML-style role tags
+      .replace(/<\/?(system|assistant|instruction)[^>]*>/gi, "")
+      // Collapse excessive whitespace
+      .replace(/\n{3,}/g, "\n\n")
+      .trim()
+  );
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -11,18 +11,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
-
-/** Standard CORS headers for the public API. */
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
-  "Access-Control-Max-Age": "86400",
-};
+import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 
 /** Handle CORS preflight requests. */
-export function OPTIONS() {
-  return new NextResponse(null, { status: 204, headers: corsHeaders });
+export function OPTIONS(request: NextRequest) {
+  return handlePreflight(request);
 }
 
 export async function GET(request: NextRequest) {
@@ -30,7 +23,7 @@ export async function GET(request: NextRequest) {
   if (!auth) {
     return NextResponse.json(
       { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: corsHeaders },
+      { status: 401, headers: getCorsHeaders(request) },
     );
   }
 
@@ -59,13 +52,13 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     console.error("[GET /api/v1/appointments] Query error:", error.message);
-    return NextResponse.json({ error: "Failed to fetch appointments" }, { status: 500, headers: corsHeaders });
+    return NextResponse.json({ error: "Failed to fetch appointments" }, { status: 500, headers: getCorsHeaders(request) });
   }
 
   return NextResponse.json({
     data,
     pagination: { total: count, limit, offset },
-  }, { headers: corsHeaders });
+  }, { headers: getCorsHeaders(request) });
 }
 
 export async function POST(request: NextRequest) {
@@ -73,7 +66,7 @@ export async function POST(request: NextRequest) {
   if (!auth) {
     return NextResponse.json(
       { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401 },
+      { status: 401, headers: getCorsHeaders(request) },
     );
   }
 
@@ -84,7 +77,7 @@ export async function POST(request: NextRequest) {
   if (missing.length > 0) {
     return NextResponse.json(
       { error: `Missing required fields: ${missing.join(", ")}` },
-      { status: 400, headers: corsHeaders },
+      { status: 400, headers: getCorsHeaders(request) },
     );
   }
 
@@ -102,7 +95,7 @@ export async function POST(request: NextRequest) {
     if (typeof body[field] === "string" && body[field].length > maxLen) {
       return NextResponse.json(
         { error: `Field '${field}' exceeds maximum length of ${maxLen} characters` },
-        { status: 400, headers: corsHeaders },
+        { status: 400, headers: getCorsHeaders(request) },
       );
     }
   }
@@ -134,8 +127,8 @@ export async function POST(request: NextRequest) {
 
   if (error) {
     console.error("[POST /api/v1/appointments] Insert error:", error.message);
-    return NextResponse.json({ error: "Failed to create appointment" }, { status: 500, headers: corsHeaders });
+    return NextResponse.json({ error: "Failed to create appointment" }, { status: 500, headers: getCorsHeaders(request) });
   }
 
-  return NextResponse.json({ data }, { status: 201, headers: corsHeaders });
+  return NextResponse.json({ data }, { status: 201, headers: getCorsHeaders(request) });
 }

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -10,18 +10,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
-
-/** Standard CORS headers for the public API. */
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
-  "Access-Control-Max-Age": "86400",
-};
+import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 
 /** Handle CORS preflight requests. */
-export function OPTIONS() {
-  return new NextResponse(null, { status: 204, headers: corsHeaders });
+export function OPTIONS(request: NextRequest) {
+  return handlePreflight(request);
 }
 
 export async function GET(request: NextRequest) {
@@ -29,7 +22,7 @@ export async function GET(request: NextRequest) {
   if (!auth) {
     return NextResponse.json(
       { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: corsHeaders },
+      { status: 401, headers: getCorsHeaders(request) },
     );
   }
 
@@ -59,13 +52,13 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     console.error("[GET /api/v1/patients] Query error:", error.message);
-    return NextResponse.json({ error: "Failed to fetch patients" }, { status: 500, headers: corsHeaders });
+    return NextResponse.json({ error: "Failed to fetch patients" }, { status: 500, headers: getCorsHeaders(request) });
   }
 
   return NextResponse.json({
     data,
     pagination: { total: count, limit, offset },
-  }, { headers: corsHeaders });
+  }, { headers: getCorsHeaders(request) });
 }
 
 export async function POST(request: NextRequest) {
@@ -73,7 +66,7 @@ export async function POST(request: NextRequest) {
   if (!auth) {
     return NextResponse.json(
       { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: corsHeaders },
+      { status: 401, headers: getCorsHeaders(request) },
     );
   }
 
@@ -84,7 +77,7 @@ export async function POST(request: NextRequest) {
   if (missing.length > 0) {
     return NextResponse.json(
       { error: `Missing required fields: ${missing.join(", ")}` },
-      { status: 400, headers: corsHeaders },
+      { status: 400, headers: getCorsHeaders(request) },
     );
   }
 
@@ -101,7 +94,7 @@ export async function POST(request: NextRequest) {
     if (typeof body[field] === "string" && body[field].length > maxLen) {
       return NextResponse.json(
         { error: `Field '${field}' exceeds maximum length of ${maxLen} characters` },
-        { status: 400, headers: corsHeaders },
+        { status: 400, headers: getCorsHeaders(request) },
       );
     }
   }
@@ -124,8 +117,8 @@ export async function POST(request: NextRequest) {
 
   if (error) {
     console.error("[POST /api/v1/patients] Insert error:", error.message);
-    return NextResponse.json({ error: "Failed to create patient" }, { status: 500, headers: corsHeaders });
+    return NextResponse.json({ error: "Failed to create patient" }, { status: 500, headers: getCorsHeaders(request) });
   }
 
-  return NextResponse.json({ data }, { status: 201, headers: corsHeaders });
+  return NextResponse.json({ data }, { status: 201, headers: getCorsHeaders(request) });
 }

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -167,10 +167,23 @@ export async function restoreBackup(
   const restored: BackupTableInfo[] = [];
   const errors: string[] = [];
 
-  // Build an ID mapping so foreign key references between restored
-  // tables stay consistent even though every record gets a new UUID.
+  // ---- Pass 1: Generate all new IDs upfront ----
+  // This avoids forward-reference breakage when table A references an
+  // ID from table B that appears later in BACKUP_TABLES.
   const idMap = new Map<string, string>();
 
+  for (const table of BACKUP_TABLES) {
+    const rows = backup.data[table];
+    if (!rows) continue;
+    for (const row of rows) {
+      const oldId = row.id as string | undefined;
+      if (oldId) {
+        idMap.set(oldId, crypto.randomUUID());
+      }
+    }
+  }
+
+  // ---- Pass 2: Remap IDs + FK references, then insert ----
   for (const table of BACKUP_TABLES) {
     const rows = backup.data[table];
     if (!rows || rows.length === 0) {
@@ -178,20 +191,14 @@ export async function restoreBackup(
       continue;
     }
 
-    // Generate new UUIDs for all records to prevent cross-tenant
-    // data injection via known/colliding IDs.
     const mappedRows = rows.map((row) => {
-      const oldId = row.id as string | undefined;
-      const newId = crypto.randomUUID();
-      if (oldId) {
-        idMap.set(oldId, newId);
-      }
-
       const mapped: Record<string, unknown> = { ...row };
-      mapped.id = newId;
+
+      // Assign the pre-generated new ID
+      const oldId = row.id as string | undefined;
+      mapped.id = oldId ? idMap.get(oldId) : crypto.randomUUID();
       mapped.clinic_id = targetClinicId;
 
-      // Remap known foreign key fields that reference other restored records
       // Strip sensitive fields from user records to prevent privilege escalation
       if (table === "users") {
         delete mapped.auth_id;
@@ -199,24 +206,19 @@ export async function restoreBackup(
         mapped.role = "patient"; // Default restored users to patient role
       }
 
-      // Remap all known foreign key fields that reference other restored records
-      const fkFields = [
-        "patient_id",
-        "doctor_id",
-        "appointment_id",
-        "invoice_id",
-        "treatment_plan_id",
-        "service_id",
-        "bed_id",
-        "room_id",
-        "department_id",
-        "admitting_doctor_id",
-        "product_id",
-        "prescription_id",
-      ];
-      for (const fk of fkFields) {
-        if (typeof mapped[fk] === "string" && idMap.has(mapped[fk] as string)) {
-          mapped[fk] = idMap.get(mapped[fk] as string);
+      // Auto-detect foreign key columns by the `_id` suffix convention
+      // instead of maintaining a hardcoded list that can drift from
+      // the actual schema.
+      for (const [key, value] of Object.entries(mapped)) {
+        if (
+          key !== "id" &&
+          key !== "clinic_id" &&
+          key !== "auth_id" &&
+          key.endsWith("_id") &&
+          typeof value === "string" &&
+          idMap.has(value)
+        ) {
+          mapped[key] = idMap.get(value);
         }
       }
 

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared CORS configuration for the public REST API.
+ *
+ * Instead of hardcoding `Access-Control-Allow-Origin: *` in every route,
+ * this module reads a comma-separated allowlist from the
+ * `ALLOWED_API_ORIGINS` environment variable.
+ *
+ * If the variable is not set, all origins are **blocked** by default
+ * (deny-by-default).  Set it to `*` explicitly during development if
+ * you need a permissive policy.
+ *
+ * Usage:
+ *   import { getCorsHeaders, handlePreflight } from "@/lib/cors";
+ *
+ *   export function OPTIONS(request: NextRequest) {
+ *     return handlePreflight(request);
+ *   }
+ *
+ *   // In GET / POST handlers:
+ *   return NextResponse.json(payload, { headers: getCorsHeaders(request) });
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Parse the allowed origins from the environment once.
+ * Returns `null` when the env var is unset (= deny all cross-origin).
+ * Returns `["*"]` when set to `*` (= allow any origin, dev only).
+ * Otherwise returns an array of explicit origins.
+ */
+function parseAllowedOrigins(): string[] | null {
+  const raw = process.env.ALLOWED_API_ORIGINS;
+  if (!raw) return null;
+  if (raw.trim() === "*") return ["*"];
+  return raw
+    .split(",")
+    .map((o) => o.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Returns the appropriate `Access-Control-Allow-Origin` value for the
+ * given request, based on the configured allowlist.
+ */
+function resolveOrigin(request: NextRequest): string | null {
+  const allowed = parseAllowedOrigins();
+  if (!allowed) return null; // deny all
+  if (allowed.includes("*")) return "*";
+
+  const requestOrigin = request.headers.get("origin")?.toLowerCase();
+  if (requestOrigin && allowed.includes(requestOrigin)) {
+    return requestOrigin;
+  }
+  return null;
+}
+
+/**
+ * Build CORS response headers for a given request.
+ * If the request origin is not allowed, the `Access-Control-Allow-Origin`
+ * header is omitted entirely (browser will block the response).
+ */
+export function getCorsHeaders(request: NextRequest): Record<string, string> {
+  const origin = resolveOrigin(request);
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Max-Age": "86400",
+  };
+  if (origin) {
+    headers["Access-Control-Allow-Origin"] = origin;
+    // When returning a specific origin (not *), the Vary header is
+    // required so caches don't serve the wrong CORS response.
+    if (origin !== "*") {
+      headers["Vary"] = "Origin";
+    }
+  }
+  return headers;
+}
+
+/**
+ * Handle an OPTIONS preflight request using the shared CORS config.
+ */
+export function handlePreflight(request: NextRequest): NextResponse {
+  return new NextResponse(null, {
+    status: 204,
+    headers: getCorsHeaders(request),
+  });
+}

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -167,21 +167,30 @@ export async function getPublicAverageRating(): Promise<number> {
   const clinicId = getClinicId();
   const supabase = await createClient();
 
-  // Fetch just the stars column (lightweight) since Supabase JS doesn't
-  // support aggregate functions like AVG() directly.
-  // Limit to the most recent 500 reviews to avoid fetching unbounded rows.
-  // For clinics with >500 reviews, consider a Postgres function or
-  // materialized view for exact averages.
-  const { data } = await supabase
+  // Use the exact row count (via Supabase HEAD request) combined with
+  // a bounded fetch to compute the average without pulling unbounded
+  // data into memory.  The `count: "exact"` option returns the total
+  // matching rows without transferring the data when used with
+  // `head: true`, but we still need the star values to sum.
+  //
+  // Ideal long-term fix: create a Postgres function
+  //   `SELECT AVG(stars) FROM reviews WHERE clinic_id = $1`
+  // and call it via `supabase.rpc("avg_clinic_rating", { cid })`.
+  //
+  // For now we fetch ALL stars (only the `stars` column — a single
+  // integer per row) to ensure the average is exact rather than
+  // silently capping at 500 rows which skews results for popular
+  // clinics.
+  const { data, count } = await supabase
     .from("reviews")
-    .select("stars")
-    .eq("clinic_id", clinicId)
-    .order("created_at", { ascending: false })
-    .limit(500);
+    .select("stars", { count: "exact" })
+    .eq("clinic_id", clinicId);
 
   if (!data || data.length === 0) return 0;
   const sum = data.reduce((s, r) => s + r.stars, 0);
-  return Math.round((sum / data.length) * 10) / 10;
+  // Use `count` (exact total) when available; fall back to data.length
+  const total = count ?? data.length;
+  return Math.round((sum / total) * 10) / 10;
 }
 
 // ── Services ──

--- a/src/lib/find-or-create-patient.ts
+++ b/src/lib/find-or-create-patient.ts
@@ -58,19 +58,23 @@ export async function findOrCreatePatient(
     }
   }
 
-  // Fall back to name-based lookup when phone is not provided
-  const { data: existing } = await supabase
+  // Fall back to name-based lookup when phone is not provided.
+  // Only reuse an existing record when exactly ONE patient matches
+  // to avoid silently attributing data to the wrong person when
+  // multiple patients share the same name (common in many cultures).
+  const { data: byName } = await supabase
     .from("users")
     .select("id")
     .eq("clinic_id", clinicId)
     .eq("name", patientName)
     .eq("role", "patient")
-    .limit(1)
-    .single();
+    .limit(2); // fetch up to 2 to detect ambiguity
 
-  if (existing) {
-    return existing.id;
+  if (byName && byName.length === 1) {
+    return byName[0].id;
   }
+  // If 0 or 2+ matches, fall through to create a new patient record
+  // so we don't accidentally merge distinct individuals.
 
   const { data: newPatient } = await supabase
     .from("users")

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -193,7 +193,7 @@ export async function updateCalendarEvent(
   const validTokens = await getValidToken(tokens);
 
   const response = await fetch(
-    `${CALENDAR_API_BASE}/calendars/${encodeURIComponent(calendarId)}/events/${eventId}`,
+    `${CALENDAR_API_BASE}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
     {
       method: "PATCH",
       headers: {
@@ -224,7 +224,7 @@ export async function deleteCalendarEvent(
   const validTokens = await getValidToken(tokens);
 
   const response = await fetch(
-    `${CALENDAR_API_BASE}/calendars/${encodeURIComponent(calendarId)}/events/${eventId}`,
+    `${CALENDAR_API_BASE}/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
     {
       method: "DELETE",
       headers: {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -391,9 +391,26 @@ export async function dispatchNotification(
       switch (channel) {
         case "whatsapp": {
           const body = substituteVariables(template.whatsappBody, variables);
-          // Dynamically import to avoid pulling server-only code into client bundles
+          // recipientId is a user UUID — look up the actual phone number
+          const { createClient } = await import("@/lib/supabase-server");
+          const waSupabase = await createClient();
+          const { data: waRecipient } = await waSupabase
+            .from("users")
+            .select("phone")
+            .eq("id", recipientId)
+            .single();
+
+          if (!waRecipient?.phone) {
+            results.push({
+              channel: "whatsapp",
+              success: false,
+              error: "Recipient has no phone number on file",
+            });
+            break;
+          }
+
           const { sendTextMessage } = await import("./whatsapp");
-          const waResult = await sendTextMessage(recipientId, body);
+          const waResult = await sendTextMessage(waRecipient.phone, body);
           results.push({
             channel: "whatsapp",
             success: waResult.success,
@@ -460,8 +477,26 @@ export async function dispatchNotification(
         }
         case "sms": {
           const body = substituteVariables(template.whatsappBody, variables);
+          // recipientId is a user UUID — look up the actual phone number
+          const { createClient: createSmsClient } = await import("@/lib/supabase-server");
+          const smsSupabase = await createSmsClient();
+          const { data: smsRecipient } = await smsSupabase
+            .from("users")
+            .select("phone")
+            .eq("id", recipientId)
+            .single();
+
+          if (!smsRecipient?.phone) {
+            results.push({
+              channel: "sms",
+              success: false,
+              error: "Recipient has no phone number on file",
+            });
+            break;
+          }
+
           const { sendSms } = await import("./sms");
-          const smsResult = await sendSms(recipientId, body);
+          const smsResult = await sendSms(smsRecipient.phone, body);
           results.push({
             channel: "sms",
             success: smsResult.success,

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -72,8 +72,16 @@ export function withAuth(
         );
       }
 
-      // If specific roles are required, enforce them
-      if (allowedRoles !== null && !allowedRoles.includes(profile.role as UserRole)) {
+      // If specific roles are required, enforce them.
+      // Passing `null` skips role checking (any authenticated user is
+      // allowed).  This is discouraged — prefer an explicit role list
+      // to follow deny-by-default.
+      if (allowedRoles === null) {
+        console.warn(
+          `[withAuth] Route accessed without explicit role restriction (user ${user.id}, role ${profile.role}). ` +
+          "Consider specifying allowedRoles for defense-in-depth.",
+        );
+      } else if (!allowedRoles.includes(profile.role as UserRole)) {
         return NextResponse.json(
           { error: "Forbidden — insufficient permissions" },
           { status: 403 },


### PR DESCRIPTION
## Summary

Fixes 10 additional issues identified in the deep analysis audit report (second batch, after PR #128).

### Changes

1. **SEC-CRIT-05 + MAINT-MED-02**: Extract shared CORS module (`src/lib/cors.ts`) with configurable origin allowlist via `ALLOWED_API_ORIGINS` env var. Replaces hardcoded `Access-Control-Allow-Origin: *` in both `v1/appointments` and `v1/patients` routes.
2. **SEC-HIGH-01**: Enhance prompt injection sanitization in chat endpoint — adds ChatML marker stripping (`<|im_start|>`), XML-style role tag removal, and spaced-character pattern matching.
3. **SEC-HIGH-05**: WhatsApp and SMS notification channels now look up the recipient's phone number from the database using the user UUID, matching how the email channel already works. Fixes the bug where `recipientId` (a UUID) was passed directly as a phone number.
4. **LOGIC-04**: Add `encodeURIComponent(eventId)` in Google Calendar update and delete API calls for defensive URL encoding.
5. **DI-CRIT-01**: Backup restore now uses a **two-pass approach** — Pass 1 generates all new UUIDs upfront, Pass 2 remaps FK references and inserts. This fixes forward-reference breakage when table A references IDs from table B that appears later in the restore order.
6. **MAINT-MED-01**: FK field detection in backup restore is now automatic (any column ending in `_id`) instead of relying on a hardcoded list that drifts from the schema.
7. **LOGIC-02**: Booking validation now uses `Intl.DateTimeFormat` with the clinic's timezone for day-of-week calculation, fixing midnight-boundary edge cases.
8. **LOGIC-03**: `findOrCreatePatient` now only reuses an existing patient by name when exactly 1 match exists. If multiple patients share the same name, a new record is created to prevent wrong-patient attribution.
9. **MAINT-HIGH-01**: `withAuth` now logs a warning when called with `null` roles, encouraging explicit role lists for defense-in-depth.
10. **EFF-MED-01**: Average rating computation removes the arbitrary 500-row cap that skewed results for popular clinics. Uses `count: "exact"` for accurate totals.

### Files Changed

- `src/lib/cors.ts` (new)
- `src/app/api/v1/appointments/route.ts`
- `src/app/api/v1/patients/route.ts`
- `src/app/api/chat/route.ts`
- `src/lib/notifications.ts`
- `src/lib/google-calendar.ts`
- `src/lib/backup.ts`
- `src/app/api/booking/route.ts`
- `src/lib/find-or-create-patient.ts`
- `src/lib/with-auth.ts`
- `src/lib/data/public.ts`