### PR TITLE
fix: complete RLS hardening — validate set_tenant_context, restrict feature table policies

### DIFF
--- a/supabase/migrations/00035_complete_rls_hardening.sql
+++ b/supabase/migrations/00035_complete_rls_hardening.sql
@@ -1,0 +1,90 @@
+-- ============================================================
+-- Migration 00035: Complete RLS Hardening
+--
+-- Addresses the remaining security gaps from the audit that
+-- were not covered by migrations 00032-00034:
+--
+-- 1. HARDEN set_tenant_context(): Validate that the supplied
+--    clinic_id actually exists in the clinics table. Prevents
+--    attackers from setting context to arbitrary/non-existent
+--    UUIDs. Keeps grants to both authenticated and anon
+--    (required by the public chatbot widget).
+--
+-- 2. RESTRICT feature_definitions SELECT: Replace USING (true)
+--    with authenticated-only to prevent unauthenticated
+--    enumeration of feature flags.
+--
+-- 3. RESTRICT feature_toggles SELECT: Same as above.
+--
+-- 4. ADD MISSING WRITE POLICIES for phase-6 tables: Migration
+--    00033 replaced permissive SELECT policies but some tables
+--    lacked INSERT/UPDATE/DELETE policies for non-super-admin
+--    users. Migration 00019 added staff_*_write policies, so
+--    this is verified as already covered.
+--
+-- Design decision: clinic_types remains USING (true) because
+-- it is genuinely public reference data needed by the signup
+-- and registration flow before a user is authenticated.
+-- Similarly, announcements lacks a clinic_id column and is
+-- platform-wide, so its USING (is_active = TRUE) is correct.
+-- ============================================================
+
+-- -------------------------------------------------------
+-- 1. HARDEN set_tenant_context()
+--
+-- Add clinic existence validation to prevent arbitrary UUID
+-- injection. The function is still callable by both
+-- authenticated and anon roles (required for the public
+-- chatbot widget which uses the anon key).
+--
+-- Risk accepted: An unauthenticated caller who knows a valid
+-- clinic UUID can set context and read public-facing data
+-- (chatbot_config, chatbot_faqs, collection_points, lab_tests,
+-- blog_posts) for that clinic. This is by design — these are
+-- public website resources.
+-- -------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION set_tenant_context(p_clinic_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  -- Validate that the clinic actually exists.
+  -- This prevents attackers from probing with random UUIDs.
+  IF NOT EXISTS (SELECT 1 FROM clinics WHERE id = p_clinic_id) THEN
+    RAISE EXCEPTION 'set_tenant_context: clinic not found: %', p_clinic_id;
+  END IF;
+
+  PERFORM set_config('app.current_clinic_id', p_clinic_id::TEXT, true);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Re-grant execute (CREATE OR REPLACE preserves grants in most
+-- PostgreSQL versions, but be explicit for safety).
+GRANT EXECUTE ON FUNCTION set_tenant_context(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION set_tenant_context(UUID) TO anon;
+
+-- -------------------------------------------------------
+-- 2. RESTRICT feature_definitions SELECT
+--
+-- Previously USING (true) — any user, including anonymous,
+-- could enumerate all feature flag definitions. Restrict to
+-- authenticated users only (the UI needs them for rendering
+-- feature gates, but unauthenticated users do not).
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "feature_definitions_select" ON feature_definitions;
+
+CREATE POLICY "feature_definitions_select_auth" ON feature_definitions
+  FOR SELECT USING (auth.uid() IS NOT NULL);
+
+-- -------------------------------------------------------
+-- 3. RESTRICT feature_toggles SELECT
+--
+-- Previously USING (true) — same reasoning as above.
+-- Feature toggles are per-clinic settings; restrict reads
+-- to authenticated users.
+-- -------------------------------------------------------
+
+DROP POLICY IF EXISTS "feature_toggles_select" ON feature_toggles;
+
+CREATE POLICY "feature_toggles_select_auth" ON feature_toggles
+  FOR SELECT USING (auth.uid() IS NOT NULL);


### PR DESCRIPTION
## Summary

Addresses remaining RLS security gaps from the audit AND fixes the Cloudflare Pages / Turbopack build failure.

### Migration 00035: Complete RLS Hardening

1. **Harden `set_tenant_context()`** — Validates that the supplied `clinic_id` exists in the `clinics` table before setting the session variable. Prevents attackers from probing with arbitrary UUIDs.
2. **Restrict `feature_definitions` SELECT** — Replaces `USING (true)` with authenticated-only (`auth.uid() IS NOT NULL`).
3. **Restrict `feature_toggles` SELECT** — Same as above.

### Fix: Turbopack Build (Cloudflare Pages)

The `next build` (Turbopack) was failing because `supabase-server.ts` had a **top-level** `import { cookies } from "next/headers"` which was pulled into forbidden contexts via import chains:
- **Client Component**: `notifications/page.tsx` → `notifications.ts` → `supabase-server.ts`
- **Edge Middleware**: `middleware.ts` → `tenant.ts` → `supabase-server.ts`
- **Edge App Route**: `chat/route.ts` → `supabase-server.ts`

**Fix**: Changed to a **dynamic import** inside `createClient()` so the module graph no longer pulls `next/headers` into forbidden contexts. Build verified locally with `npm run build:cf`.

### Design Decisions (documented in migration)

- `clinic_types` stays `USING (true)` — genuinely public reference data needed by signup flow
- `announcements` stays `USING (is_active = TRUE)` — platform-wide table, no `clinic_id` column
- `set_tenant_context()` grants kept for both `authenticated` and `anon` — required by public chatbot widget

### Audit Findings Addressed

| ID | Severity | Status |
|---|---|---|
| RLS-06 | LOW | Fixed (clinic existence validation) |
| RLS-03 partial | MEDIUM | Fixed (feature_definitions restricted) |
| RLS-03 partial | MEDIUM | Fixed (feature_toggles restricted) |
| Build | BLOCKER | Fixed (Turbopack `next/headers` import chain) |

### Note on Cloudflare Pages CI

The Cloudflare Pages integration check still shows as failed — this is a **pre-existing failure** also present on `main` branch (likely missing `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` env vars in the Cloudflare Pages project settings). The build succeeds locally with `npm run build:cf`.