### PR TITLE
fix: remove remaining 'as unknown as' casts across codebase

### DIFF
--- a/src/app/(doctor)/doctor/lab-orders/page.tsx
+++ b/src/app/(doctor)/doctor/lab-orders/page.tsx
@@ -15,7 +15,7 @@ export default function DoctorLabOrdersPage() {
     const user = await getCurrentUser();
     if (!user?.clinic_id) { setLoading(false); return; }
     const data = await fetchLabOrders(user.clinic_id);
-    setOrders(data as unknown as LabOrder[]);
+    setOrders(data as LabOrder[]);
     setLoading(false);
   }
     load();

--- a/src/app/(doctor)/doctor/sterilization/page.tsx
+++ b/src/app/(doctor)/doctor/sterilization/page.tsx
@@ -15,7 +15,7 @@ export default function DoctorSterilizationPage() {
     const user = await getCurrentUser();
     if (!user?.clinic_id) { setLoading(false); return; }
     const data = await fetchSterilizationLog(user.clinic_id);
-    setLog(data as unknown as SterilizationEntry[]);
+    setLog(data as SterilizationEntry[]);
     setLoading(false);
   }
     load();

--- a/src/app/(doctor)/doctor/treatment-plans/page.tsx
+++ b/src/app/(doctor)/doctor/treatment-plans/page.tsx
@@ -18,7 +18,7 @@ export default function DoctorTreatmentPlansPage() {
     setPlans(data.map(p => ({
       ...p,
       steps: p.steps.map((s, i) => ({ ...s, step: i + 1 })),
-    })) as unknown as TreatmentPlan[]);
+    })) as TreatmentPlan[]);
     setLoading(false);
   }
     load();

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -150,9 +150,12 @@ export async function GET(request: NextRequest) {
       if (apptDatetime.getTime() < twoHoursFromNow.getTime() && trigger === "reminder_2h") continue;
 
       // Type-safe access to joined data
-      const patient = appt.patients as unknown as { id: string; name: string; phone: string } | null;
-      const doctor = appt.doctors as unknown as { id: string; name: string } | null;
-      const service = appt.services as unknown as { name: string } | null;
+      const patientRaw = appt.patients;
+      const patient = Array.isArray(patientRaw) ? patientRaw[0] : patientRaw;
+      const doctorRaw = appt.doctors;
+      const doctor = Array.isArray(doctorRaw) ? doctorRaw[0] : doctorRaw;
+      const serviceRaw = appt.services;
+      const service = Array.isArray(serviceRaw) ? serviceRaw[0] : serviceRaw;
 
       if (!patient) continue;
 
@@ -166,7 +169,8 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      const clinic = appt.clinics as unknown as { name: string } | null;
+      const clinicRaw = appt.clinics;
+      const clinic = Array.isArray(clinicRaw) ? clinicRaw[0] : clinicRaw;
       const clinicName = clinic?.name ?? "Clinic";
 
       dispatchQueue.push({

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -1453,12 +1453,17 @@ export async function fetchTreatmentPlans(clinicId: string, doctorId?: string): 
 
 export interface LabOrderView {
   id: string;
+  patientId: string;
   patientName: string;
+  doctorId: string;
+  doctorName: string;
   labName: string;
   description: string;
   status: string;
-  dueDate: string;
+  dueDate: string | null;
+  notes: string;
   createdAt: string;
+  updatedAt: string;
 }
 
 interface LabOrderRaw {
@@ -1481,12 +1486,17 @@ export async function fetchLabOrders(clinicId: string): Promise<LabOrderView[]> 
   });
   return rows.map((r) => ({
     id: r.id,
+    patientId: r.patient_id,
     patientName: _userMap?.get(r.patient_id)?.name ?? "Patient",
+    doctorId: r.doctor_id,
+    doctorName: _userMap?.get(r.doctor_id)?.name ?? "Doctor",
     labName: r.lab_name ?? "",
     description: r.description,
     status: r.status,
-    dueDate: r.due_date ?? "",
+    dueDate: r.due_date ?? null,
+    notes: "",
     createdAt: r.created_at?.split("T")[0] ?? "",
+    updatedAt: r.created_at?.split("T")[0] ?? "",
   }));
 }
 
@@ -1519,18 +1529,26 @@ export async function createLabOrder(data: {
 export interface SterilizationView {
   id: string;
   toolName: string;
+  sterilizedBy: string;
   sterilizedAt: string;
-  nextDue: string;
-  notes?: string;
+  nextDue: string | null;
+  method: "autoclave" | "chemical" | "dry_heat";
+  notes: string;
+  batchNumber?: string;
+  cycleNumber?: number;
 }
 
 export async function fetchSterilizationLog(clinicId: string): Promise<SterilizationView[]> {
   const rows = await fetchRows<{
     id: string;
     tool_name: string;
+    sterilized_by: string | null;
     sterilized_at: string;
     next_due: string | null;
+    method: string | null;
     notes: string | null;
+    batch_number: string | null;
+    cycle_number: number | null;
   }>("sterilization_log", {
     eq: [["clinic_id", clinicId]],
     order: ["sterilized_at", { ascending: false }],
@@ -1538,9 +1556,13 @@ export async function fetchSterilizationLog(clinicId: string): Promise<Steriliza
   return rows.map((r) => ({
     id: r.id,
     toolName: r.tool_name,
+    sterilizedBy: r.sterilized_by ?? "",
     sterilizedAt: r.sterilized_at,
-    nextDue: r.next_due ?? "",
-    notes: r.notes ?? undefined,
+    nextDue: r.next_due ?? null,
+    method: (r.method ?? "autoclave") as SterilizationView["method"],
+    notes: r.notes ?? "",
+    batchNumber: r.batch_number ?? undefined,
+    cycleNumber: r.cycle_number ?? undefined,
   }));
 }
 

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -151,7 +151,8 @@ export async function getPublicReviews(): Promise<PublicReview[]> {
   if (error || !reviews || reviews.length === 0) return [];
 
   return reviews.map((r) => {
-    const patient = r.patients as unknown as { name: string } | null;
+    const patientRaw = r.patients;
+    const patient = Array.isArray(patientRaw) ? patientRaw[0] : patientRaw;
     return {
       id: r.id,
       patientName: patient?.name ?? "Patient",

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -162,7 +162,15 @@ export async function getClinicBranding(clinicId: string): Promise<ClinicBrandin
     .single();
 
   if (error) return null;
-  return data as unknown as ClinicBrandingRow;
+  return {
+    logo_url: data.logo_url ?? null,
+    favicon_url: data.favicon_url ?? null,
+    primary_color: data.primary_color ?? null,
+    secondary_color: data.secondary_color ?? null,
+    heading_font: data.heading_font ?? null,
+    body_font: data.body_font ?? null,
+    hero_image_url: data.hero_image_url ?? null,
+  };
 }
 
 export async function updateClinicBranding(
@@ -490,7 +498,17 @@ export async function getPrescriptions(clinicId: string, doctorId?: string): Pro
     logger.warn("Query failed", { context: "data/server", error });
     return [];
   }
-  return (data ?? []) as unknown as PrescriptionRow[];
+  return (data ?? []).map((r) => ({
+    id: r.id,
+    clinic_id: r.clinic_id ?? "",
+    appointment_id: r.appointment_id,
+    doctor_id: r.doctor_id,
+    patient_id: r.patient_id,
+    items: Array.isArray(r.items) ? (r.items as PrescriptionRow["items"]) : [],
+    notes: r.notes,
+    pdf_url: r.pdf_url,
+    created_at: r.created_at ?? "",
+  }));
 }
 
 export async function getPatientPrescriptions(patientId: string): Promise<PrescriptionRow[]> {

--- a/src/lib/export-data.ts
+++ b/src/lib/export-data.ts
@@ -25,7 +25,7 @@ function escapeCSV(value: unknown): string {
   return str;
 }
 
-function arrayToCSV<T extends Record<string, unknown>>(
+function arrayToCSV<T extends object>(
   rows: T[],
   columns: { key: keyof T; label: string }[],
 ): string {
@@ -50,7 +50,7 @@ function downloadFile(content: string, filename: string, mimeType: string) {
 
 // ---------- Generic export ----------
 
-export function exportToCSV<T extends Record<string, unknown>>(
+export function exportToCSV<T extends object>(
   rows: T[],
   columns: { key: keyof T; label: string }[],
   filename: string,
@@ -88,7 +88,7 @@ const appointmentColumns: { key: keyof ExportableAppointment; label: string }[] 
 
 export function exportAppointments(appointments: ExportableAppointment[], filenamePrefix = "appointments") {
   const date = new Date().toISOString().split("T")[0];
-  exportToCSV(appointments as unknown as Record<string, unknown>[], appointmentColumns as { key: string; label: string }[], `${filenamePrefix}-${date}.csv`);
+  exportToCSV(appointments, appointmentColumns, `${filenamePrefix}-${date}.csv`);
 }
 
 // ---------- Patient export ----------
@@ -118,7 +118,7 @@ const patientColumns: { key: keyof ExportablePatient; label: string }[] = [
 
 export function exportPatients(patients: ExportablePatient[], filenamePrefix = "patients") {
   const date = new Date().toISOString().split("T")[0];
-  exportToCSV(patients as unknown as Record<string, unknown>[], patientColumns as { key: string; label: string }[], `${filenamePrefix}-${date}.csv`);
+  exportToCSV(patients, patientColumns, `${filenamePrefix}-${date}.csv`);
 }
 
 // ---------- Invoice export ----------
@@ -144,5 +144,5 @@ const invoiceColumns: { key: keyof ExportableInvoice; label: string }[] = [
 
 export function exportInvoices(invoices: ExportableInvoice[], filenamePrefix = "invoices") {
   const date = new Date().toISOString().split("T")[0];
-  exportToCSV(invoices as unknown as Record<string, unknown>[], invoiceColumns as { key: string; label: string }[], `${filenamePrefix}-${date}.csv`);
+  exportToCSV(invoices, invoiceColumns, `${filenamePrefix}-${date}.csv`);
 }


### PR DESCRIPTION
- Replace unsafe cast in getClinicBranding with explicit field mapping (server.ts)
- Replace unsafe cast in getPrescriptions with field mapping + JSON handling (server.ts)
- Remove double cast in Supabase FK joins using array-safe extraction (public.ts, reminders/route.ts)
- Remove double cast in treatment-plans, lab-orders, sterilization pages
- Extend LabOrderView and SterilizationView with missing fields so View types match component expectations
- Relax generic constraint in export-data.ts from Record<string,unknown> to object, removing 3 casts