### PR TITLE
fix: pass clinic_id via HTTP headers for RLS — fixes empty public data queries

### DIFF
--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import type { Database } from "@/lib/types/database";
-import { setTenantContext } from "@/lib/tenant-context";
+import { setTenantContext, isValidClinicId } from "@/lib/tenant-context";
+import { logger } from "@/lib/logger";
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -49,15 +50,62 @@ export async function createClient() {
 /**
  * Create a Supabase server client with tenant context set.
  *
- * Sets `app.current_clinic_id` as a PostgreSQL session variable so that
- * RLS policies can use it as an additional isolation check. This is the
- * preferred way to create a client for tenant-scoped operations.
+ * Passes the clinic_id as a custom HTTP header (`x-clinic-id`) on every
+ * request so that PostgREST makes it available in PostgreSQL as
+ * `current_setting('request.header.x-clinic-id', true)`.  RLS policies
+ * read this header to scope anonymous queries to the correct tenant.
+ *
+ * The old `set_tenant_context` RPC is kept as a best-effort fallback
+ * for any code paths that run within a single PostgREST transaction
+ * (e.g. SECURITY DEFINER functions).
  *
  * @param clinicId - The clinic UUID to scope all operations to
- * @throws Error if clinicId is missing/invalid or if setting context fails
+ * @throws Error if clinicId is missing/invalid
  */
 export async function createTenantClient(clinicId: string) {
-  const client = await createClient();
-  await setTenantContext(client, clinicId);
+  if (!clinicId || !isValidClinicId(clinicId)) {
+    throw new Error(`createTenantClient: invalid clinicId: ${clinicId}`);
+  }
+
+  const { cookies } = await import("next/headers");
+  const cookieStore = await cookies();
+
+  const client = createServerClient<Database>(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // Server Component context — safe to ignore
+          }
+        },
+      },
+      global: {
+        headers: { "x-clinic-id": clinicId },
+      },
+    },
+  );
+
+  // Best-effort: also set the session variable for same-transaction queries.
+  // This is redundant with the header approach but provides defense-in-depth
+  // for any SECURITY DEFINER functions that read app.current_clinic_id.
+  try {
+    await setTenantContext(client, clinicId);
+  } catch (err) {
+    logger.warn("setTenantContext RPC failed (header fallback active)", {
+      context: "supabase-server",
+      clinicId,
+      error: err,
+    });
+  }
+
   return client;
 }

