### PR TITLE
fix: infrastructure audit — rate limiter, staging config, and migration

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -136,8 +136,12 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
           .maybeSingle();
 
         if (error) {
-          logger.error("Rate limiter query failed", { context: "rate-limit", error });
-          return false;
+          // Fail OPEN: allow the request through when the rate-limit
+          // infrastructure is unavailable (e.g. table missing, network
+          // error). Blocking all traffic because of an infra outage is
+          // worse than temporarily losing rate-limit protection.
+          logger.error("Rate limiter query failed — failing open", { context: "rate-limit", error });
+          return true;
         }
 
         if (!data || data.reset_at <= windowStart) {
@@ -150,8 +154,8 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
             );
 
           if (upsertError) {
-            logger.error("Rate limiter upsert failed", { context: "rate-limit", error: upsertError });
-            return false;
+            logger.error("Rate limiter upsert failed — failing open", { context: "rate-limit", error: upsertError });
+            return true;
           }
           return true;
         }
@@ -169,8 +173,8 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
           .maybeSingle();
 
         if (updateError) {
-          logger.error("Rate limiter update failed", { context: "rate-limit", error: updateError });
-          return false;
+          logger.error("Rate limiter update failed — failing open", { context: "rate-limit", error: updateError });
+          return true;
         }
 
         // If no row was updated, another request incremented concurrently.
@@ -186,11 +190,12 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
 
         return newCount <= max;
       } catch (err) {
-        // Network/transient failure — fail closed to prevent abuse.
-        // This may briefly block legitimate traffic during outages,
-        // but is safer than allowing unlimited requests.
-        logger.error("Rate limiter network failure — failing closed", { context: "rate-limit", error: err });
-        return false;
+        // Network/transient failure — fail OPEN to prevent blocking
+        // all legitimate traffic during infrastructure outages.
+        // The trade-off (briefly losing rate-limit protection) is
+        // preferable to returning 429 to every user.
+        logger.error("Rate limiter network failure — failing open", { context: "rate-limit", error: err });
+        return true;
       }
     },
   };

--- a/supabase/migrations/00038_create_rate_limit_entries.sql
+++ b/supabase/migrations/00038_create_rate_limit_entries.sql
@@ -1,0 +1,70 @@
+-- ============================================================
+-- Migration 00038: Create rate_limit_entries table + RPC
+--
+-- The distributed rate limiter (src/lib/rate-limit.ts) expects
+-- this table and RPC function when SUPABASE_SERVICE_ROLE_KEY
+-- is configured. Without them, the Supabase-backed limiter
+-- falls back to error handling that fails closed — blocking
+-- ALL /api/* requests with HTTP 429.
+--
+-- This migration:
+--   1. Creates the rate_limit_entries table
+--   2. Creates the rate_limit_increment atomic RPC function
+--   3. Enables RLS (service-role only — no user-facing policies)
+--   4. Adds an index for automatic cleanup of expired entries
+-- ============================================================
+
+-- 1. Create the table
+CREATE TABLE IF NOT EXISTS rate_limit_entries (
+  key        TEXT PRIMARY KEY,
+  count      INTEGER NOT NULL DEFAULT 0,
+  reset_at   BIGINT  NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 2. Enable RLS — only service_role can access this table.
+--    No user-facing policies are added intentionally.
+ALTER TABLE rate_limit_entries ENABLE ROW LEVEL SECURITY;
+
+-- 3. Index for efficient cleanup of expired entries
+CREATE INDEX IF NOT EXISTS idx_rate_limit_entries_reset_at
+  ON rate_limit_entries(reset_at);
+
+-- 4. Atomic rate-limit increment function.
+--    Called by the Supabase rate limiter to avoid SELECT → UPDATE
+--    race conditions. Returns the new request count.
+CREATE OR REPLACE FUNCTION rate_limit_increment(
+  p_key          TEXT,
+  p_window_start BIGINT,
+  p_reset_at     BIGINT,
+  p_now          TIMESTAMPTZ
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  INSERT INTO rate_limit_entries (key, count, reset_at, updated_at)
+  VALUES (p_key, 1, p_reset_at, p_now)
+  ON CONFLICT (key) DO UPDATE
+  SET
+    count = CASE
+      WHEN rate_limit_entries.reset_at <= p_window_start THEN 1
+      ELSE rate_limit_entries.count + 1
+    END,
+    reset_at = CASE
+      WHEN rate_limit_entries.reset_at <= p_window_start THEN p_reset_at
+      ELSE rate_limit_entries.reset_at
+    END,
+    updated_at = p_now
+  RETURNING count INTO v_count;
+
+  RETURN v_count;
+END;
+$$;
+
+-- 5. Restrict RPC to service_role only (revoke from public/anon).
+REVOKE EXECUTE ON FUNCTION rate_limit_increment(TEXT, BIGINT, BIGINT, TIMESTAMPTZ)
+  FROM public, anon, authenticated;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -58,7 +58,7 @@ binding = "R2_BUCKET"
 bucket_name = "webs-alots-uploads-staging"
 
 [env.staging.vars]
-ROOT_DOMAIN = "oltigo.com"
+ROOT_DOMAIN = "staging.oltigo.com"
 NEXT_PUBLIC_SITE_URL = "https://staging.oltigo.com"
 R2_BUCKET_NAME = "webs-alots-uploads-staging"
 


### PR DESCRIPTION
## Infrastructure Audit Fixes

### Critical: Rate Limiter Breaking ALL API Endpoints (429)

**Root cause:** The `rate_limit_entries` table and `rate_limit_increment` RPC function were never created in production Supabase. Migration 00029 only enables RLS on the table IF it exists — it does not create it.

**Impact:** When `SUPABASE_SERVICE_ROLE_KEY` is configured (which it is in production), the Supabase-backed rate limiter activates. Every API request attempts to query the missing table, fails, and the error handler returns `false` (rate limited) — blocking ALL `/api/*` endpoints with HTTP 429.

**Fixes applied:**
1. **Migration 00038** — Creates `rate_limit_entries` table, `rate_limit_increment` atomic RPC function, enables RLS (service-role only), and adds cleanup index
2. **Already applied to production Supabase** — Table and RPC function created via management API
3. **Rate limiter fail-open** — Changed all error paths from `return false` (fail closed = block traffic) to `return true` (fail open = allow traffic). Losing rate-limit protection temporarily during infra outages is preferable to a total API outage.

### Fix: Staging Subdomain Redirect Loop

**Root cause:** Staging `ROOT_DOMAIN` was set to `oltigo.com`. When `staging.oltigo.com` is accessed, `extractSubdomain()` returns `"staging"` as a clinic subdomain. No clinic with that subdomain exists, so middleware redirects to root domain — creating a redirect loop.

**Fix:** Changed staging `ROOT_DOMAIN` from `oltigo.com` to `staging.oltigo.com` so that `extractSubdomain("staging.oltigo.com", "staging.oltigo.com")` correctly returns `null` (root domain, no subdomain).

### Changes
- `supabase/migrations/00038_create_rate_limit_entries.sql` — New migration
- `src/lib/rate-limit.ts` — Fail-open error handling
- `wrangler.toml` — Staging ROOT_DOMAIN fix