### PR TITLE
chore: rename domain from groupsmix.com to oltigo.com

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -70,8 +70,8 @@ const nextConfig: NextConfig = {
       // Redirect www to non-www (canonical domain)
       {
         source: "/:path*",
-        has: [{ type: "host", value: "www.groupsmix.com" }],
-        destination: "https://groupsmix.com/:path*",
+        has: [{ type: "host", value: "www.oltigo.com" }],
+        destination: "https://oltigo.com/:path*",
         permanent: true,
       },
     ];

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,14 +17,14 @@ bucket_name = "webs-alots-uploads"
 
 # ---- Non-Sensitive Environment Variables ----
 [vars]
-ROOT_DOMAIN = "groupsmix.com"
-NEXT_PUBLIC_SITE_URL = "https://groupsmix.com"
+ROOT_DOMAIN = "oltigo.com"
+NEXT_PUBLIC_SITE_URL = "https://oltigo.com"
 R2_BUCKET_NAME = "webs-alots-uploads"
 
 # ---- Workers Routes (custom domain + wildcard subdomains) ----
 routes = [
-  { pattern = "groupsmix.com/*", zone_name = "groupsmix.com" },
-  { pattern = "*.groupsmix.com/*", zone_name = "groupsmix.com" },
+  { pattern = "oltigo.com/*", zone_name = "oltigo.com" },
+  { pattern = "*.oltigo.com/*", zone_name = "oltigo.com" },
 ]
 
 # ---- Cron Triggers ----
@@ -35,7 +35,7 @@ crons = ["*/30 * * * *", "0 2 * * *"]
 
 # ---- Staging Environment ----
 # Deploy with: wrangler deploy --env staging
-# URL: staging.groupsmix.com
+# URL: staging.oltigo.com
 # Uses separate Supabase project for data isolation
 [env.staging]
 name = "webs-alots-staging"
@@ -43,7 +43,7 @@ main = "worker-cron-handler.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 routes = [
-  { pattern = "staging.groupsmix.com/*", zone_name = "groupsmix.com" },
+  { pattern = "staging.oltigo.com/*", zone_name = "oltigo.com" },
 ]
 
 [env.staging.assets]
@@ -55,8 +55,8 @@ binding = "R2_BUCKET"
 bucket_name = "webs-alots-uploads-staging"
 
 [env.staging.vars]
-ROOT_DOMAIN = "groupsmix.com"
-NEXT_PUBLIC_SITE_URL = "https://staging.groupsmix.com"
+ROOT_DOMAIN = "oltigo.com"
+NEXT_PUBLIC_SITE_URL = "https://staging.oltigo.com"
 R2_BUCKET_NAME = "webs-alots-uploads-staging"
 
 # ---- Staging Cron Triggers ----


### PR DESCRIPTION
## Summary

Renames all domain references from `groupsmix.com` to `oltigo.com` across the codebase.

## Changes

### `wrangler.toml`
- `ROOT_DOMAIN`: groupsmix.com → oltigo.com (production + staging)
- `NEXT_PUBLIC_SITE_URL`: updated for both production and staging
- All Cloudflare Workers route patterns updated to oltigo.com
- All `zone_name` values updated to oltigo.com

### `next.config.ts`
- www-to-non-www redirect: www.groupsmix.com → www.oltigo.com redirecting to oltigo.com

## Post-merge action items

After merging, you will also need to update:
1. **Cloudflare**: Add oltigo.com as a zone, configure DNS records + wildcard
2. **Supabase**: Update `site_url` and redirect allowlist in both production and staging
3. **GitHub Actions secrets**: Update `NEXT_PUBLIC_SITE_URL` if set

---

[Devin session](https://app.devin.ai/sessions/88ea02956a6444b3a41eadf49d40fe0e)