### PR TITLE
fix: close multi-tenant security gaps found in audit

### DIFF
--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -1,5 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { customFieldCreateSchema, customFieldUpdateSchema, safeParse } from "@/lib/validations";
@@ -11,8 +10,9 @@ export const runtime = "edge";
  * GET /api/custom-fields?clinic_type_key=...&entity_type=...
  *
  * Returns custom field definitions for a given clinic type and entity.
+ * Requires authentication to prevent unauthenticated enumeration.
  */
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (request, { supabase }) => {
   try {
     const clinicTypeKey = request.nextUrl.searchParams.get("clinic_type_key");
     const entityType = request.nextUrl.searchParams.get("entity_type");
@@ -23,8 +23,6 @@ export async function GET(request: NextRequest) {
         { status: 400 },
       );
     }
-
-    const supabase = await createClient();
 
     let query = supabase
       .from("custom_field_definitions")
@@ -54,7 +52,7 @@ export async function GET(request: NextRequest) {
       { status: 500 },
     );
   }
-}
+}, null);
 
 /**
  * POST /api/custom-fields

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -435,9 +435,9 @@ export interface NotificationRow {
   sent_at: string;
 }
 
-export async function getNotifications(userId: string): Promise<NotificationRow[]> {
+export async function getNotifications(clinicId: string, userId: string): Promise<NotificationRow[]> {
   return query<NotificationRow>("notifications", {
-    eq: [["user_id", userId]],
+    eq: [["clinic_id", clinicId], ["user_id", userId]],
     order: ["sent_at", { ascending: false }],
   });
 }
@@ -487,9 +487,9 @@ export async function getPrescriptions(clinicId: string, doctorId?: string): Pro
   let q = supabase
     .from("prescriptions")
     .select("*")
+    .eq("clinic_id", clinicId)
     .order("created_at", { ascending: false });
 
-  // Prescriptions table may not have clinic_id directly; filter via doctor/patient clinic
   if (doctorId) {
     q = q.eq("doctor_id", doctorId);
   }
@@ -512,9 +512,9 @@ export async function getPrescriptions(clinicId: string, doctorId?: string): Pro
   }));
 }
 
-export async function getPatientPrescriptions(patientId: string): Promise<PrescriptionRow[]> {
+export async function getPatientPrescriptions(clinicId: string, patientId: string): Promise<PrescriptionRow[]> {
   return query<PrescriptionRow>("prescriptions", {
-    eq: [["patient_id", patientId]],
+    eq: [["clinic_id", clinicId], ["patient_id", patientId]],
     order: ["created_at", { ascending: false }],
   });
 }
@@ -535,9 +535,9 @@ export interface ConsultationNoteRow {
   updated_at: string;
 }
 
-export async function getConsultationNotes(doctorId: string): Promise<ConsultationNoteRow[]> {
+export async function getConsultationNotes(clinicId: string, doctorId: string): Promise<ConsultationNoteRow[]> {
   return query<ConsultationNoteRow>("consultation_notes", {
-    eq: [["doctor_id", doctorId]],
+    eq: [["clinic_id", clinicId], ["doctor_id", doctorId]],
     order: ["created_at", { ascending: false }],
   });
 }
@@ -578,9 +578,9 @@ export interface FamilyMemberRow {
   created_at: string;
 }
 
-export async function getFamilyMembers(userId: string): Promise<FamilyMemberRow[]> {
+export async function getFamilyMembers(clinicId: string, userId: string): Promise<FamilyMemberRow[]> {
   return query<FamilyMemberRow>("family_members", {
-    eq: [["primary_user_id", userId]],
+    eq: [["clinic_id", clinicId], ["primary_user_id", userId]],
   });
 }
 
@@ -598,9 +598,9 @@ export interface OdontogramRow {
   updated_at: string;
 }
 
-export async function getOdontogram(patientId: string): Promise<OdontogramRow[]> {
+export async function getOdontogram(clinicId: string, patientId: string): Promise<OdontogramRow[]> {
   return query<OdontogramRow>("odontogram", {
-    eq: [["patient_id", patientId]],
+    eq: [["clinic_id", clinicId], ["patient_id", patientId]],
     order: ["tooth_number", { ascending: true }],
   });
 }
@@ -623,17 +623,17 @@ export interface TreatmentPlanRow {
 }
 
 export async function getTreatmentPlans(clinicId: string, doctorId?: string): Promise<TreatmentPlanRow[]> {
-  const eq: [string, unknown][] = [];
+  const eq: [string, unknown][] = [["clinic_id", clinicId]];
   if (doctorId) eq.push(["doctor_id", doctorId]);
   return query<TreatmentPlanRow>("treatment_plans", {
-    eq: eq.length > 0 ? eq : undefined,
+    eq,
     order: ["created_at", { ascending: false }],
   });
 }
 
-export async function getPatientTreatmentPlans(patientId: string): Promise<TreatmentPlanRow[]> {
+export async function getPatientTreatmentPlans(clinicId: string, patientId: string): Promise<TreatmentPlanRow[]> {
   return query<TreatmentPlanRow>("treatment_plans", {
-    eq: [["patient_id", patientId]],
+    eq: [["clinic_id", clinicId], ["patient_id", patientId]],
     order: ["created_at", { ascending: false }],
   });
 }
@@ -679,16 +679,16 @@ export interface InstallmentRow {
   created_at: string;
 }
 
-export async function getInstallments(treatmentPlanId: string): Promise<InstallmentRow[]> {
+export async function getInstallments(clinicId: string, treatmentPlanId: string): Promise<InstallmentRow[]> {
   return query<InstallmentRow>("installments", {
-    eq: [["treatment_plan_id", treatmentPlanId]],
+    eq: [["clinic_id", clinicId], ["treatment_plan_id", treatmentPlanId]],
     order: ["due_date", { ascending: true }],
   });
 }
 
-export async function getPatientInstallments(patientId: string): Promise<InstallmentRow[]> {
+export async function getPatientInstallments(clinicId: string, patientId: string): Promise<InstallmentRow[]> {
   return query<InstallmentRow>("installments", {
-    eq: [["patient_id", patientId]],
+    eq: [["clinic_id", clinicId], ["patient_id", patientId]],
     order: ["due_date", { ascending: true }],
   });
 }

--- a/supabase/migrations/00031_fix_unauthenticated_cross_tenant_rls.sql
+++ b/supabase/migrations/00031_fix_unauthenticated_cross_tenant_rls.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- Migration 00031: Fix unauthenticated cross-tenant RLS leaks
+--
+-- PROBLEM: Five RLS policies use `OR auth.uid() IS NULL` which
+-- allows unauthenticated requests (using the public anon key)
+-- to read ALL rows across ALL tenants. The intent was to allow
+-- public website widgets (chatbot, blog, lab tests) to read
+-- data for the current clinic, but the policies didn't scope
+-- unauthenticated access to a specific clinic.
+--
+-- FIX: For unauthenticated access, require that the application
+-- layer has set `app.current_clinic_id` via the
+-- `set_tenant_context()` RPC (migration 00030). This ensures
+-- unauthenticated reads are scoped to the specific clinic
+-- whose context was established by the Next.js middleware.
+--
+-- Affected tables:
+--   - chatbot_config
+--   - chatbot_faqs
+--   - collection_points
+--   - lab_tests
+--   - blog_posts
+-- ============================================================
+
+-- -------------------------------------------------------
+-- chatbot_config: scope unauthenticated reads to current tenant
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "chatbot_config_select_clinic" ON chatbot_config;
+CREATE POLICY "chatbot_config_select_clinic" ON chatbot_config
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = NULLIF(current_setting('app.current_clinic_id', true), '')::uuid
+    )
+  );
+
+-- -------------------------------------------------------
+-- chatbot_faqs: scope unauthenticated reads to current tenant
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "chatbot_faqs_select_clinic" ON chatbot_faqs;
+CREATE POLICY "chatbot_faqs_select_clinic" ON chatbot_faqs
+  FOR SELECT USING (
+    is_active = TRUE
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR (
+        auth.uid() IS NULL
+        AND clinic_id = NULLIF(current_setting('app.current_clinic_id', true), '')::uuid
+      )
+    )
+  );
+
+-- -------------------------------------------------------
+-- collection_points: scope unauthenticated reads to current tenant
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "public_collection_points_read" ON collection_points;
+CREATE POLICY "public_collection_points_read" ON collection_points
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = NULLIF(current_setting('app.current_clinic_id', true), '')::uuid
+    )
+  );
+
+-- -------------------------------------------------------
+-- lab_tests: scope unauthenticated reads to current tenant
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "public_lab_tests_read" ON lab_tests;
+CREATE POLICY "public_lab_tests_read" ON lab_tests
+  FOR SELECT USING (
+    is_active = TRUE
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR (
+        auth.uid() IS NULL
+        AND clinic_id = NULLIF(current_setting('app.current_clinic_id', true), '')::uuid
+      )
+    )
+  );
+
+-- -------------------------------------------------------
+-- blog_posts: scope unauthenticated reads to current tenant
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "blog_posts_select_published" ON blog_posts;
+CREATE POLICY "blog_posts_select_published" ON blog_posts
+  FOR SELECT USING (
+    is_published = TRUE
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR (
+        auth.uid() IS NULL
+        AND clinic_id = NULLIF(current_setting('app.current_clinic_id', true), '')::uuid
+      )
+    )
+  );


### PR DESCRIPTION
## Summary

Fixes all 4 security issues identified in the multi-tenant security audit.

### Issue #3 (MEDIUM): RLS unauthenticated cross-tenant reads
5 RLS policies (`chatbot_config`, `chatbot_faqs`, `collection_points`, `lab_tests`, `blog_posts`) used `OR auth.uid() IS NULL` which allowed unauthenticated users to read ALL rows across ALL tenants via direct Supabase API with the public anon key.

**Fix:** Migration `00031` replaces the blanket `auth.uid() IS NULL` with a scoped check against `app.current_clinic_id` session variable, ensuring unauthenticated reads are limited to the specific clinic whose context was set by the application layer.

### Issue #2 (LOW): Data layer functions ignoring clinicId parameter
`getPrescriptions()` and `getTreatmentPlans()` accepted a `clinicId` parameter but never used it in queries.

**Fix:** Added `.eq("clinic_id", clinicId)` filtering to both functions.

### Issue #4 (LOW): Defense-in-depth gaps in data layer
~10 data layer functions relied solely on RLS without application-level `clinic_id` filtering.

**Fix:** Added `clinicId` parameter and `.eq("clinic_id", clinicId)` filtering to: `getPatientPrescriptions`, `getConsultationNotes`, `getNotifications`, `getFamilyMembers`, `getOdontogram`, `getPatientTreatmentPlans`, `getInstallments`, `getPatientInstallments`.

### Issue #1 (LOW): Unauthenticated GET /api/custom-fields
The GET endpoint was a plain function without authentication.

**Fix:** Wrapped in `withAuth(handler, null)` to require authentication.

## Files Changed
- `supabase/migrations/00031_fix_unauthenticated_cross_tenant_rls.sql` (new)
- `src/lib/data/server.ts`
- `src/app/api/custom-fields/route.ts`

---
[Devin session](https://app.devin.ai/sessions/ae7344772f2742d68399fa4a6f0d937d)