### PR TITLE
feat: production-grade multi-tenant security hardening

### DIFF
--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -6,7 +6,7 @@
  */
 
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { createTenantClient } from "@/lib/supabase-server";
 import { requireTenant } from "@/lib/tenant";
 import {
   uploadToR2,
@@ -61,7 +61,7 @@ export async function GET() {
   try {
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
-    const supabase = await createClient();
+    const supabase = await createTenantClient(clinicId);
 
     const { data, error } = await supabase
       .from("clinics")

--- a/src/app/api/cron/billing/route.ts
+++ b/src/app/api/cron/billing/route.ts
@@ -11,6 +11,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { processRenewal } from "@/lib/subscription-billing";
 import { verifyCronSecret } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import { assertClinicId } from "@/lib/assert-tenant";
 
 export async function GET(request: NextRequest) {
   // DRY: Use shared cron secret verification helper
@@ -34,14 +36,29 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  logger.info("Billing cron started", {
+    context: "cron/billing",
+    subscriptionCount: subscriptions?.length ?? 0,
+  });
+
   const results: { clinicId: string; success: boolean; error?: string }[] = [];
   const BATCH_SIZE = 10;
-  // SAFETY ASSERTION: Filter out any subscriptions without a clinic_id to
-  // prevent cross-tenant operations. This should never happen with correct
+  // SAFETY ASSERTION: Filter out any subscriptions without a valid clinic_id
+  // to prevent cross-tenant operations. This should never happen with correct
   // data integrity but acts as defense-in-depth.
   const subs = (subscriptions ?? []).filter((sub) => {
     if (!sub.clinic_id) {
       results.push({ clinicId: "unknown", success: false, error: "Missing clinic_id — skipped for tenant safety" });
+      return false;
+    }
+    try {
+      assertClinicId(sub.clinic_id, "cron/billing:subscription");
+    } catch {
+      logger.warn("Invalid clinic_id on subscription — skipped", {
+        context: "cron/billing",
+        clinicId: sub.clinic_id,
+      });
+      results.push({ clinicId: sub.clinic_id, success: false, error: "Invalid clinic_id format" });
       return false;
     }
     return true;

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -4,6 +4,7 @@ import { dispatchNotification } from "@/lib/notifications";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { verifyCronSecret } from "@/lib/cron-auth";
 import { logger } from "@/lib/logger";
+import { assertClinicId } from "@/lib/assert-tenant";
 
 /**
  * GET /api/cron/reminders
@@ -121,6 +122,17 @@ export async function GET(request: NextRequest) {
         logger.warn("Skipping appointment without clinic_id", {
           context: "cron/reminders",
           appointmentId: appt.id,
+        });
+        continue;
+      }
+
+      try {
+        assertClinicId(appt.clinic_id as string, "cron/reminders:appointment");
+      } catch {
+        logger.warn("Invalid clinic_id on appointment — skipped", {
+          context: "cron/reminders",
+          appointmentId: appt.id,
+          clinicId: appt.clinic_id as string,
         });
         continue;
       }

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase-server";
 import { verifyCmiCallback } from "@/lib/cmi";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
+import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 
 /**
  * POST /api/payments/cmi/callback
@@ -40,6 +41,20 @@ export async function POST(request: NextRequest) {
         .single();
 
       if (payment && payment.status !== PAYMENT_STATUS.COMPLETED) {
+        // Set tenant context for defense-in-depth RLS enforcement
+        if (payment.clinic_id) {
+          try {
+            await setTenantContext(supabase, payment.clinic_id);
+            logTenantContext(payment.clinic_id, "payments/cmi/callback:approved");
+          } catch (tenantErr) {
+            logger.error("Failed to set tenant context for CMI callback", {
+              context: "payments/cmi/callback",
+              clinicId: payment.clinic_id,
+              error: tenantErr,
+            });
+          }
+        }
+
         // Mark payment as completed — scoped to the payment's clinic_id
         // to prevent any cross-tenant state mutation.
         await supabase
@@ -72,6 +87,19 @@ export async function POST(request: NextRequest) {
         .single();
 
       if (failedPayment) {
+        // Set tenant context for defense-in-depth
+        if (failedPayment.clinic_id) {
+          try {
+            await setTenantContext(supabase, failedPayment.clinic_id);
+            logTenantContext(failedPayment.clinic_id, "payments/cmi/callback:failed");
+          } catch (tenantErr) {
+            logger.error("Failed to set tenant context for CMI callback (failed payment)", {
+              context: "payments/cmi/callback",
+              clinicId: failedPayment.clinic_id,
+              error: tenantErr,
+            });
+          }
+        }
         await supabase
           .from("payments")
           .update({ status: PAYMENT_STATUS.FAILED })

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -3,6 +3,8 @@ import { createClient } from "@/lib/supabase-server";
 import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
+import { assertClinicId } from "@/lib/assert-tenant";
+import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 
 /**
  * POST /api/payments/webhook
@@ -78,6 +80,18 @@ export async function POST(request: NextRequest) {
 
         // Record payment in Supabase (idempotent via upsert on reference)
         if (clinicId && patientId) {
+          try {
+            assertClinicId(clinicId, "payments/webhook:checkout.completed");
+            await setTenantContext(supabase, clinicId);
+          } catch (tenantErr) {
+            logger.error("Invalid tenant context in Stripe webhook", {
+              context: "payments/webhook",
+              clinicId,
+              error: tenantErr,
+            });
+            break;
+          }
+          logTenantContext(clinicId, "payments/webhook:checkout.completed");
           await supabase.from("payments").upsert(
             {
               clinic_id: clinicId,
@@ -117,6 +131,18 @@ export async function POST(request: NextRequest) {
         const failedAppointmentId = intent.metadata?.appointment_id;
 
         if (failedClinicId && failedPatientId) {
+          try {
+            assertClinicId(failedClinicId, "payments/webhook:payment_failed");
+            await setTenantContext(supabase, failedClinicId);
+          } catch (tenantErr) {
+            logger.error("Invalid tenant context in Stripe webhook (failed payment)", {
+              context: "payments/webhook",
+              clinicId: failedClinicId,
+              error: tenantErr,
+            });
+            break;
+          }
+          logTenantContext(failedClinicId, "payments/webhook:payment_failed");
           await supabase.from("payments").insert({
             clinic_id: failedClinicId,
             patient_id: failedPatientId,

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -8,12 +8,13 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { createTenantClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 import { logger } from "@/lib/logger";
 import { v1AppointmentCreateSchema, safeParse } from "@/lib/validations";
+import { logTenantContext } from "@/lib/tenant-context";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -29,7 +30,8 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const supabase = await createClient();
+  logTenantContext(auth.clinicId, "v1/appointments:GET");
+  const supabase = await createTenantClient(auth.clinicId);
   const url = new URL(request.url);
   const date = url.searchParams.get("date");
   const status = url.searchParams.get("status");
@@ -92,7 +94,8 @@ export async function POST(request: NextRequest) {
       ? `${body.appointment_date}T${body.end_time}`
       : new Date(new Date(slotStartNormalized).getTime() + 30 * 60_000).toISOString(); // default 30 min
 
-    const supabase = await createClient();
+    logTenantContext(auth.clinicId, "v1/appointments:POST");
+    const supabase = await createTenantClient(auth.clinicId);
     const { data, error } = await supabase
       .from("appointments")
       .insert({

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -8,12 +8,13 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { createTenantClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 import { logger } from "@/lib/logger";
 import type { TablesInsert } from "@/lib/types/database";
 import { v1PatientCreateSchema, safeParse } from "@/lib/validations";
+import { logTenantContext } from "@/lib/tenant-context";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -29,7 +30,8 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const supabase = await createClient();
+  logTenantContext(auth.clinicId, "v1/patients:GET");
+  const supabase = await createTenantClient(auth.clinicId);
   const url = new URL(request.url);
   const search = url.searchParams.get("search");
   const limit = Math.min(Number(url.searchParams.get("limit") || 50), 100);
@@ -85,7 +87,8 @@ export async function POST(request: NextRequest) {
     }
     const body = parsed.data;
 
-    const supabase = await createClient();
+    logTenantContext(auth.clinicId, "v1/patients:POST");
+    const supabase = await createTenantClient(auth.clinicId);
     // The users table has columns (full_name, date_of_birth, gender,
     // insurance_type, address) that are not yet in the generated
     // Supabase types.  Use a Record<string, unknown> insert so the

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/notifications";
 import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
+import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 
 export const runtime = "edge";
 
@@ -113,6 +114,22 @@ export async function POST(request: NextRequest) {
         // Cannot resolve clinic — skip to maintain tenant isolation
         continue;
       }
+
+      // Set tenant context on the Supabase client for defense-in-depth
+      try {
+        await setTenantContext(supabase, clinicId);
+      } catch (tenantErr) {
+        logger.error("Failed to set tenant context for webhook", {
+          context: "webhooks",
+          clinicId,
+          error: tenantErr,
+        });
+        continue;
+      }
+
+      logTenantContext(clinicId, "webhooks/whatsapp", {
+        senderPhone: msgInfo.senderPhone,
+      });
 
       // Patient lookup is now always scoped to the resolved clinic
       const { data: patient } = await supabase

--- a/src/lib/assert-tenant.ts
+++ b/src/lib/assert-tenant.ts
@@ -1,0 +1,71 @@
+/**
+ * Global Tenant Assertion Layer
+ *
+ * Provides assertion functions that MUST be called before any database
+ * operation requiring tenant isolation. These act as a final safety net
+ * to ensure no cross-tenant data access is possible.
+ *
+ * Usage:
+ *   import { assertClinicId, assertTenantMatch } from "@/lib/assert-tenant";
+ *
+ *   // Before any DB operation:
+ *   assertClinicId(clinicId, "appointments.insert");
+ *
+ *   // Before cross-referencing entities:
+ *   assertTenantMatch(doctor.clinic_id, clinicId, "doctor", "appointment");
+ */
+
+import { isValidClinicId } from "@/lib/tenant-context";
+
+/**
+ * Assert that a clinic_id is present and valid before a database operation.
+ *
+ * @param clinicId - The clinic_id to validate
+ * @param operation - Description of the DB operation (for error messages)
+ * @throws Error if clinicId is missing, empty, or not a valid UUID
+ */
+export function assertClinicId(
+  clinicId: string | null | undefined,
+  operation: string,
+): asserts clinicId is string {
+  if (!clinicId) {
+    throw new Error(
+      `[TENANT SAFETY] clinic_id is required for "${operation}" but was ${clinicId === null ? "null" : "undefined"}. Aborting to prevent cross-tenant access.`,
+    );
+  }
+
+  if (!isValidClinicId(clinicId)) {
+    throw new Error(
+      `[TENANT SAFETY] Invalid clinic_id format for "${operation}": "${clinicId}". Aborting to prevent cross-tenant access.`,
+    );
+  }
+}
+
+/**
+ * Assert that two clinic_id values match, ensuring an entity belongs
+ * to the expected tenant before performing a cross-reference operation.
+ *
+ * @param entityClinicId - The clinic_id from the entity being referenced
+ * @param expectedClinicId - The expected clinic_id from the current tenant context
+ * @param entityType - Type of entity being referenced (for error messages)
+ * @param operation - Description of the operation (for error messages)
+ * @throws Error if the clinic_ids do not match
+ */
+export function assertTenantMatch(
+  entityClinicId: string | null | undefined,
+  expectedClinicId: string,
+  entityType: string,
+  operation: string,
+): void {
+  if (!entityClinicId) {
+    throw new Error(
+      `[TENANT SAFETY] ${entityType} has no clinic_id during "${operation}". Aborting to prevent cross-tenant access.`,
+    );
+  }
+
+  if (entityClinicId !== expectedClinicId) {
+    throw new Error(
+      `[TENANT SAFETY] ${entityType} belongs to clinic "${entityClinicId}" but operation "${operation}" is for clinic "${expectedClinicId}". Cross-tenant access blocked.`,
+    );
+  }
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -31,6 +31,8 @@ const transports: LogTransport[] = [];
 
 interface LogMeta {
   context?: string;
+  /** Tenant clinic_id for multi-tenant audit trail */
+  clinicId?: string | null;
   error?: unknown;
   [key: string]: unknown;
 }
@@ -47,13 +49,14 @@ function formatError(err: unknown): Record<string, unknown> {
 }
 
 function emit(level: LogLevel, message: string, meta?: LogMeta): void {
-  const { context, error, ...extra } = meta ?? {};
+  const { context, clinicId, error, ...extra } = meta ?? {};
   const payload: Record<string, unknown> = {
     level,
     message,
     timestamp: new Date().toISOString(),
   };
   if (context) payload.context = context;
+  if (clinicId !== undefined) payload.clinicId = clinicId;
   if (error !== undefined) payload.error = formatError(error);
   if (Object.keys(extra).length > 0) Object.assign(payload, extra);
 

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -6,8 +6,10 @@
  * payment processing when configured.
  */
 
-import { createClient } from "@/lib/supabase-server";
+import { createTenantClient } from "@/lib/supabase-server";
 import { logger } from "@/lib/logger";
+import { assertClinicId } from "@/lib/assert-tenant";
+import { logTenantContext } from "@/lib/tenant-context";
 
 // ---- Types ----
 
@@ -200,9 +202,10 @@ export async function checkPlanLimits(
   clinicId: string,
   plan: SubscriptionPlan,
 ): Promise<{ withinLimits: boolean; exceeded: string[] }> {
+  assertClinicId(clinicId, "subscription-billing:checkPlanLimits");
   const config = getPlanConfig(plan);
   const exceeded: string[] = [];
-  const supabase = await createClient();
+  const supabase = await createTenantClient(clinicId);
 
   // Run all three independent count queries in parallel
   const now = new Date();
@@ -255,11 +258,14 @@ export async function processRenewal(
 ): Promise<{ success: boolean; error?: string }> {
   // SAFETY ASSERTION: Block execution if clinic_id is missing or invalid
   // to prevent cross-tenant operations in the billing pipeline.
-  if (!clinicId || typeof clinicId !== "string" || clinicId.trim() === "") {
+  try {
+    assertClinicId(clinicId, "subscription-billing:processRenewal");
+  } catch {
     return { success: false, error: "Missing or invalid clinic_id — blocked for tenant safety" };
   }
 
-  const supabase = await createClient();
+  logTenantContext(clinicId, "subscription-billing:processRenewal");
+  const supabase = await createTenantClient(clinicId);
 
   // Fetch current subscription
   const { data: sub, error: fetchError } = await supabase
@@ -425,7 +431,7 @@ async function logBillingEvent(
   clinicId: string,
   event: Omit<BillingEvent, "id" | "clinicId" | "createdAt">,
 ): Promise<void> {
-  const supabase = await createClient();
+  const supabase = await createTenantClient(clinicId);
   await supabase.from("billing_events").insert({
     clinic_id: clinicId,
     type: event.type,

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
 import type { Database } from "@/lib/types/database";
+import { setTenantContext } from "@/lib/tenant-context";
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -10,6 +11,11 @@ function requireEnv(name: string): string {
   return value;
 }
 
+/**
+ * Create a Supabase server client with cookie-based auth.
+ * Use this for requests where tenant context will be set separately
+ * (e.g. middleware, auth flows).
+ */
 export async function createClient() {
   const cookieStore = await cookies();
 
@@ -34,4 +40,20 @@ export async function createClient() {
       },
     },
   );
+}
+
+/**
+ * Create a Supabase server client with tenant context set.
+ *
+ * Sets `app.current_clinic_id` as a PostgreSQL session variable so that
+ * RLS policies can use it as an additional isolation check. This is the
+ * preferred way to create a client for tenant-scoped operations.
+ *
+ * @param clinicId - The clinic UUID to scope all operations to
+ * @throws Error if clinicId is missing/invalid or if setting context fails
+ */
+export async function createTenantClient(clinicId: string) {
+  const client = await createClient();
+  await setTenantContext(client, clinicId);
+  return client;
 }

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -1,0 +1,115 @@
+/**
+ * Tenant Context Enforcement
+ *
+ * Sets `app.current_clinic_id` as a PostgreSQL session variable on every
+ * Supabase client connection. This provides defense-in-depth alongside RLS
+ * policies that check `get_user_clinic_id()`.
+ *
+ * WHY: Even if application-level filtering is accidentally omitted from a
+ * query, the database-level session variable ensures RLS policies can
+ * independently verify the intended tenant, preventing cross-tenant access.
+ *
+ * USAGE:
+ *   const supabase = await createClient();
+ *   await setTenantContext(supabase, clinicId);
+ *   // All subsequent queries on this client are now scoped
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/types/database";
+import { logger } from "@/lib/logger";
+
+/**
+ * Validate that a clinic_id looks like a valid UUID.
+ * Prevents SQL injection via malformed clinic_id values.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidClinicId(clinicId: string): boolean {
+  return UUID_RE.test(clinicId);
+}
+
+/**
+ * Set the tenant context on a Supabase client by setting the PostgreSQL
+ * session variable `app.current_clinic_id`.
+ *
+ * This MUST be called before any tenant-scoped database operation.
+ * RLS policies can then use `current_setting('app.current_clinic_id', true)`
+ * as an additional isolation check.
+ *
+ * @throws Error if clinicId is missing or invalid
+ */
+export async function setTenantContext(
+  supabase: SupabaseClient<Database>,
+  clinicId: string,
+): Promise<void> {
+  if (!clinicId) {
+    throw new Error("Tenant context error: clinic_id is required but was empty");
+  }
+
+  if (!isValidClinicId(clinicId)) {
+    throw new Error(`Tenant context error: invalid clinic_id format: ${clinicId}`);
+  }
+
+  // Use rpc() with a type assertion because the set_tenant_context function
+  // is added by migration 00030 and not yet in the generated Database types.
+  // Once the migration is applied and types are regenerated, the assertion
+  // can be removed.
+  const { error } = await (supabase.rpc as CallableFunction)(
+    "set_tenant_context",
+    { p_clinic_id: clinicId },
+  );
+
+  if (error) {
+    logger.error("Failed to set tenant context", {
+      context: "tenant-context",
+      clinicId,
+      error,
+    });
+    const message = typeof error === "object" && error !== null && "message" in error
+      ? (error as { message: string }).message
+      : String(error);
+    throw new Error(`Tenant context error: failed to set app.current_clinic_id: ${message}`);
+  }
+}
+
+/**
+ * Assert that a tenant context exists and is valid.
+ * Call this before any database operation that requires tenant isolation.
+ *
+ * @param clinicId - The clinic_id to validate
+ * @param operation - Description of the operation (for error messages)
+ * @throws Error if clinicId is missing or invalid
+ */
+export function assertTenantContext(
+  clinicId: string | null | undefined,
+  operation: string,
+): asserts clinicId is string {
+  if (!clinicId) {
+    throw new Error(
+      `Tenant assertion failed: clinic_id is required for ${operation} but was ${clinicId === null ? "null" : "undefined"}`,
+    );
+  }
+
+  if (!isValidClinicId(clinicId)) {
+    throw new Error(
+      `Tenant assertion failed: invalid clinic_id format for ${operation}: ${clinicId}`,
+    );
+  }
+}
+
+/**
+ * Log tenant context for audit trail.
+ * Call this at the entry point of every request handler.
+ */
+export function logTenantContext(
+  clinicId: string | null | undefined,
+  context: string,
+  extra?: Record<string, unknown>,
+): void {
+  logger.info("Tenant context resolved", {
+    context,
+    clinicId: clinicId ?? "none",
+    ...extra,
+  });
+}

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -11,6 +11,7 @@
 
 import { headers } from "next/headers";
 import { clinicConfig } from "@/config/clinic.config";
+import { logTenantContext } from "@/lib/tenant-context";
 
 /** Minimal tenant info passed via request headers from middleware. */
 export interface TenantInfo {
@@ -62,6 +63,7 @@ export async function requireTenant(): Promise<TenantInfo> {
   if (!tenant?.clinicId) {
     throw new Error("Tenant context is required but was not resolved. Ensure the request includes a valid subdomain.");
   }
+  logTenantContext(tenant.clinicId, "requireTenant");
   return tenant;
 }
 
@@ -100,8 +102,8 @@ export interface TenantClinicConfig {
  */
 export async function getClinicConfig(clinicId: string): Promise<TenantClinicConfig> {
   // Dynamic import to avoid circular dependency
-  const { createClient } = await import("@/lib/supabase-server");
-  const supabase = await createClient();
+  const { createTenantClient } = await import("@/lib/supabase-server");
+  const supabase = await createTenantClient(clinicId);
 
   const { data } = await supabase
     .from("clinics")

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -21,6 +21,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/types/database";
 import type { User } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
+import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 
 export interface AuthContext {
   supabase: SupabaseClient<Database>;
@@ -85,6 +86,26 @@ export function withAuth(
           { status: 403 },
         );
       }
+
+      // Set tenant context on the Supabase client so RLS policies
+      // can use app.current_clinic_id as an additional isolation check.
+      if (profile.clinic_id) {
+        try {
+          await setTenantContext(supabase, profile.clinic_id);
+        } catch (tenantErr) {
+          logger.error("Failed to set tenant context in withAuth", {
+            context: "with-auth",
+            clinicId: profile.clinic_id,
+            error: tenantErr,
+          });
+          // Continue — RLS via get_user_clinic_id() still protects
+        }
+      }
+
+      logTenantContext(profile.clinic_id, "with-auth", {
+        userId: profile.id,
+        role: profile.role,
+      });
 
       return handler(request, {
         supabase,

--- a/supabase/migrations/00030_tenant_context_hardening.sql
+++ b/supabase/migrations/00030_tenant_context_hardening.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- Migration 00030: Tenant Context Hardening
+--
+-- Adds a PostgreSQL function to set `app.current_clinic_id` as
+-- a session variable from the application layer. This provides
+-- defense-in-depth alongside existing RLS policies that use
+-- `get_user_clinic_id()`.
+--
+-- The application calls this function via Supabase RPC after
+-- creating a client, ensuring every connection has an explicit
+-- tenant context that RLS can verify independently of the
+-- authenticated user's profile.
+-- ============================================================
+
+-- 1. Create the set_tenant_context function
+--    Called by the application layer to set the session variable
+--    before any tenant-scoped database operations.
+CREATE OR REPLACE FUNCTION set_tenant_context(p_clinic_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  PERFORM set_config('app.current_clinic_id', p_clinic_id::TEXT, true);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Grant execute to authenticated users and the anon role
+-- (anon is used by cron jobs and webhooks that don't have a user session)
+GRANT EXECUTE ON FUNCTION set_tenant_context(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION set_tenant_context(UUID) TO anon;
+
+-- 2. Create a helper function to read the current tenant context
+--    Returns NULL if no context has been set (safe default).
+CREATE OR REPLACE FUNCTION get_tenant_context()
+RETURNS UUID AS $$
+BEGIN
+  RETURN NULLIF(current_setting('app.current_clinic_id', true), '')::UUID;
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_tenant_context() TO authenticated;
+GRANT EXECUTE ON FUNCTION get_tenant_context() TO anon;


### PR DESCRIPTION
- Add tenant-context.ts: sets app.current_clinic_id as PostgreSQL session variable
- Add assert-tenant.ts: global assertion layer for tenant validation
- Add createTenantClient() to supabase-server.ts for tenant-scoped clients
- Update with-auth.ts: set tenant context after authentication
- Update tenant.ts: integrate tenant context logging and createTenantClient
- Update logger.ts: add clinicId field to structured log metadata
- Harden cron jobs (reminders, billing) with assertClinicId checks
- Harden webhooks (WhatsApp, Stripe, CMI) with setTenantContext
- Harden v1 API routes with createTenantClient and logTenantContext
- Harden branding route with createTenantClient
- Harden subscription-billing with assertClinicId and createTenantClient
- Add migration 00030: set_tenant_context and get_tenant_context SQL functions