### PR TITLE
fix: resolve security audit findings (Supabase auth config + R2 bucket isolation + HSTS alignment)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -110,7 +110,7 @@ function withSecurityHeaders(
   cspHeaderValue: string,
 ): NextResponse {
   response.headers.set("Content-Security-Policy", cspHeaderValue);
-  response.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+  response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
   response.headers.set("X-Content-Type-Options", "nosniff");
   return response;
 }
@@ -296,7 +296,7 @@ export async function middleware(request: NextRequest) {
     });
     noSupabaseResponse.headers.set("Content-Security-Policy", cspHeaderValue);
     noSupabaseResponse.headers.set("x-nonce", nonce);
-    noSupabaseResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+    noSupabaseResponse.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
     return noSupabaseResponse;
   }
 
@@ -305,7 +305,7 @@ export async function middleware(request: NextRequest) {
   });
   supabaseResponse.headers.set("Content-Security-Policy", cspHeaderValue);
   supabaseResponse.headers.set("x-nonce", nonce);
-  supabaseResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+  supabaseResponse.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -324,7 +324,7 @@ export async function middleware(request: NextRequest) {
           });
           supabaseResponse.headers.set("Content-Security-Policy", cspHeaderValue);
           supabaseResponse.headers.set("x-nonce", nonce);
-          supabaseResponse.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+          supabaseResponse.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
           cookiesToSet.forEach(({ name, value, options }) =>
             supabaseResponse.cookies.set(name, value, options)
           );

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -52,12 +52,12 @@ binding = "ASSETS"
 
 [[env.staging.r2_buckets]]
 binding = "R2_BUCKET"
-bucket_name = "webs-alots-uploads"
+bucket_name = "webs-alots-uploads-staging"
 
 [env.staging.vars]
 ROOT_DOMAIN = "groupsmix.com"
 NEXT_PUBLIC_SITE_URL = "https://staging.groupsmix.com"
-R2_BUCKET_NAME = "webs-alots-uploads"
+R2_BUCKET_NAME = "webs-alots-uploads-staging"
 
 # ---- Staging Cron Triggers ----
 # Same schedule as production


### PR DESCRIPTION
## Security Audit Remediation

Fixes all actionable findings from the production security audit report.

### Code Changes

**MEDIUM-02: Separate staging R2 bucket from production**
- Changed staging `bucket_name` from `webs-alots-uploads` to `webs-alots-uploads-staging` in `wrangler.toml`
- Prevents staging test data from leaking into production and vice versa

**LOW: Align HSTS max-age with Cloudflare**
- Changed `max-age` from `63072000` (2 years) to `31536000` (1 year) in `middleware.ts`
- Aligns with Cloudflare's live HSTS setting to avoid discrepancy

### Supabase Auth Config (applied via Management API)

| Finding | Severity | Fix Applied |
|---------|----------|-------------|
| CRITICAL-01: `site_url` → wrong domain | CRITICAL | Updated to `https://groupsmix.com` |
| CRITICAL-02: Empty `uri_allow_list` | CRITICAL | Added `https://groupsmix.com/**`, `https://*.groupsmix.com/**`, `https://webs-alots.pages.dev/**` |
| MEDIUM-01: Password change without re-auth | MEDIUM | Enabled `security_update_password_require_reauthentication` |

### Remaining Items (require Pro plan or manual action)

| Finding | Severity | Action Required |
|---------|----------|-----------------|
| HIGH-01: Audit logging disabled | HIGH | Enable in Supabase Dashboard (API returned unchanged — may require Pro plan) |
| HIGH-02: No session expiry/timeout | HIGH | Requires Supabase Pro plan — set `sessions_timebox=86400`, `sessions_inactivity_timeout=3600` |

---

*Session: https://app.devin.ai/sessions/ab8c999683104dabb069b3e6ed5511c7*