### PR TITLE
fix: critical security hardening — auth bypass, open redirect, tenant isolation

### DIFF
--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -6,6 +6,10 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { clinicDateTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { bookingCancelSchema, safeParse } from "@/lib/validations";
+import { STAFF_ROLES } from "@/lib/auth-roles";
+import type { UserRole } from "@/lib/types/database";
+
+const CANCEL_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
 
 export const runtime = "edge";
 
@@ -26,16 +30,21 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     const { tenant, config: tenantConfig } = await requireTenantWithConfig();
     const clinicId = tenant.clinicId;
 
-    // Fetch the appointment
+    // Fetch the appointment (include patient_id for ownership check)
     const { data: appt, error: fetchError } = await supabase
       .from("appointments")
-      .select("id, doctor_id, appointment_date, start_time, status")
+      .select("id, patient_id, doctor_id, appointment_date, start_time, status")
       .eq("id", body.appointmentId)
       .eq("clinic_id", clinicId)
       .single();
 
     if (fetchError || !appt) {
       return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
+    }
+
+    // Ownership check: patients can only cancel their OWN appointments
+    if (profile.role === "patient" && appt.patient_id !== profile.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     if (appt.status === APPOINTMENT_STATUS.CANCELLED || appt.status === APPOINTMENT_STATUS.COMPLETED || appt.status === APPOINTMENT_STATUS.RESCHEDULED) {
@@ -113,14 +122,14 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     logger.warn("Operation failed", { context: "booking/cancel", error: err });
     return NextResponse.json({ error: "Failed to cancel appointment" }, { status: 500 });
   }
-}, null);
+}, CANCEL_ROLES);
 
 /**
  * GET /api/booking/cancel?appointmentId=...
  *
  * Check if an appointment can be cancelled.
  */
-export const GET = withAuth(async (request, { supabase }) => {
+export const GET = withAuth(async (request, { supabase, profile }) => {
   const appointmentId = request.nextUrl.searchParams.get("appointmentId");
 
   if (!appointmentId) {
@@ -131,12 +140,17 @@ export const GET = withAuth(async (request, { supabase }) => {
 
   const { data: appt, error } = await supabase
     .from("appointments")
-    .select("id, appointment_date, start_time, status")
+    .select("id, patient_id, appointment_date, start_time, status")
     .eq("id", appointmentId)
     .eq("clinic_id", tenant.clinicId)
     .single();
 
   if (error || !appt) {
+    return NextResponse.json({ canCancel: false, reason: "Appointment not found" });
+  }
+
+  // Ownership check: patients can only check cancellability of their OWN appointments
+  if (profile.role === "patient" && appt.patient_id !== profile.id) {
     return NextResponse.json({ canCancel: false, reason: "Appointment not found" });
   }
 
@@ -167,4 +181,4 @@ export const GET = withAuth(async (request, { supabase }) => {
   }
 
   return NextResponse.json({ canCancel: true, hoursRemaining: hoursUntilAppt });
-}, null);
+}, CANCEL_ROLES);

--- a/src/app/api/booking/reschedule/route.ts
+++ b/src/app/api/booking/reschedule/route.ts
@@ -6,6 +6,10 @@ import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
 import { logger } from "@/lib/logger";
 import { rescheduleSchema, safeParse } from "@/lib/validations";
+import { STAFF_ROLES } from "@/lib/auth-roles";
+import type { UserRole } from "@/lib/types/database";
+
+const RESCHEDULE_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
 
 export const runtime = "edge";
 
@@ -48,16 +52,21 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       );
     }
 
-    // Get the existing appointment (include doctor_id and service_id for validation)
+    // Get the existing appointment (include patient_id for ownership check)
     const { data: existing, error: fetchError } = await supabase
       .from("appointments")
-      .select("id, status, clinic_id, doctor_id, service_id")
+      .select("id, status, clinic_id, patient_id, doctor_id, service_id")
       .eq("id", body.appointmentId)
       .eq("clinic_id", clinicId)
       .single();
 
     if (fetchError || !existing) {
       return NextResponse.json({ error: "Appointment not found" }, { status: 404 });
+    }
+
+    // Ownership check: patients can only reschedule their OWN appointments
+    if (profile.role === "patient" && existing.patient_id !== profile.id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     // Only allow rescheduling appointments in a valid state
@@ -131,4 +140,4 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     logger.warn("Operation failed", { context: "booking/reschedule", error: err });
     return NextResponse.json({ error: "Failed to reschedule appointment" }, { status: 500 });
   }
-}, null);
+}, RESCHEDULE_ROLES);

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -46,10 +46,10 @@ export const runtime = "edge";
 async function verifyBookingToken(token: string): Promise<boolean> {
   const secret = process.env.BOOKING_TOKEN_SECRET;
   if (!secret) {
-    // Only allow the dev-bypass token in explicit development mode.
-    // Any other environment (production, staging, test) rejects all tokens
-    // when BOOKING_TOKEN_SECRET is not configured.
-    if (process.env.NODE_ENV === "development") return token === "dev-bypass";
+    // HIGH-05: BOOKING_TOKEN_SECRET is required in ALL environments.
+    // Dev bypass removed — configure the secret even in development
+    // to prevent accidental leakage of unauthenticated booking access.
+    logger.error("BOOKING_TOKEN_SECRET is not configured — rejecting all booking tokens", { context: "booking" });
     return false;
   }
 

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -6,6 +6,10 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { WAITING_LIST_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
 import { waitingListSchema, safeParse } from "@/lib/validations";
+import { STAFF_ROLES } from "@/lib/auth-roles";
+import type { UserRole } from "@/lib/types/database";
+
+const WAITING_LIST_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
 
 export const runtime = "edge";
 
@@ -72,14 +76,14 @@ export const POST = withAuth(async (request, { supabase }) => {
     logger.warn("Operation failed", { context: "booking/waiting-list", error: err });
     return NextResponse.json({ error: "Failed to add to waiting list" }, { status: 500 });
   }
-}, null);
+}, WAITING_LIST_ROLES);
 
 /**
  * GET /api/booking/waiting-list?patientId=...  OR  ?doctorId=...&date=...
  *
  * Get waiting list entries.
  */
