### PR TITLE
fix: address audit weaknesses — type safety, chatbot auth, pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+npx tsc --noEmit

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -128,6 +128,18 @@ export async function POST(request: NextRequest) {
     // Determine intelligence level
     const intelligence = ctx.chatbotConfig?.intelligence ?? "basic";
 
+    // SEC-01: Require authentication for all intelligence tiers.
+    // Basic and smart tiers were previously unauthenticated, enabling
+    // bot-driven abuse of the chatbot and Cloudflare Workers AI quota.
+    const supabaseForAuth = await createClient();
+    const { data: { user: chatUser } } = await supabaseForAuth.auth.getUser();
+    if (!chatUser) {
+      return NextResponse.json(
+        { error: "Authentication required to use the chatbot" },
+        { status: 401 },
+      );
+    }
+
     // --- BASIC: keyword matching, no AI ---
     if (intelligence === "basic") {
       const reply = getBasicResponse(lastMessage.content, ctx);
@@ -186,17 +198,7 @@ export async function POST(request: NextRequest) {
     }
 
     // --- ADVANCED: OpenAI-compatible API (paid) ---
-    // The advanced tier consumes paid API credits. Require authentication
-    // to prevent unauthenticated abuse.
-    const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json(
-        { error: "Authentication required for advanced AI chat" },
-        { status: 401 },
-      );
-    }
-
+    // Authentication is already enforced above (SEC-01) for all tiers.
     const apiKey = process.env.OPENAI_API_KEY;
     const baseUrl = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
     const model = process.env.OPENAI_MODEL || "gpt-4o-mini";

--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
       .order("sort_order", { ascending: true });
 
     if (entityType) {
-      query = query.eq("entity_type", entityType as unknown as never);
+      query = query.eq("entity_type", entityType);
     }
 
     const { data, error } = await query;

--- a/src/app/api/custom-fields/values/route.ts
+++ b/src/app/api/custom-fields/values/route.ts
@@ -26,8 +26,7 @@ export const GET = withAuth(async (request, { supabase }) => {
     .from("custom_field_values")
     .select("*")
     .eq("clinic_id", clinicId)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .eq("entity_type", entityType as any)
+    .eq("entity_type", entityType)
     .eq("entity_id", entityId)
     .single();
 
@@ -74,8 +73,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       .from("custom_field_definitions")
       .select("field_key, field_type")
       .eq("clinic_id", clinic_id)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .eq("entity_type", entity_type as any);
+      .eq("entity_type", entity_type);
 
     if (definitions && definitions.length > 0) {
       const defMap = new Map(
@@ -174,8 +172,7 @@ export const PATCH = withAuth(async (request, { supabase }) => {
       .from("custom_field_definitions")
       .select("field_key, field_type")
       .eq("clinic_id", clinic_id)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .eq("entity_type", entity_type as any);
+      .eq("entity_type", entity_type);
 
     if (definitions && definitions.length > 0) {
       const defMap = new Map(

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -46,8 +46,7 @@ export async function GET(request: NextRequest) {
     query = query.eq("appointment_date", date);
   }
   if (status) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    query = query.eq("status", status as any);
+    query = query.eq("status", status);
   }
 
   const { data, count, error } = await query;

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -12,6 +12,7 @@ import { createClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 import { logger } from "@/lib/logger";
+import type { TablesInsert } from "@/lib/types/database";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -103,19 +104,23 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = await createClient();
+    // The users table has columns (full_name, date_of_birth, gender,
+    // insurance_type, address) that are not yet in the generated
+    // Supabase types.  Use a Record<string, unknown> insert so the
+    // payload is still checked at the JS level without a blanket `any`.
+    const insertPayload: Record<string, unknown> = {
+      clinic_id: auth.clinicId,
+      role: "patient",
+      full_name: body.full_name,
+      email: body.email || null,
+      phone: body.phone || null,
+      date_of_birth: body.date_of_birth || null,
+      gender: body.gender || null,
+      insurance_type: body.insurance_type || null,
+      address: body.address || null,
+    };
     const { data, error } = await supabase.from("users")
-      .insert({
-        clinic_id: auth.clinicId,
-        role: "patient",
-        full_name: body.full_name,
-        email: body.email || null,
-        phone: body.phone || null,
-        date_of_birth: body.date_of_birth || null,
-        gender: body.gender || null,
-        insurance_type: body.insurance_type || null,
-        address: body.address || null,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any)
+      .insert(insertPayload as TablesInsert<"users">)
       .select()
       .single();
 

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -171,9 +171,11 @@ export async function getPublicAverageRating(): Promise<number> {
   // no data transferred).  Falls back to application-level computation
   // if the RPC function doesn't exist yet.
   try {
-    const { data: rpcResult, error: rpcError } = await supabase
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .rpc("avg_clinic_rating" as any, { cid: clinicId });
+    // avg_clinic_rating is a DB function not yet in the generated
+    // Supabase types.  Use a targeted cast instead of blanket `as any`.
+    type UntypedRpc = (fn: string, args: Record<string, unknown>) => ReturnType<typeof supabase.rpc>;
+    const rpc = supabase.rpc.bind(supabase) as unknown as UntypedRpc;
+    const { data: rpcResult, error: rpcError } = await rpc("avg_clinic_rating", { cid: clinicId });
 
     if (!rpcError && rpcResult !== null && rpcResult !== undefined) {
       const avg = typeof rpcResult === "number" ? rpcResult : Number(rpcResult);


### PR DESCRIPTION
## Summary

Addresses the audit weaknesses identified across type safety, security, and developer tooling.

### Type Safety Fixes
- **BUG-04** (`src/app/api/v1/patients/route.ts`): Replaced blanket `as any` cast with typed `Record<string, unknown>` intermediate variable
- **BUG-05** (`src/app/api/v1/appointments/route.ts`): Removed `status as unknown as never` double-cast
- **BUG-06** (`src/app/api/custom-fields/values/route.ts`, `src/app/api/custom-fields/route.ts`): Removed `as any` / `as unknown as never` casts on entity_type filters
- **BUG-08** (`src/lib/data/public.ts`): Replaced `as any` RPC cast with targeted `UntypedRpc` type alias

### Security Fix
- **SEC-01** (`src/app/api/chat/route.ts`): All chatbot tiers (basic/smart/advanced) now require authentication. Previously only the advanced tier checked auth, allowing unauthenticated abuse of basic/smart tiers and Cloudflare Workers AI quota.

### Developer Tooling
- **Pre-commit hooks** (`.husky/pre-commit`): Added `npx tsc --noEmit` typecheck step so commits that fail type checks are blocked.

### Verification
- `npm run lint` — 0 errors, 0 warnings
- `npx tsc --noEmit` — 0 errors

---
*[Devin session](https://app.devin.ai/sessions/aa81697484c6462883318ede8944aec3)*