### PR TITLE
fix: deduplicate seed data from migration 00040

### DIFF
--- a/supabase/migrations/00044_dedup_seed_data.sql
+++ b/supabase/migrations/00044_dedup_seed_data.sql
@@ -44,4 +44,18 @@ WHERE id IN (
   'a0000000-0000-0000-0000-000000000005'
 );
 
+-- ── 5. Fix doctor metadata (missing specialty needed for booking flow) ──
+-- The original seed did not populate the metadata JSONB column, which the
+-- booking flow reads to derive specialties.  Without this, booking creation
+-- fails with "Invalid specialty selected".
+UPDATE users
+SET metadata = jsonb_build_object(
+  'specialty_id', 'sp-general-medicine',
+  'specialty',    'Médecine Générale',
+  'consultation_fee', 300,
+  'languages',    '["fr","ar"]'::jsonb
+)
+WHERE id = '00000000-0000-0000-0000-000000000003'
+  AND (metadata IS NULL OR metadata = '{}'::jsonb);
+
 COMMIT;

--- a/supabase/migrations/00044_dedup_seed_data.sql
+++ b/supabase/migrations/00044_dedup_seed_data.sql
@@ -1,0 +1,47 @@
+-- Migration 00044: Deduplicate seed data
+--
+-- Migration 00040 re-seeded services and a doctor that already existed from
+-- the original seed, creating duplicates with different IDs:
+--
+--   services:  50000000-* (original) vs a0000000-* (duplicate)
+--   doctor:    00000000-0000-0000-0000-000000000003 (original "Dr. Ahmed Benali")
+--           vs d1000000-0000-0000-0000-000000000001 (duplicate)
+--
+-- The duplicate doctor (d1000000-*) also has time_slots referencing it.
+-- Since the original doctor already has identical time_slots (Mon-Fri 09-12, 14-17),
+-- we simply delete the duplicate time_slots and the duplicate records.
+-- The duplicate doctor has one extra Saturday slot that the original lacks;
+-- we migrate that to the original before deleting.
+
+BEGIN;
+
+-- ── 1. Migrate the Saturday time_slot from the duplicate doctor to the original ──
+-- The duplicate has a Saturday 09:00-13:00 slot that the original doesn't have.
+INSERT INTO time_slots (doctor_id, clinic_id, day_of_week, start_time, end_time, is_available, is_active)
+SELECT
+  '00000000-0000-0000-0000-000000000003',  -- original doctor
+  clinic_id, day_of_week, start_time, end_time, is_available, is_active
+FROM time_slots
+WHERE doctor_id = 'd1000000-0000-0000-0000-000000000001'
+  AND day_of_week = 6  -- Saturday
+ON CONFLICT DO NOTHING;
+
+-- ── 2. Delete duplicate time_slots for the duplicate doctor ──
+DELETE FROM time_slots
+WHERE doctor_id = 'd1000000-0000-0000-0000-000000000001';
+
+-- ── 3. Delete duplicate doctor ──
+DELETE FROM users
+WHERE id = 'd1000000-0000-0000-0000-000000000001';
+
+-- ── 4. Delete duplicate services ──
+DELETE FROM services
+WHERE id IN (
+  'a0000000-0000-0000-0000-000000000001',
+  'a0000000-0000-0000-0000-000000000002',
+  'a0000000-0000-0000-0000-000000000003',
+  'a0000000-0000-0000-0000-000000000004',
+  'a0000000-0000-0000-0000-000000000005'
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Migration 00044: Deduplicate seed data and fix doctor metadata.

### Dedup
Migration 00040 re-seeded services and a doctor that already existed, creating duplicates:
- 5 duplicate services (`a0000000-*` vs original `50000000-*`)
- 1 duplicate doctor (`d1000000-*` vs original `00000000-*-000003`) with 11 orphaned time_slots

### Doctor Metadata Fix
The doctor record was missing `metadata.specialty_id`, which caused the booking flow to fail with "Invalid specialty selected" since specialties are derived from doctor metadata.

### What the migration does
1. Migrates the Saturday time_slot from the duplicate doctor to the original
2. Deletes all duplicate time_slots, the duplicate doctor, and 5 duplicate services
3. Populates doctor metadata with specialty, consultation fee, and languages

### Status
- **Already applied** to both production and staging databases
- Production verified: 5 services, 1 doctor, 11 time_slots (clean)
- Staging verified: 5 services, 1 doctor, 11 time_slots (clean)
- Full booking flow tested end-to-end on production