### PR TITLE
fix: add tenant?.clinicId to useEffect/useCallback dependency arrays (addresses #171 & #172)

### DIFF
--- a/src/app/(admin)/admin/billing/page.tsx
+++ b/src/app/(admin)/admin/billing/page.tsx
@@ -47,7 +47,7 @@ export default function ClientBillingPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [tenant?.clinicId]);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/src/app/(equipment)/equipment/dashboard/page.tsx
+++ b/src/app/(equipment)/equipment/dashboard/page.tsx
@@ -46,7 +46,7 @@ export default function EquipmentDashboardPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading..." />;

--- a/src/app/(equipment)/equipment/inventory/page.tsx
+++ b/src/app/(equipment)/equipment/inventory/page.tsx
@@ -107,7 +107,7 @@ export default function EquipmentInventoryPage() {
     return () => { controller.abort(); };
     }
     init();
-  }, []);
+  }, [tenant?.clinicId]);
 
   const openAddDialog = () => {
     setEditingItem(null);

--- a/src/app/(equipment)/equipment/maintenance/page.tsx
+++ b/src/app/(equipment)/equipment/maintenance/page.tsx
@@ -117,7 +117,7 @@ export default function EquipmentMaintenancePage() {
     return () => { controller.abort(); };
     }
     init();
-  }, []);
+  }, [tenant?.clinicId]);
 
   const openAddDialog = () => {
     setEditingRecord(null);

--- a/src/app/(equipment)/equipment/rentals/page.tsx
+++ b/src/app/(equipment)/equipment/rentals/page.tsx
@@ -123,7 +123,7 @@ export default function EquipmentRentalsPage() {
     return () => { controller.abort(); };
     }
     init();
-  }, []);
+  }, [tenant?.clinicId]);
 
   const openAddDialog = () => {
     setEditingRental(null);

--- a/src/app/(lab)/lab-panel/dashboard/page.tsx
+++ b/src/app/(lab)/lab-panel/dashboard/page.tsx
@@ -30,7 +30,7 @@ export default function LabDashboardPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading dashboard..." />;

--- a/src/app/(lab)/lab-panel/patient-history/page.tsx
+++ b/src/app/(lab)/lab-panel/patient-history/page.tsx
@@ -49,7 +49,7 @@ export default function PatientHistoryPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   useEffect(() => {
     function loadOrders() {
@@ -62,7 +62,7 @@ export default function PatientHistoryPage() {
         .finally(() => setOrdersLoading(false));
     }
     loadOrders();
-  }, [selectedPatientId]);
+  }, [selectedPatientId, tenant?.clinicId]);
 
   useEffect(() => {
     function loadResults() {

--- a/src/app/(lab)/lab-panel/reports/page.tsx
+++ b/src/app/(lab)/lab-panel/reports/page.tsx
@@ -32,7 +32,7 @@ export default function LabReportsPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading reports..." />;

--- a/src/app/(lab)/lab-panel/results/page.tsx
+++ b/src/app/(lab)/lab-panel/results/page.tsx
@@ -81,7 +81,7 @@ export default function ResultsPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   useEffect(() => {
     if (!selectedOrderId) {

--- a/src/app/(lab)/lab-panel/test-orders/page.tsx
+++ b/src/app/(lab)/lab-panel/test-orders/page.tsx
@@ -80,7 +80,7 @@ export default function TestOrdersPage() {
       if (!controller.signal.aborted) setLoading(false);
     });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const handleCreateOrder = async () => {
     if (!newOrder.patientId) return;

--- a/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/catalog/page.tsx
@@ -74,7 +74,7 @@ export default function ParapharmacyCatalogPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const openCreate = () => {
     setEditingId(null);

--- a/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/dashboard/page.tsx
@@ -44,7 +44,7 @@ export default function ParapharmacyDashboardPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading dashboard..." />;

--- a/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/inventory/page.tsx
@@ -29,7 +29,7 @@ export default function ParapharmacyInventoryPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading inventory..." />;

--- a/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
+++ b/src/app/(parapharmacy)/parapharmacy/sales/page.tsx
@@ -65,7 +65,7 @@ export default function ParapharmacySalesPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const addToCart = (product: ProductView) => {
     setCart((prev) => {

--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -91,7 +91,7 @@ export default function PharmacistDashboardPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const pendingRx = prescriptions.filter((p) => p.status === "pending" || p.status === "reviewing");
   const lowStock = getLowStockProducts(products);

--- a/src/app/(pharmacist)/pharmacist/expiry/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/expiry/page.tsx
@@ -26,7 +26,7 @@ export default function ExpiryTrackerPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const products = useMemo(() => {
     return allProducts

--- a/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
@@ -55,7 +55,7 @@ export default function LoyaltyPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading loyalty data..." />;

--- a/src/app/(pharmacist)/pharmacist/orders/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/orders/page.tsx
@@ -44,7 +44,7 @@ export default function OrdersPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading orders..." />;

--- a/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
@@ -47,7 +47,7 @@ export default function PrescriptionsPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading prescriptions..." />;

--- a/src/app/(pharmacist)/pharmacist/sales/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/sales/page.tsx
@@ -33,7 +33,7 @@ export default function SalesPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const filteredSales = useMemo(() => {
     return allSales.filter((s) => s.date === dateFilter);

--- a/src/app/(pharmacist)/pharmacist/stock/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/stock/page.tsx
@@ -57,7 +57,7 @@ export default function StockPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const filtered = useMemo(() => {
     let results: ProductView[];

--- a/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
@@ -32,7 +32,7 @@ export default function SuppliersPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading suppliers..." />;

--- a/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
@@ -117,7 +117,7 @@ export default function CatalogPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const filtered = useMemo(() => {
     let results: PublicPharmacyProduct[];

--- a/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
@@ -111,7 +111,7 @@ export default function PrescriptionHistoryPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return (

--- a/src/app/(pharmacy-public)/pharmacy/promotions/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/promotions/page.tsx
@@ -85,7 +85,7 @@ export default function PromotionsPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const featured = useMemo(() => {
     let results = products.filter((p) => p.stockQuantity > 0);

--- a/src/app/(radiology)/radiology/dashboard/page.tsx
+++ b/src/app/(radiology)/radiology/dashboard/page.tsx
@@ -30,7 +30,7 @@ export default function RadiologyDashboardPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading dashboard..." />;

--- a/src/app/(radiology)/radiology/images/page.tsx
+++ b/src/app/(radiology)/radiology/images/page.tsx
@@ -52,7 +52,7 @@ export default function RadiologyImagesPage() {
       setAllOrders(all);
       setOrders(all.filter((o) => o.imageCount > 0));
     });
-  }, []);
+  }, [tenant?.clinicId]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -69,7 +69,7 @@ export default function RadiologyImagesPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();

--- a/src/app/(radiology)/radiology/orders/page.tsx
+++ b/src/app/(radiology)/radiology/orders/page.tsx
@@ -91,7 +91,7 @@ export default function RadiologyOrdersPage() {
       if (!controller.signal.aborted) setLoading(false);
     });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const handleCreateOrder = async () => {
     if (!newOrder.patientId || !newOrder.modality) return;

--- a/src/app/(radiology)/radiology/reports/page.tsx
+++ b/src/app/(radiology)/radiology/reports/page.tsx
@@ -31,7 +31,7 @@ export default function RadiologyReportsPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const handleGeneratePdf = async (order: RadiologyOrderView) => {
     setGeneratingPdf(order.id);

--- a/src/app/(radiology)/radiology/templates/page.tsx
+++ b/src/app/(radiology)/radiology/templates/page.tsx
@@ -30,7 +30,7 @@ export default function RadiologyTemplatesPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading templates..." />;

--- a/src/app/(radiology)/radiology/viewer/page.tsx
+++ b/src/app/(radiology)/radiology/viewer/page.tsx
@@ -25,7 +25,7 @@ export default function DicomViewerPage() {
     })
     .finally(() => { if (!controller.signal.aborted) setLoading(false); });
     return () => { controller.abort(); };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const dicomOrders = orders.filter((o) =>
     o.images.some((img) => img.isDicom || img.dicomStudyUid)

--- a/src/components/admin/clinic-center-dashboard-kpis.tsx
+++ b/src/components/admin/clinic-center-dashboard-kpis.tsx
@@ -48,7 +48,7 @@ export function ClinicCenterDashboardKPIsComponent() {
       .catch((err: unknown) => { logger.warn("Operation failed", { context: "clinic-center-dashboard-kpis", error: err }); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading clinic/center KPIs..." />;

--- a/src/components/admin/clinic-stats.tsx
+++ b/src/components/admin/clinic-stats.tsx
@@ -34,7 +34,7 @@ export function ClinicStats() {
       logger.warn("Operation failed", { context: "clinic-stats", error: err });
     });
     return () => { cancelled = true; };
-  }, []);
+  }, [tenant?.clinicId]);
 
   const totalPatients = dashData?.totalPatients ?? 0;
   const completedAppts = dashData?.completedAppointments ?? 0;

--- a/src/components/admin/lab-dashboard-kpis.tsx
+++ b/src/components/admin/lab-dashboard-kpis.tsx
@@ -45,7 +45,7 @@ export function LabDashboardKPIsComponent() {
       .catch((err: unknown) => { logger.warn("Operation failed", { context: "lab-dashboard-kpis", error: err }); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, []);
+  }, [tenant?.clinicId]);
 
   if (loading) {
     return <PageLoader message="Loading lab KPIs..." />;

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -145,7 +145,7 @@ export function BookingForm() {
       logger.warn("Operation failed", { context: "booking-form", error: err });
     });
     return () => { cancelled = true; };
-  }, []);
+  }, [tenant?.clinicId]);
 
   // Fetch available slots when date or doctor changes
   useEffect(() => {

--- a/src/components/dental/dental-booking-extras.tsx
+++ b/src/components/dental/dental-booking-extras.tsx
@@ -31,7 +31,7 @@ export function DentalBookingExtras({
     fetchDentalTreatmentTypes(clinicId).then(setDentalTreatmentTypes).catch((err) => {
       logger.warn("Operation failed", { context: "dental-booking-extras", error: err });
     });
-  }, []);
+  }, [tenant?.clinicId]);
 
   const categories = Array.from(new Set(dentalTreatmentTypes.map((t) => t.category)));
 

--- a/src/components/patient/reschedule-dialog.tsx
+++ b/src/components/patient/reschedule-dialog.tsx
@@ -65,7 +65,7 @@ export function RescheduleDialog({ appointment, onClose, onReschedule }: Resched
       setAllSlots([]);
       setSlotCounts({});
     });
-  }, [selectedDate, appointment.doctorId]);
+  }, [selectedDate, appointment.doctorId, tenant?.clinicId]);
 
   const handleReschedule = async () => {
     if (!selectedDate || !selectedTime) return;


### PR DESCRIPTION
## Summary

Addresses the issues identified in PRs #171 and #172 by adding `tenant?.clinicId` to `useEffect` and `useCallback` dependency arrays across 37 files.

### Problem
Both PRs #171 and #172 attempted to fix multi-tenant architecture by replacing hardcoded `clinicConfig.clinicId` with request-based tenant resolution. While the core tenant resolution was completed in PRs #173 and #174 (already merged), 39 lint warnings remained:
- `useEffect`/`useCallback` hooks referenced `tenant?.clinicId` but did not include it in their dependency arrays
- This meant components would not re-fetch data when the tenant context changed

### Changes
- Added `tenant?.clinicId` to dependency arrays in all 37 affected files
- Covers: equipment, lab, parapharmacy, pharmacist, pharmacy-public, radiology pages + admin components + booking/dental/patient components

### Verification
- TypeScript: 0 errors
- ESLint: 0 errors, 0 warnings (was 39 warnings)
- Tests: 249/249 passing
- Pre-commit hooks (lint-staged + tsc): passed

Related: #171, #172