### PR TITLE
fix: add challenges.cloudflare.com to CSP frame-src for Turnstile

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -145,8 +145,8 @@ function buildCsp(nonce: string): string {
     "font-src 'self' data:",
     // API connections: self + Supabase + WhatsApp + Cloudflare + Google
     "connect-src 'self' *.supabase.co wss://*.supabase.co graph.facebook.com api.twilio.com api.cloudflare.com *.googleapis.com",
-    // Frames: Google Maps embeds only
-    "frame-src 'self' www.google.com",
+    // Frames: Google Maps embeds + Cloudflare Turnstile CAPTCHA
+    "frame-src 'self' www.google.com https://challenges.cloudflare.com",
     // Form actions: self only
     "form-action 'self'",
     // Base URI: self only


### PR DESCRIPTION
## Problem

Even after PR #195 (which added the Turnstile site key to the build), the Turnstile CAPTCHA widget still does not render. The browser console shows:

> Refused to frame `https://challenges.cloudflare.com/` because it violates the following Content Security Policy directive: "frame-src 'self' www.google.com"

## Root Cause

The CSP `frame-src` directive in `src/middleware.ts` only allows `self` and `www.google.com`. Cloudflare Turnstile loads its widget in an iframe from `https://challenges.cloudflare.com`, which is blocked by this policy.

## Fix

Added `https://challenges.cloudflare.com` to the `frame-src` CSP directive so the Turnstile iframe can load.

This is the companion fix to PR #195. After merging both, the CAPTCHA widget will render and auth will work.