### PR TITLE
fix: resolve 5 medium-risk security vulnerabilities (S10-S14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "recharts": "^3.8.0",
         "shadcn": "^4.0.8",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@opennextjs/cloudflare": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "recharts": "^3.8.0",
     "shadcn": "^4.0.8",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@opennextjs/cloudflare": "^1.17.1",

--- a/src/components/receptionist/daily-report.tsx
+++ b/src/components/receptionist/daily-report.tsx
@@ -83,10 +83,18 @@ export function DailyReport() {
     const content = reportRef.current;
     if (!content) return;
 
-    // Sanitize innerHTML: clone the DOM subtree and strip any <script> tags
-    // to prevent XSS if upstream components ever inject unescaped HTML.
+    // Sanitize innerHTML: clone the DOM subtree and strip <script> tags plus
+    // dangerous event-handler attributes (onclick, onerror, onload, etc.) to
+    // prevent XSS if upstream components ever inject unescaped HTML.
     const clone = content.cloneNode(true) as HTMLElement;
     clone.querySelectorAll("script").forEach((s) => s.remove());
+    clone.querySelectorAll("*").forEach((el) => {
+      for (const attr of Array.from(el.attributes)) {
+        if (attr.name.startsWith("on")) {
+          el.removeAttribute(attr.name);
+        }
+      }
+    });
     const sanitizedHtml = clone.innerHTML;
 
     const printWindow = window.open("", "_blank");

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -14,12 +14,21 @@ export function register() {
     process.env.NODE_ENV === "production" &&
     process.env.SEED_PASSWORDS_ROTATED !== "true"
   ) {
-    throw new Error(
-      "FATAL: Seed user passwords have not been rotated. " +
-      "Migration 00019 created users with the default password " +
-      '"seed-password-change-me". These accounts are publicly known ' +
-      "and must be rotated before running in production. " +
-      "Set SEED_PASSWORDS_ROTATED=true after changing all seed passwords.",
-    );
+    // Log a structured message before throwing so monitoring tools can
+    // surface the exact remediation steps without parsing the error stack.
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] Seed user passwords have not been rotated.\n" +
+      "\n" +
+      "Migration 00019 created users with the default password\n" +
+      '"seed-password-change-me". These credentials are publicly known.\n' +
+      "\n" +
+      "To fix:\n" +
+      "  1. Log into Supabase and change ALL seed user passwords.\n" +
+      "  2. Set the environment variable SEED_PASSWORDS_ROTATED=true\n" +
+      "  3. Re-deploy the application.\n" +
+      "\n" +
+      "The application will NOT start until this is resolved.";
+    console.error(message);
+    throw new Error(message);
   }
 }

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -171,15 +171,16 @@ export async function restoreBackup(
   success: boolean;
   restored: BackupTableInfo[];
   errors: string[];
+  warnings: string[];
 }> {
   // Authorization: only clinic_admin or super_admin may restore backups
   if (callerRole !== "clinic_admin" && callerRole !== "super_admin") {
-    return { success: false, restored: [], errors: ["Unauthorized: only clinic admins can restore backups"] };
+    return { success: false, restored: [], errors: ["Unauthorized: only clinic admins can restore backups"], warnings: [] };
   }
 
   const validation = validateBackup(json);
   if (!validation.valid) {
-    return { success: false, restored: [], errors: [validation.error!] };
+    return { success: false, restored: [], errors: [validation.error!], warnings: [] };
   }
 
   // Reuse the already-parsed object from validation to avoid double JSON.parse
@@ -187,6 +188,7 @@ export async function restoreBackup(
   const supabase = await createClient();
   const restored: BackupTableInfo[] = [];
   const errors: string[] = [];
+  const warnings: string[] = [];
 
   // ---- Pass 1: Generate all new IDs upfront ----
   // This avoids forward-reference breakage when table A references an
@@ -226,11 +228,20 @@ export async function restoreBackup(
       mapped.id = oldId ? idMap.get(oldId) : crypto.randomUUID();
       mapped.clinic_id = targetClinicId;
 
-      // Strip sensitive fields from user records to prevent privilege escalation
+      // Strip sensitive fields from user records to prevent privilege escalation.
+      // WARNING: All restored users are reset to "patient" role regardless of
+      // their original role. Doctors, admins, and other staff will need their
+      // roles re-assigned manually after restore.
       if (table === "users") {
+        const originalRole = mapped.role as string | undefined;
         delete mapped.auth_id;
         delete mapped.role;
-        mapped.role = "patient"; // Default restored users to patient role
+        mapped.role = "patient";
+        if (originalRole && originalRole !== "patient") {
+          warnings.push(
+            `User "${mapped.name ?? mapped.id}" had role "${originalRole}" — reset to "patient" for security. Re-assign manually.`,
+          );
+        }
       }
 
       // FIX (HIGH-02): Use explicit FK mapping instead of fragile _id suffix
@@ -303,5 +314,6 @@ export async function restoreBackup(
     success: errors.length === 0,
     restored,
     errors,
+    warnings,
   };
 }

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -143,10 +143,15 @@ export async function getPresignedUploadUrl(
   // HIGH-07: Do NOT set ContentLength here — it enforces an exact byte count,
   // not a maximum.  Files smaller than maxSizeBytes would be rejected by S3.
   // Size enforcement is handled server-side via the upload API route validation.
+  //
+  // S13-FIX: Set Content-Disposition to "attachment" so browsers will never
+  // render uploaded files inline (prevents stored XSS via HTML/JS uploads
+  // that bypass the server-side magic-byte validation).
   const command = new PutObjectCommand({
     Bucket: config.bucketName,
     Key: key,
     ContentType: contentType,
+    ContentDisposition: "attachment",
   });
 
   return getSignedUrl(client, command, { expiresIn });


### PR DESCRIPTION
## Summary

Fixes all 5 medium-risk security vulnerabilities identified in the codebase audit.

### Changes

| # | Issue | Fix |
|---|-------|-----|
| **S10** | `zod` not in `package.json` | Added `zod` as a direct dependency via `npm install zod`. Was only available as transitive dep — a package update could break all API validation. |
| **S11** | `SEED_PASSWORDS_ROTATED` error unclear | Replaced terse error with structured `[STARTUP HEALTH CHECK FAILED]` message including numbered remediation steps. Also logs via `console.error` before throwing so monitoring tools capture it. |
| **S12** | Backup restore silently resets user roles | Added `warnings[]` to `restoreBackup()` return type. Now surfaces per-user warnings when doctor/admin roles are reset to "patient" during restore. |
| **S13** | Pre-signed uploads bypass magic-byte check | Set `Content-Disposition: attachment` on all pre-signed R2 upload URLs. Browsers will download rather than render uploaded files inline, preventing stored XSS. |
| **S14** | `daily-report.tsx` incomplete HTML sanitization | Added loop to strip all `on*` event-handler attributes (`onclick`, `onerror`, `onload`, etc.) from cloned DOM nodes, in addition to existing `<script>` tag removal. |

### Verification

- TypeScript (`tsc --noEmit`): **0 errors**
- Tests (`vitest run`): **249/249 passing**
- Pre-commit hooks: passed

---
[Devin session](https://app.devin.ai/sessions/af7fee3f818b4136a2ab4a9f8f94885f)