### PR TITLE
fix: comprehensive multi-tenant security hardening

### DIFF
--- a/src/app/api/cron/billing/route.ts
+++ b/src/app/api/cron/billing/route.ts
@@ -36,7 +36,16 @@ export async function GET(request: NextRequest) {
 
   const results: { clinicId: string; success: boolean; error?: string }[] = [];
   const BATCH_SIZE = 10;
-  const subs = subscriptions ?? [];
+  // SAFETY ASSERTION: Filter out any subscriptions without a clinic_id to
+  // prevent cross-tenant operations. This should never happen with correct
+  // data integrity but acts as defense-in-depth.
+  const subs = (subscriptions ?? []).filter((sub) => {
+    if (!sub.clinic_id) {
+      results.push({ clinicId: "unknown", success: false, error: "Missing clinic_id — skipped for tenant safety" });
+      return false;
+    }
+    return true;
+  });
 
   for (let i = 0; i < subs.length; i += BATCH_SIZE) {
     const batch = subs.slice(i, i + BATCH_SIZE);

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -114,6 +114,17 @@ export async function GET(request: NextRequest) {
     }[] = [];
 
     for (const appt of appointments) {
+      // SAFETY ASSERTION: Skip appointments without clinic_id to prevent
+      // cross-tenant operations. This should never happen with correct RLS
+      // but acts as defense-in-depth.
+      if (!appt.clinic_id) {
+        logger.warn("Skipping appointment without clinic_id", {
+          context: "cron/reminders",
+          appointmentId: appt.id,
+        });
+        continue;
+      }
+
       // Parse appointment datetime, falling back to slot_start when
       // appointment_date or start_time are NULL.
       let apptDatetime: Date;

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -32,39 +32,52 @@ export async function POST(request: NextRequest) {
     if (callbackData.status === "approved") {
       // Find the payment by order ID (stored as gateway_session_id)
       // Only process if not already completed (idempotency check)
+      // Include clinic_id in SELECT to scope subsequent updates to the same tenant.
       const { data: payment } = await supabase
         .from("payments")
-        .select("id, appointment_id, status")
+        .select("id, appointment_id, clinic_id, status")
         .eq("gateway_session_id", callbackData.orderId)
         .single();
 
       if (payment && payment.status !== PAYMENT_STATUS.COMPLETED) {
-        // Mark payment as completed
+        // Mark payment as completed — scoped to the payment's clinic_id
+        // to prevent any cross-tenant state mutation.
         await supabase
           .from("payments")
           .update({
             status: PAYMENT_STATUS.COMPLETED,
             reference: callbackData.transactionId || callbackData.orderId,
           })
-          .eq("id", payment.id);
+          .eq("id", payment.id)
+          .eq("clinic_id", payment.clinic_id);
 
-        // Confirm the appointment if applicable
-        if (payment.appointment_id) {
+        // Confirm the appointment if applicable — scoped to clinic_id
+        if (payment.appointment_id && payment.clinic_id) {
           await supabase
             .from("appointments")
             .update({ status: APPOINTMENT_STATUS.CONFIRMED })
             .eq("id", payment.appointment_id)
+            .eq("clinic_id", payment.clinic_id)
             .in("status", [APPOINTMENT_STATUS.PENDING, APPOINTMENT_STATUS.SCHEDULED]);
         }
       }
 
       // Payment approved — status updated in DB above
     } else {
-      // Mark payment as failed
-      await supabase
+      // Mark payment as failed — fetch clinic_id first to scope the update
+      const { data: failedPayment } = await supabase
         .from("payments")
-        .update({ status: PAYMENT_STATUS.FAILED })
-        .eq("gateway_session_id", callbackData.orderId);
+        .select("id, clinic_id")
+        .eq("gateway_session_id", callbackData.orderId)
+        .single();
+
+      if (failedPayment) {
+        await supabase
+          .from("payments")
+          .update({ status: PAYMENT_STATUS.FAILED })
+          .eq("id", failedPayment.id)
+          .eq("clinic_id", failedPayment.clinic_id);
+      }
 
       // Payment not approved — marked as failed in DB above
     }

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -93,12 +93,14 @@ export async function POST(request: NextRequest) {
           );
         }
 
-        // Update appointment payment status if applicable
-        if (appointmentId) {
+        // Update appointment payment status if applicable — scoped to
+        // clinic_id to prevent cross-tenant appointment state mutation.
+        if (appointmentId && clinicId) {
           await supabase
             .from("appointments")
             .update({ status: APPOINTMENT_STATUS.CONFIRMED })
             .eq("id", appointmentId)
+            .eq("clinic_id", clinicId)
             .eq("status", APPOINTMENT_STATUS.PENDING);
         }
 

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -141,15 +141,18 @@ export async function POST(request: NextRequest) {
           .single();
 
         if (upperText === "CONFIRM" && appt) {
+          // Scope update to clinic_id to prevent cross-tenant mutation
           await supabase
             .from("appointments")
             .update({ status: "confirmed" })
-            .eq("id", appt.id);
+            .eq("id", appt.id)
+            .eq("clinic_id", clinicId);
         } else if (upperText === "CANCEL" && appt) {
           await supabase
             .from("appointments")
             .update({ status: "cancelled", cancellation_reason: "Cancelled via WhatsApp" })
-            .eq("id", appt.id);
+            .eq("id", appt.id)
+            .eq("clinic_id", clinicId);
         }
 
         // Notify the relevant staff member (doctor assigned to the appointment)

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -77,7 +77,12 @@ function shouldUseSupabase(): boolean {
 function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
   const { windowMs, max } = options;
 
-  // Use the service role key for direct DB access (bypasses RLS).
+  // SECURITY NOTE: Service role key intentionally used here.
+  // rate_limit_entries is a global infrastructure table (not tenant-scoped)
+  // that tracks per-IP request counts. It contains no clinic/patient data and
+  // is NOT subject to multi-tenant isolation. RLS is enabled on the table as
+  // defense-in-depth (blocks anon/authenticated access) but the service role
+  // bypasses it to perform atomic counter operations.
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !serviceRoleKey) {

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -253,6 +253,12 @@ export async function checkPlanLimits(
 export async function processRenewal(
   clinicId: string,
 ): Promise<{ success: boolean; error?: string }> {
+  // SAFETY ASSERTION: Block execution if clinic_id is missing or invalid
+  // to prevent cross-tenant operations in the billing pipeline.
+  if (!clinicId || typeof clinicId !== "string" || clinicId.trim() === "") {
+    return { success: false, error: "Missing or invalid clinic_id — blocked for tenant safety" };
+  }
+
   const supabase = await createClient();
 
   // Fetch current subscription

--- a/supabase/migrations/00029_multitenant_security_hardening.sql
+++ b/supabase/migrations/00029_multitenant_security_hardening.sql
@@ -1,0 +1,574 @@
+-- ============================================================
+-- Migration 00029: Multi-Tenant Security Hardening
+--
+-- Fixes all remaining critical multi-tenant security issues:
+--
+-- 1. FIX BROKEN RLS POLICIES
+--    - odontogram: WITH CHECK missing clinic_id
+--    - installments: WITH CHECK missing clinic_id
+--    - notifications: INSERT missing clinic_id scoping
+--    - chatbot_config: SELECT leaks all configs cross-tenant
+--    - chatbot_faqs: SELECT leaks active FAQs cross-tenant
+--    - patient appointments: SELECT/INSERT missing clinic_id
+--    - appointment_doctors: staff WITH CHECK missing clinic_id
+--    - collection_points: public SELECT leaks cross-tenant
+--    - lab_tests: public SELECT leaks cross-tenant
+--    - blog_posts: public SELECT leaks cross-tenant
+--
+-- 2. ADD MISSING CLINIC_ID COLUMNS + RLS HARDENING
+--    - prescriptions: add clinic_id, backfill, add RLS
+--    - consultation_notes: add clinic_id, backfill, add RLS
+--    - family_members: add clinic_id, backfill, add RLS
+--    - odontogram: add clinic_id, backfill
+--
+-- 3. ADD INDEXES for tenant isolation performance
+--
+-- 4. HARDEN rate_limit_entries RLS (service-role only)
+-- ============================================================
+
+-- ============================================================
+-- 1. FIX BROKEN RLS POLICIES
+-- ============================================================
+
+-- -------------------------------------------------------
+-- 1a. ODONTOGRAM: WITH CHECK missing clinic_id check
+-- The old policy allowed a doctor/admin to INSERT odontogram
+-- records for patients in ANY clinic.
+-- -------------------------------------------------------
+
+-- First add clinic_id column to odontogram (currently missing)
+ALTER TABLE odontogram
+  ADD COLUMN IF NOT EXISTS clinic_id UUID REFERENCES clinics(id) ON DELETE CASCADE;
+
+-- Backfill clinic_id from the patient's clinic
+UPDATE odontogram o
+SET clinic_id = u.clinic_id
+FROM users u
+WHERE o.patient_id = u.id
+  AND o.clinic_id IS NULL;
+
+-- Create index for tenant queries
+CREATE INDEX IF NOT EXISTS idx_odontogram_clinic ON odontogram(clinic_id);
+
+DROP POLICY IF EXISTS "odontogram_manage_doctor" ON odontogram;
+CREATE POLICY "odontogram_manage_doctor" ON odontogram
+  FOR ALL USING (
+    get_user_role() IN ('doctor', 'clinic_admin')
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    get_user_role() IN ('doctor', 'clinic_admin')
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1b. INSTALLMENTS: WITH CHECK missing clinic_id check
+-- The old policy allowed staff to INSERT installments for
+-- treatment plans belonging to ANY clinic.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "installments_manage_staff" ON installments;
+CREATE POLICY "installments_manage_staff" ON installments
+  FOR ALL USING (
+    get_user_role() IN ('clinic_admin', 'receptionist')
+    AND EXISTS (
+      SELECT 1 FROM treatment_plans tp
+      JOIN users u ON u.id = tp.doctor_id
+      WHERE tp.id = installments.treatment_plan_id
+        AND u.clinic_id = get_user_clinic_id()
+    )
+  ) WITH CHECK (
+    get_user_role() IN ('clinic_admin', 'receptionist')
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1c. NOTIFICATIONS: INSERT missing clinic_id scoping
+-- The old policy allowed any staff member to insert
+-- notifications without clinic_id validation, enabling
+-- cross-tenant notification injection.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "notifications_insert_staff" ON notifications;
+CREATE POLICY "notifications_insert_staff" ON notifications
+  FOR INSERT WITH CHECK (
+    get_user_role() IN ('clinic_admin', 'receptionist', 'doctor')
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1d. CHATBOT_CONFIG: SELECT USING (TRUE) leaks all configs
+-- Any authenticated user could read chatbot configs for ALL
+-- clinics. Restrict to own clinic + unauthenticated access
+-- (public chatbot widget needs it for the current clinic).
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "chatbot_config_select_public" ON chatbot_config;
+CREATE POLICY "chatbot_config_select_clinic" ON chatbot_config
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR auth.uid() IS NULL  -- Unauthenticated (public chatbot widget)
+  );
+
+-- -------------------------------------------------------
+-- 1e. CHATBOT_FAQS: SELECT leaks active FAQs cross-tenant
+-- Same issue as chatbot_config — restrict to own clinic.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "chatbot_faqs_select_public" ON chatbot_faqs;
+CREATE POLICY "chatbot_faqs_select_clinic" ON chatbot_faqs
+  FOR SELECT USING (
+    is_active = TRUE
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR auth.uid() IS NULL  -- Unauthenticated (public chatbot widget)
+    )
+  );
+
+-- -------------------------------------------------------
+-- 1f. PATIENT APPOINTMENTS: SELECT/INSERT missing clinic_id
+-- A patient could see/create appointments across clinics
+-- since the policy only checked patient_id, not clinic_id.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "patient_appointments_select" ON appointments;
+CREATE POLICY "patient_appointments_select" ON appointments
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND get_user_role() = 'patient'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "patient_appointments_insert" ON appointments;
+CREATE POLICY "patient_appointments_insert" ON appointments
+  FOR INSERT WITH CHECK (
+    patient_id = get_my_user_id()
+    AND get_user_role() = 'patient'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "patient_appointments_update" ON appointments;
+CREATE POLICY "patient_appointments_update" ON appointments
+  FOR UPDATE USING (
+    patient_id = get_my_user_id()
+    AND get_user_role() = 'patient'
+    AND clinic_id = get_user_clinic_id()
+    AND status IN ('pending', 'confirmed')
+  ) WITH CHECK (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+    AND status IN ('pending', 'confirmed', 'cancelled', 'rescheduled')
+  );
+
+-- -------------------------------------------------------
+-- 1g. APPOINTMENT_DOCTORS: staff WITH CHECK missing clinic_id
+-- Staff could associate doctors with appointments in other
+-- clinics since WITH CHECK didn't verify clinic_id.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "staff_appointment_doctors" ON appointment_doctors;
+CREATE POLICY "staff_appointment_doctors" ON appointment_doctors
+  FOR ALL USING (
+    is_clinic_staff()
+    AND EXISTS (
+      SELECT 1 FROM appointments a
+      WHERE a.id = appointment_doctors.appointment_id
+        AND a.clinic_id = get_user_clinic_id()
+    )
+  ) WITH CHECK (
+    is_clinic_staff()
+    AND EXISTS (
+      SELECT 1 FROM appointments a
+      WHERE a.id = appointment_doctors.appointment_id
+        AND a.clinic_id = get_user_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- 1h. COLLECTION_POINTS: public SELECT USING (TRUE) leaks
+-- all collection points across tenants. Restrict to own
+-- clinic + unauthenticated (public website needs it).
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "public_collection_points_read" ON collection_points;
+CREATE POLICY "public_collection_points_read" ON collection_points
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR auth.uid() IS NULL  -- Unauthenticated (public website)
+  );
+
+-- -------------------------------------------------------
+-- 1i. LAB_TESTS: public SELECT leaks cross-tenant
+-- Same issue — restrict to own clinic + unauthenticated.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "public_lab_tests_read" ON lab_tests;
+CREATE POLICY "public_lab_tests_read" ON lab_tests
+  FOR SELECT USING (
+    is_active = TRUE
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR auth.uid() IS NULL  -- Unauthenticated (public website)
+    )
+  );
+
+-- -------------------------------------------------------
+-- 1j. BLOG_POSTS: public SELECT leaks cross-tenant
+-- Published blog posts from ALL clinics are visible to any
+-- authenticated user. Restrict to own clinic + unauthenticated.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "blog_posts_select_published" ON blog_posts;
+CREATE POLICY "blog_posts_select_published" ON blog_posts
+  FOR SELECT USING (
+    is_published = TRUE
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR auth.uid() IS NULL  -- Unauthenticated (public website)
+    )
+  );
+
+-- -------------------------------------------------------
+-- 1k. PAYMENTS: patient SELECT missing clinic_id
+-- A patient could see their payment records across clinics.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "payments_select_patient" ON payments;
+CREATE POLICY "payments_select_patient" ON payments
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1l. REVIEWS: patient INSERT/UPDATE missing clinic_id
+-- A patient could create/update reviews for any clinic.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "reviews_insert_patient" ON reviews;
+CREATE POLICY "reviews_insert_patient" ON reviews
+  FOR INSERT WITH CHECK (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "reviews_update_patient" ON reviews;
+CREATE POLICY "reviews_update_patient" ON reviews
+  FOR UPDATE USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1m. DOCUMENTS: own-user SELECT/INSERT missing clinic_id
+-- A patient could read/upload documents across clinics.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "documents_select_own" ON documents;
+CREATE POLICY "documents_select_own" ON documents
+  FOR SELECT USING (
+    user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "documents_insert_own" ON documents;
+CREATE POLICY "documents_insert_own" ON documents
+  FOR INSERT WITH CHECK (
+    user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1n. PRESCRIPTIONS: patient SELECT / doctor manage
+-- missing clinic_id. Add clinic_id column and fix policies.
+-- -------------------------------------------------------
+
+ALTER TABLE prescriptions
+  ADD COLUMN IF NOT EXISTS clinic_id UUID REFERENCES clinics(id) ON DELETE CASCADE;
+
+-- Backfill from doctor's clinic
+UPDATE prescriptions p
+SET clinic_id = u.clinic_id
+FROM users u
+WHERE p.doctor_id = u.id
+  AND p.clinic_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_prescriptions_clinic ON prescriptions(clinic_id);
+
+DROP POLICY IF EXISTS "prescriptions_select_patient" ON prescriptions;
+CREATE POLICY "prescriptions_select_patient" ON prescriptions
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "prescriptions_manage_doctor" ON prescriptions;
+CREATE POLICY "prescriptions_manage_doctor" ON prescriptions
+  FOR ALL USING (
+    doctor_id = get_my_user_id()
+    AND get_user_role() = 'doctor'
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    doctor_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "prescriptions_select_admin" ON prescriptions;
+CREATE POLICY "prescriptions_select_admin" ON prescriptions
+  FOR SELECT USING (
+    get_user_role() = 'clinic_admin'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1o. CONSULTATION_NOTES: missing clinic_id column.
+-- Add clinic_id, backfill, and fix policies.
+-- -------------------------------------------------------
+
+ALTER TABLE consultation_notes
+  ADD COLUMN IF NOT EXISTS clinic_id UUID REFERENCES clinics(id) ON DELETE CASCADE;
+
+UPDATE consultation_notes cn
+SET clinic_id = u.clinic_id
+FROM users u
+WHERE cn.doctor_id = u.id
+  AND cn.clinic_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_consultation_notes_clinic ON consultation_notes(clinic_id);
+
+DROP POLICY IF EXISTS "consultation_notes_manage_doctor" ON consultation_notes;
+CREATE POLICY "consultation_notes_manage_doctor" ON consultation_notes
+  FOR ALL USING (
+    doctor_id = get_my_user_id()
+    AND get_user_role() = 'doctor'
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    doctor_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "consultation_notes_select_admin" ON consultation_notes;
+CREATE POLICY "consultation_notes_select_admin" ON consultation_notes
+  FOR SELECT USING (
+    get_user_role() = 'clinic_admin'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "consultation_notes_select_patient" ON consultation_notes;
+CREATE POLICY "consultation_notes_select_patient" ON consultation_notes
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+    AND private = FALSE
+  );
+
+-- -------------------------------------------------------
+-- 1p. FAMILY_MEMBERS: missing clinic_id column.
+-- A user could see family members of patients in other
+-- clinics via the staff policy (only checks primary_user_id
+-- join, but doesn't enforce on WITH CHECK).
+-- -------------------------------------------------------
+
+ALTER TABLE family_members
+  ADD COLUMN IF NOT EXISTS clinic_id UUID REFERENCES clinics(id) ON DELETE CASCADE;
+
+UPDATE family_members fm
+SET clinic_id = u.clinic_id
+FROM users u
+WHERE fm.primary_user_id = u.id
+  AND fm.clinic_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_family_members_clinic ON family_members(clinic_id);
+
+DROP POLICY IF EXISTS "family_members_manage_own" ON family_members;
+CREATE POLICY "family_members_manage_own" ON family_members
+  FOR ALL USING (
+    primary_user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    primary_user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "family_members_select_staff" ON family_members;
+CREATE POLICY "family_members_select_staff" ON family_members
+  FOR SELECT USING (
+    is_clinic_staff()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1q. TREATMENT_PLANS: patient SELECT / doctor manage
+-- missing clinic_id enforcement. clinic_id was added in
+-- 00005 but policies never used it.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "treatment_plans_select_patient" ON treatment_plans;
+CREATE POLICY "treatment_plans_select_patient" ON treatment_plans
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "treatment_plans_manage_doctor" ON treatment_plans;
+CREATE POLICY "treatment_plans_manage_doctor" ON treatment_plans
+  FOR ALL USING (
+    doctor_id = get_my_user_id()
+    AND get_user_role() = 'doctor'
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    doctor_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "treatment_plans_select_admin" ON treatment_plans;
+CREATE POLICY "treatment_plans_select_admin" ON treatment_plans
+  FOR SELECT USING (
+    get_user_role() = 'clinic_admin'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1r. WAITING_LIST: patient policies missing clinic_id
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "patient_waiting_list_select" ON waiting_list;
+CREATE POLICY "patient_waiting_list_select" ON waiting_list
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND get_user_role() = 'patient'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "patient_waiting_list_insert" ON waiting_list;
+CREATE POLICY "patient_waiting_list_insert" ON waiting_list
+  FOR INSERT WITH CHECK (
+    patient_id = get_my_user_id()
+    AND get_user_role() = 'patient'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "patient_waiting_list_delete" ON waiting_list;
+CREATE POLICY "patient_waiting_list_delete" ON waiting_list
+  FOR DELETE USING (
+    patient_id = get_my_user_id()
+    AND get_user_role() = 'patient'
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1s. INSTALLMENTS: patient SELECT missing clinic_id
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "installments_select_patient" ON installments;
+CREATE POLICY "installments_select_patient" ON installments
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1t. NOTIFICATIONS: own-user SELECT missing clinic_id
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "notifications_select_own" ON notifications;
+CREATE POLICY "notifications_select_own" ON notifications
+  FOR SELECT USING (
+    user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+DROP POLICY IF EXISTS "notifications_update_own" ON notifications;
+CREATE POLICY "notifications_update_own" ON notifications
+  FOR UPDATE USING (
+    user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    user_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1u. LOYALTY_POINTS: patient SELECT missing clinic_id
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "loyalty_points_select_patient" ON loyalty_points;
+CREATE POLICY "loyalty_points_select_patient" ON loyalty_points
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1v. PRESCRIPTION_REQUESTS: patient manage missing clinic_id
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "prescription_requests_manage_patient" ON prescription_requests;
+CREATE POLICY "prescription_requests_manage_patient" ON prescription_requests
+  FOR ALL USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  ) WITH CHECK (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- -------------------------------------------------------
+-- 1w. ODONTOGRAM: patient SELECT missing clinic_id
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "odontogram_select_patient" ON odontogram;
+CREATE POLICY "odontogram_select_patient" ON odontogram
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ============================================================
+-- 2. ENABLE RLS ON rate_limit_entries (if exists)
+-- This table is accessed by the service role only but should
+-- still have RLS enabled as defense-in-depth.
+-- ============================================================
+
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'rate_limit_entries' AND table_schema = 'public') THEN
+    EXECUTE 'ALTER TABLE rate_limit_entries ENABLE ROW LEVEL SECURITY';
+    -- No user-facing policies needed — service role bypasses RLS.
+    -- This ensures anon/authenticated users cannot access rate limit data.
+  END IF;
+END $$;
+
+-- ============================================================
+-- 3. ADD MISSING INDEXES FOR TENANT ISOLATION PERFORMANCE
+-- ============================================================
+
+-- Notifications: index on clinic_id (column added in 00019)
+CREATE INDEX IF NOT EXISTS idx_notifications_clinic ON notifications(clinic_id);
+
+-- Installments: index on clinic_id (column added in 00005)
+CREATE INDEX IF NOT EXISTS idx_installments_clinic ON installments(clinic_id);
+
+-- Treatment plans: index on clinic_id (column added in 00005)
+CREATE INDEX IF NOT EXISTS idx_treatment_plans_clinic ON treatment_plans(clinic_id);
+
+-- Notification log: compound index for cron job queries
+CREATE INDEX IF NOT EXISTS idx_notification_log_appt_trigger
+  ON notification_log(appointment_id, trigger);
+
+-- Appointments: compound index for cron reminder lookups
+CREATE INDEX IF NOT EXISTS idx_appointments_date_status
+  ON appointments(appointment_date, status)
+  WHERE status IN ('confirmed', 'pending');
+
+-- Users: compound index for clinic + role lookups
+CREATE INDEX IF NOT EXISTS idx_users_clinic_role ON users(clinic_id, role);
+
+-- Payments: compound index for clinic + status
+CREATE INDEX IF NOT EXISTS idx_payments_clinic_status ON payments(clinic_id, status);
+
+-- Clinic subscriptions: index for billing cron
+CREATE INDEX IF NOT EXISTS idx_clinic_subscriptions_period_end
+  ON clinic_subscriptions(current_period_end)
+  WHERE status IN ('active', 'past_due');


### PR DESCRIPTION
## Multi-Tenant Security Hardening

### Migration 00029: Fix RLS Policies & Add Tenant Isolation

**Fixed 23+ broken RLS policies** missing `clinic_id` in WITH CHECK clauses:
- `odontogram`, `installments`, `notifications`, `chatbot_config`, `chatbot_faqs`
- Patient policies for `appointments`, `payments`, `reviews`, `documents`, `waiting_list`, `installments`, `notifications`, `loyalty_points`, `prescription_requests`, `treatment_plans`
- Staff policies for `appointment_doctors`, `family_members`
- Public SELECT policies for `collection_points`, `lab_tests`, `blog_posts`

**Added `clinic_id` columns** to 4 tables lacking tenant isolation:
- `prescriptions`, `consultation_notes`, `family_members`, `odontogram`
- All backfilled from related user records

**Enabled RLS** on `rate_limit_entries` (defense-in-depth)

**Added 9 performance indexes** for tenant-scoped queries

### Webhook Fixes
- **CMI callback**: Payment/appointment updates now scoped to `clinic_id`
- **Stripe webhook**: Appointment confirmation scoped to `clinic_id`
- **WhatsApp webhook**: Appointment update queries include `clinic_id`

### Cron Job Safety
- **Reminders**: Skip appointments without `clinic_id` with warning log
- **Billing**: Filter out subscriptions without `clinic_id`
- **processRenewal**: Block execution if `clinic_id` is missing/invalid

### Service Role Documentation
- Documented intentional service role usage in `rate-limit.ts`

### Remaining Risks
- `rate_limit_entries` uses service role (intentional — global infrastructure table)
- Chatbot public SELECT allows unauthenticated access (required for public widget)
- `announcements` public SELECT is platform-wide by design