### PR TITLE
fix: remove pages_build_output_dir to avoid ASSETS binding conflict with Cloudflare Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The middleware enforces Origin-header checks on all mutation requests (`POST`, `
 
 This project deploys as a **Cloudflare Worker** using [OpenNext for Cloudflare](https://opennext.js.org/cloudflare), **not** Cloudflare Pages. The build produces a Worker bundle (`.open-next/worker.js`) and static assets (`.open-next/assets/`), both served by the Workers runtime.
 
-> **Note:** This repo supports both Cloudflare Workers (`wrangler deploy`) and Cloudflare Pages deployments. The `pages_build_output_dir` in `wrangler.toml` tells Pages where to find static assets after `npm run build:cf`.
+> **Note:** A Cloudflare Pages project is also connected to this repo. The Pages output directory (`destination_dir`) is configured via the Cloudflare dashboard/API to `.open-next/assets`. Do **not** add `pages_build_output_dir` to `wrangler.toml` — the `ASSETS` binding name used by OpenNext is reserved by Pages and will cause the build to fail.
 
 ### Manual Deploy
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,12 +4,10 @@ main = "worker-cron-handler.ts"
 compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
-# Cloudflare Pages: tells Pages where to find static assets after build.
-# This property is ignored by `wrangler deploy` (Workers), so it is safe
-# to keep alongside the Workers configuration.
-pages_build_output_dir = ".open-next/assets"
-
 # Static assets served by the Workers runtime
+# NOTE: The "ASSETS" binding name is reserved by Cloudflare Pages, so do NOT
+# add pages_build_output_dir here — it would cause Pages to parse this file
+# and reject the binding. Pages output dir is configured via the dashboard API.
 [assets]
 directory = ".open-next/assets"
 binding = "ASSETS"


### PR DESCRIPTION
## Problem

PR #187 added `pages_build_output_dir` to `wrangler.toml`, which caused Cloudflare Pages to parse the full wrangler config. This triggered an error because the `ASSETS` binding name (used by `@opennextjs/cloudflare`) is reserved by Pages:

```
The name 'ASSETS' is reserved in Pages projects.
Please use a different name for your Assets binding.
```

## Fix

- **Removed `pages_build_output_dir`** from `wrangler.toml` — without it, Pages skips parsing the file and falls back to the dashboard-configured `destination_dir` (already fixed via API to `.open-next/assets`).
- **Added a comment** in `wrangler.toml` explaining why `pages_build_output_dir` must not be added.
- **Updated README** with accurate deployment notes.

The actual fix for Pages was updating `destination_dir` from `.worker-next/assets` to `.open-next/assets` via the Cloudflare API (already done).