### PR TITLE
fix: exempt /api/health from rate limiting, fix ESLint config and tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -14,6 +15,9 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
   ]),
   {
+    plugins: {
+      "react-hooks": reactHooksPlugin,
+    },
     rules: {
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/rules-of-hooks": "warn",

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -16,19 +16,19 @@ describe("extractClientIp", () => {
     expect(extractClientIp(req as never)).toBe("1.2.3.4");
   });
 
-  it("falls back to X-Real-IP", () => {
+  it("returns 'unknown' when only X-Real-IP is present (not trusted)", () => {
     const req = createMockRequest({ "x-real-ip": "5.6.7.8" });
-    expect(extractClientIp(req as never)).toBe("5.6.7.8");
+    expect(extractClientIp(req as never)).toBe("unknown");
   });
 
-  it("falls back to X-Forwarded-For (first entry)", () => {
+  it("returns 'unknown' when only X-Forwarded-For is present (not trusted)", () => {
     const req = createMockRequest({ "x-forwarded-for": "10.0.0.1, 10.0.0.2" });
-    expect(extractClientIp(req as never)).toBe("10.0.0.1");
+    expect(extractClientIp(req as never)).toBe("unknown");
   });
 
-  it("trims whitespace from X-Forwarded-For", () => {
+  it("ignores X-Forwarded-For even with whitespace", () => {
     const req = createMockRequest({ "x-forwarded-for": "  10.0.0.1  , 10.0.0.2" });
-    expect(extractClientIp(req as never)).toBe("10.0.0.1");
+    expect(extractClientIp(req as never)).toBe("unknown");
   });
 
   it("returns 'unknown' when no headers present", () => {
@@ -45,12 +45,12 @@ describe("extractClientIp", () => {
     expect(extractClientIp(req as never)).toBe("1.1.1.1");
   });
 
-  it("prefers X-Real-IP over X-Forwarded-For", () => {
+  it("ignores X-Real-IP and X-Forwarded-For without CF-Connecting-IP", () => {
     const req = createMockRequest({
       "x-real-ip": "2.2.2.2",
       "x-forwarded-for": "3.3.3.3",
     });
-    expect(extractClientIp(req as never)).toBe("2.2.2.2");
+    expect(extractClientIp(req as never)).toBe("unknown");
   });
 });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,6 +35,14 @@ const CSRF_EXEMPT_PREFIXES = [
   "/api/cron/billing",
 ];
 
+// Lightweight API routes that should skip rate limiting AND the heavy
+// Supabase auth/subdomain path in the middleware.  These are hit by
+// load-balancers, monitoring tools, and uptime probes — they must
+// never be rate-limited or fail because of cookie/auth issues.
+const LIGHTWEIGHT_API_PATHS = new Set([
+  "/api/health",
+]);
+
 function isCsrfExempt(pathname: string): boolean {
   return CSRF_EXEMPT_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
@@ -280,10 +288,25 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // --- Fast path for lightweight API routes (health checks, etc.) ---
+  // These endpoints must respond quickly and reliably for load-balancers
+  // and monitoring probes.  They skip rate limiting, Supabase auth, and
+  // subdomain resolution — none of which are needed for their function.
+  if (LIGHTWEIGHT_API_PATHS.has(pathname)) {
+    const lightResponse = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+    lightResponse.headers.set("Content-Security-Policy", cspHeaderValue);
+    lightResponse.headers.set("x-nonce", nonce);
+    lightResponse.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+    lightResponse.headers.set("X-Content-Type-Options", "nosniff");
+    return lightResponse;
+  }
+
   // --- Rate limiting for API requests ---
   // S1: Apply rate limiting to ALL HTTP methods (not just mutations).
-  // GET endpoints like /api/v1/*, /api/chat, /api/health can be abused
-  // for data scraping or resource exhaustion.
+  // GET endpoints like /api/v1/*, /api/chat can be abused for data
+  // scraping or resource exhaustion.
   if (pathname.startsWith("/api/")) {
     const rateLimitKey = extractClientIp(request);
 

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -12,7 +12,8 @@
  * @see https://opennext.js.org/cloudflare/howtos/custom-worker
  */
 
-// @ts-expect-error — .open-next/worker.js is generated at build time
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — .open-next/worker.js is generated at build time
 import { default as handler } from "./.open-next/worker.js";
 
 /**


### PR DESCRIPTION
## Summary

### 1. Exempt `/api/health` from rate limiting (HIGH priority)
- Added `LIGHTWEIGHT_API_PATHS` fast path in middleware that returns immediately with security headers
- Health checks now skip rate limiting, Supabase auth, and subdomain resolution
- Fixes production 500 and staging 429 on health endpoint
- Load balancers and monitoring probes will no longer be blocked

### 2. Fix ESLint flat config (pre-existing CI blocker)
- Explicitly import `eslint-plugin-react-hooks` so the custom rules block can reference `react-hooks/*` rules
- Without this, `eslint` crashes with "could not find plugin react-hooks"

### 3. Fix worker-cron-handler.ts TypeScript error (pre-existing CI blocker)
- Use `@ts-ignore` with `eslint-disable` for the build-time generated `.open-next/worker.js` import
- `@ts-expect-error` fails because the error is not present at typecheck time (file generated during build)

### 4. Fix 4 rate-limit tests
- Updated tests to match the CF-Connecting-IP-only behavior
- `X-Forwarded-For` and `X-Real-IP` are no longer trusted (intentional security change from prior session)
- All 249 tests now pass

## Testing
- ✅ `npm test` — 249 passed, 0 failed
- ✅ `npx tsc --noEmit` — clean
- ✅ `npx eslint` — clean (on changed files)
