### PR TITLE
fix: security audit remediation — RLS clinic_id hardening + booking tenant context

### DIFF
--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -8,7 +8,7 @@ import {
   getPublicServices,
   getPublicSpecialties,
 } from "@/lib/data/public";
-import { createClient } from "@/lib/supabase-server";
+import { createTenantClient } from "@/lib/supabase-server";
 import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
@@ -202,9 +202,9 @@ export async function POST(request: NextRequest) {
     }
     const body = parsed.data;
 
-    const supabase = await createClient();
     const { tenant, config: tenantConfig } = await requireTenantWithConfig();
     const clinicId = tenant.clinicId;
+    const supabase = await createTenantClient(clinicId);
 
     const validation = await validateBookingRequest(body, tenantConfig.timezone, tenantConfig.workingHours);
     if (validation.error) {

--- a/supabase/migrations/00036_patient_select_clinic_id_hardening.sql
+++ b/supabase/migrations/00036_patient_select_clinic_id_hardening.sql
@@ -1,0 +1,283 @@
+-- ============================================================
+-- Migration 00036: Patient SELECT Policy Clinic-ID Hardening
+--
+-- Defense-in-depth improvement: adds AND clinic_id = get_user_clinic_id()
+-- to all patient SELECT policies that currently only check
+-- patient_id = get_my_user_id().
+--
+-- WHY: While patient_id alone is globally unique (UUID) and the
+-- auth_id UNIQUE constraint on the users table prevents a patient
+-- from existing in multiple clinics, adding the clinic_id check
+-- provides an extra safety net against hypothetical future bugs
+-- that might allow cross-clinic patient_id references.
+--
+-- RISK: None — this is strictly additive. A patient can only
+-- belong to one clinic, so the additional clause never filters
+-- out legitimate rows.
+--
+-- Addresses: Security Audit Finding A (defense-in-depth)
+-- ============================================================
+
+-- ============================================================
+-- 1. SPECIALTY MODULES (from 00018 / 00011)
+-- ============================================================
+
+-- growth_measurements
+DROP POLICY IF EXISTS "patient_growth_measurements_read" ON growth_measurements;
+CREATE POLICY "patient_growth_measurements_read" ON growth_measurements
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- vaccinations
+DROP POLICY IF EXISTS "patient_vaccinations_read" ON vaccinations;
+CREATE POLICY "patient_vaccinations_read" ON vaccinations
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- developmental_milestones
+DROP POLICY IF EXISTS "patient_developmental_milestones_read" ON developmental_milestones;
+CREATE POLICY "patient_developmental_milestones_read" ON developmental_milestones
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- pregnancies
+DROP POLICY IF EXISTS "patient_pregnancies_read" ON pregnancies;
+CREATE POLICY "patient_pregnancies_read" ON pregnancies
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ultrasound_records
+DROP POLICY IF EXISTS "patient_ultrasound_records_read" ON ultrasound_records;
+CREATE POLICY "patient_ultrasound_records_read" ON ultrasound_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- vision_tests
+DROP POLICY IF EXISTS "patient_vision_tests_read" ON vision_tests;
+CREATE POLICY "patient_vision_tests_read" ON vision_tests
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- iop_measurements
+DROP POLICY IF EXISTS "patient_iop_measurements_read" ON iop_measurements;
+CREATE POLICY "patient_iop_measurements_read" ON iop_measurements
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ============================================================
+-- 2. SPECIALIST FEATURES (from 00018 / 00012)
+-- ============================================================
+
+-- skin_photos
+DROP POLICY IF EXISTS "patient_skin_photos_read" ON skin_photos;
+CREATE POLICY "patient_skin_photos_read" ON skin_photos
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- skin_conditions
+DROP POLICY IF EXISTS "patient_skin_conditions_read" ON skin_conditions;
+CREATE POLICY "patient_skin_conditions_read" ON skin_conditions
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ecg_records
+DROP POLICY IF EXISTS "patient_ecg_records_read" ON ecg_records;
+CREATE POLICY "patient_ecg_records_read" ON ecg_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- blood_pressure_readings
+DROP POLICY IF EXISTS "patient_bp_readings_read" ON blood_pressure_readings;
+CREATE POLICY "patient_bp_readings_read" ON blood_pressure_readings
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- heart_monitoring_notes
+DROP POLICY IF EXISTS "patient_heart_notes_read" ON heart_monitoring_notes;
+CREATE POLICY "patient_heart_notes_read" ON heart_monitoring_notes
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- hearing_tests
+DROP POLICY IF EXISTS "patient_hearing_tests_read" ON hearing_tests;
+CREATE POLICY "patient_hearing_tests_read" ON hearing_tests
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ent_exam_records
+DROP POLICY IF EXISTS "patient_ent_exams_read" ON ent_exam_records;
+CREATE POLICY "patient_ent_exams_read" ON ent_exam_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- xray_records
+DROP POLICY IF EXISTS "patient_xray_records_read" ON xray_records;
+CREATE POLICY "patient_xray_records_read" ON xray_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- fracture_records
+DROP POLICY IF EXISTS "patient_fracture_records_read" ON fracture_records;
+CREATE POLICY "patient_fracture_records_read" ON fracture_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- rehab_plans
+DROP POLICY IF EXISTS "patient_rehab_plans_read" ON rehab_plans;
+CREATE POLICY "patient_rehab_plans_read" ON rehab_plans
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- psych_medications
+DROP POLICY IF EXISTS "patient_psych_meds_read" ON psych_medications;
+CREATE POLICY "patient_psych_meds_read" ON psych_medications
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- eeg_records
+DROP POLICY IF EXISTS "patient_eeg_records_read" ON eeg_records;
+CREATE POLICY "patient_eeg_records_read" ON eeg_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- neuro_exam_records
+DROP POLICY IF EXISTS "patient_neuro_exams_read" ON neuro_exam_records;
+CREATE POLICY "patient_neuro_exams_read" ON neuro_exam_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- urology_exams
+DROP POLICY IF EXISTS "patient_urology_exams_read" ON urology_exams;
+CREATE POLICY "patient_urology_exams_read" ON urology_exams
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- spirometry_records
+DROP POLICY IF EXISTS "patient_spirometry_read" ON spirometry_records;
+CREATE POLICY "patient_spirometry_read" ON spirometry_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- respiratory_tests
+DROP POLICY IF EXISTS "patient_respiratory_tests_read" ON respiratory_tests;
+CREATE POLICY "patient_respiratory_tests_read" ON respiratory_tests
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- blood_sugar_readings
+DROP POLICY IF EXISTS "patient_blood_sugar_read" ON blood_sugar_readings;
+CREATE POLICY "patient_blood_sugar_read" ON blood_sugar_readings
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- hormone_levels
+DROP POLICY IF EXISTS "patient_hormone_levels_read" ON hormone_levels;
+CREATE POLICY "patient_hormone_levels_read" ON hormone_levels
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- diabetes_management
+DROP POLICY IF EXISTS "patient_diabetes_mgmt_read" ON diabetes_management;
+CREATE POLICY "patient_diabetes_mgmt_read" ON diabetes_management
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- joint_assessments
+DROP POLICY IF EXISTS "patient_joint_assessments_read" ON joint_assessments;
+CREATE POLICY "patient_joint_assessments_read" ON joint_assessments
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- mobility_tests
+DROP POLICY IF EXISTS "patient_mobility_tests_read" ON mobility_tests;
+CREATE POLICY "patient_mobility_tests_read" ON mobility_tests
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ============================================================
+-- 3. DIAGNOSTIC (from 00018 / 00014)
+-- ============================================================
+
+-- radiology_orders
+DROP POLICY IF EXISTS "patient_radiology_orders_read" ON radiology_orders;
+CREATE POLICY "patient_radiology_orders_read" ON radiology_orders
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- ============================================================
+-- 4. INVOICES & MEDICAL RECORDS (from 00023)
+-- ============================================================
+
+-- invoices
+DROP POLICY IF EXISTS "patient_invoices_read" ON invoices;
+CREATE POLICY "patient_invoices_read" ON invoices
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );
+
+-- medical_records
+DROP POLICY IF EXISTS "patient_medical_records_read" ON medical_records;
+CREATE POLICY "patient_medical_records_read" ON medical_records
+  FOR SELECT USING (
+    patient_id = get_my_user_id()
+    AND clinic_id = get_user_clinic_id()
+  );


