### PR TITLE
fix: replace hardcoded clinicConfig.clinicId with request-based tenan…

### DIFF
--- a/src/app/(admin)/admin/billing/page.tsx
+++ b/src/app/(admin)/admin/billing/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Loader2 } from "lucide-react";
 import { tierColors, type TierSlug } from "@/lib/config/pricing";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchClinicSubscription,
   type ClinicSubscriptionView,
@@ -27,6 +28,7 @@ import {
 } from "@/lib/super-admin-actions";
 
 export default function ClientBillingPage() {
+  const { clinicId } = useTenant();
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const [selectedUpgrade, setSelectedUpgrade] = useState<TierSlug | null>(null);
   const [currentSub, setCurrentSub] = useState<ClinicSubscriptionView | null>(null);
@@ -36,7 +38,7 @@ export default function ClientBillingPage() {
   const loadData = useCallback(async () => {
     try {
       const [sub, tiers] = await Promise.all([
-        fetchClinicSubscription(clinicConfig.clinicId),
+        fetchClinicSubscription(clinicId),
         fetchPricingTiers(),
       ]);
       setCurrentSub(sub);

--- a/src/app/(dentist-public)/dentist/gallery/page.tsx
+++ b/src/app/(dentist-public)/dentist/gallery/page.tsx
@@ -6,7 +6,7 @@ import { buttonVariants } from "@/components/ui/button";
 import Link from "next/link";
 import { getPublicBranding } from "@/lib/data/public";
 import { createClient } from "@/lib/supabase-server";
-import { clinicConfig } from "@/config/clinic.config";
+import { requireTenant } from "@/lib/tenant";
 
 export const metadata: Metadata = {
   title: "Before & After Gallery",
@@ -23,11 +23,12 @@ interface GalleryCase {
 }
 
 async function getApprovedBeforeAfterCases(): Promise<GalleryCase[]> {
+  const tenant = await requireTenant();
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("before_after_photos")
     .select("id, description, category, before_date, after_date")
-    .eq("clinic_id", clinicConfig.clinicId)
+    .eq("clinic_id", tenant.clinicId)
     .not("after_date", "is", null)
     .order("before_date", { ascending: false });
 

--- a/src/app/(equipment)/equipment/dashboard/page.tsx
+++ b/src/app/(equipment)/equipment/dashboard/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchEquipmentInventory, fetchEquipmentRentals, fetchEquipmentMaintenance } from "@/lib/data/client";
 import type { EquipmentItemView, EquipmentRentalView, EquipmentMaintenanceView } from "@/lib/data/client";
 import { useEquipmentLocale } from "../../layout";
@@ -16,6 +17,7 @@ import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function EquipmentDashboardPage() {
+  const { clinicId } = useTenant();
   const { locale } = useEquipmentLocale();
   const { t } = useEquipmentI18n(locale);
   const [inventory, setInventory] = useState<EquipmentItemView[]>([]);
@@ -26,7 +28,7 @@ export default function EquipmentDashboardPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([
       fetchEquipmentInventory(cId),
       fetchEquipmentRentals(cId),

--- a/src/app/(equipment)/equipment/inventory/page.tsx
+++ b/src/app/(equipment)/equipment/inventory/page.tsx
@@ -12,6 +12,7 @@ import {
 import { Search, Package, ChevronDown, Plus, Pencil, Trash2, Wrench } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchEquipmentInventory,
   createEquipmentItem,
@@ -59,6 +60,7 @@ const emptyForm: EquipmentFormState = {
 };
 
 export default function EquipmentInventoryPage() {
+  const { clinicId } = useTenant();
   const { locale } = useEquipmentLocale();
   const { t } = useEquipmentI18n(locale);
   const [items, setItems] = useState<EquipmentItemView[]>([]);
@@ -86,7 +88,7 @@ export default function EquipmentInventoryPage() {
 
   function reload() {
     setLoading(true);
-    fetchEquipmentInventory(clinicConfig.clinicId)
+    fetchEquipmentInventory(clinicId)
       .then(setItems)
       .finally(() => setLoading(false));
   }
@@ -95,7 +97,7 @@ export default function EquipmentInventoryPage() {
     const controller = new AbortController();
     function init() {
       setLoading(true);
-      fetchEquipmentInventory(clinicConfig.clinicId)
+      fetchEquipmentInventory(clinicId)
         .then(setItems)
         .catch((err) => {
       if (!controller.signal.aborted) {
@@ -159,7 +161,7 @@ export default function EquipmentInventoryPage() {
       });
     } else {
       await createEquipmentItem({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         name: form.name,
         category: form.category,
         serial_number: form.serialNumber || undefined,

--- a/src/app/(equipment)/equipment/maintenance/page.tsx
+++ b/src/app/(equipment)/equipment/maintenance/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Search, Wrench, ChevronDown, CalendarClock, Plus, Pencil, Trash2, AlertTriangle } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchEquipmentMaintenance, fetchEquipmentInventory,
   createEquipmentMaintenance, updateEquipmentMaintenance, deleteEquipmentMaintenance,
@@ -57,6 +58,7 @@ const emptyForm: MaintenanceFormState = {
 };
 
 export default function EquipmentMaintenancePage() {
+  const { clinicId } = useTenant();
   const { locale } = useEquipmentLocale();
   const { t } = useEquipmentI18n(locale);
   const [records, setRecords] = useState<EquipmentMaintenanceView[]>([]);
@@ -94,7 +96,7 @@ export default function EquipmentMaintenancePage() {
 
   function reload() {
     setLoading(true);
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([fetchEquipmentMaintenance(cId), fetchEquipmentInventory(cId)])
       .then(([r, e]) => { setRecords(r); setEquipment(e); })
       .finally(() => setLoading(false));
@@ -104,7 +106,7 @@ export default function EquipmentMaintenancePage() {
     const controller = new AbortController();
     function init() {
       setLoading(true);
-      const cId = clinicConfig.clinicId;
+      const cId = clinicId;
       Promise.all([fetchEquipmentMaintenance(cId), fetchEquipmentInventory(cId)])
         .then(([r, e]) => { setRecords(r); setEquipment(e); })
         .catch((err) => {
@@ -157,7 +159,7 @@ export default function EquipmentMaintenancePage() {
       });
     } else {
       await createEquipmentMaintenance({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         equipment_id: form.equipmentId,
         type: form.type,
         description: form.description || undefined,

--- a/src/app/(equipment)/equipment/rentals/page.tsx
+++ b/src/app/(equipment)/equipment/rentals/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Search, HandCoins, ChevronDown, AlertTriangle, Plus, Pencil, Trash2, RotateCcw } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchEquipmentRentals, fetchEquipmentInventory,
   createEquipmentRental, updateEquipmentRental, deleteEquipmentRental,
@@ -53,6 +54,7 @@ const emptyRentalForm: RentalFormState = {
 };
 
 export default function EquipmentRentalsPage() {
+  const { clinicId } = useTenant();
   const { locale } = useEquipmentLocale();
   const { t } = useEquipmentI18n(locale);
   const [rentals, setRentals] = useState<EquipmentRentalView[]>([]);
@@ -100,7 +102,7 @@ export default function EquipmentRentalsPage() {
 
   function reload() {
     setLoading(true);
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([fetchEquipmentRentals(cId), fetchEquipmentInventory(cId)])
       .then(([r, e]) => { setRentals(r); setEquipment(e); })
       .finally(() => setLoading(false));
@@ -110,7 +112,7 @@ export default function EquipmentRentalsPage() {
     const controller = new AbortController();
     function init() {
       setLoading(true);
-      const cId = clinicConfig.clinicId;
+      const cId = clinicId;
       Promise.all([fetchEquipmentRentals(cId), fetchEquipmentInventory(cId)])
         .then(([r, e]) => { setRentals(r); setEquipment(e); })
         .catch((err) => {
@@ -166,7 +168,7 @@ export default function EquipmentRentalsPage() {
       });
     } else {
       await createEquipmentRental({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         equipment_id: form.equipmentId,
         client_name: form.clientName,
         client_phone: form.clientPhone || undefined,

--- a/src/app/(lab)/lab-panel/dashboard/page.tsx
+++ b/src/app/(lab)/lab-panel/dashboard/page.tsx
@@ -9,18 +9,20 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchLabTestOrders } from "@/lib/data/client";
 import type { LabTestOrderView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function LabDashboardPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchLabTestOrders(clinicConfig.clinicId)
+    fetchLabTestOrders(clinicId)
       .then((d) => { if (!controller.signal.aborted) setOrders(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(lab)/lab-panel/patient-history/page.tsx
+++ b/src/app/(lab)/lab-panel/patient-history/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Search, History, FlaskConical, TrendingUp, TrendingDown, Minus } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchPatients, fetchPatientLabOrders, fetchLabTestResults } from "@/lib/data/client";
 import type { PatientView, LabTestOrderView, LabTestResultView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -26,6 +27,7 @@ function FlagBadge({ flag }: { flag: string }) {
 }
 
 export default function PatientHistoryPage() {
+  const { clinicId } = useTenant();
   const [patients, setPatients] = useState<PatientView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -39,7 +41,7 @@ export default function PatientHistoryPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchPatients(clinicConfig.clinicId)
+    fetchPatients(clinicId)
       .then((d) => { if (!controller.signal.aborted) setPatients(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {
@@ -56,7 +58,7 @@ export default function PatientHistoryPage() {
       setOrdersLoading(true);
       setSelectedOrderId(null);
       setSelectedOrderResults([]);
-      fetchPatientLabOrders(clinicConfig.clinicId, selectedPatientId)
+      fetchPatientLabOrders(clinicId, selectedPatientId)
         .then(setPatientOrders)
         .finally(() => setOrdersLoading(false));
     }

--- a/src/app/(lab)/lab-panel/reports/page.tsx
+++ b/src/app/(lab)/lab-panel/reports/page.tsx
@@ -7,11 +7,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, FileText, Download } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchLabTestOrders } from "@/lib/data/client";
 import type { LabTestOrderView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function LabReportsPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -19,7 +21,7 @@ export default function LabReportsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchLabTestOrders(clinicConfig.clinicId)
+    fetchLabTestOrders(clinicId)
       .then((all) => {
       if (controller.signal.aborted) return;
         setOrders(all.filter((o) => o.status === "completed" || o.status === "validated"));

--- a/src/app/(lab)/lab-panel/results/page.tsx
+++ b/src/app/(lab)/lab-panel/results/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { Search, FlaskConical, ArrowUpDown, TrendingUp, TrendingDown, Minus, Plus, Loader2, FileText } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchLabTestOrders, fetchLabTestResults, saveLabTestResult } from "@/lib/data/client";
 import type { LabTestOrderView, LabTestResultView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -33,6 +34,7 @@ function flagColor(flag: string): string {
 }
 
 export default function ResultsPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
   const [results, setResults] = useState<LabTestResultView[]>([]);
@@ -67,7 +69,7 @@ export default function ResultsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchLabTestOrders(clinicConfig.clinicId)
+    fetchLabTestOrders(clinicId)
       .then((all) => {
       if (controller.signal.aborted) return;
         const active = all.filter((o) => o.status !== "cancelled");
@@ -127,7 +129,7 @@ export default function ResultsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           orderId: selectedOrderId,
-          clinicId: clinicConfig.clinicId,
+          clinicId: clinicId,
           patientName: order.patientName,
           orderNumber: order.orderNumber,
           results: results.map((r) => ({

--- a/src/app/(lab)/lab-panel/test-orders/page.tsx
+++ b/src/app/(lab)/lab-panel/test-orders/page.tsx
@@ -19,6 +19,7 @@ import {
   Clock, CheckCircle, Loader2, UserPlus, ArrowRight,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchLabTestOrders, fetchLabTestCatalog, fetchPatients,
   createLabTestOrder, updateLabOrderStatus, assignLabTechnician,
@@ -30,6 +31,7 @@ const statusOptions = ["all", "pending", "sample_collected", "in_progress", "com
 const priorityOptions = ["normal", "urgent", "stat"] as const;
 
 export default function TestOrdersPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<LabTestOrderView[]>([]);
   const [catalog, setCatalog] = useState<LabTestCatalogView[]>([]);
   const [patients, setPatients] = useState<PatientView[]>([]);
@@ -56,15 +58,15 @@ export default function TestOrdersPage() {
   const [updatingStatusId, setUpdatingStatusId] = useState<string | null>(null);
 
   const refreshOrders = useCallback(() => {
-    fetchLabTestOrders(clinicConfig.clinicId).then(setOrders);
+    fetchLabTestOrders(clinicId).then(setOrders);
   }, []);
 
   useEffect(() => {
     const controller = new AbortController();
     Promise.all([
-      fetchLabTestOrders(clinicConfig.clinicId),
-      fetchLabTestCatalog(clinicConfig.clinicId),
-      fetchPatients(clinicConfig.clinicId),
+      fetchLabTestOrders(clinicId),
+      fetchLabTestCatalog(clinicId),
+      fetchPatients(clinicId),
     ]).then(([o, c, p]) => {
       if (controller.signal.aborted) return;
       setOrders(o);
@@ -85,7 +87,7 @@ export default function TestOrdersPage() {
     setNewOrderSaving(true);
     try {
       await createLabTestOrder({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         patient_id: newOrder.patientId,
         priority: newOrder.priority,
         clinical_notes: newOrder.clinicalNotes || undefined,

--- a/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { Search, ShoppingBag, Plus, Pencil, Trash2, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchParapharmacyProducts, fetchParapharmacyCategories, getStockStatus,
   createParapharmacyProduct, updateParapharmacyProduct, deleteParapharmacyProduct,
@@ -34,6 +35,7 @@ const defaultForm = {
 };
 
 export default function ParapharmacyCatalogPage() {
+  const { clinicId } = useTenant();
   const [products, setProducts] = useState<ProductView[]>([]);
   const [categories, setCategories] = useState<ParapharmacyCategoryView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -50,12 +52,12 @@ export default function ParapharmacyCatalogPage() {
   const [deleting, setDeleting] = useState(false);
 
   const refreshProducts = useCallback(() => {
-    fetchParapharmacyProducts(clinicConfig.clinicId).then(setProducts);
+    fetchParapharmacyProducts(clinicId).then(setProducts);
   }, []);
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([
       fetchParapharmacyProducts(cId),
       fetchParapharmacyCategories(cId),
@@ -112,7 +114,7 @@ export default function ParapharmacyCatalogPage() {
         });
       } else {
         await createParapharmacyProduct({
-          clinic_id: clinicConfig.clinicId,
+          clinic_id: clinicId,
           name: form.name,
           generic_name: form.genericName || undefined,
           category: form.category || undefined,

--- a/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchParapharmacyProducts,
   fetchParapharmacyCategories,
@@ -19,6 +20,7 @@ import type { ProductView, ParapharmacyCategoryView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ParapharmacyDashboardPage() {
+  const { clinicId } = useTenant();
   const [products, setProducts] = useState<ProductView[]>([]);
   const [categories, setCategories] = useState<ParapharmacyCategoryView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -26,7 +28,7 @@ export default function ParapharmacyDashboardPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([
       fetchParapharmacyProducts(cId),
       fetchParapharmacyCategories(cId),

--- a/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
@@ -6,11 +6,13 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Search, Package, AlertTriangle } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchParapharmacyProducts, getStockStatus, getExpiryStatus } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ParapharmacyInventoryPage() {
+  const { clinicId } = useTenant();
   const [products, setProducts] = useState<ProductView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -19,7 +21,7 @@ export default function ParapharmacyInventoryPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchParapharmacyProducts(clinicConfig.clinicId)
+    fetchParapharmacyProducts(clinicId)
       .then((d) => { if (!controller.signal.aborted) setProducts(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { Search, Receipt, DollarSign, Plus, Minus, ShoppingCart, Loader2, Trash2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchDailySales, fetchParapharmacyProducts, createParapharmacySale } from "@/lib/data/client";
 import type { DailySaleView, ProductView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -27,6 +28,7 @@ interface CartItem {
 }
 
 export default function ParapharmacySalesPage() {
+  const { clinicId } = useTenant();
   const [sales, setSales] = useState<DailySaleView[]>([]);
   const [products, setProducts] = useState<ProductView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -42,14 +44,14 @@ export default function ParapharmacySalesPage() {
   const [saving, setSaving] = useState(false);
 
   const refreshSales = useCallback(() => {
-    fetchDailySales(clinicConfig.clinicId).then(setSales);
+    fetchDailySales(clinicId).then(setSales);
   }, []);
 
   useEffect(() => {
     const controller = new AbortController();
     Promise.all([
-      fetchDailySales(clinicConfig.clinicId),
-      fetchParapharmacyProducts(clinicConfig.clinicId),
+      fetchDailySales(clinicId),
+      fetchParapharmacyProducts(clinicId),
     ])
       .then(([s, p]) => {
       if (controller.signal.aborted) return;
@@ -103,7 +105,7 @@ export default function ParapharmacySalesPage() {
     setSaving(true);
     try {
       await createParapharmacySale({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         patient_name: customerName,
         payment_method: paymentMethod,
         items: cart.map((c) => ({

--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchProducts,
   fetchPrescriptionRequests,
@@ -51,6 +52,7 @@ function toDateStr(d: Date): string {
 }
 
 export default function PharmacistDashboardPage() {
+  const { clinicId } = useTenant();
   const [products, setProducts] = useState<ProductView[]>([]);
   const [prescriptions, setPrescriptions] = useState<PharmacyPrescriptionView[]>([]);
   const [sales, setSales] = useState<DailySaleView[]>([]);
@@ -67,7 +69,7 @@ export default function PharmacistDashboardPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([
       fetchProducts(cId),
       fetchPrescriptionRequests(cId),

--- a/src/app/(pharmacist)/pharmacist/expiry/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/expiry/page.tsx
@@ -5,18 +5,20 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, Check, Clock, X } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchProducts, getExpiryStatus } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function ExpiryTrackerPage() {
+  const { clinicId } = useTenant();
   const [allProducts, setAllProducts] = useState<ProductView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchProducts(clinicConfig.clinicId)
+    fetchProducts(clinicId)
       .then((d) => { if (!controller.signal.aborted) setAllProducts(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
@@ -11,6 +11,7 @@ import {
   ArrowDown, ArrowUp, History,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchLoyaltyMembers, fetchLoyaltyTransactions, getPointsValue } from "@/lib/data/client";
 import type { LoyaltyMemberView, LoyaltyTransactionView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -34,6 +35,7 @@ const transactionTypeConfig: Record<TransactionType, { label: string; color: str
 };
 
 export default function LoyaltyPage() {
+  const { clinicId } = useTenant();
   const [allMembers, setAllMembers] = useState<LoyaltyMemberView[]>([]);
   const [allTransactions, setAllTransactions] = useState<LoyaltyTransactionView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -44,7 +46,7 @@ export default function LoyaltyPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([fetchLoyaltyMembers(cId), fetchLoyaltyTransactions(cId)])
       .then(([m, t]) => { setAllMembers(m); setAllTransactions(t); })
       .catch((err) => {

--- a/src/app/(pharmacist)/pharmacist/orders/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/orders/page.tsx
@@ -9,6 +9,7 @@ import {
   Send, X, FileText,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchPurchaseOrders, fetchSuppliers } from "@/lib/data/client";
 import type { PurchaseOrderView, SupplierView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -25,6 +26,7 @@ const statusConfig: Record<OrderStatus, { label: string; color: string; icon: Re
 };
 
 export default function OrdersPage() {
+  const { clinicId } = useTenant();
   const [allOrders, setAllOrders] = useState<PurchaseOrderView[]>([]);
   const [allSuppliers, setAllSuppliers] = useState<SupplierView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -33,7 +35,7 @@ export default function OrdersPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([fetchPurchaseOrders(cId), fetchSuppliers(cId)])
       .then(([o, s]) => { setAllOrders(o); setAllSuppliers(s); })
       .catch((err) => {

--- a/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
@@ -10,6 +10,7 @@ import {
   Search, Phone, MessageCircle, RefreshCw, X, ClipboardList,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchPrescriptionRequests } from "@/lib/data/client";
 import type { PharmacyPrescriptionView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -29,6 +30,7 @@ const statusConfig: Record<PrescriptionStatus, { label: string; color: string; i
 const statusFilters: PrescriptionStatus[] = ["pending", "reviewing", "partially-ready", "ready", "picked-up", "delivered"];
 
 export default function PrescriptionsPage() {
+  const { clinicId } = useTenant();
   const [allPrescriptions, setAllPrescriptions] = useState<PharmacyPrescriptionView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -37,7 +39,7 @@ export default function PrescriptionsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchPrescriptionRequests(clinicConfig.clinicId)
+    fetchPrescriptionRequests(clinicId)
       .then((d) => { if (!controller.signal.aborted) setAllPrescriptions(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(pharmacist)/pharmacist/sales/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/sales/page.tsx
@@ -9,11 +9,13 @@ import {
   Shield, Gift,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchDailySales } from "@/lib/data/client";
 import type { DailySaleView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SalesPage() {
+  const { clinicId } = useTenant();
   const [allSales, setAllSales] = useState<DailySaleView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -23,7 +25,7 @@ export default function SalesPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchDailySales(clinicConfig.clinicId)
+    fetchDailySales(clinicId)
       .then((d) => { if (!controller.signal.aborted) setAllSales(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(pharmacist)/pharmacist/stock/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/stock/page.tsx
@@ -10,6 +10,7 @@ import {
   ArrowUpDown, ShoppingCart,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import {
   fetchProducts,
   searchProductsLocal,
@@ -37,6 +38,7 @@ const stockFilters = [
 ];
 
 export default function StockPage() {
+  const { clinicId } = useTenant();
   const [allProducts, setAllProducts] = useState<ProductView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -47,7 +49,7 @@ export default function StockPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchProducts(clinicConfig.clinicId)
+    fetchProducts(clinicId)
       .then((d) => { if (!controller.signal.aborted) setAllProducts(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
@@ -9,11 +9,13 @@ import {
   Truck, ShoppingCart, Package,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchSuppliers, fetchPurchaseOrders } from "@/lib/data/client";
 import type { SupplierView, PurchaseOrderView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function SuppliersPage() {
+  const { clinicId } = useTenant();
   const [allSuppliers, setAllSuppliers] = useState<SupplierView[]>([]);
   const [allOrders, setAllOrders] = useState<PurchaseOrderView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -21,7 +23,7 @@ export default function SuppliersPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    const cId = clinicConfig.clinicId;
+    const cId = clinicId;
     Promise.all([fetchSuppliers(cId), fetchPurchaseOrders(cId)])
       .then(([s, o]) => { setAllSuppliers(s); setAllOrders(o); })
       .catch((err) => {

--- a/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Search, Filter, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { createClient } from "@/lib/supabase-client";
 
 interface PublicPharmacyProduct {
@@ -49,8 +50,7 @@ function searchProducts(
   );
 }
 
-async function fetchProductsClient(): Promise<PublicPharmacyProduct[]> {
-  const clinicId = clinicConfig.clinicId;
+async function fetchProductsClient(clinicId: string): Promise<PublicPharmacyProduct[]> {
   const supabase = createClient();
 
   const [{ data: products }, { data: stockRows }] = await Promise.all([
@@ -99,6 +99,7 @@ const categories = [
 ];
 
 export default function CatalogPage() {
+  const { clinicId } = useTenant();
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [allProducts, setAllProducts] = useState<PublicPharmacyProduct[]>([]);
@@ -107,7 +108,8 @@ export default function CatalogPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchProductsClient()
+    if (!clinicId) return;
+    fetchProductsClient(clinicId)
       .then((d) => { if (!controller.signal.aborted) setAllProducts(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Clock, Check, Package, Truck, AlertCircle, RefreshCw, Eye, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { createClient } from "@/lib/supabase-client";
 
 interface PrescriptionItem {
@@ -36,8 +37,7 @@ interface PharmacyPrescription {
   whatsappNotified: boolean;
 }
 
-async function fetchPrescriptionsClient(): Promise<PharmacyPrescription[]> {
-  const clinicId = clinicConfig.clinicId;
+async function fetchPrescriptionsClient(clinicId: string): Promise<PharmacyPrescription[]> {
   const supabase = createClient();
 
   const { data: requests, error } = await supabase
@@ -95,13 +95,15 @@ const statusConfig: Record<PharmacyPrescription["status"], { label: string; colo
 };
 
 export default function PrescriptionHistoryPage() {
+  const { clinicId } = useTenant();
   const [prescriptions, setPrescriptions] = useState<PharmacyPrescription[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchPrescriptionsClient()
+    if (!clinicId) return;
+    fetchPrescriptionsClient(clinicId)
       .then((d) => { if (!controller.signal.aborted) setPrescriptions(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(pharmacy-public)/pharmacy/promotions/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/promotions/page.tsx
@@ -9,6 +9,7 @@ import {
   Loader2, Sparkles,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { createClient } from "@/lib/supabase-client";
 import Link from "next/link";
 
@@ -25,8 +26,7 @@ interface PromotionProduct {
   active: boolean;
 }
 
-async function fetchFeaturedProducts(): Promise<PromotionProduct[]> {
-  const clinicId = clinicConfig.clinicId;
+async function fetchFeaturedProducts(clinicId: string): Promise<PromotionProduct[]> {
   const supabase = createClient();
 
   const [{ data: products }, { data: stockRows }] = await Promise.all([
@@ -67,6 +67,7 @@ const promoCategories = [
 ];
 
 export default function PromotionsPage() {
+  const { clinicId } = useTenant();
   const [products, setProducts] = useState<PromotionProduct[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -75,7 +76,8 @@ export default function PromotionsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchFeaturedProducts()
+    if (!clinicId) return;
+    fetchFeaturedProducts(clinicId)
       .then((d) => { if (!controller.signal.aborted) setProducts(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(radiology)/radiology/dashboard/page.tsx
+++ b/src/app/(radiology)/radiology/dashboard/page.tsx
@@ -9,18 +9,20 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyDashboardPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchRadiologyOrders(clinicConfig.clinicId)
+    fetchRadiologyOrders(clinicId)
       .then((d) => { if (!controller.signal.aborted) setOrders(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(radiology)/radiology/images/page.tsx
+++ b/src/app/(radiology)/radiology/images/page.tsx
@@ -26,11 +26,13 @@ import {
 import { Search, Image as ImageIcon, ExternalLink, Eye, FileImage, Upload, Loader2, X } from "lucide-react";
 import Link from "next/link";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyImagesPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
   const [allOrders, setAllOrders] = useState<RadiologyOrderView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -47,7 +49,7 @@ export default function RadiologyImagesPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const refreshOrders = useCallback(() => {
-    fetchRadiologyOrders(clinicConfig.clinicId).then((all) => {
+    fetchRadiologyOrders(clinicId).then((all) => {
       setAllOrders(all);
       setOrders(all.filter((o) => o.imageCount > 0));
     });
@@ -55,7 +57,7 @@ export default function RadiologyImagesPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchRadiologyOrders(clinicConfig.clinicId)
+    fetchRadiologyOrders(clinicId)
       .then((all) => {
       if (controller.signal.aborted) return;
         setAllOrders(all);
@@ -96,7 +98,7 @@ export default function RadiologyImagesPage() {
         const formData = new FormData();
         formData.append("file", uploadFiles[i]);
         formData.append("orderId", uploadOrderId);
-        formData.append("clinicId", clinicConfig.clinicId);
+        formData.append("clinicId", clinicId);
         await fetch("/api/radiology/upload", { method: "POST", body: formData });
       }
       setUploadOpen(false);

--- a/src/app/(radiology)/radiology/orders/page.tsx
+++ b/src/app/(radiology)/radiology/orders/page.tsx
@@ -28,6 +28,7 @@ import {
   FileText, Loader2,
 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchRadiologyOrders, fetchRadiologyTemplates } from "@/lib/data/client";
 import type { RadiologyOrderView, RadiologyTemplateView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -37,6 +38,7 @@ const modalityOptions = ["xray", "ct", "mri", "ultrasound", "mammography", "pet"
 const priorityOptions = ["normal", "urgent", "stat"] as const;
 
 export default function RadiologyOrdersPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
   const [templates, setTemplates] = useState<RadiologyTemplateView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -69,14 +71,14 @@ export default function RadiologyOrdersPage() {
   const [updatingStatusId, setUpdatingStatusId] = useState<string | null>(null);
 
   const refreshOrders = useCallback(() => {
-    fetchRadiologyOrders(clinicConfig.clinicId).then(setOrders);
+    fetchRadiologyOrders(clinicId).then(setOrders);
   }, []);
 
   useEffect(() => {
     const controller = new AbortController();
     Promise.all([
-      fetchRadiologyOrders(clinicConfig.clinicId),
-      fetchRadiologyTemplates(clinicConfig.clinicId),
+      fetchRadiologyOrders(clinicId),
+      fetchRadiologyTemplates(clinicId),
     ]).then(([o, t]) => {
       if (controller.signal.aborted) return;
       setOrders(o);
@@ -99,7 +101,7 @@ export default function RadiologyOrdersPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          clinicId: clinicConfig.clinicId,
+          clinicId: clinicId,
           patientId: newOrder.patientId,
           modality: newOrder.modality,
           bodyPart: newOrder.bodyPart || undefined,
@@ -181,7 +183,7 @@ export default function RadiologyOrdersPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         orderId: order.id,
-        clinicId: clinicConfig.clinicId,
+        clinicId: clinicId,
         patientName: order.patientName,
         modality: order.modality,
         bodyPart: order.bodyPart,

--- a/src/app/(radiology)/radiology/reports/page.tsx
+++ b/src/app/(radiology)/radiology/reports/page.tsx
@@ -7,11 +7,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search, FileText, Download, Scan, Loader2 } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyReportsPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -21,7 +23,7 @@ export default function RadiologyReportsPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchRadiologyOrders(clinicConfig.clinicId)
+    fetchRadiologyOrders(clinicId)
       .then((all) => setOrders(all.filter((o) => o.status === "reported" || o.status === "validated")))
       .catch((err) => {
       if (!controller.signal.aborted) {
@@ -40,7 +42,7 @@ export default function RadiologyReportsPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           orderId: order.id,
-          clinicId: clinicConfig.clinicId,
+          clinicId: clinicId,
           patientName: order.patientName,
           modality: order.modality,
           bodyPart: order.bodyPart,
@@ -55,7 +57,7 @@ export default function RadiologyReportsPage() {
         if (data.pdfUrl) {
           window.open(data.pdfUrl, "_blank");
           // Refresh to get updated pdfUrl
-          fetchRadiologyOrders(clinicConfig.clinicId)
+          fetchRadiologyOrders(clinicId)
             .then((all) => setOrders(all.filter((o) => o.status === "reported" || o.status === "validated")));
         }
       }

--- a/src/app/(radiology)/radiology/templates/page.tsx
+++ b/src/app/(radiology)/radiology/templates/page.tsx
@@ -7,11 +7,13 @@ import { Input } from "@/components/ui/input";
 import { Search, FileStack, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchRadiologyTemplates } from "@/lib/data/client";
 import type { RadiologyTemplateView } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 
 export default function RadiologyTemplatesPage() {
+  const { clinicId } = useTenant();
   const [templates, setTemplates] = useState<RadiologyTemplateView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -20,7 +22,7 @@ export default function RadiologyTemplatesPage() {
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchRadiologyTemplates(clinicConfig.clinicId)
+    fetchRadiologyTemplates(clinicId)
       .then((d) => { if (!controller.signal.aborted) setTemplates(d); })
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/(radiology)/radiology/viewer/page.tsx
+++ b/src/app/(radiology)/radiology/viewer/page.tsx
@@ -5,17 +5,19 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ExternalLink, Monitor, Info, FileImage, Scan } from "lucide-react";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchRadiologyOrders } from "@/lib/data/client";
 import type { RadiologyOrderView } from "@/lib/data/client";
 
 export default function DicomViewerPage() {
+  const { clinicId } = useTenant();
   const [orders, setOrders] = useState<RadiologyOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetchRadiologyOrders(clinicConfig.clinicId)
+    fetchRadiologyOrders(clinicId)
       .then((all) => setOrders(all.filter((o) => o.imageCount > 0)))
       .catch((err) => {
       if (!controller.signal.aborted) {

--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -6,6 +6,7 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { clinicDateTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { bookingCancelSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -16,6 +17,8 @@ export const runtime = "edge";
  */
 export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(bookingCancelSchema, raw);
     if (!parsed.success) {
@@ -28,7 +31,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       .from("appointments")
       .select("id, doctor_id, appointment_date, start_time, status")
       .eq("id", body.appointmentId)
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .single();
 
     if (fetchError || !appt) {
@@ -81,7 +84,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     const { data: candidate } = await supabase
       .from("waiting_list")
       .select("id")
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .eq("doctor_id", appt.doctor_id)
       .eq("preferred_date", appt.appointment_date)
       .eq("status", WAITING_LIST_STATUS.WAITING)
@@ -101,7 +104,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       action: "appointment.cancelled",
       type: "booking",
       actor: profile.id,
-      clinicId: profile.clinic_id ?? clinicConfig.clinicId,
+      clinicId,
       description: `Appointment ${body.appointmentId} cancelled. Reason: ${body.reason ?? "Cancelled by patient"}`,
     });
 
@@ -117,7 +120,8 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
  *
  * Check if an appointment can be cancelled.
  */
-export const GET = withAuth(async (request, { supabase }) => {
+export const GET = withAuth(async (request, { supabase, profile }) => {
+  const clinicId = await resolveClinicId(profile.clinic_id);
   const appointmentId = request.nextUrl.searchParams.get("appointmentId");
 
   if (!appointmentId) {
@@ -128,7 +132,7 @@ export const GET = withAuth(async (request, { supabase }) => {
     .from("appointments")
     .select("id, appointment_date, start_time, status")
     .eq("id", appointmentId)
-    .eq("clinic_id", clinicConfig.clinicId)
+    .eq("clinic_id", clinicId)
     .single();
 
   if (error || !appt) {

--- a/src/app/api/booking/emergency-slot/route.ts
+++ b/src/app/api/booking/emergency-slot/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { clinicConfig } from "@/config/clinic.config";
 import { withAuth } from "@/lib/with-auth";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
@@ -8,6 +7,7 @@ import { computeEndTime } from "@/lib/timezone";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { emergencySlotSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -16,8 +16,10 @@ export const runtime = "edge";
  *
  * Create an emergency slot (doctor only) or book an existing one.
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(emergencySlotSchema, raw);
     if (!parsed.success) {
@@ -37,7 +39,7 @@ export const POST = withAuth(async (request, { supabase }) => {
         .from("users")
         .select("id")
         .eq("id", body.doctorId)
-        .eq("clinic_id", clinicConfig.clinicId)
+        .eq("clinic_id", clinicId)
         .eq("role", "doctor")
         .single();
 
@@ -57,7 +59,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       const { data: slot, error: insertError } = await supabase
         .from("emergency_slots")
         .insert({
-          clinic_id: clinicConfig.clinicId,
+          clinic_id: clinicId,
           doctor_id: body.doctorId,
           slot_date: body.date,
           start_time: body.startTime,
@@ -98,7 +100,7 @@ export const POST = withAuth(async (request, { supabase }) => {
         .from("emergency_slots")
         .update({ is_booked: true })
         .eq("id", body.slotId)
-        .eq("clinic_id", clinicConfig.clinicId)
+        .eq("clinic_id", clinicId)
         .eq("is_booked", false)
         .select("id, doctor_id, slot_date, start_time, end_time")
         .single();
@@ -112,7 +114,7 @@ export const POST = withAuth(async (request, { supabase }) => {
 
       // Find or create patient (prefer phone-based lookup to avoid name collisions)
       const patientId = await findOrCreatePatient(
-        supabase, clinicConfig.clinicId, body.patientId, body.patientName,
+        supabase, clinicId, body.patientId, body.patientName,
         { phone: body.patientPhone },
       );
       if (!patientId) {
@@ -131,7 +133,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       const { data: appointment, error: apptError } = await supabase
         .from("appointments")
         .insert({
-          clinic_id: clinicConfig.clinicId,
+          clinic_id: clinicId,
           patient_id: patientId,
           doctor_id: claimedSlot.doctor_id,
           service_id: body.serviceId ?? null,
@@ -164,7 +166,7 @@ export const POST = withAuth(async (request, { supabase }) => {
         supabase,
         action: "appointment.emergency_booked",
         type: "booking",
-        clinicId: clinicConfig.clinicId,
+        clinicId,
         description: `Emergency appointment ${appointment.id} created for patient ${patientId} with doctor ${claimedSlot.doctor_id} on ${claimedSlot.slot_date}`,
       });
 
@@ -187,14 +189,15 @@ export const POST = withAuth(async (request, { supabase }) => {
  *
  * Get available emergency slots. Requires authentication.
  */
-export const GET = withAuth(async (request, { supabase }) => {
+export const GET = withAuth(async (request, { supabase, profile }) => {
+  const clinicId = await resolveClinicId(profile.clinic_id);
   const doctorId = request.nextUrl.searchParams.get("doctorId") ?? undefined;
   const date = request.nextUrl.searchParams.get("date") ?? undefined;
 
   let q = supabase
     .from("emergency_slots")
     .select("id, doctor_id, slot_date, start_time, end_time, reason, is_booked, created_at")
-    .eq("clinic_id", clinicConfig.clinicId);
+    .eq("clinic_id", clinicId);
 
   if (doctorId) {
     q = q.eq("doctor_id", doctorId);

--- a/src/app/api/booking/payment/confirm/route.ts
+++ b/src/app/api/booking/payment/confirm/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { logAuditEvent } from "@/lib/audit-log";
-import { clinicConfig } from "@/config/clinic.config";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { paymentConfirmSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -14,8 +14,10 @@ export const runtime = "edge";
  *
  * Confirm a pending payment.
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(paymentConfirmSchema, raw);
     if (!parsed.success) {
@@ -28,7 +30,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       .from("payments")
       .select("id, status, appointment_id")
       .eq("id", body.paymentId)
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .single();
 
     if (fetchError || !payment) {
@@ -63,7 +65,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       supabase,
       action: "payment_confirmed",
       type: "payment",
-      clinicId: clinicConfig.clinicId,
+      clinicId,
       description: `Payment ${body.paymentId} confirmed`,
     });
 

--- a/src/app/api/booking/payment/initiate/route.ts
+++ b/src/app/api/booking/payment/initiate/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { logAuditEvent } from "@/lib/audit-log";
-import { clinicConfig } from "@/config/clinic.config";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { paymentInitiateSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -14,8 +14,10 @@ export const runtime = "edge";
  *
  * Initiate a payment for an appointment.
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(paymentInitiateSchema, raw);
     if (!parsed.success) {
@@ -28,7 +30,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       .from("appointments")
       .select("id")
       .eq("id", body.appointmentId)
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .single();
 
     if (apptError || !appt) {
@@ -40,7 +42,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       .from("payments")
       .select("id")
       .eq("appointment_id", body.appointmentId)
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .not("status", "in", '("refunded","failed")')
       .limit(1)
       .single();
@@ -52,7 +54,7 @@ export const POST = withAuth(async (request, { supabase }) => {
     // Find or create patient using shared utility (prefers phone-based lookup
     // over name-based to avoid assigning payments to the wrong patient).
     const patientId = await findOrCreatePatient(
-      supabase, clinicConfig.clinicId, body.patientId, body.patientName,
+      supabase, clinicId, body.patientId, body.patientName,
     );
     if (!patientId) {
       return NextResponse.json({ error: "Failed to resolve patient" }, { status: 500 });
@@ -64,7 +66,7 @@ export const POST = withAuth(async (request, { supabase }) => {
     const { data: payment, error: insertError } = await supabase
       .from("payments")
       .insert({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         appointment_id: body.appointmentId,
         patient_id: patientId,
         amount: body.amount,
@@ -93,7 +95,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       supabase,
       action: "payment_initiated",
       type: "payment",
-      clinicId: clinicConfig.clinicId,
+      clinicId,
       description: `Payment initiated: ${body.paymentType} ${body.amount} via ${method} for appointment ${body.appointmentId}`,
     });
 

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import { logAuditEvent } from "@/lib/audit-log";
-import { clinicConfig } from "@/config/clinic.config";
 import type { UserRole } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { paymentRefundSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -15,8 +15,10 @@ const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
  *
  * Refund a completed payment (full or partial).
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(paymentRefundSchema, raw);
     if (!parsed.success) {
@@ -29,7 +31,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       .from("payments")
       .select("id, status, amount, refunded_amount")
       .eq("id", body.paymentId)
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .single();
 
     if (fetchError || !payment) {
@@ -84,7 +86,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       supabase,
       action: "payment_refunded",
       type: "payment",
-      clinicId: clinicConfig.clinicId,
+      clinicId,
       description: `Payment ${body.paymentId} refunded: ${refundAmount} of ${payment.amount}`,
     });
 

--- a/src/app/api/booking/recurring/route.ts
+++ b/src/app/api/booking/recurring/route.ts
@@ -9,6 +9,7 @@ import { computeEndTime } from "@/lib/timezone";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { recurringSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -36,8 +37,10 @@ function addInterval(date: Date, pattern: "weekly" | "biweekly" | "monthly"): Da
  *
  * Create a recurring booking series or cancel one.
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(recurringSchema, raw);
     if (!parsed.success) {
@@ -67,7 +70,7 @@ export const POST = withAuth(async (request, { supabase }) => {
 
       // Find or create patient (prefer phone-based lookup to avoid name collisions)
       const patientId = await findOrCreatePatient(
-        supabase, clinicConfig.clinicId, body.patientId, body.patientName,
+        supabase, clinicId, body.patientId, body.patientName,
         { phone: body.patientPhone },
       );
       if (!patientId) {
@@ -108,7 +111,7 @@ export const POST = withAuth(async (request, { supabase }) => {
         const slotEnd = `${dateStr}T${endTime}:00`;
 
         appointmentRows.push({
-          clinic_id: clinicConfig.clinicId,
+          clinic_id: clinicId,
           patient_id: patientId,
           doctor_id: body.doctorId,
           service_id: body.serviceId ?? null,
@@ -139,7 +142,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       const { data: existingAppts } = await supabase
         .from("appointments")
         .select("appointment_date, start_time, end_time")
-        .eq("clinic_id", clinicConfig.clinicId)
+        .eq("clinic_id", clinicId)
         .eq("doctor_id", body.doctorId)
         .in("appointment_date", datesToCheck)
         .neq("status", APPOINTMENT_STATUS.CANCELLED);
@@ -204,7 +207,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       const { data: groupAppts } = await supabase
         .from("appointments")
         .select("id, status")
-        .eq("clinic_id", clinicConfig.clinicId)
+        .eq("clinic_id", clinicId)
         .eq("recurrence_group_id", body.groupId);
 
       if (!groupAppts || groupAppts.length === 0) {

--- a/src/app/api/booking/reschedule/route.ts
+++ b/src/app/api/booking/reschedule/route.ts
@@ -6,6 +6,7 @@ import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
 import { logger } from "@/lib/logger";
 import { rescheduleSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -18,6 +19,8 @@ export const runtime = "edge";
  */
 export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(rescheduleSchema, raw);
     if (!parsed.success) {
@@ -51,7 +54,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       .from("appointments")
       .select("id, status, clinic_id, doctor_id, service_id")
       .eq("id", body.appointmentId)
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .single();
 
     if (fetchError || !existing) {
@@ -116,7 +119,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       action: "appointment.rescheduled",
       type: "booking",
       actor: profile.id,
-      clinicId: profile.clinic_id ?? clinicConfig.clinicId,
+      clinicId,
       description: `Appointment ${body.appointmentId} rescheduled to ${body.newDate} ${body.newTime}`,
     });
 

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -16,6 +16,7 @@ import { computeEndTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { safeParse } from "@/lib/validations";
 import { z } from "zod";
+import { requireTenant } from "@/lib/tenant";
 
 const bookingRequestSchema = z.object({
   specialtyId: z.string().min(1),
@@ -212,6 +213,8 @@ export async function POST(request: NextRequest) {
     const service = validation.services.find((s) => s.id === body.serviceId);
 
     const supabase = await createClient();
+    const tenant = await requireTenant();
+    const clinicId = tenant.clinicId;
 
     // Verify doctorId and serviceId belong to this clinic in a single
     // parallel query instead of two sequential ones.  This also avoids
@@ -222,14 +225,14 @@ export async function POST(request: NextRequest) {
         .from("users")
         .select("id")
         .eq("id", body.doctorId)
-        .eq("clinic_id", clinicConfig.clinicId)
+        .eq("clinic_id", clinicId)
         .eq("role", "doctor")
         .single(),
       supabase
         .from("services")
         .select("id")
         .eq("id", body.serviceId)
-        .eq("clinic_id", clinicConfig.clinicId)
+        .eq("clinic_id", clinicId)
         .single(),
     ]);
 
@@ -244,7 +247,7 @@ export async function POST(request: NextRequest) {
     // Find or create a patient record using the shared utility
     // (prefers phone-based lookup to avoid name collisions)
     const patientId = await findOrCreatePatient(
-      supabase, clinicConfig.clinicId, "patient-new", body.patient.name,
+      supabase, clinicId, "patient-new", body.patient.name,
       { phone: body.patient.phone, email: body.patient.email },
     );
     if (!patientId) {
@@ -275,7 +278,7 @@ export async function POST(request: NextRequest) {
     const { data: appointment, error: apptError } = await supabase
       .from("appointments")
       .insert({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         patient_id: patientId,
         doctor_id: body.doctorId,
         service_id: body.serviceId,
@@ -316,7 +319,7 @@ export async function POST(request: NextRequest) {
     const { count: slotCount } = await supabase
       .from("appointments")
       .select("id", { count: "exact", head: true })
-      .eq("clinic_id", clinicConfig.clinicId)
+      .eq("clinic_id", clinicId)
       .eq("doctor_id", body.doctorId)
       .eq("appointment_date", body.date)
       .eq("start_time", body.time)
@@ -343,7 +346,7 @@ export async function POST(request: NextRequest) {
       supabase,
       action: "appointment.created",
       type: "booking",
-      clinicId: clinicConfig.clinicId,
+      clinicId,
       description: `Appointment ${appointment.id} created for patient ${patientId} with doctor ${body.doctorId}`,
     });
 

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { clinicConfig } from "@/config/clinic.config";
 import { withAuth } from "@/lib/with-auth";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 import { logAuditEvent } from "@/lib/audit-log";
 import { WAITING_LIST_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
 import { waitingListSchema, safeParse } from "@/lib/validations";
+import { resolveClinicId } from "@/lib/tenant";
 
 export const runtime = "edge";
 
@@ -14,8 +14,10 @@ export const runtime = "edge";
  *
  * Add a patient to the waiting list.
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const raw = await request.json();
     const parsed = safeParse(waitingListSchema, raw);
     if (!parsed.success) {
@@ -25,7 +27,7 @@ export const POST = withAuth(async (request, { supabase }) => {
 
     // Find or create patient (prefer phone-based lookup to avoid name collisions)
     const patientId = await findOrCreatePatient(
-      supabase, clinicConfig.clinicId, body.patientId, body.patientName,
+      supabase, clinicId, body.patientId, body.patientName,
       { phone: body.patientPhone },
     );
     if (!patientId) {
@@ -35,7 +37,7 @@ export const POST = withAuth(async (request, { supabase }) => {
     const { data: entry, error } = await supabase
       .from("waiting_list")
       .insert({
-        clinic_id: clinicConfig.clinicId,
+        clinic_id: clinicId,
         patient_id: patientId,
         doctor_id: body.doctorId,
         preferred_date: body.preferredDate,
@@ -56,7 +58,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       supabase,
       action: "waiting_list.added",
       type: "booking",
-      clinicId: clinicConfig.clinicId,
+      clinicId,
       description: `Patient ${patientId} added to waiting list (entry ${entry.id}) for doctor ${body.doctorId} on ${body.preferredDate}`,
     });
 
@@ -76,13 +78,12 @@ export const POST = withAuth(async (request, { supabase }) => {
  *
  * Get waiting list entries.
  */
-export const GET = withAuth(async (request, { supabase }) => {
+export const GET = withAuth(async (request, { supabase, profile }) => {
+  const clinicId = await resolveClinicId(profile.clinic_id);
   const patientId = request.nextUrl.searchParams.get("patientId");
   const doctorId = request.nextUrl.searchParams.get("doctorId");
   const date = request.nextUrl.searchParams.get("date");
   const time = request.nextUrl.searchParams.get("time");
-
-  const clinicId = clinicConfig.clinicId;
 
   if (patientId) {
     const { data: entries } = await supabase
@@ -122,8 +123,10 @@ export const GET = withAuth(async (request, { supabase }) => {
  *
  * Remove a patient from the waiting list.
  */
-export const DELETE = withAuth(async (request, { supabase }) => {
+export const DELETE = withAuth(async (request, { supabase, profile }) => {
   try {
+    const clinicId = await resolveClinicId(profile.clinic_id);
+
     const body = (await request.json()) as { entryId: string };
 
     if (!body.entryId) {
@@ -134,7 +137,7 @@ export const DELETE = withAuth(async (request, { supabase }) => {
       .from("waiting_list")
       .delete()
       .eq("id", body.entryId)
-      .eq("clinic_id", clinicConfig.clinicId);
+      .eq("clinic_id", clinicId);
 
     if (error) {
       logger.warn("Operation failed", { context: "booking/waiting-list", error });
@@ -146,7 +149,7 @@ export const DELETE = withAuth(async (request, { supabase }) => {
       supabase,
       action: "waiting_list.removed",
       type: "booking",
-      clinicId: clinicConfig.clinicId,
+      clinicId,
       description: `Waiting list entry ${body.entryId} removed`,
     });
 

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -17,6 +17,7 @@ import type { UserRole } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { brandingUpdateSchema, safeParse } from "@/lib/validations";
+import { requireTenant, resolveClinicId } from "@/lib/tenant";
 
 const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
 
@@ -59,7 +60,8 @@ const FIELD_MAP: Record<string, string> = {
 
 export async function GET() {
   try {
-    const clinicId = clinicConfig.clinicId;
+    const tenant = await requireTenant();
+    const clinicId = tenant.clinicId;
     const supabase = await createClient();
 
     const { data, error } = await supabase
@@ -108,8 +110,8 @@ export async function GET() {
 
 // ── PUT — update text branding fields (colors, fonts) ──
 
-export const PUT = withAuth(async (request, { supabase }) => {
-  const clinicId = clinicConfig.clinicId;
+export const PUT = withAuth(async (request, { supabase, profile }) => {
+  const clinicId = await resolveClinicId(profile.clinic_id);
   const raw = await request.json();
   const parsed = safeParse(brandingUpdateSchema, raw);
   if (!parsed.success) {
@@ -166,8 +168,8 @@ export const PUT = withAuth(async (request, { supabase }) => {
 
 // ── POST — upload a branding image and save URL ──
 
-export const POST = withAuth(async (request, { supabase }) => {
-  const clinicId = clinicConfig.clinicId;
+export const POST = withAuth(async (request, { supabase, profile }) => {
+  const clinicId = await resolveClinicId(profile.clinic_id);
 
   if (!isR2Configured()) {
     return NextResponse.json(

--- a/src/components/admin/clinic-center-dashboard-kpis.tsx
+++ b/src/components/admin/clinic-center-dashboard-kpis.tsx
@@ -17,6 +17,7 @@ import {
   type ClinicCenterDashboardKPIs,
 } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { PageLoader } from "@/components/ui/page-loader";
 import { logger } from "@/lib/logger";
 
@@ -30,11 +31,11 @@ import { logger } from "@/lib/logger";
  *  - Revenue by department
  */
 export function ClinicCenterDashboardKPIsComponent() {
+  const { clinicId } = useTenant();
   const [data, setData] = useState<ClinicCenterDashboardKPIs | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const clinicId = clinicConfig.clinicId;
     let cancelled = false;
     if (!clinicId) {
       Promise.resolve().then(() => { if (!cancelled) setLoading(false); });

--- a/src/components/admin/clinic-stats.tsx
+++ b/src/components/admin/clinic-stats.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { fetchDashboardStats, fetchTodayAppointments, type DashboardStats } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { logger } from "@/lib/logger";
 
 /**
@@ -14,11 +15,11 @@ import { logger } from "@/lib/logger";
  * Key metrics cards: patient count, no-show rate, booking sources, busiest hours.
  */
 export function ClinicStats() {
+  const { clinicId } = useTenant();
   const [dashData, setDashData] = useState<DashboardStats | null>(null);
   const [todayCount, setTodayCount] = useState(0);
 
   useEffect(() => {
-    const clinicId = clinicConfig.clinicId;
     if (!clinicId) return;
 
     let cancelled = false;

--- a/src/components/admin/lab-dashboard-kpis.tsx
+++ b/src/components/admin/lab-dashboard-kpis.tsx
@@ -14,6 +14,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { fetchLabDashboardKPIs, type LabDashboardKPIs } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { PageLoader } from "@/components/ui/page-loader";
 import { logger } from "@/lib/logger";
 
@@ -27,11 +28,11 @@ import { logger } from "@/lib/logger";
  *  - Average turnaround time
  */
 export function LabDashboardKPIsComponent() {
+  const { clinicId } = useTenant();
   const [data, setData] = useState<LabDashboardKPIs | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const clinicId = clinicConfig.clinicId;
     let cancelled = false;
     if (!clinicId) {
       Promise.resolve().then(() => { if (!cancelled) setLoading(false); });

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react";
 import { ChevronLeft, ChevronRight, Check, Stethoscope, User, ShieldCheck, Repeat, Users, Loader2 } from "lucide-react";
 import { fetchDoctors, fetchServices, type DoctorView, type ServiceView } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -91,6 +92,7 @@ function mapService(s: ServiceView): Service {
 }
 
 export function BookingForm() {
+  const { clinicId } = useTenant();
   const steps = useMemo(() => getSteps(), []);
   const [step, setStep] = useState(0);
   const [selectedSpecialty, setSelectedSpecialty] = useState("");
@@ -126,7 +128,6 @@ export function BookingForm() {
 
   // Load doctors, services, and specialties from Supabase on mount
   useEffect(() => {
-    const clinicId = clinicConfig.clinicId;
     if (!clinicId) return;
 
     let cancelled = false;

--- a/src/components/dental/dental-booking-extras.tsx
+++ b/src/components/dental/dental-booking-extras.tsx
@@ -7,6 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { fetchDentalTreatmentTypes, type DentalTreatmentTypeView } from "@/lib/data/client";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { logger } from "@/lib/logger";
 
 interface DentalBookingExtrasProps {
@@ -22,10 +23,10 @@ export function DentalBookingExtras({
   sedationRequested,
   onSedationChange,
 }: DentalBookingExtrasProps) {
+  const { clinicId } = useTenant();
   const [dentalTreatmentTypes, setDentalTreatmentTypes] = useState<DentalTreatmentTypeView[]>([]);
 
   useEffect(() => {
-    const clinicId = clinicConfig.clinicId;
     if (!clinicId) return;
     fetchDentalTreatmentTypes(clinicId).then(setDentalTreatmentTypes).catch((err) => {
       logger.warn("Operation failed", { context: "dental-booking-extras", error: err });

--- a/src/components/patient/reschedule-dialog.tsx
+++ b/src/components/patient/reschedule-dialog.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { BookingCalendar } from "@/components/booking/calendar";
 import { TimeSlotPicker } from "@/components/booking/time-slots";
 import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/lib/hooks/use-tenant";
 import { fetchAvailableSlots, fetchGeneratedSlots, fetchSlotBookingCounts } from "@/lib/data/client";
 
 interface RescheduleAppointment {
@@ -31,6 +32,7 @@ interface RescheduleDialogProps {
  * for an existing appointment.
  */
 export function RescheduleDialog({ appointment, onClose, onReschedule }: RescheduleDialogProps) {
+  const { clinicId } = useTenant();
   const [selectedDate, setSelectedDate] = useState("");
   const [selectedTime, setSelectedTime] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -49,7 +51,6 @@ export function RescheduleDialog({ appointment, onClose, onReschedule }: Resched
       setSlotCounts({});
       return;
     }
-    const clinicId = clinicConfig.clinicId;
     Promise.all([
       fetchAvailableSlots(clinicId, selectedDate, appointment.doctorId),
       fetchGeneratedSlots(clinicId, selectedDate, appointment.doctorId),

--- a/src/lib/data/lab-public.ts
+++ b/src/lib/data/lab-public.ts
@@ -2,13 +2,14 @@
  * Server-side data fetching for Lab & Radiology public-facing pages.
  *
  * These functions use the server Supabase client and scope queries
- * to the current clinic via `clinicConfig.clinicId`.
+ * to the current tenant resolved from the request context.
  * Tables are accessed gracefully — if a table doesn't exist yet the
  * function returns an empty array instead of crashing.
  */
 
 import { createClient } from "@/lib/supabase-server";
 import { clinicConfig } from "@/config/clinic.config";
+import { requireTenant } from "@/lib/tenant";
 
 // ── Types ──
 
@@ -41,14 +42,15 @@ export interface CollectionPoint {
 
 // ── Helpers ──
 
-function getClinicId(): string {
-  return clinicConfig.clinicId;
+async function getClinicId(): Promise<string> {
+  const tenant = await requireTenant();
+  return tenant.clinicId;
 }
 
 // ── Lab Tests / Exams ──
 
 export async function getPublicLabTests(): Promise<LabTest[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -92,7 +94,7 @@ export function searchLabTests(tests: LabTest[], query: string): LabTest[] {
 // ── Collection Points ──
 
 export async function getPublicCollectionPoints(): Promise<CollectionPoint[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -2,7 +2,7 @@
  * Server-side data fetching for public-facing pages.
  *
  * These functions use the server Supabase client and scope all queries
- * to the current clinic via `clinicConfig.clinicId`.
+ * to the current tenant resolved from the request context (via middleware headers).
  * They return data shaped to match the existing UI types so pages
  * can swap from demo-data imports with minimal changes.
  */
@@ -10,6 +10,7 @@
 import { createClient } from "@/lib/supabase-server";
 import { clinicConfig } from "@/config/clinic.config";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import { requireTenant } from "@/lib/tenant";
 
 // ── Types (match existing UI shapes) ──
 
@@ -80,14 +81,15 @@ export interface ClinicBranding {
 
 // ── Helpers ──
 
-function getClinicId(): string {
-  return clinicConfig.clinicId;
+async function getClinicId(): Promise<string> {
+  const tenant = await requireTenant();
+  return tenant.clinicId;
 }
 
 // ── Clinic Branding ──
 
 export async function getPublicBranding(): Promise<ClinicBranding> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -138,7 +140,7 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
 // ── Reviews ──
 
 export async function getPublicReviews(): Promise<PublicReview[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   // Fetch reviews with patient names via Supabase join (single query)
@@ -165,7 +167,7 @@ export async function getPublicReviews(): Promise<PublicReview[]> {
 }
 
 export async function getPublicAverageRating(): Promise<number> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   // Try DB-level AVG via Supabase RPC first (single row returned,
@@ -210,7 +212,7 @@ export async function getPublicAverageRating(): Promise<number> {
 // ── Services ──
 
 export async function getPublicServices(): Promise<PublicService[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -236,7 +238,7 @@ export async function getPublicServices(): Promise<PublicService[]> {
 // ── Doctors ──
 
 export async function getPublicDoctors(): Promise<PublicDoctor[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -301,7 +303,7 @@ export interface TimeSlotConfig {
 export async function getPublicTimeSlots(
   doctorId?: string,
 ): Promise<TimeSlotConfig[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   let q = supabase
@@ -372,7 +374,7 @@ export async function getPublicSlotBookingCounts(
   date: string,
   doctorId: string,
 ): Promise<Record<string, number>> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const dayStart = `${date}T00:00:00`;
@@ -440,7 +442,7 @@ export interface PublicPharmacyProduct {
 }
 
 export async function getPublicPharmacyProducts(): Promise<PublicPharmacyProduct[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const [{ data: products }, { data: stockRows }] = await Promise.all([
@@ -520,7 +522,7 @@ export interface PublicPharmacyService {
 }
 
 export async function getPublicPharmacyServices(): Promise<PublicPharmacyService[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase
@@ -555,7 +557,7 @@ export interface PublicOnDutySchedule {
 }
 
 export async function getPublicOnDutySchedule(): Promise<PublicOnDutySchedule[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   // Try fetching from on_duty_schedule table if it exists
@@ -624,7 +626,7 @@ export interface PublicPharmacyPrescription {
 }
 
 export async function getPublicPharmacyPrescriptions(): Promise<PublicPharmacyPrescription[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data: requests, error } = await supabase
@@ -676,7 +678,7 @@ export async function getPublicPharmacyPrescriptions(): Promise<PublicPharmacyPr
 // ── Blog Posts ──
 
 export async function getPublicBlogPosts(): Promise<PublicBlogPost[]> {
-  const clinicId = getClinicId();
+  const clinicId = await getClinicId();
   const supabase = await createClient();
 
   const { data, error } = await supabase

--- a/src/lib/hooks/use-tenant.ts
+++ b/src/lib/hooks/use-tenant.ts
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Client-side tenant hook.
+ *
+ * Resolves the current clinic_id from the authenticated user's profile.
+ * This replaces all client-side usage of `clinicConfig.clinicId` for
+ * database queries, ensuring multi-tenant isolation.
+ *
+ * Usage:
+ *   const { clinicId, isLoading } = useTenant();
+ */
+
+import { useState, useEffect } from "react";
+import { getCurrentUser } from "@/lib/data/client";
+
+interface TenantState {
+  clinicId: string | null;
+  isLoading: boolean;
+}
+
+/**
+ * Returns the current user's clinic_id from their authenticated profile.
+ * Falls back to null if not authenticated or profile has no clinic_id.
+ */
+export function useTenant(): TenantState {
+  const [state, setState] = useState<TenantState>({
+    clinicId: null,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolve() {
+      try {
+        const user = await getCurrentUser();
+        if (!cancelled) {
+          setState({
+            clinicId: user?.clinic_id ?? null,
+            isLoading: false,
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setState({ clinicId: null, isLoading: false });
+        }
+      }
+    }
+
+    void resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -45,3 +45,41 @@ export async function getTenant(): Promise<TenantInfo | null> {
     clinicTier: h.get(TENANT_HEADERS.clinicTier) ?? "",
   };
 }
+
+/**
+ * Get the current tenant or throw if not resolved.
+ *
+ * Use this in API routes and server functions where a tenant is REQUIRED.
+ * Throws a descriptive error if the tenant could not be resolved from
+ * the request context (e.g. missing subdomain).
+ */
+export async function requireTenant(): Promise<TenantInfo> {
+  const tenant = await getTenant();
+  if (!tenant?.clinicId) {
+    throw new Error(
+      "Tenant resolution failed: no clinic_id in request context. " +
+      "Ensure the request is routed through a valid tenant subdomain.",
+    );
+  }
+  return tenant;
+}
+
+/**
+ * Resolve the clinic_id for the current request.
+ *
+ * For authenticated API routes that receive an AuthContext from withAuth(),
+ * prefer using the profile's clinic_id (which comes from the user's DB record).
+ * Falls back to the tenant header resolved by middleware.
+ *
+ * @param profileClinicId - The clinic_id from the authenticated user's profile (may be null for super_admin).
+ * @returns The resolved clinic_id string.
+ * @throws Error if neither source provides a clinic_id.
+ */
+export async function resolveClinicId(profileClinicId?: string | null): Promise<string> {
+  if (profileClinicId) return profileClinicId;
+  const tenant = await getTenant();
+  if (tenant?.clinicId) return tenant.clinicId;
+  throw new Error(
+    "Tenant resolution failed: no clinic_id from user profile or request headers.",
+  );
+}


### PR DESCRIPTION
…t resolution

- Add requireTenant() and resolveClinicId() helpers in tenant.ts
- Create useTenant() client hook for client components
- Refactor data layer (public.ts, lab-public.ts) to use async getClinicId()
- Refactor all API routes to use request-based tenant resolution
- Refactor 38 client components to use useTenant() hook
- Fix server component (dentist/gallery) to use requireTenant()
- Preserve clinicConfig for branding/UI only, never for DB queries
- All database queries now derive clinic_id from request context