### PR TITLE
fix: audit-plan fixes — slot capacity, CRON_SECRET guard, nosniff headers

### DIFF
--- a/src/app/api/booking/reschedule/route.ts
+++ b/src/app/api/booking/reschedule/route.ts
@@ -4,6 +4,7 @@ import { requireTenantWithConfig } from "@/lib/tenant";
 import { getPublicAvailableSlots } from "@/lib/data/public";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
+import { computeEndTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { rescheduleSchema, safeParse } from "@/lib/validations";
 import { STAFF_ROLES } from "@/lib/auth-roles";
@@ -65,7 +66,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     // Get the existing appointment (include patient_id for ownership check)
     const { data: existing, error: fetchError } = await supabase
       .from("appointments")
-      .select("id, status, clinic_id, patient_id, doctor_id, service_id")
+      .select("id, status, clinic_id, patient_id, doctor_id, service_id, appointment_date, start_time, end_time, slot_start, slot_end")
       .eq("id", body.appointmentId)
       .eq("clinic_id", clinicId)
       .single();
@@ -96,7 +97,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       );
     }
 
-    // Calculate end_time and slot boundaries
+    // Calculate end_time and slot boundaries using shared computeEndTime
     let duration = tenantConfig.booking.slotDuration;
     if (existing.service_id) {
       const { data: svc } = await supabase
@@ -109,9 +110,13 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       }
     }
 
-    const [h, m] = body.newTime.split(":").map(Number);
-    const endMinutes = h * 60 + m + duration;
-    const endTime = `${Math.floor(endMinutes / 60).toString().padStart(2, "0")}:${(endMinutes % 60).toString().padStart(2, "0")}`;
+    const { endTime, overflows } = computeEndTime(body.newTime, duration);
+    if (overflows) {
+      return NextResponse.json(
+        { error: "Appointment would extend past midnight. Please choose an earlier time." },
+        { status: 400 },
+      );
+    }
     const slotStart = `${body.newDate}T${body.newTime}:00`;
     const slotEnd = `${body.newDate}T${endTime}:00`;
 
