### PR TITLE
fix: strip attacker-controlled tenant headers from incoming requests

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -178,6 +178,15 @@ export async function middleware(request: NextRequest) {
   requestHeaders.set("x-nonce", nonce);
   requestHeaders.set("Content-Security-Policy", cspHeaderValue);
 
+  // --- SECURITY: Strip all tenant headers from the incoming request ---
+  // Tenant context MUST only come from subdomain resolution (server-side).
+  // Without this, an attacker could inject x-tenant-clinic-id (or any
+  // x-tenant-* header) on a root-domain request and impersonate another
+  // tenant on public endpoints like /api/booking and /api/branding.
+  for (const key of Object.values(TENANT_HEADERS)) {
+    requestHeaders.delete(key);
+  }
+
   // --- Subdomain resolution ---
   const subdomain = extractSubdomain(hostname, rootDomain);
 


### PR DESCRIPTION
The middleware copies all incoming request headers but did not remove x-tenant-* headers before forwarding to downstream handlers. An attacker could send a forged x-tenant-clinic-id header on a root-domain request to impersonate another tenant on public endpoints (/api/booking, /api/branding, /api/chat).

Now all TENANT_HEADERS values are deleted from the forwarded request headers immediately after copying. Tenant context can only be set by the middleware's own subdomain resolution logic.