-export const GET = withAuth(async (request, { supabase }) => {
+export const GET = withAuth(async (request, { supabase, profile }) => {
   const patientId = request.nextUrl.searchParams.get("patientId");
   const doctorId = request.nextUrl.searchParams.get("doctorId");
   const date = request.nextUrl.searchParams.get("date");
@@ -87,6 +91,11 @@ export const GET = withAuth(async (request, { supabase }) => {
 
   const tenant = await requireTenant();
   const clinicId = tenant.clinicId;
+
+  // Ownership check: patients can only view their OWN waiting list entries
+  if (profile.role === "patient" && patientId && patientId !== profile.id) {
+    return NextResponse.json({ entries: [] });
+  }
 
   if (patientId) {
     const { data: entries } = await supabase
@@ -119,14 +128,14 @@ export const GET = withAuth(async (request, { supabase }) => {
     { error: "patientId, or doctorId and date are required" },
     { status: 400 },
   );
-}, null);
+}, WAITING_LIST_ROLES);
 
 /**
  * DELETE /api/booking/waiting-list
  *
  * Remove a patient from the waiting list.
  */
-export const DELETE = withAuth(async (request, { supabase }) => {
+export const DELETE = withAuth(async (request, { supabase, profile }) => {
   try {
     const body = (await request.json()) as { entryId: string };
 
@@ -136,6 +145,20 @@ export const DELETE = withAuth(async (request, { supabase }) => {
 
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
+
+    // For patients, verify they own this waiting list entry before deleting
+    if (profile.role === "patient") {
+      const { data: entry } = await supabase
+        .from("waiting_list")
+        .select("patient_id")
+        .eq("id", body.entryId)
+        .eq("clinic_id", clinicId)
+        .single();
+
+      if (!entry || entry.patient_id !== profile.id) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
 
     const { error } = await supabase
       .from("waiting_list")
@@ -162,4 +185,4 @@ export const DELETE = withAuth(async (request, { supabase }) => {
     logger.warn("Operation failed", { context: "booking/waiting-list", error: err });
     return NextResponse.json({ error: "Failed to remove from waiting list" }, { status: 500 });
   }
-}, null);
+}, WAITING_LIST_ROLES);

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -93,7 +93,14 @@ export async function GET() {
       );
     }
 
-    return NextResponse.json(data, {
+    // MED-01: Redact potentially sensitive contact fields from the
+    // unauthenticated public branding response.  Name, colors, fonts,
+    // images, and template settings are intentionally public (needed to
+    // render the clinic's branded booking page).  Phone and address are
+    // PII that should only be visible to authenticated users.
+    const { phone: _phone, address: _address, ...publicData } = data;
+
+    return NextResponse.json(publicData, {
       headers: {
         "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
       },

--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -52,7 +52,7 @@ export const GET = withAuth(async (request, { supabase }) => {
       { status: 500 },
     );
   }
-}, null);
+}, ["super_admin", "clinic_admin", "receptionist", "doctor", "patient"]);
 
 /**
  * POST /api/custom-fields

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { impersonateSchema, safeParse } from "@/lib/validations";
+import { createClient } from "@/lib/supabase-server";
 
 /**
  * POST /api/impersonate
@@ -22,7 +23,34 @@ export const POST = withAuth(async (request, { supabase, user }) => {
     if (!parsed.success) {
       return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
-    const { clinicId, clinicName } = parsed.data;
+    const { clinicId, clinicName, password } = parsed.data as {
+      clinicId: string;
+      clinicName?: string;
+      password?: string;
+    };
+
+    // HIGH-03: Require re-authentication before impersonation.
+    // The super_admin must provide their current password to prove
+    // the session has not been hijacked.
+    if (!password) {
+      return NextResponse.json(
+        { error: "Password is required to start impersonation" },
+        { status: 400 },
+      );
+    }
+
+    const reauthClient = await createClient();
+    const { error: reauthError } = await reauthClient.auth.signInWithPassword({
+      email: user.email ?? "",
+      password,
+    });
+
+    if (reauthError) {
+      return NextResponse.json(
+        { error: "Re-authentication failed. Please verify your password." },
+        { status: 401 },
+      );
+    }
 
     // Verify the clinic exists
     const { data: clinic } = await supabase

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -84,6 +84,22 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
     // Non-staff users can only read their own notifications
     const userId = isStaff && requestedUserId ? requestedUserId : profile.id;
 
+    // Tenant isolation: staff can only read notifications of users in the same clinic
+    if (isStaff && requestedUserId && profile.role !== "super_admin" && profile.clinic_id) {
+      const { data: targetUser } = await supabase
+        .from("users")
+        .select("clinic_id")
+        .eq("id", requestedUserId)
+        .single();
+
+      if (!targetUser || targetUser.clinic_id !== profile.clinic_id) {
+        return NextResponse.json(
+          { error: "User not found in your clinic" },
+          { status: 403 },
+        );
+      }
+    }
+
     const channel = searchParams.get("channel");
     const type = searchParams.get("type");
     const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10) || 50, 100);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -131,7 +131,7 @@ export const POST = withAuth(async (request, { profile }) => {
  * Body: { key: string, contentType: string }
  * Returns: { valid: true } or { error: string } (with 400 status + deletion)
  */
-export const PUT = withAuth(async (request) => {
+export const PUT = withAuth(async (request, { profile }) => {
   if (!isR2Configured()) {
     return NextResponse.json(
       { error: "File storage is not configured" },
@@ -146,6 +146,16 @@ export const PUT = withAuth(async (request) => {
     return NextResponse.json(
       { error: "key and contentType are required" },
       { status: 400 },
+    );
+  }
+
+  // Tenant isolation: verify the R2 key belongs to this user's clinic.
+  // Keys follow the pattern: {clinicId}/{category}/{filename}
+  const clinicId = profile.clinic_id ?? (profile.role === "super_admin" ? null : null);
+  if (clinicId && !key.startsWith(`${clinicId}/`)) {
+    return NextResponse.json(
+      { error: "Access denied: file does not belong to your clinic" },
+      { status: 403 },
     );
   }
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,10 +1,24 @@
 import { createClient } from "@/lib/supabase-server";
 import { NextResponse } from "next/server";
 
+/**
+ * Validate that a redirect path is a safe, same-origin relative path.
+ * Rejects protocol-relative URLs (//evil.com), absolute URLs, and
+ * paths containing encoded characters that could bypass the check.
+ */
+const SAFE_PATH_REGEX = /^\/[a-zA-Z0-9\-_/]*$/;
+
+function getSafeRedirectPath(raw: string | null): string {
+  if (raw && SAFE_PATH_REGEX.test(raw)) {
+    return raw;
+  }
+  return "/patient/dashboard";
+}
+
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/patient/dashboard";
+  const next = getSafeRedirectPath(searchParams.get("next"));
 
   if (code) {
     const supabase = await createClient();

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -135,7 +135,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
 
         if (error) {
           logger.error("Rate limiter query failed", { context: "rate-limit", error });
-          return true;
+          return false;
         }
 
         if (!data || data.reset_at <= windowStart) {
@@ -149,6 +149,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
 
           if (upsertError) {
             logger.error("Rate limiter upsert failed", { context: "rate-limit", error: upsertError });
+            return false;
           }
           return true;
         }
@@ -167,7 +168,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
 
         if (updateError) {
           logger.error("Rate limiter update failed", { context: "rate-limit", error: updateError });
-          return true;
+          return false;
         }
 
         // If no row was updated, another request incremented concurrently.
@@ -183,10 +184,11 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
 
         return newCount <= max;
       } catch (err) {
-        // Network/transient failure — fail open to avoid blocking
-        // legitimate traffic.  Log so operators can investigate.
-        logger.error("Rate limiter network failure — failing open", { context: "rate-limit", error: err });
-        return true;
+        // Network/transient failure — fail closed to prevent abuse.
+        // This may briefly block legitimate traffic during outages,
+        // but is safer than allowing unlimited requests.
+        logger.error("Rate limiter network failure — failing closed", { context: "rate-limit", error: err });
+        return false;
       }
     },
   };

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -25,19 +25,21 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
 
 /**
- * Extract the real client IP from a request, respecting common reverse-proxy
- * headers.  Cloudflare sets `CF-Connecting-IP`; other proxies use
- * `X-Forwarded-For` (first entry) or `X-Real-IP`.  Falls back to "unknown"
- * which effectively rate-limits all header-less requests together — safe for
- * a server behind a trusted proxy.
+ * Extract the real client IP from a request.
+ *
+ * Priority order (HIGH-02 hardened):
+ *   1. CF-Connecting-IP — set by Cloudflare's edge, cannot be spoofed by
+ *      the client when traffic goes through Cloudflare.
+ *   2. "unknown" fallback — groups all unidentified requests together,
+ *      which is safe behind a trusted proxy.
+ *
+ * X-Forwarded-For and X-Real-IP are intentionally NOT used because they
+ * are attacker-controlled when the request does not pass through a trusted
+ * proxy that overwrites them.  Since this app runs behind Cloudflare,
+ * CF-Connecting-IP is the only trustworthy source of client IP.
  */
 export function extractClientIp(request: NextRequest): string {
-  return (
-    request.headers.get("cf-connecting-ip") ??
-    request.headers.get("x-real-ip") ??
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
-    "unknown"
-  );
+  return request.headers.get("cf-connecting-ip") ?? "unknown";
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
## Security Fixes (10 vulnerabilities addressed)

### Critical (3)
- **CRIT-01**: Prevent open redirect in `/auth/callback` — validate `next` param against strict regex
- **CRIT-02**: Replace `withAuth(..., null)` with explicit role arrays on booking cancel, reschedule, waiting-list, and custom-fields GET
- **CRIT-03**: Add ownership validation — patients can only cancel/reschedule their own appointments and manage their own waiting list entries

### High (4)
- **HIGH-01**: Rate limiter now fails **closed** on errors instead of failing open
- **HIGH-02**: Remove `X-Forwarded-For` and `X-Real-IP` from `extractClientIp()` — only trust `CF-Connecting-IP` to prevent IP spoofing
- **HIGH-03**: Require password re-authentication before starting impersonation session
- **HIGH-06**: Add cross-tenant isolation to notifications GET — staff can only read notifications for users in their own clinic

### Medium (3)
- **HIGH-05**: Remove dev-bypass token from booking token verification — `BOOKING_TOKEN_SECRET` required in ALL environments
- **MED-01**: Redact phone and address from unauthenticated branding GET response
- **MED-02**: Add tenant isolation to upload PUT — verify R2 key prefix matches user's clinic_id

### Files Changed (12)
| File | Fix |
|------|-----|
| `src/app/auth/callback/route.ts` | Open redirect prevention |
| `src/app/api/booking/cancel/route.ts` | Role + ownership checks |
| `src/app/api/booking/reschedule/route.ts` | Role + ownership checks |
| `src/app/api/booking/waiting-list/route.ts` | Role + ownership checks |
| `src/app/api/booking/route.ts` | Dev bypass removal |
| `src/app/api/custom-fields/route.ts` | Explicit auth roles |
| `src/app/api/notifications/route.ts` | Cross-tenant isolation |
| `src/app/api/upload/route.ts` | Tenant isolation on PUT |
| `src/app/api/branding/route.ts` | PII redaction |
| `src/app/api/impersonate/route.ts` | Re-authentication |
| `src/lib/rate-limit.ts` | Fail closed + IP spoofing fix |

### CI Status
- ✅ Lint & Type Check: **passed**
- ❌ Cloudflare Pages: failed (pre-existing — also fails on `main`)

---
*[Devin session](https://app.devin.ai/sessions/331db080ee6445fead55cf8f646454ef)*