@@ -130,6 +135,44 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
 
     if (updateError) {
       return NextResponse.json({ error: "Failed to update appointment" }, { status: 500 });
+    }
+
+    // ── Post-update maxPerSlot enforcement (TOCTOU guard) ──────────────
+    // Same pattern as the main booking route: after updating we count how
+    // many active bookings now exist for this slot.  If the count exceeds
+    // maxPerSlot the just-updated row lost a race and must be rolled back.
+    const maxPerSlot = tenantConfig.booking.maxPerSlot;
+    const { count: slotCount } = await supabase
+      .from("appointments")
+      .select("id", { count: "exact", head: true })
+      .eq("clinic_id", clinicId)
+      .eq("doctor_id", existing.doctor_id)
+      .eq("appointment_date", body.newDate)
+      .eq("start_time", body.newTime)
+      .in("status", [
+        APPOINTMENT_STATUS.CONFIRMED,
+        APPOINTMENT_STATUS.PENDING,
+        APPOINTMENT_STATUS.RESCHEDULED,
+      ]);
+
+    if (slotCount !== null && slotCount > maxPerSlot) {
+      // Roll back: revert the appointment to its original state
+      await supabase
+        .from("appointments")
+        .update({
+          appointment_date: existing.appointment_date,
+          start_time: existing.start_time,
+          end_time: existing.end_time,
+          slot_start: existing.slot_start,
+          slot_end: existing.slot_end,
+          status: existing.status,
+        })
+        .eq("id", body.appointmentId);
+
+      return NextResponse.json(
+        { error: "This slot has just been fully booked. Please choose another time." },
+        { status: 409 },
+      );
     }
 
     await logAuditEvent({

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -328,6 +328,7 @@ export async function POST(request: NextRequest) {
       .in("status", [
         APPOINTMENT_STATUS.CONFIRMED,
         APPOINTMENT_STATUS.PENDING,
+        APPOINTMENT_STATUS.RESCHEDULED,
       ]);
 
     if (slotCount !== null && slotCount > maxPerSlot) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -121,6 +121,17 @@ function withSecurityHeaders(
 }
 
 /**
+ * Apply security headers to redirect responses.  Redirects have no body
+ * so CSP is omitted, but HSTS and X-Content-Type-Options still apply.
+ */
+function secureRedirect(url: string | URL, init?: number | ResponseInit): NextResponse {
+  const response = NextResponse.redirect(url, init);
+  response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  return response;
+}
+
+/**
  * Build the Content-Security-Policy header value with a per-request nonce
  * for script-src (replaces 'unsafe-inline').
  *
@@ -166,7 +177,7 @@ export async function middleware(request: NextRequest) {
   if (hostWithoutPort === `www.${rootDomain?.split(":")[0] ?? ""}`) {
     const url = request.nextUrl.clone();
     url.host = rootDomain ?? hostname.replace(/^www\./, "");
-    return NextResponse.redirect(url, 301);
+    return secureRedirect(url, 301);
   }
 
   // --- Generate a per-request nonce for CSP ---
@@ -302,7 +313,7 @@ export async function middleware(request: NextRequest) {
     if (isProtectedRoute(pathname)) {
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("redirect", pathname);
-      return NextResponse.redirect(loginUrl);
+      return secureRedirect(loginUrl);
     }
     const noSupabaseResponse = NextResponse.next({
       request: { headers: requestHeaders },
@@ -362,7 +373,7 @@ export async function middleware(request: NextRequest) {
       const rootUrl = rootDomain
         ? `${request.nextUrl.protocol}//${rootDomain}`
         : request.nextUrl.origin;
-      return NextResponse.redirect(rootUrl);
+      return secureRedirect(rootUrl);
     }
 
     // Attach tenant info to all responses so pages can read it
@@ -404,7 +415,7 @@ export async function middleware(request: NextRequest) {
     if (user && (pathname === "/login" || pathname === "/register") && profile) {
       const dashboardPath =
         ROLE_DASHBOARD_MAP[profile.role] || "/patient/dashboard";
-      return NextResponse.redirect(new URL(dashboardPath, request.url));
+      return secureRedirect(new URL(dashboardPath, request.url));
     }
     return supabaseResponse;
   }
@@ -413,7 +424,7 @@ export async function middleware(request: NextRequest) {
   if (isProtectedRoute(pathname) && !user) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("redirect", pathname);
-    return NextResponse.redirect(loginUrl);
+    return secureRedirect(loginUrl);
   }
 
   // If authenticated, check role-based access
@@ -429,7 +440,7 @@ export async function middleware(request: NextRequest) {
     if (allowedPrefix && !pathname.startsWith(allowedPrefix)) {
       const dashboardPath =
         ROLE_DASHBOARD_MAP[profile.role] || "/patient/dashboard";
-      return NextResponse.redirect(new URL(dashboardPath, request.url));
+      return secureRedirect(new URL(dashboardPath, request.url));
     }
   }
 

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -47,9 +47,11 @@ export default {
     const headers: HeadersInit = {};
 
     const cronSecret = env.CRON_SECRET;
-    if (cronSecret) {
-      headers["Authorization"] = `Bearer ${cronSecret}`;
+    if (!cronSecret) {
+      console.error(`[Cron] CRON_SECRET is not set — skipping ${route} to prevent unauthenticated requests`);
+      return;
     }
+    headers["Authorization"] = `Bearer ${cronSecret}`;
 
     const request = new Request(url.toString(), { headers });
 


### PR DESCRIPTION
## Audit-Plan Fixes

Applies the prioritized fixes from the audit report, in order:

### 1. `/api/booking/verify` endpoint
**Already in place** from PR #221. The endpoint exists at `src/app/api/booking/verify/route.ts` and issues HMAC-SHA256 booking tokens after phone validation, completing the end-to-end booking flow.

### 2. Reschedule slot capacity (NEW FIX)
- **Main booking route** (`src/app/api/booking/route.ts`): Added `RESCHEDULED` to the post-insert `maxPerSlot` status filter so rescheduled appointments are counted toward slot capacity (previously only `CONFIRMED` and `PENDING` were counted).
- **Reschedule route** (`src/app/api/booking/reschedule/route.ts`): Added post-update TOCTOU guard matching the main booking route pattern — after updating the appointment, counts active bookings at the new slot and rolls back if `maxPerSlot` is exceeded. Also added midnight overflow protection via shared `computeEndTime()` and expanded the SELECT query to include fields needed for rollback.

### 3. Reschedule timezone-aware day-of-week
**Already in place** from PR #221. The reschedule route uses `Intl.DateTimeFormat` with `timeZone: tenantConfig.timezone` (same approach as the main booking flow).

### 4. Type-check in `deploy.yml`
**Already in place** from PR #221. The deploy workflow lint job includes `npx tsc --noEmit`.

### 5. CRON_SECRET required in production (NEW FIX)
- `src/lib/env.ts` already enforces `CRON_SECRET` as required in production (from PR #221).
- **`worker-cron-handler.ts`**: Now refuses to fire cron jobs when `CRON_SECRET` is missing, logging an error and returning early instead of silently sending unauthenticated requests that would be rejected by `verifyCronSecret()` anyway.

### 6. `X-Content-Type-Options: nosniff` on all middleware paths (NEW FIX)
- Added `secureRedirect()` helper function to `src/middleware.ts`.
- All 6 redirect response paths (www redirect, no-supabase login redirect, unknown subdomain redirect, authenticated-user-on-login redirect, unauthenticated protected route redirect, wrong-role redirect) now include `X-Content-Type-Options: nosniff` and `Strict-Transport-Security` headers.
- Error responses (CSRF, rate limit, payload-too-large) and normal responses already had these headers via `withSecurityHeaders()`.

### 7. Lint + typecheck + tests
- **Lint**: Clean (0 errors)
- **Typecheck**: Clean (0 errors)
- **Tests**: 245 passed, 4 failed (pre-existing failures in `rate-limit.test.ts` unrelated to these changes — same failures on `main`)

---

**Not included per instructions:** Turnstile, anti-bot protection, Cloudflare protection.