### PR TITLE
fix: read x-clinic-id from request.headers JSON instead of individual GUC

### DIFF
--- a/supabase/migrations/00042_fix_get_request_clinic_id_headers_json.sql
+++ b/supabase/migrations/00042_fix_get_request_clinic_id_headers_json.sql
@@ -1,0 +1,58 @@
+-- ============================================================
+-- Migration 00042: Fix get_request_clinic_id() — read from
+-- request.headers JSON instead of individual header GUCs
+--
+-- Supabase PostgREST exposes all HTTP request headers as a
+-- single JSON object in the `request.headers` GUC variable,
+-- NOT as individual `request.header.<name>` settings.
+--
+-- Migration 00041 assumed `current_setting('request.header.x-clinic-id', true)`
+-- would return the header value, but this always returned NULL because
+-- the individual header GUCs are not set in Supabase's PostgREST.
+--
+-- Fix: Parse the `request.headers` JSON to extract `x-clinic-id`.
+-- Keeps the individual GUC lookup as a fallback for forward compatibility.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION get_request_clinic_id()
+RETURNS UUID AS $$
+DECLARE
+  headers_json jsonb;
+  header_val TEXT;
+  session_val TEXT;
+BEGIN
+  -- 1. Try request.headers JSON (Supabase PostgREST exposes all headers here)
+  BEGIN
+    headers_json := current_setting('request.headers', true)::jsonb;
+    IF headers_json IS NOT NULL THEN
+      header_val := headers_json ->> 'x-clinic-id';
+      IF header_val IS NOT NULL AND header_val <> '' THEN
+        RETURN header_val::UUID;
+      END IF;
+    END IF;
+  EXCEPTION
+    WHEN OTHERS THEN
+      NULL;
+  END;
+
+  -- 2. Try the individual header GUC (legacy PostgREST behavior)
+  header_val := current_setting('request.header.x-clinic-id', true);
+  IF header_val IS NOT NULL AND header_val <> '' THEN
+    RETURN header_val::UUID;
+  END IF;
+
+  -- 3. Fall back to the session variable (set by set_tenant_context RPC)
+  session_val := current_setting('app.current_clinic_id', true);
+  IF session_val IS NOT NULL AND session_val <> '' THEN
+    RETURN session_val::UUID;
+  END IF;
+
+  RETURN NULL;
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_request_clinic_id() TO authenticated;
+GRANT EXECUTE ON FUNCTION get_request_clinic_id() TO anon;


### PR DESCRIPTION
## Problem

Migration 00041 introduced `get_request_clinic_id()` which reads the `x-clinic-id` HTTP header via `current_setting('request.header.x-clinic-id', true)`. However, Supabase PostgREST exposes all HTTP request headers as a **single JSON object** in the `request.headers` GUC variable — individual `request.header.<name>` settings are **not** populated.

This caused the function to always return NULL, meaning all anonymous RLS-protected queries returned empty results.

## Fix

Migration 00042 replaces `get_request_clinic_id()` to:
1. Parse `current_setting('request.headers', true)::jsonb` and extract `x-clinic-id` from the JSON
2. Fall back to the individual GUC (`request.header.x-clinic-id`) for forward compatibility
3. Fall back to the session variable (`app.current_clinic_id`) for SECURITY DEFINER functions

## Status

- Already applied directly to both **production** and **staging** databases
- This PR adds the migration file to the repo for tracking

Devin session: https://app.devin.ai/sessions/768c416e22504e3688c00d3148dff499