### PR TITLE
fix: add missing public routes to middleware (testimonials, doctor-profile, doctor-services, dentist, lab)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -53,11 +53,16 @@ const PUBLIC_ROUTES = [
   "/auth/callback",
   "/how-to-book",
   "/location",
+  "/testimonials",
+  "/doctor-profile",
+  "/doctor-services",
 ];
 
 // Public route prefixes (no auth required)
 const PUBLIC_PREFIXES = [
   "/pharmacy",
+  "/dentist",
+  "/lab",
 ];
 
 // Protected route prefixes (require authentication)


### PR DESCRIPTION
## Summary

Fixes broken navigation / dead links on public pages by adding missing routes to the middleware PUBLIC_ROUTES and PUBLIC_PREFIXES arrays.

## Changes

### Middleware (src/middleware.ts)

**PUBLIC_ROUTES** - Added 3 missing pages:
- `/testimonials` - Patient testimonials page
- `/doctor-profile` - Doctor profile/team page
- `/doctor-services` - Detailed services page

**PUBLIC_PREFIXES** - Added 2 missing route prefixes:
- `/dentist` - Dentist public pages (gallery, prices, services)
- `/lab` - Lab public pages (tests, results, contact, collection points)

## Problem

These routes had valid page components in the `(public)`, `(dentist-public)`, and `(lab-public)` route groups but were not listed in the middleware's public route arrays. While they technically worked by falling through the middleware's default handler, they did not receive proper public route treatment (e.g., authenticated users visiting these pages would not be redirected properly from login/register).

## Testing

- Lint: passes
- TypeScript: passes
- Build: passes

---
[Devin Session](https://app.devin.ai/sessions/a8b96603cb1e462196aabb2d272adcb2)