### PR TITLE
fix: resolve /api/health and /api/branding 500 errors on Cloudflare Workers

### DIFF
--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -7,7 +7,7 @@
 
 import { NextResponse } from "next/server";
 import { createTenantClient } from "@/lib/supabase-server";
-import { requireTenant } from "@/lib/tenant";
+import { getTenant, requireTenant } from "@/lib/tenant";
 import {
   uploadToR2,
   isR2Configured,
@@ -59,7 +59,15 @@ const FIELD_MAP: Record<string, string> = {
 
 export async function GET() {
   try {
-    const tenant = await requireTenant();
+    const tenant = await getTenant();
+
+    if (!tenant?.clinicId) {
+      return NextResponse.json(
+        { error: "No clinic context. This endpoint requires a clinic subdomain." },
+        { status: 400 },
+      );
+    }
+
     const clinicId = tenant.clinicId;
     const supabase = await createTenantClient(clinicId);
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase-server";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
 
 export const runtime = "edge";
@@ -9,20 +9,36 @@ export const runtime = "edge";
  *
  * Health check endpoint for monitoring and load balancer probes.
  * Returns service status, uptime, and database connectivity.
+ *
+ * Uses a direct Supabase client (anon key, no cookies) instead of the
+ * cookie-based `createClient()` from `supabase-server.ts`.  Health
+ * checks are hit by load balancers and monitoring tools that don't
+ * carry browser cookies, and depending on `next/headers` cookies()
+ * can fail in certain Cloudflare Workers edge contexts.
  */
 export async function GET() {
   const checks: Record<string, { status: string; latencyMs?: number; error?: string }> = {};
 
   // Database connectivity check
   try {
-    const dbStart = Date.now();
-    const supabase = await createClient();
-    const { error } = await supabase.from("clinics").select("id").limit(1);
-    const dbLatency = Date.now() - dbStart;
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-    checks.database = error
-      ? { status: "degraded", latencyMs: dbLatency, error: "Database query failed" }
-      : { status: "ok", latencyMs: dbLatency };
+    if (!supabaseUrl || !supabaseAnonKey) {
+      checks.database = {
+        status: "degraded",
+        error: "Supabase credentials not configured",
+      };
+    } else {
+      const dbStart = Date.now();
+      const supabase = createSupabaseClient(supabaseUrl, supabaseAnonKey);
+      const { error } = await supabase.from("clinics").select("id").limit(1);
+      const dbLatency = Date.now() - dbStart;
+
+      checks.database = error
+        ? { status: "degraded", latencyMs: dbLatency, error: "Database query failed" }
+        : { status: "ok", latencyMs: dbLatency };
+    }
   } catch (err) {
     logger.warn("Operation failed", { context: "health", error: err });
     checks.database = {


### PR DESCRIPTION
## Summary

Fixes the `/api/health` and `/api/branding` endpoints returning 500 errors on Cloudflare Workers (identified in the infra audit report, separate from the rate limiting fix in #217).

## Changes

### `/api/health` — Remove dependency on `next/headers` cookies

The health check endpoint was using the cookie-based `createClient()` from `supabase-server.ts`, which calls `cookies()` from `next/headers`. Health checks are hit by load balancers and monitoring tools that don't carry browser cookies, and `cookies()` can fail in certain Cloudflare Workers edge contexts.

**Fix:** Use a direct Supabase client (`@supabase/supabase-js` with anon key) that doesn't depend on request cookies or `next/headers`.

### `/api/branding` GET — Handle missing tenant gracefully

The GET handler called `requireTenant()` which throws when no subdomain is present (root domain requests). The thrown error was caught by the generic catch block and returned as a 500.

**Fix:** Use `getTenant()` (non-throwing) and return a clear 400 response when no clinic context is available, instead of a misleading 500.

## Related

- Follow-up to #217 (rate limiting + staging fixes)
- Addresses the "API 500 errors" blocker from the infra audit report