### PR DESCRIPTION
## Security Audit Remediation

Applies minimal, safe fixes for the two confirmed findings from the corrected multi-tenant security audit report.

### Finding A — Patient SELECT RLS Policy Hardening (defense-in-depth)

**File:** `supabase/migrations/00036_patient_select_clinic_id_hardening.sql`

Adds `AND clinic_id = get_user_clinic_id()` to **31 patient SELECT RLS policies** that previously only checked `patient_id = get_my_user_id()`. While not exploitable today (UUID uniqueness + auth_id UNIQUE constraint prevent cross-clinic access), this provides an extra safety net against hypothetical future bugs.

**Affected tables:** growth_measurements, vaccinations, developmental_milestones, pregnancies, ultrasound_records, vision_tests, iop_measurements, skin_photos, skin_conditions, ecg_records, blood_pressure_readings, heart_monitoring_notes, hearing_tests, ent_exam_records, xray_records, fracture_records, rehab_plans, psych_medications, eeg_records, neuro_exam_records, urology_exams, spirometry_records, respiratory_tests, blood_sugar_readings, hormone_levels, diabetes_management, joint_assessments, mobility_tests, radiology_orders, invoices, medical_records.

### Finding C — Booking Route Tenant Context (defense-in-depth)

**File:** `src/app/api/booking/route.ts`

Switches from `createClient()` to `createTenantClient(clinicId)` so that `app.current_clinic_id` is set as a PostgreSQL session variable. All queries already explicitly scope by `clinic_id`, so this adds the same defense-in-depth layer used by all other tenant-scoped routes (`/api/branding`, `/api/v1/*`).

### Verification

- ESLint: clean
- TypeScript (`tsc --noEmit`): clean
- No breaking changes
- No features removed
- No architecture changes

### What was NOT changed (and why)

- **Finding B** (`set_tenant_context()` callable by anon): Documented accepted design decision — public chatbot widget requires it, only exposes public website data.
- **clinic_types USING(true)**: Intentional — platform-wide reference data.
- **announcements without clinic_id**: Intentional — platform-wide broadcasts from super_admin.