### PR TITLE
feat: SaaS landing page for oltigo.com root domain

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,12 +1,22 @@
 import { PublicHeader } from "@/components/public/header";
 import { PublicFooter } from "@/components/public/footer";
 import { getPublicBranding } from "@/lib/data/public";
+import { getTenant } from "@/lib/tenant";
 
 export default async function PublicLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const tenant = await getTenant();
+
+  // Root domain (no tenant) → render children directly.
+  // The landing page provides its own header/footer.
+  if (!tenant) {
+    return <>{children}</>;
+  }
+
+  // Subdomain → wrap with clinic branding, header, and footer
   const branding = await getPublicBranding();
 
   return (

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { getTenant } from "@/lib/tenant";
+import { LandingPage } from "@/components/landing/landing-page";
 import { HeroSection } from "@/components/public/hero-section";
 import { ServicesPreview } from "@/components/public/services-preview";
 import {
@@ -22,22 +24,49 @@ import {
   LocationSection,
 } from "@/components/public/sections";
 
-export const metadata: Metadata = {
-  title: "Accueil — Cabinet Médical",
-  description:
-    "Bienvenue dans notre cabinet médical. Prenez rendez-vous en ligne, consultez nos services et découvrez notre équipe médicale.",
-  openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+  const tenant = await getTenant();
+
+  if (!tenant) {
+    return {
+      title: "Oltigo — La plateforme complète pour gérer votre cabinet médical",
+      description:
+        "Créez le site de votre cabinet, gérez les rendez-vous et développez votre activité facilement. Plateforme SaaS pour médecins et cabinets au Maroc.",
+      openGraph: {
+        title: "Oltigo — La plateforme complète pour gérer votre cabinet médical",
+        description:
+          "Créez le site de votre cabinet, gérez les rendez-vous et développez votre activité facilement.",
+        type: "website",
+        locale: "fr_MA",
+        siteName: "Oltigo",
+      },
+    };
+  }
+
+  return {
     title: "Accueil — Cabinet Médical",
     description:
-      "Bienvenue dans notre cabinet médical. Prenez rendez-vous en ligne, consultez nos services.",
-  },
-};
+      "Bienvenue dans notre cabinet médical. Prenez rendez-vous en ligne, consultez nos services et découvrez notre équipe médicale.",
+    openGraph: {
+      title: "Accueil — Cabinet Médical",
+      description:
+        "Bienvenue dans notre cabinet médical. Prenez rendez-vous en ligne, consultez nos services.",
+    },
+  };
+}
 
 const linkBtnOutline =
   "inline-flex items-center justify-center rounded-lg border border-border bg-background px-2.5 py-1.5 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors";
 
 export default async function HomePage() {
-  // Fetch branding, reviews, and average rating in parallel to reduce TTFB
+  const tenant = await getTenant();
+
+  // Root domain (no subdomain) → show SaaS landing page
+  if (!tenant) {
+    return <LandingPage />;
+  }
+
+  // Subdomain → show clinic homepage with tenant data
   const [branding, reviews, avgRating] = await Promise.all([
     getPublicBranding(),
     getPublicReviews(),

--- a/src/components/landing/cta-section.tsx
+++ b/src/components/landing/cta-section.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export function CtaSection() {
+  return (
+    <section className="bg-gray-900 py-20 sm:py-28">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Lancez votre cabinet en ligne dès aujourd&apos;hui
+          </h2>
+          <p className="mt-4 text-lg text-gray-400">
+            Rejoignez les professionnels de santé qui simplifient la gestion de
+            leur cabinet avec Oltigo.
+          </p>
+          <div className="mt-10">
+            <Link
+              href="/register"
+              className="inline-flex h-12 items-center justify-center rounded-xl bg-white px-8 text-sm font-semibold text-gray-900 shadow-lg transition-all hover:bg-gray-100"
+            >
+              Créer un compte gratuit
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/demo-section.tsx
+++ b/src/components/landing/demo-section.tsx
@@ -1,0 +1,57 @@
+import { ExternalLink } from "lucide-react";
+
+export function DemoSection() {
+  return (
+    <section id="demo" className="bg-white py-20 sm:py-28">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            Voyez le résultat
+          </h2>
+          <p className="mt-4 text-lg text-gray-600">
+            Découvrez à quoi ressemble un site de cabinet créé avec Oltigo.
+          </p>
+        </div>
+
+        <div className="mt-12 flex justify-center">
+          <a
+            href="https://dr-ahmed.oltigo.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group w-full max-w-2xl"
+          >
+            <div className="overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-lg transition-all group-hover:border-gray-300 group-hover:shadow-xl">
+              {/* Browser chrome mockup */}
+              <div className="flex items-center gap-2 border-b border-gray-200 bg-white px-4 py-3">
+                <div className="flex gap-1.5">
+                  <div className="h-3 w-3 rounded-full bg-gray-200" />
+                  <div className="h-3 w-3 rounded-full bg-gray-200" />
+                  <div className="h-3 w-3 rounded-full bg-gray-200" />
+                </div>
+                <div className="mx-auto flex items-center gap-2 rounded-lg bg-gray-50 px-4 py-1.5 text-sm text-gray-500">
+                  <span>dr-ahmed.oltigo.com</span>
+                  <ExternalLink className="h-3 w-3" />
+                </div>
+              </div>
+
+              {/* Placeholder content */}
+              <div className="px-8 py-12 text-center">
+                <div className="mx-auto mb-6 h-12 w-12 rounded-xl bg-gray-200" />
+                <div className="mx-auto mb-3 h-5 w-48 rounded bg-gray-200" />
+                <div className="mx-auto mb-8 h-4 w-64 rounded bg-gray-100" />
+                <div className="mx-auto grid max-w-sm grid-cols-3 gap-3">
+                  <div className="h-20 rounded-lg bg-gray-200" />
+                  <div className="h-20 rounded-lg bg-gray-200" />
+                  <div className="h-20 rounded-lg bg-gray-200" />
+                </div>
+                <p className="mt-8 text-sm font-medium text-gray-500">
+                  Cliquez pour voir le site en direct
+                </p>
+              </div>
+            </div>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/features-section.tsx
+++ b/src/components/landing/features-section.tsx
@@ -1,0 +1,68 @@
+import {
+  CalendarDays,
+  ClipboardList,
+  MonitorSmartphone,
+  Zap,
+} from "lucide-react";
+
+const features = [
+  {
+    icon: CalendarDays,
+    title: "Gestion des rendez-vous",
+    description:
+      "Planifiez, confirmez et suivez tous vos rendez-vous depuis une seule interface simple et intuitive.",
+  },
+  {
+    icon: ClipboardList,
+    title: "Gestion des patients",
+    description:
+      "Dossiers patients complets, historique des visites et suivi médical centralisé et sécurisé.",
+  },
+  {
+    icon: MonitorSmartphone,
+    title: "Site web du cabinet",
+    description:
+      "Un site professionnel prêt à l'emploi pour votre cabinet, accessible sur mobile et ordinateur.",
+  },
+  {
+    icon: Zap,
+    title: "Automatisation intelligente",
+    description:
+      "Rappels automatiques, notifications et gestion de la liste d'attente pour gagner du temps.",
+  },
+] as const;
+
+export function FeaturesSection() {
+  return (
+    <section id="fonctionnalites" className="bg-white py-20 sm:py-28">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            Tout ce dont votre cabinet a besoin
+          </h2>
+          <p className="mt-4 text-lg text-gray-600">
+            Des outils simples et puissants pour vous concentrer sur
+            l&apos;essentiel : vos patients.
+          </p>
+        </div>
+
+        <div className="mt-16 grid gap-8 sm:grid-cols-2">
+          {features.map(({ icon: Icon, title, description }) => (
+            <div
+              key={title}
+              className="group rounded-2xl border border-gray-100 bg-white p-8 transition-all hover:border-gray-200 hover:shadow-lg hover:shadow-gray-100/50"
+            >
+              <div className="mb-5 flex h-11 w-11 items-center justify-center rounded-xl bg-gray-900 text-white transition-colors group-hover:bg-blue-600">
+                <Icon className="h-5 w-5" />
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-600">
+                {description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+
+export function HeroSection() {
+  return (
+    <section className="relative overflow-hidden bg-white pb-20 pt-16 sm:pb-28 sm:pt-24">
+      {/* Subtle gradient background */}
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-0 h-[500px] bg-gradient-to-b from-blue-50/60 to-transparent" />
+        <div className="absolute right-0 top-0 h-[400px] w-[400px] rounded-full bg-blue-100/30 blur-3xl" />
+        <div className="absolute left-0 top-40 h-[300px] w-[300px] rounded-full bg-indigo-100/20 blur-3xl" />
+      </div>
+
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="text-4xl font-bold leading-tight tracking-tight text-gray-900 sm:text-5xl lg:text-6xl">
+            La plateforme complète pour gérer votre{" "}
+            <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+              cabinet médical
+            </span>
+          </h1>
+
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-gray-600 sm:text-xl">
+            Créez le site de votre cabinet, gérez les rendez-vous et
+            développez votre activité facilement.
+          </p>
+
+          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/register"
+              className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-gray-900 px-8 text-sm font-semibold text-white shadow-lg shadow-gray-900/20 transition-all hover:bg-gray-800 hover:shadow-xl sm:w-auto"
+            >
+              Commencer maintenant
+            </Link>
+            <a
+              href="#comment-ca-marche"
+              className="inline-flex h-12 w-full items-center justify-center rounded-xl border border-gray-200 bg-white px-8 text-sm font-semibold text-gray-700 transition-all hover:border-gray-300 hover:bg-gray-50 sm:w-auto"
+            >
+              Voir comment ça marche
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/how-it-works-section.tsx
+++ b/src/components/landing/how-it-works-section.tsx
@@ -1,0 +1,53 @@
+const steps = [
+  {
+    number: "01",
+    title: "Créez votre compte",
+    description: "Inscrivez-vous en quelques secondes et configurez votre cabinet.",
+  },
+  {
+    number: "02",
+    title: "Ajoutez vos services",
+    description: "Définissez vos consultations, tarifs et horaires de travail.",
+  },
+  {
+    number: "03",
+    title: "Partagez votre lien",
+    description: "Envoyez votre lien unique à vos patients pour qu'ils prennent rendez-vous.",
+  },
+  {
+    number: "04",
+    title: "Recevez des rendez-vous",
+    description: "Les patients réservent en ligne et vous gérez tout depuis votre tableau de bord.",
+  },
+] as const;
+
+export function HowItWorksSection() {
+  return (
+    <section id="comment-ca-marche" className="bg-gray-50 py-20 sm:py-28">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            Comment ça marche
+          </h2>
+          <p className="mt-4 text-lg text-gray-600">
+            Lancez votre présence en ligne en 4 étapes simples.
+          </p>
+        </div>
+
+        <div className="mt-16 grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {steps.map(({ number, title, description }) => (
+            <div key={number} className="relative">
+              <div className="mb-4 text-4xl font-bold text-gray-200">
+                {number}
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-gray-600">
+                {description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/index.ts
+++ b/src/components/landing/index.ts
@@ -1,0 +1,8 @@
+export { LandingHeader } from "./landing-header";
+export { HeroSection } from "./hero-section";
+export { TrustSection } from "./trust-section";
+export { FeaturesSection } from "./features-section";
+export { HowItWorksSection } from "./how-it-works-section";
+export { DemoSection } from "./demo-section";
+export { CtaSection } from "./cta-section";
+export { LandingFooter } from "./landing-footer";

--- a/src/components/landing/landing-footer.tsx
+++ b/src/components/landing/landing-footer.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+const links = [
+  { label: "À propos", href: "/about" },
+  { label: "Contact", href: "/contact" },
+  { label: "Connexion", href: "/login" },
+  { label: "Confidentialité", href: "/privacy" },
+] as const;
+
+export function LandingFooter() {
+  return (
+    <footer className="border-t border-gray-100 bg-white py-12">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="flex flex-col items-center justify-between gap-6 sm:flex-row">
+          <Link
+            href="/"
+            className="text-lg font-bold tracking-tight text-gray-900"
+          >
+            Oltigo
+          </Link>
+
+          <nav className="flex flex-wrap items-center justify-center gap-6">
+            {links.map(({ label, href }) => (
+              <Link
+                key={href}
+                href={href}
+                className="text-sm text-gray-500 transition-colors hover:text-gray-900"
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        <div className="mt-8 border-t border-gray-100 pt-8 text-center text-xs text-gray-400">
+          &copy; {new Date().getFullYear()} Oltigo. Tous droits réservés.
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+export function LandingHeader() {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-gray-100 bg-white/80 backdrop-blur-lg">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
+        <Link href="/" className="text-xl font-bold tracking-tight text-gray-900">
+          Oltigo
+        </Link>
+
+        <nav className="hidden items-center gap-8 md:flex">
+          <a href="#fonctionnalites" className="text-sm text-gray-600 transition-colors hover:text-gray-900">
+            Fonctionnalités
+          </a>
+          <a href="#comment-ca-marche" className="text-sm text-gray-600 transition-colors hover:text-gray-900">
+            Comment ça marche
+          </a>
+          <a href="#demo" className="text-sm text-gray-600 transition-colors hover:text-gray-900">
+            Démo
+          </a>
+        </nav>
+
+        <div className="flex items-center gap-3">
+          <Link
+            href="/login"
+            className="hidden text-sm font-medium text-gray-600 transition-colors hover:text-gray-900 sm:inline-flex"
+          >
+            Connexion
+          </Link>
+          <Link
+            href="/register"
+            className="inline-flex h-9 items-center rounded-lg bg-gray-900 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+          >
+            Commencer
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -1,0 +1,31 @@
+import { LandingHeader } from "./landing-header";
+import { HeroSection } from "./hero-section";
+import { TrustSection } from "./trust-section";
+import { FeaturesSection } from "./features-section";
+import { HowItWorksSection } from "./how-it-works-section";
+import { DemoSection } from "./demo-section";
+import { CtaSection } from "./cta-section";
+import { LandingFooter } from "./landing-footer";
+
+/**
+ * SaaS landing page shown on the root domain (oltigo.com).
+ *
+ * This page does NOT load any tenant/clinic data.
+ * Clinic websites live on subdomains (e.g. dr-ahmed.oltigo.com).
+ */
+export function LandingPage() {
+  return (
+    <div className="flex min-h-screen flex-col bg-white">
+      <LandingHeader />
+      <main className="flex-1">
+        <HeroSection />
+        <TrustSection />
+        <FeaturesSection />
+        <HowItWorksSection />
+        <DemoSection />
+        <CtaSection />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/src/components/landing/trust-section.tsx
+++ b/src/components/landing/trust-section.tsx
@@ -1,0 +1,42 @@
+import {
+  CalendarCheck,
+  Users,
+  Globe,
+  ShieldCheck,
+} from "lucide-react";
+
+const items = [
+  { icon: CalendarCheck, label: "Gestion intelligente des rendez-vous" },
+  { icon: Users, label: "Suivi des patients" },
+  { icon: Globe, label: "Site professionnel pour votre cabinet" },
+  { icon: ShieldCheck, label: "Sécurité des données" },
+] as const;
+
+export function TrustSection() {
+  return (
+    <section className="border-y border-gray-100 bg-gray-50/50 py-14">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <p className="text-center text-sm font-medium uppercase tracking-wide text-gray-500">
+          Utilisé par des médecins et cabinets pour gérer leurs rendez-vous
+          efficacement
+        </p>
+
+        <div className="mt-10 grid grid-cols-2 gap-6 sm:grid-cols-4">
+          {items.map(({ icon: Icon, label }) => (
+            <div
+              key={label}
+              className="flex flex-col items-center gap-3 text-center"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white shadow-sm ring-1 ring-gray-100">
+                <Icon className="h-5 w-5 text-gray-700" />
+              </div>
+              <span className="text-sm font-medium text-gray-700">
+                {label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Professional SaaS landing page for the root domain (oltigo.com). This page is shown when visiting the root domain (no subdomain), while clinic websites on subdomains continue to work exactly as before.

### What this PR does

**New landing page components** (`src/components/landing/`):
- **Header** — sticky nav with logo, section links, login/register CTAs
- **Hero** — gradient headline, subtitle, dual CTA buttons
- **Trust** — social proof bar with 4 trust indicators (icons + labels)
- **Features** — 4-card grid: appointments, patients, website, automation
- **How it Works** — 4-step numbered flow (create account → receive bookings)
- **Demo** — browser mockup linking to dr-ahmed.oltigo.com
- **CTA** — dark section with free signup button
- **Footer** — minimal links (about, contact, login, privacy)

**Routing logic** (`src/app/(public)/page.tsx` + `layout.tsx`):
- `getTenant()` returns `null` on root domain → renders `<LandingPage />`
- `getTenant()` returns tenant on subdomain → renders existing clinic homepage
- Layout skips tenant header/footer on root domain (landing has its own)
- Dynamic `generateMetadata()` returns SaaS meta on root, clinic meta on subdomains

### Design
- Modern SaaS style (Stripe / Doctolib inspired)
- Clean spacing, simple typography, mobile-first
- Fully responsive (mobile + desktop)
- French content, structure ready for Arabic/English
- No external heavy libraries — only Tailwind CSS + lucide-react icons

### What it does NOT do
- Does NOT load any tenant/clinic data on root domain
- Does NOT call tenant APIs on the homepage
- Does NOT break existing subdomain clinic pages
- Does NOT mention technical details (RLS, architecture, etc.)

### Checks
- TypeScript: `tsc --noEmit` passes
- ESLint: `npm run lint` passes
- Pre-commit hooks: all passed