### PR TITLE
fix: enforce request-based tenant isolation across API routes and data layer

### DIFF
--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -6,7 +6,6 @@
  */
 
 import { NextResponse } from "next/server";
-import { clinicConfig } from "@/config/clinic.config";
 import { createClient } from "@/lib/supabase-server";
 import { requireTenant } from "@/lib/tenant";
 import {
@@ -75,7 +74,7 @@ export async function GET() {
     if (error || !data) {
       return NextResponse.json(
         {
-          name: clinicConfig.name,
+          name: tenant.clinicName || "Clinic",
           logo_url: null,
           favicon_url: null,
           primary_color: "#1E4DA1",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchChatbotContext, buildSystemPrompt, getBasicResponse } from "@/lib/chatbot-data";
-import { TENANT_HEADERS } from "@/lib/tenant";
+import { requireTenant } from "@/lib/tenant";
 import { createClient } from "@/lib/supabase-server";
 import { chatLimiter, extractClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
@@ -16,9 +16,8 @@ export const runtime = "edge";
  *   - smart:    Cloudflare Workers AI (free tier)
  *   - advanced: OpenAI-compatible API (paid)
  *
- * The clinic is resolved from:
- *   1. x-tenant-clinic-id header (set by middleware from subdomain)
- *   2. clinicId in request body (fallback)
+ * The clinic is resolved from the tenant context (set by middleware from subdomain).
+ * clinicId in the request body is ignored — tenant MUST come from request context.
  */
 /** Max number of conversation history messages sent to the LLM. */
 const MAX_HISTORY_LENGTH = 20;
@@ -72,22 +71,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Resolve clinic ID from tenant headers or request body
-    const tenantClinicId = request.headers.get(TENANT_HEADERS.clinicId);
+    // Resolve clinic ID strictly from tenant context (middleware headers)
+    const tenant = await requireTenant();
+    const clinicId = tenant.clinicId;
     const raw = await request.json();
     const parsed = safeParse(chatRequestSchema, raw);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
     const body = parsed.data;
-    const clinicId = tenantClinicId || body.clinicId;
-
-    if (!clinicId) {
-      return NextResponse.json(
-        { error: "No clinic context. Please access via a clinic subdomain." },
-        { status: 400 },
-      );
-    }
 
     const lastMessage = body.messages[body.messages.length - 1];
     if (!lastMessage || lastMessage.role !== "user" || !lastMessage.content.trim()) {

--- a/src/app/api/custom-fields/values/route.ts
+++ b/src/app/api/custom-fields/values/route.ts
@@ -8,18 +8,19 @@ import type { Json } from "@/lib/types/database";
 export const runtime = "edge";
 
 /**
- * GET /api/custom-fields/values?clinic_id=...&entity_type=...&entity_id=...
+ * GET /api/custom-fields/values?entity_type=...&entity_id=...
  *
  * Returns custom field values for a specific entity instance.
+ * clinic_id is derived from the authenticated user's profile.
  */
-export const GET = withAuth(async (request, { supabase }) => {
-  const clinicId = request.nextUrl.searchParams.get("clinic_id");
+export const GET = withAuth(async (request, { supabase, profile }) => {
+  const clinicId = profile.clinic_id;
   const entityType = request.nextUrl.searchParams.get("entity_type");
   const entityId = request.nextUrl.searchParams.get("entity_id");
 
   if (!clinicId || !entityType || !entityId) {
     return NextResponse.json(
-      { error: "clinic_id, entity_type, and entity_id are required" },
+      { error: "entity_type and entity_id are required, and user must belong to a clinic" },
       { status: 400 },
     );
   }
@@ -51,14 +52,22 @@ export const GET = withAuth(async (request, { supabase }) => {
  *
  * Save (upsert) custom field values for a specific entity instance.
  */
-export const POST = withAuth(async (request, { supabase }) => {
+export const POST = withAuth(async (request, { supabase, profile }) => {
   try {
     const raw = await request.json();
     const parsed = safeParse(customFieldValuesSchema, raw);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
-    const { clinic_id, entity_type, entity_id, field_values } = parsed.data;
+    const { entity_type, entity_id, field_values } = parsed.data;
+    // Always derive clinic_id from the authenticated user's profile
+    const clinic_id = profile.clinic_id;
+    if (!clinic_id) {
+      return NextResponse.json(
+        { error: "User must belong to a clinic" },
+        { status: 400 },
+      );
+    }
 
     const { data: definitions } = await supabase
       .from("custom_field_definitions")
@@ -139,14 +148,22 @@ export const POST = withAuth(async (request, { supabase }) => {
  *
  * Partially update custom field values (merge with existing).
  */
-export const PATCH = withAuth(async (request, { supabase }) => {
+export const PATCH = withAuth(async (request, { supabase, profile }) => {
   try {
     const raw = await request.json();
     const parsed = safeParse(customFieldValuesSchema, raw);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
-    const { clinic_id, entity_type, entity_id, field_values } = parsed.data;
+    const { entity_type, entity_id, field_values } = parsed.data;
+    // Always derive clinic_id from the authenticated user's profile
+    const clinic_id = profile.clinic_id;
+    if (!clinic_id) {
+      return NextResponse.json(
+        { error: "User must belong to a clinic" },
+        { status: 400 },
+      );
+    }
 
     const { data: definitions } = await supabase
       .from("custom_field_definitions")

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -1,7 +1,8 @@
 /**
  * POST /api/lab/report-html — Generate an HTML report for a lab test order
  *
- * Body: { orderId, clinicId, patientName, orderNumber, results }
+ * Body: { orderId, patientName, orderNumber, results }
+ * clinic_id is derived from the authenticated user's profile.
  *
  * Generates an HTML report, uploads to R2, and updates the order's pdf_url.
  * Returns: { pdfUrl }
@@ -115,14 +116,22 @@ function generateLabReportHtml(data: {
 </html>`;
 }
 
-export const POST = withAuth(async (request) => {
+export const POST = withAuth(async (request, { profile }) => {
   try {
     const raw = await request.json();
     const parsed = safeParse(labReportSchema, raw);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
-    const { orderId, clinicId, patientName, orderNumber, results } = parsed.data;
+    const { orderId, patientName, orderNumber, results } = parsed.data;
+    // Derive clinic_id from the authenticated user's profile — never from the request body
+    const clinicId = profile.clinic_id;
+    if (!clinicId) {
+      return NextResponse.json(
+        { error: "User must belong to a clinic" },
+        { status: 400 },
+      );
+    }
 
     const generatedAt = new Date().toLocaleString("en-US", {
       dateStyle: "long",

--- a/src/app/api/radiology/orders/route.ts
+++ b/src/app/api/radiology/orders/route.ts
@@ -2,7 +2,8 @@
  * POST /api/radiology/orders — Create a new radiology order
  * PATCH /api/radiology/orders — Update order status or save report
  *
- * POST body: { clinicId, patientId, modality, bodyPart?, clinicalIndication?, priority?, scheduledAt?, orderingDoctorId? }
+ * POST body: { patientId, modality, bodyPart?, clinicalIndication?, priority?, scheduledAt?, orderingDoctorId? }
+ * clinic_id is derived from the authenticated user's profile.
  * PATCH body (status update): { orderId, action: "status", status }
  * PATCH body (save report): { orderId, action: "report", findings, impression, reportText, templateId?, radiologistId? }
  */
@@ -18,14 +19,22 @@ import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { radiologyOrderCreateSchema, radiologyOrderPatchSchema, safeParse } from "@/lib/validations";
 
-export const POST = withAuth(async (request) => {
+export const POST = withAuth(async (request, { profile }) => {
   try {
     const raw = await request.json();
     const parsed = safeParse(radiologyOrderCreateSchema, raw);
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
-    const { clinicId, patientId, modality, bodyPart, clinicalIndication, priority, scheduledAt, orderingDoctorId } = parsed.data;
+    const { patientId, modality, bodyPart, clinicalIndication, priority, scheduledAt, orderingDoctorId } = parsed.data;
+    // Derive clinic_id from the authenticated user's profile — never from the request body
+    const clinicId = profile.clinic_id;
+    if (!clinicId) {
+      return NextResponse.json(
+        { error: "User must belong to a clinic" },
+        { status: 400 },
+      );
+    }
 
     const result = await createRadiologyOrder({
       clinic_id: clinicId,

--- a/src/app/api/radiology/report-pdf/route.ts
+++ b/src/app/api/radiology/report-pdf/route.ts
@@ -1,7 +1,8 @@
 /**
  * POST /api/radiology/report-pdf — Generate a PDF report for a radiology order
  *
- * Body: { orderId, clinicId, patientName, modality, bodyPart?, findings, impression, reportText, radiologistName? }
+ * Body: { orderId, patientName, modality, bodyPart?, findings, impression, reportText, radiologistName? }
+ * clinic_id is derived from the authenticated user's profile.
  *
  * Generates a simple PDF, uploads to R2, and updates the order's pdf_url.
  * Returns: { pdfUrl }
@@ -64,7 +65,7 @@ function generateReportHtml(data: {
 </html>`;
 }
 
-export const POST = withAuth(async (request) => {
+export const POST = withAuth(async (request, { profile }) => {
   try {
     const raw = await request.json();
     const parsed = safeParse(radiologyReportPdfSchema, raw);
@@ -73,7 +74,6 @@ export const POST = withAuth(async (request) => {
     }
     const {
       orderId,
-      clinicId,
       patientName,
       modality,
       bodyPart,
@@ -82,6 +82,14 @@ export const POST = withAuth(async (request) => {
       reportText,
       radiologistName,
     } = parsed.data;
+    // Derive clinic_id from the authenticated user's profile — never from the request body
+    const clinicId = profile.clinic_id;
+    if (!clinicId) {
+      return NextResponse.json(
+        { error: "User must belong to a clinic" },
+        { status: 400 },
+      );
+    }
 
     if (!findings && !impression && !reportText) {
       return NextResponse.json(

--- a/src/lib/data/client.ts
+++ b/src/lib/data/client.ts
@@ -13,7 +13,6 @@
 
 import { createClient } from "@/lib/supabase-client";
 import { logger } from "@/lib/logger";
-import { clinicConfig } from "@/config/clinic.config";
 import type { Database } from "@/lib/types/database";
 
 /**
@@ -407,7 +406,7 @@ function mapService(raw: ServiceRaw): ServiceView {
     description: raw.description ?? "",
     duration: raw.duration_minutes ?? raw.duration_min ?? 30,
     price: raw.price ?? 0,
-    currency: raw.currency ?? clinicConfig.currency,
+    currency: raw.currency ?? "MAD",
     active: raw.is_active ?? true,
     category: raw.category ?? undefined,
   };
@@ -2528,9 +2527,9 @@ export async function fetchGeneratedSlots(
 
   const result: string[] = [];
   // Use tenant-specific config passed by the caller.
-  // Falls back to static clinicConfig only as a last resort.
-  const duration = bookingConfig?.slotDuration ?? clinicConfig.booking.slotDuration;
-  const buffer = bookingConfig?.bufferTime ?? clinicConfig.booking.bufferTime;
+  // Falls back to sensible defaults if bookingConfig is not provided.
+  const duration = bookingConfig?.slotDuration ?? 30;
+  const buffer = bookingConfig?.bufferTime ?? 5;
 
   for (const config of daySlots) {
     const [startH, startM] = config.startTime.split(":").map(Number);
@@ -2595,8 +2594,8 @@ export async function fetchAvailableSlots(
   ]);
 
   // Use tenant-specific config passed by the caller.
-  // Falls back to static clinicConfig only as a last resort.
-  const maxPerSlot = bookingConfig?.maxPerSlot ?? clinicConfig.booking.maxPerSlot;
+  // Falls back to a sensible default if bookingConfig is not provided.
+  const maxPerSlot = bookingConfig?.maxPerSlot ?? 1;
   return allSlots.filter((slot) => (bookingCounts[slot] ?? 0) < maxPerSlot);
 }
 

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -8,7 +8,6 @@
  */
 
 import { createClient } from "@/lib/supabase-server";
-import { clinicConfig } from "@/config/clinic.config";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { requireTenant, getClinicConfig } from "@/lib/tenant";
 
@@ -81,8 +80,13 @@ export interface ClinicBranding {
 
 // ── Helpers ──
 
-async function getClinicId(): Promise<string> {
+async function getTenantInfo() {
   const tenant = await requireTenant();
+  return tenant;
+}
+
+async function getClinicId(): Promise<string> {
+  const tenant = await getTenantInfo();
   return tenant.clinicId;
 }
 
@@ -98,6 +102,9 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
     .eq("id", clinicId)
     .single();
 
+  // Resolve tenant info for fallback values (never use static clinicConfig)
+  const tenant = await getTenantInfo();
+
   if (error || !data) {
     return {
       logoUrl: null,
@@ -107,14 +114,14 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
       headingFont: "Geist",
       bodyFont: "Geist",
       heroImageUrl: null,
-      clinicName: clinicConfig.name,
+      clinicName: tenant.clinicName || "Clinic",
       tagline: null,
       coverPhotoUrl: null,
       templateId: "modern",
       sectionVisibility: {},
-      phone: clinicConfig.contact.phone ?? null,
-      address: clinicConfig.contact.address ?? null,
-      email: clinicConfig.contact.email ?? null,
+      phone: null,
+      address: null,
+      email: null,
     };
   }
 
@@ -126,14 +133,14 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
     headingFont: data.heading_font ?? "Geist",
     bodyFont: data.body_font ?? "Geist",
     heroImageUrl: data.hero_image_url ?? null,
-    clinicName: data.name ?? clinicConfig.name,
+    clinicName: data.name ?? (tenant.clinicName || "Clinic"),
     tagline: (data.tagline as string | null) ?? null,
     coverPhotoUrl: (data.cover_photo_url as string | null) ?? null,
     templateId: (data.template_id as string | null) ?? "modern",
     sectionVisibility: (data.section_visibility as Record<string, boolean> | null) ?? {},
-    phone: (data.phone as string | null) ?? clinicConfig.contact.phone ?? null,
-    address: (data.address as string | null) ?? clinicConfig.contact.address ?? null,
-    email: (data.owner_email as string | null) ?? clinicConfig.contact.email ?? null,
+    phone: (data.phone as string | null) ?? null,
+    address: (data.address as string | null) ?? null,
+    email: (data.owner_email as string | null) ?? null,
   };
 }
 

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -207,7 +207,8 @@ export const customFieldUpdateSchema = z.object({
 });
 
 export const customFieldValuesSchema = z.object({
-  clinic_id: z.string().min(1),
+  /** @deprecated Ignored by the server — clinic_id is derived from the authenticated user's profile. */
+  clinic_id: z.string().optional(),
   entity_type: z.string().min(1).max(100),
   entity_id: z.string().min(1),
   field_values: z.record(z.string(), z.unknown()),
@@ -217,7 +218,8 @@ export const customFieldValuesSchema = z.object({
 
 export const labReportSchema = z.object({
   orderId: z.string().min(1),
-  clinicId: z.string().min(1),
+  /** @deprecated Ignored by the server — clinicId is derived from the authenticated user's profile. */
+  clinicId: z.string().optional(),
   patientName: z.string().min(1).max(200),
   orderNumber: z.string().min(1).max(100),
   results: z
@@ -237,7 +239,8 @@ export const labReportSchema = z.object({
 // ── Radiology ───────────────────────────────────────────────────────────
 
 export const radiologyOrderCreateSchema = z.object({
-  clinicId: z.string().min(1),
+  /** @deprecated Ignored by the server — clinicId is derived from the authenticated user's profile. */
+  clinicId: z.string().optional(),
   patientId: z.string().min(1),
   modality: z.string().min(1).max(100),
   bodyPart: z.string().max(200).optional(),
@@ -270,7 +273,8 @@ export const radiologyOrderPatchSchema = z.discriminatedUnion("action", [
 
 export const radiologyReportPdfSchema = z.object({
   orderId: z.string().min(1),
-  clinicId: z.string().min(1),
+  /** @deprecated Ignored by the server — clinicId is derived from the authenticated user's profile. */
+  clinicId: z.string().optional(),
   patientName: z.string().min(1).max(200),
   modality: z.string().min(1).max(100),
   bodyPart: z.string().max(200).optional(),


### PR DESCRIPTION
## Summary

Fixes critical multi-tenant architecture issue where API routes accepted untrusted clinic_id from request body/query params instead of deriving tenant from request context.

## Changes

### API Routes Fixed
- custom-fields/values: clinic_id now derived from profile.clinic_id instead of query params/body
- radiology/orders: clinicId from profile.clinic_id instead of request body
- radiology/report-pdf: clinicId from profile.clinic_id instead of request body
- lab/report-html: clinicId from profile.clinic_id instead of request body
- chat: Strictly uses requireTenant() instead of body.clinicId fallback
- branding: Uses tenant.clinicName instead of clinicConfig.name fallback

### Data Layer
- data/public.ts: Removed clinicConfig import; fallbacks now use tenant info or neutral defaults
- data/client.ts: Removed clinicConfig import; uses inline defaults for currency/booking config

### Validation Schemas
- Made clinicId/clinic_id optional in schemas for backward compatibility

### Safety Guards
- All refactored routes include runtime checks that return 400 if clinic_id is missing from user profile

## Verification
- Zero clinicConfig imports remain in API routes or data layer
- Zero demo-clinic hardcoded strings found
- All DB queries use tenant-derived clinic_id
- ESLint + TypeScript pass clean