### PR TITLE
feat: integrate Cloudflare Turnstile captcha for login and registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Used for SEO metadata, sitemap, robots.txt, and OpenGraph tags
 NEXT_PUBLIC_SITE_URL=https://yourdomain.com
 
+# ---- Cloudflare Turnstile CAPTCHA [Required if Supabase captcha enabled] ----
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+
 # ---- Subdomain Routing [Optional] ----
 # Set to your root domain (e.g., "yourdomain.com") to enable
 # clinic subdomains like clinicname.yourdomain.com

--- a/.env.local.example
+++ b/.env.local.example
@@ -5,6 +5,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Site URL — used for SEO metadata, sitemap, robots.txt, and OpenGraph tags
 NEXT_PUBLIC_SITE_URL=https://yourdomain.com
 
+# Cloudflare Turnstile CAPTCHA (required if Supabase captcha is enabled)
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+
 # WhatsApp Business API (Meta Cloud API)
 WHATSAPP_PHONE_NUMBER_ID=your-phone-number-id
 WHATSAPP_ACCESS_TOKEN=your-access-token

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { Phone, ShieldCheck, ArrowLeft, Heart, Mail, Lock } from "lucide-react";
 import {
   Card,
@@ -15,6 +15,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { signInWithOTP, verifyOTP, signInWithPassword } from "@/lib/auth";
+import { Turnstile } from "@/components/turnstile";
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
 
 export default function LoginPage() {
   const [method, setMethod] = useState<"email" | "phone">("email");
@@ -25,14 +28,29 @@ export default function LoginPage() {
   const [otp, setOtp] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+
+  const handleCaptchaVerify = useCallback((token: string) => {
+    setCaptchaToken(token);
+  }, []);
+
+  const handleCaptchaExpire = useCallback(() => {
+    setCaptchaToken(null);
+  }, []);
 
   async function handleEmailLogin(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
+
+    if (TURNSTILE_SITE_KEY && !captchaToken) {
+      setError("Veuillez compl\u00e9ter la v\u00e9rification de s\u00e9curit\u00e9.");
+      return;
+    }
+
     setLoading(true);
 
     try {
-      const result = await signInWithPassword(email, password);
+      const result = await signInWithPassword(email, password, captchaToken ?? undefined);
       if (result.error) {
         setError(result.error);
         setLoading(false);
@@ -46,10 +64,16 @@ export default function LoginPage() {
   async function handleSendOTP(e?: React.FormEvent) {
     if (e) e.preventDefault();
     setError(null);
+
+    if (TURNSTILE_SITE_KEY && !captchaToken) {
+      setError("Veuillez compl\u00e9ter la v\u00e9rification de s\u00e9curit\u00e9.");
+      return;
+    }
+
     setLoading(true);
 
     try {
-      const result = await signInWithOTP(phone);
+      const result = await signInWithOTP(phone, captchaToken ?? undefined);
 
       if (result.error) {
         setError(result.error);
@@ -71,7 +95,7 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const result = await verifyOTP(phone, otp);
+      const result = await verifyOTP(phone, otp, captchaToken ?? undefined);
       if (result.error) {
         setError(result.error);
         setLoading(false);
@@ -193,6 +217,13 @@ export default function LoginPage() {
                   className="text-base"
                 />
               </div>
+              {TURNSTILE_SITE_KEY && (
+                <Turnstile
+                  siteKey={TURNSTILE_SITE_KEY}
+                  onVerify={handleCaptchaVerify}
+                  onExpire={handleCaptchaExpire}
+                />
+              )}
               <Button type="submit" className="w-full" disabled={loading}>
                 {loading ? "Connexion..." : "Se connecter"}
               </Button>
@@ -234,6 +265,13 @@ export default function LoginPage() {
                   Nous vous enverrons un code de vérification unique par SMS.
                 </p>
               </div>
+              {TURNSTILE_SITE_KEY && (
+                <Turnstile
+                  siteKey={TURNSTILE_SITE_KEY}
+                  onVerify={handleCaptchaVerify}
+                  onExpire={handleCaptchaExpire}
+                />
+              )}
               <Button type="submit" className="w-full" disabled={loading}>
                 {loading ? "Envoi du code..." : "Envoyer le code de vérification"}
               </Button>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { UserPlus, ShieldCheck, ArrowLeft, Heart } from "lucide-react";
 import {
   Card,
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { registerPatient, verifyOTP } from "@/lib/auth";
+import { Turnstile } from "@/components/turnstile";
 import {
   Select,
   SelectTrigger,
@@ -22,6 +23,8 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
 
 export default function RegisterPage() {
   const [step, setStep] = useState<"info" | "otp">("info");
@@ -35,10 +38,25 @@ export default function RegisterPage() {
   const [otp, setOtp] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null);
+
+  const handleCaptchaVerify = useCallback((token: string) => {
+    setCaptchaToken(token);
+  }, []);
+
+  const handleCaptchaExpire = useCallback(() => {
+    setCaptchaToken(null);
+  }, []);
 
   async function handleRegister(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
+
+    if (TURNSTILE_SITE_KEY && !captchaToken) {
+      setError("Veuillez compl\u00e9ter la v\u00e9rification de s\u00e9curit\u00e9.");
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -49,6 +67,7 @@ export default function RegisterPage() {
         age: age ? parseInt(age, 10) : undefined,
         gender: gender || undefined,
         insurance: insurance || undefined,
+        captchaToken: captchaToken ?? undefined,
       });
 
       if (result.error) {
@@ -71,7 +90,7 @@ export default function RegisterPage() {
     setLoading(true);
 
     try {
-      const result = await verifyOTP(phone, otp);
+      const result = await verifyOTP(phone, otp, captchaToken ?? undefined);
       if (result.error) {
         setError(result.error);
         setLoading(false);
@@ -201,6 +220,13 @@ export default function RegisterPage() {
                   </SelectContent>
                 </Select>
               </div>
+              {TURNSTILE_SITE_KEY && (
+                <Turnstile
+                  siteKey={TURNSTILE_SITE_KEY}
+                  onVerify={handleCaptchaVerify}
+                  onExpire={handleCaptchaExpire}
+                />
+              )}
               <Button type="submit" className="w-full" disabled={loading}>
                 {loading ? "Création du compte..." : "Créer un compte"}
               </Button>

--- a/src/components/turnstile.tsx
+++ b/src/components/turnstile.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+const TURNSTILE_SCRIPT_URL = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+interface TurnstileProps {
+  siteKey: string;
+  onVerify: (token: string) => void;
+  onExpire?: () => void;
+  onError?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        options: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "expired-callback"?: () => void;
+          "error-callback"?: () => void;
+          theme?: "light" | "dark" | "auto";
+        }
+      ) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+export function Turnstile({ siteKey, onVerify, onExpire, onError }: TurnstileProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const scriptLoadedRef = useRef(false);
+
+  const renderWidget = useCallback(() => {
+    if (!containerRef.current || !window.turnstile || widgetIdRef.current !== null) return;
+
+    widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      sitekey: siteKey,
+      callback: onVerify,
+      "expired-callback": onExpire,
+      "error-callback": onError,
+      theme: "auto",
+    });
+  }, [siteKey, onVerify, onExpire, onError]);
+
+  useEffect(() => {
+    if (scriptLoadedRef.current) {
+      renderWidget();
+      return;
+    }
+
+    const existingScript = document.querySelector(
+      `script[src="${TURNSTILE_SCRIPT_URL}"]`
+    );
+
+    if (existingScript) {
+      scriptLoadedRef.current = true;
+      renderWidget();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = TURNSTILE_SCRIPT_URL;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      scriptLoadedRef.current = true;
+      renderWidget();
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      if (widgetIdRef.current !== null && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+  }, [renderWidget]);
+
+  return <div ref={containerRef} className="flex justify-center my-2" />;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -39,13 +39,15 @@ const ROLE_DASHBOARD_MAP: Record<UserProfile["role"], string> = {
  */
 export async function signInWithPassword(
   email: string,
-  password: string
+  password: string,
+  captchaToken?: string
 ): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
   const { error } = await supabase.auth.signInWithPassword({
     email,
     password,
+    options: captchaToken ? { captchaToken } : undefined,
   });
 
   if (error) {
@@ -66,11 +68,12 @@ export async function signInWithPassword(
  * Send OTP to a phone number via Supabase Auth.
  * Returns an error message if the request fails.
  */
-export async function signInWithOTP(phone: string): Promise<{ error: string | null }> {
+export async function signInWithOTP(phone: string, captchaToken?: string): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
   const { error } = await supabase.auth.signInWithOtp({
     phone,
+    options: captchaToken ? { captchaToken } : undefined,
   });
 
   if (error) {
@@ -86,7 +89,8 @@ export async function signInWithOTP(phone: string): Promise<{ error: string | nu
  */
 export async function verifyOTP(
   phone: string,
-  token: string
+  token: string,
+  captchaToken?: string
 ): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
@@ -94,6 +98,7 @@ export async function verifyOTP(
     phone,
     token,
     type: "sms",
+    options: captchaToken ? { captchaToken } : undefined,
   });
 
   if (error) {
@@ -122,12 +127,14 @@ export async function registerPatient(data: {
   age?: number;
   gender?: string;
   insurance?: string;
+  captchaToken?: string;
 }): Promise<{ error: string | null }> {
   const supabase = await createClient();
 
   const { error } = await supabase.auth.signInWithOtp({
     phone: data.phone,
     options: {
+      captchaToken: data.captchaToken,
       data: {
         name: data.name,
         phone: data.phone,


### PR DESCRIPTION
## Summary

Fixes the "captcha verification process failed" error by integrating Cloudflare Turnstile captcha into login and registration pages.

## Changes

- **New component**: `src/components/turnstile.tsx` — reusable Turnstile widget that loads the Cloudflare script and renders the captcha
- **Updated auth functions** (`src/lib/auth.ts`): `signInWithPassword`, `signInWithOTP`, `verifyOTP`, and `registerPatient` now accept an optional `captchaToken` parameter and pass it to Supabase auth calls
- **Updated login page**: Turnstile widget added to both email+password and phone OTP forms; captcha token is validated before submission
- **Updated register page**: Turnstile widget added to registration form; captcha token passed to `registerPatient`
- **Updated env examples**: Added `NEXT_PUBLIC_TURNSTILE_SITE_KEY` to `.env.example` and `.env.local.example`

## Setup

Set `NEXT_PUBLIC_TURNSTILE_SITE_KEY` in your environment to your Cloudflare Turnstile site key. The widget only renders when this key is configured.

## Testing

- Lint passes (`npm run lint`)
- TypeScript check passes (`npx tsc --noEmit`)