### PR TITLE
fix: root domain fallback — show default clinic data on public pages

### DIFF
--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -89,12 +89,39 @@ async function getTenantInfo() {
   return await getTenant();
 }
 
+/** Cached default clinic ID for root-domain fallback (avoids repeated DB queries). */
+let _defaultClinicId: string | null | undefined;
+
 /**
- * Get the current clinic ID, or null when on the root domain.
+ * Get the current clinic ID from tenant context, or fall back to the
+ * first active clinic when accessed on the root domain (no subdomain).
+ *
+ * This ensures public pages (services, reviews, doctors, etc.) display
+ * real data even when the site is accessed at the root domain without
+ * a subdomain.
  */
 async function getClinicId(): Promise<string | null> {
   const tenant = await getTenantInfo();
-  return tenant?.clinicId ?? null;
+  if (tenant?.clinicId) return tenant.clinicId;
+
+  // Root domain fallback: resolve the first active clinic
+  if (_defaultClinicId !== undefined) return _defaultClinicId;
+
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("clinics")
+      .select("id")
+      .eq("is_active", true)
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .single();
+    _defaultClinicId = data?.id ?? null;
+  } catch {
+    _defaultClinicId = null;
+  }
+
+  return _defaultClinicId;
 }
 
 // ── Clinic Branding ──


### PR DESCRIPTION
## Summary

When the site is accessed on the root domain (oltigo.com, no subdomain), public pages (services, reviews, doctors, etc.) were showing empty data because there was no tenant context. This fix adds a fallback that resolves the first active clinic from the database, so the root domain displays real clinic data.

## Changes

- **`src/lib/data/public.ts`**: Updated `getClinicId()` to fall back to the first active clinic when no subdomain/tenant is resolved. The result is cached to avoid repeated DB queries.

## What this fixes

- Services page showing empty on root domain
- Reviews section not displaying on homepage
- Doctors/team section missing on homepage
- Branding (clinic name, colors) now loads from DB even on root domain

## Testing

- TypeScript: `npx tsc --noEmit` — zero errors
- Lint: `npm run lint` — clean
- Local dev server verified: root domain now shows "Cabinet Dr. Ahmed Benali" with real services data