### PR TITLE
fix: lazy-load cookies from next/headers to fix Turbopack build

### DIFF
--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,5 +1,4 @@
 import { createServerClient } from "@supabase/ssr";
-import { cookies } from "next/headers";
 import type { Database } from "@/lib/types/database";
 import { setTenantContext } from "@/lib/tenant-context";
 
@@ -15,8 +14,13 @@ function requireEnv(name: string): string {
  * Create a Supabase server client with cookie-based auth.
  * Use this for requests where tenant context will be set separately
  * (e.g. middleware, auth flows).
+ *
+ * NOTE: `cookies` is loaded via dynamic import to avoid pulling
+ * `next/headers` into Client Components, Edge Middleware, and other
+ * contexts where it is not available (Next.js 16 / Turbopack).
  */
 export async function createClient() {
+  const { cookies } = await import("next/headers");
   const cookieStore = await cookies();
 
   return createServerClient<Database>(


### PR DESCRIPTION
In Next.js 16 / Turbopack, the top-level import of cookies from next/headers caused the build to fail because supabase-server.ts was transitively imported into Client Components, Edge Middleware, and Edge App Routes where next/headers is not available.

Switch to a dynamic import inside createClient() so the module graph no longer pulls next/headers into forbidden contexts.