### PR TITLE
fix: consolidate escapeHtml (7->1) and migrate CSP script-src to nonce-based

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,29 +26,8 @@ const securityHeaders = [
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",
   },
-  {
-    // Content Security Policy
-    key: "Content-Security-Policy",
-    value: [
-      "default-src 'self'",
-      // Scripts: self + inline (Next.js hydration requires it)
-      "script-src 'self' 'unsafe-inline'",
-      // Styles: self + inline (Tailwind, shadcn)
-      "style-src 'self' 'unsafe-inline'",
-      // Images: self + R2 storage + Supabase storage + data URIs + blobs
-      "img-src 'self' data: blob: *.supabase.co *.r2.cloudflarestorage.com *.r2.dev",
-      // Fonts: self + common CDNs
-      "font-src 'self' data:",
-      // API connections: self + Supabase + WhatsApp + Cloudflare + Google
-      "connect-src 'self' *.supabase.co wss://*.supabase.co graph.facebook.com api.twilio.com api.cloudflare.com *.googleapis.com",
-      // Frames: Google Maps embeds only
-      "frame-src 'self' www.google.com",
-      // Form actions: self only
-      "form-action 'self'",
-      // Base URI: self only
-      "base-uri 'self'",
-    ].join("; "),
-  },
+  // Content Security Policy is set dynamically in middleware.ts
+  // with a per-request nonce for script-src (instead of 'unsafe-inline').
 ];
 
 const nextConfig: NextConfig = {

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -13,6 +13,7 @@ import { updateLabOrderPdfUrl } from "@/lib/data/server";
 import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
+import { escapeHtml } from "@/lib/escape-html";
 
 interface LabResultItem {
   testName: string;
@@ -21,14 +22,6 @@ interface LabResultItem {
   referenceMin: number | null;
   referenceMax: number | null;
   flag: string | null;
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
 }
 
 function flagLabel(flag: string | null): string {

--- a/src/app/api/radiology/report-pdf/route.ts
+++ b/src/app/api/radiology/report-pdf/route.ts
@@ -13,14 +13,7 @@ import { updateRadiologyOrderPdfUrl } from "@/lib/data/server";
 import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
+import { escapeHtml } from "@/lib/escape-html";
 
 function generateReportHtml(data: {
   patientName: string;

--- a/src/components/morocco/ordonnance-writer.tsx
+++ b/src/components/morocco/ordonnance-writer.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { escapeHtml } from "@/lib/escape-html";
 
 // ---- Types ----
 
@@ -45,18 +46,6 @@ interface OrdonnanceData {
   diagnosis?: string;
   medications: OrdonnanceMedication[];
   notes?: string;
-}
-
-// ---- HTML Escaping ----
-
-function escapeHtml(str: string | undefined | null): string {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 // ---- Formes pharmaceutiques ----

--- a/src/components/qr-code-generator.tsx
+++ b/src/components/qr-code-generator.tsx
@@ -11,6 +11,7 @@
 import { useState, useMemo, useCallback, useRef } from "react";
 import { Download, Printer, Copy, Check, QrCode } from "lucide-react";
 import QRCodeLib from "qrcode";
+import { escapeHtml } from "@/lib/escape-html";
 
 interface QrCodeGeneratorProps {
   url: string;
@@ -18,16 +19,6 @@ interface QrCodeGeneratorProps {
   subtitle?: string;
   size?: number;
   className?: string;
-}
-
-function escapeHtml(str: string | undefined | null): string {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 // ---- Component ----

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -14,18 +14,9 @@
  */
 
 import { logger } from "@/lib/logger";
+import { escapeHtml } from "@/lib/escape-html";
 
 const RESEND_API_URL = "https://api.resend.com/emails";
-
-/** Escape HTML special characters to prevent injection in email templates. */
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
 
 export interface EmailSendResult {
   success: boolean;

--- a/src/lib/escape-html.ts
+++ b/src/lib/escape-html.ts
@@ -1,0 +1,15 @@
+/**
+ * Escape HTML special characters to prevent XSS when interpolating
+ * user-controlled data into HTML template literals.
+ *
+ * Handles `undefined` and `null` gracefully by returning an empty string.
+ */
+export function escapeHtml(str: string | undefined | null): string {
+  if (!str) return "";
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/lib/invoice-generator.ts
+++ b/src/lib/invoice-generator.ts
@@ -17,22 +17,7 @@ import {
   type PatientInsurance,
   calculateResteACharge,
 } from "./morocco";
-
-// ---- HTML Escaping ----
-
-/**
- * Escape HTML special characters to prevent XSS when interpolating
- * user-controlled data into HTML template literals.
- */
-function escapeHtml(str: string | undefined | null): string {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
+import { escapeHtml } from "./escape-html";
 
 // ---- Invoice Types ----
 

--- a/src/lib/prescription-pdf.ts
+++ b/src/lib/prescription-pdf.ts
@@ -7,19 +7,7 @@
  * browser print/save-as-PDF. Uses the same pattern as invoice-generator.ts.
  */
 
-/**
- * Escape HTML special characters to prevent XSS when interpolating
- * user-controlled data into HTML template literals.
- */
-function escapeHtml(str: string | undefined | null): string {
-  if (!str) return "";
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
+import { escapeHtml } from "@/lib/escape-html";
 
 interface PrescriptionMedication {
   name: string;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -100,10 +100,44 @@ function setTenantHeaders(
  *  rejected before any route handler runs, preventing memory exhaustion. */
 const MAX_BODY_BYTES = 25 * 1024 * 1024;
 
+/**
+ * Build the Content-Security-Policy header value with a per-request nonce
+ * for script-src (replaces 'unsafe-inline').
+ *
+ * style-src retains 'unsafe-inline' because Tailwind CSS and shadcn/ui
+ * inject inline styles that cannot be nonce-gated without significant
+ * architectural changes.
+ */
+function buildCsp(nonce: string): string {
+  const isDev = process.env.NODE_ENV === "development";
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    // Styles: self + inline (Tailwind, shadcn)
+    "style-src 'self' 'unsafe-inline'",
+    // Images: self + R2 storage + Supabase storage + data URIs + blobs
+    "img-src 'self' data: blob: *.supabase.co *.r2.cloudflarestorage.com *.r2.dev",
+    // Fonts: self + common CDNs
+    "font-src 'self' data:",
+    // API connections: self + Supabase + WhatsApp + Cloudflare + Google
+    "connect-src 'self' *.supabase.co wss://*.supabase.co graph.facebook.com api.twilio.com api.cloudflare.com *.googleapis.com",
+    // Frames: Google Maps embeds only
+    "frame-src 'self' www.google.com",
+    // Form actions: self only
+    "form-action 'self'",
+    // Base URI: self only
+    "base-uri 'self'",
+  ].join("; ");
+}
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const hostname = request.headers.get("host") ?? "";
   const rootDomain = process.env.ROOT_DOMAIN;
+
+  // --- Generate a per-request nonce for CSP ---
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const cspHeaderValue = buildCsp(nonce);
 
   // --- Global body size limit ---
   const contentLength = request.headers.get("content-length");
@@ -113,6 +147,12 @@ export async function middleware(request: NextRequest) {
       { status: 413 },
     );
   }
+
+  // --- Inject CSP nonce into request headers so Server Components
+  //     can read it via headers().get('x-nonce') ---
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", cspHeaderValue);
 
   // --- Subdomain resolution ---
   const subdomain = extractSubdomain(hostname, rootDomain);
@@ -206,12 +246,19 @@ export async function middleware(request: NextRequest) {
       loginUrl.searchParams.set("redirect", pathname);
       return NextResponse.redirect(loginUrl);
     }
-    return NextResponse.next({ request });
+    const noSupabaseResponse = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+    noSupabaseResponse.headers.set("Content-Security-Policy", cspHeaderValue);
+    noSupabaseResponse.headers.set("x-nonce", nonce);
+    return noSupabaseResponse;
   }
 
   let supabaseResponse = NextResponse.next({
-    request,
+    request: { headers: requestHeaders },
   });
+  supabaseResponse.headers.set("Content-Security-Policy", cspHeaderValue);
+  supabaseResponse.headers.set("x-nonce", nonce);
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -226,8 +273,10 @@ export async function middleware(request: NextRequest) {
             request.cookies.set(name, value)
           );
           supabaseResponse = NextResponse.next({
-            request,
+            request: { headers: requestHeaders },
           });
+          supabaseResponse.headers.set("Content-Security-Policy", cspHeaderValue);
+          supabaseResponse.headers.set("x-nonce", nonce);
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
           );


### PR DESCRIPTION
Addresses audit items #4 and #3.

### #4: Consolidate duplicated escapeHtml into shared utility
- Created src/lib/escape-html.ts with robust implementation
- Replaced 7 local definitions with imports from shared module
- Bug fix: lab and radiology routes were missing single-quote escape

### #3: Migrate CSP script-src from unsafe-inline to nonce-based
- Per-request nonce generation in middleware.ts
- script-src uses nonce + strict-dynamic instead of unsafe-inline
- style-src retains unsafe-inline (Tailwind requirement)
- Dev mode adds unsafe-eval for React debugging