--- a/supabase/migrations/00041_fix_rls_use_request_headers.sql
+++ b/supabase/migrations/00041_fix_rls_use_request_headers.sql
@@ -1,0 +1,183 @@
+-- ============================================================
+-- Migration 00041: Fix RLS policies — use request headers
+--
+-- The tenant-scoped RLS policies added in migration 00039 rely on
+-- the PostgreSQL session variable `app.current_clinic_id` set via
+-- the `set_tenant_context` RPC.  However, each Supabase PostgREST
+-- API call (.rpc(), .from().select(), etc.) is a separate HTTP
+-- request mapped to a separate database transaction.  Because
+-- `set_config(..., true)` is transaction-local, the variable set
+-- by the RPC is gone before the next query runs.
+--
+-- Fix: PostgREST exposes every HTTP request header as a
+-- PostgreSQL runtime setting in the `request.header.*` namespace.
+-- The application now sends `x-clinic-id: <uuid>` on every
+-- request via the Supabase client's `global.headers` option.
+-- RLS policies read this header with:
+--
+--   current_setting('request.header.x-clinic-id', true)
+--
+-- This is per-request (not per-transaction), so every query in
+-- the same HTTP request sees the correct tenant context.
+--
+-- For backward compatibility the policies also fall back to
+-- `app.current_clinic_id` (for SECURITY DEFINER functions that
+-- set it within the same transaction).
+--
+-- Helper function: get_request_clinic_id() encapsulates the
+-- lookup logic so individual policies stay readable.
+-- ============================================================
+
+-- ============================================================
+-- HELPER: get_request_clinic_id()
+--
+-- Returns the clinic UUID from (in priority order):
+--   1. The x-clinic-id request header (per-request, set by app)
+--   2. The app.current_clinic_id session variable (per-txn fallback)
+-- Returns NULL if neither is set.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION get_request_clinic_id()
+RETURNS UUID AS $$
+DECLARE
+  header_val TEXT;
+  session_val TEXT;
+BEGIN
+  -- 1. Try the request header (set by the Supabase client via global.headers)
+  header_val := current_setting('request.header.x-clinic-id', true);
+  IF header_val IS NOT NULL AND header_val <> '' THEN
+    RETURN header_val::UUID;
+  END IF;
+
+  -- 2. Fall back to the session variable (set by set_tenant_context RPC)
+  session_val := current_setting('app.current_clinic_id', true);
+  IF session_val IS NOT NULL AND session_val <> '' THEN
+    RETURN session_val::UUID;
+  END IF;
+
+  RETURN NULL;
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_request_clinic_id() TO authenticated;
+GRANT EXECUTE ON FUNCTION get_request_clinic_id() TO anon;
+
+
+-- ============================================================
+-- Update RLS policies to use get_request_clinic_id()
+--
+-- Pattern for anonymous access:
+--   auth.uid() IS NULL AND clinic_id = get_request_clinic_id()
+--
+-- Authenticated users still use get_user_clinic_id() (unchanged).
+-- ============================================================
+
+-- -------------------------------------------------------
+-- APPOINTMENTS
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "appointments_select_public" ON appointments;
+CREATE POLICY "appointments_select_public" ON appointments
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- REVIEWS
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "reviews_select_public" ON reviews;
+CREATE POLICY "reviews_select_public" ON reviews
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- BEFORE_AFTER_PHOTOS
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "before_after_photos_select_public" ON before_after_photos;
+CREATE POLICY "before_after_photos_select_public" ON before_after_photos
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- USERS (public doctors)
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "users_select_public_doctors" ON users;
+CREATE POLICY "users_select_public_doctors" ON users
+  FOR SELECT USING (
+    role = 'doctor'
+    AND (
+      clinic_id = get_user_clinic_id()
+      OR (
+        auth.uid() IS NULL
+        AND clinic_id = get_request_clinic_id()
+      )
+    )
+  );
+
+-- -------------------------------------------------------
+-- PRODUCTS
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "products_select_public" ON products;
+CREATE POLICY "products_select_public" ON products
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- SERVICES
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "services_select_public" ON services;
+CREATE POLICY "services_select_public" ON services
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- TIME_SLOTS
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "time_slots_select_public" ON time_slots;
+CREATE POLICY "time_slots_select_public" ON time_slots
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );
+
+-- -------------------------------------------------------
+-- ON_DUTY_SCHEDULE
+-- -------------------------------------------------------
+DROP POLICY IF EXISTS "on_duty_schedule_select_public" ON on_duty_schedule;
+CREATE POLICY "on_duty_schedule_select_public" ON on_duty_schedule
+  FOR SELECT USING (
+    clinic_id = get_user_clinic_id()
+    OR (
+      auth.uid() IS NULL
+      AND clinic_id = get_request_clinic_id()
+    )
+  );


### PR DESCRIPTION
## Root Cause

The `set_tenant_context` RPC uses `set_config(app.current_clinic_id, ..., true)` which is **transaction-local**. Each Supabase PostgREST API call (`.rpc()`, `.from().select()`) is a separate HTTP request = separate database transaction. The variable set by the RPC is immediately lost before the next query runs.

This is why PR #225 did not fix the empty public data queries — `createPublicTenantClient()` calls `setTenantContext()` which sets the variable in one transaction, but the subsequent `.from("time_slots").select(...)` runs in a different transaction where the variable is gone.

## Fix

### Code (`supabase-server.ts`)
- `createTenantClient` now passes `x-clinic-id` as a custom HTTP header via Supabase client `global.headers`
- PostgREST exposes this as `current_setting("request.header.x-clinic-id", true)` in PostgreSQL
- This is **per-request** (not per-transaction), so every query in the same HTTP request sees the correct tenant context
- The old `setTenantContext` RPC is kept as best-effort fallback for SECURITY DEFINER functions

### Migration 00041
- New `get_request_clinic_id()` helper function: reads clinic_id from request header first, falls back to session variable
- All 8 public-access RLS policies updated: appointments, reviews, before_after_photos, users (doctors), products, services, time_slots, on_duty_schedule

## Action Required After Merge

Apply migration 00041 to both production and staging Supabase DBs before/after deploying the code.

---

Session: https://app.devin.ai/sessions/b441cd5bebfc429c9efb2cf9718b2a8c