### PR TITLE
feat: wire dispatchNotification() into booking create, cancel, and reschedule routes

### DIFF
--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -6,6 +6,8 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { clinicDateTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { bookingCancelSchema, safeParse } from "@/lib/validations";
+import { dispatchNotification } from "@/lib/notifications";
+import type { TemplateVariables } from "@/lib/notifications";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import type { UserRole } from "@/lib/types/database";
 
@@ -30,7 +32,7 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     // Fetch the appointment (include patient_id for ownership check)
     const { data: appt, error: fetchError } = await supabase
       .from("appointments")
-      .select("id, patient_id, doctor_id, appointment_date, start_time, status")
+      .select("id, patient_id, doctor_id, service_id, appointment_date, start_time, status")
       .eq("id", body.appointmentId)
       .eq("clinic_id", clinicId)
       .single();
@@ -113,6 +115,39 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       clinicId: profile.clinic_id ?? clinicId,
       description: `Appointment ${body.appointmentId} cancelled. Reason: ${body.reason ?? "Cancelled by patient"}`,
     });
+
+    // ── Dispatch cancellation notifications (fire-and-forget) ──────
+    // Notification failure must NOT affect the cancellation outcome.
+    try {
+      // Fetch doctor and service names for notification variables
+      const [doctorResult, serviceResult, patientResult] = await Promise.all([
+        supabase.from("users").select("name").eq("id", appt.doctor_id).single(),
+        appt.service_id
+          ? supabase.from("services").select("name").eq("id", appt.service_id).single()
+          : Promise.resolve({ data: null }),
+        supabase.from("users").select("name").eq("id", appt.patient_id).single(),
+      ]);
+
+      const notifVars: TemplateVariables = {
+        patient_name: patientResult.data?.name ?? "Patient",
+        doctor_name: doctorResult.data?.name ?? "Doctor",
+        clinic_name: tenant.clinicName,
+        service_name: serviceResult.data?.name ?? "Consultation",
+        date: appt.appointment_date ?? "",
+        time: appt.start_time ?? "",
+        cancellation_reason: body.reason ?? "Cancelled by patient",
+      };
+
+      // cancellation → patient, doctor, receptionist
+      Promise.allSettled([
+        dispatchNotification("cancellation", notifVars, appt.patient_id, ["in_app", "email", "whatsapp"]),
+        dispatchNotification("cancellation", notifVars, appt.doctor_id, ["in_app"]),
+      ]).catch((err) => {
+        logger.warn("Cancellation notification dispatch failed", { context: "booking/cancel", error: err });
+      });
+    } catch (err) {
+      logger.warn("Failed to prepare cancellation notifications", { context: "booking/cancel", error: err });
+    }
 
     return NextResponse.json({ status: APPOINTMENT_STATUS.CANCELLED, message: "Appointment cancelled successfully" });
   } catch (err) {

--- a/src/app/api/booking/reschedule/route.ts
+++ b/src/app/api/booking/reschedule/route.ts
@@ -7,6 +7,8 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { computeEndTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { rescheduleSchema, safeParse } from "@/lib/validations";
+import { dispatchNotification } from "@/lib/notifications";
+import type { TemplateVariables } from "@/lib/notifications";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import type { UserRole } from "@/lib/types/database";
 
@@ -180,6 +182,38 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       clinicId: profile.clinic_id ?? clinicId,
       description: `Appointment ${body.appointmentId} rescheduled to ${body.newDate} ${body.newTime}`,
     });
+
+    // ── Dispatch reschedule notifications (fire-and-forget) ──────────
+    // Notification failure must NOT affect the reschedule outcome.
+    try {
+      // Fetch names for notification variables
+      const [doctorResult, serviceResult, patientResult] = await Promise.all([
+        supabase.from("users").select("name").eq("id", existing.doctor_id).single(),
+        existing.service_id
+          ? supabase.from("services").select("name").eq("id", existing.service_id).single()
+          : Promise.resolve({ data: null }),
+        supabase.from("users").select("name").eq("id", existing.patient_id).single(),
+      ]);
+
+      const notifVars: TemplateVariables = {
+        patient_name: patientResult.data?.name ?? "Patient",
+        doctor_name: doctorResult.data?.name ?? "Doctor",
+        clinic_name: tenant.clinicName,
+        service_name: serviceResult.data?.name ?? "Consultation",
+        date: body.newDate,
+        time: body.newTime,
+      };
+
+      // rescheduled → patient, doctor
+      Promise.allSettled([
+        dispatchNotification("rescheduled", notifVars, existing.patient_id, ["in_app", "email", "whatsapp"]),
+        dispatchNotification("rescheduled", notifVars, existing.doctor_id, ["in_app"]),
+      ]).catch((err) => {
+        logger.warn("Reschedule notification dispatch failed", { context: "booking/reschedule", error: err });
+      });
+    } catch (err) {
+      logger.warn("Failed to prepare reschedule notifications", { context: "booking/reschedule", error: err });
+    }
 
     return NextResponse.json({
       status: APPOINTMENT_STATUS.RESCHEDULED,

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -17,6 +17,8 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { computeEndTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { safeParse } from "@/lib/validations";
+import { dispatchNotification } from "@/lib/notifications";
+import type { TemplateVariables } from "@/lib/notifications";
 import { z } from "zod";
 
 const bookingRequestSchema = z.object({
@@ -357,6 +359,25 @@ export async function POST(request: NextRequest) {
       type: "booking",
       clinicId,
       description: `Appointment ${appointment.id} created for patient ${patientId} with doctor ${body.doctorId}`,
+    });
+
+    // ── Dispatch notifications (fire-and-forget) ──────────────────
+    // Notification failure must NOT affect the booking outcome.
+    const notifVars: TemplateVariables = {
+      patient_name: body.patient.name,
+      doctor_name: doctor?.name ?? "Doctor",
+      clinic_name: tenant.clinicName,
+      service_name: service?.name ?? "Consultation",
+      date: body.date,
+      time: body.time,
+    };
+
+    // booking_confirmation → patient, new_booking → staff
+    Promise.allSettled([
+      dispatchNotification("booking_confirmation", notifVars, patientId, ["in_app", "email", "whatsapp"]),
+      dispatchNotification("new_booking", notifVars, body.doctorId, ["in_app"]),
+    ]).catch((err) => {
+      logger.warn("Booking notification dispatch failed", { context: "booking/route", error: err });
     });
 
     return NextResponse.json({

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -282,6 +282,19 @@ export const defaultNotificationTemplates: NotificationTemplate[] = [
     priority: "low",
     recipientRoles: ["receptionist", "clinic_admin"],
   },
+  {
+    id: "tpl_rescheduled",
+    trigger: "rescheduled",
+    name: "rescheduled",
+    label: "Appointment Rescheduled",
+    channels: ["whatsapp", "in_app", "email"],
+    subject: "Appointment Rescheduled",
+    body: "Your appointment with {{doctor_name}} has been rescheduled to {{date}} at {{time}}. Service: {{service_name}}. {{clinic_name}}",
+    whatsappBody: "Hello {{patient_name}}, your appointment with {{doctor_name}} has been rescheduled to {{date}} at {{time}}. Contact us at {{clinic_phone}} if you have questions. {{clinic_name}}",
+    enabled: true,
+    priority: "high",
+    recipientRoles: ["patient", "doctor", "receptionist"],
+  },
 ];
 
 // ---- Trigger Metadata ----


### PR DESCRIPTION
## Summary

Wires `dispatchNotification()` calls into all three booking API routes so patients and staff actually receive notifications when bookings are created, cancelled, or rescheduled.

## Changes

### `src/lib/notifications.ts`
- Added `rescheduled` template to `defaultNotificationTemplates` with WhatsApp, in-app, and email channels

### `src/app/api/booking/route.ts` (Create)
- Dispatches `booking_confirmation` to patient (in_app, email, whatsapp)
- Dispatches `new_booking` to doctor (in_app)
- Fire-and-forget via `Promise.allSettled` — notification failure never rolls back a successful booking

### `src/app/api/booking/cancel/route.ts`
- Added `service_id` to appointment select query for notification variables
- Fetches doctor, patient, and service names for template variables
- Dispatches `cancellation` to patient (in_app, email, whatsapp) and doctor (in_app)
- Wrapped in try-catch so notification prep failures are logged but never affect cancellation outcome

### `src/app/api/booking/reschedule/route.ts`
- Fetches doctor, patient, and service names for template variables
- Dispatches `rescheduled` to patient (in_app, email, whatsapp) and doctor (in_app)
- Same fire-and-forget pattern with try-catch safety

## Design Decisions
- **Fire-and-forget**: All notification dispatches use `Promise.allSettled` so a failed email/WhatsApp never corrupts a successful booking action
- **Graceful degradation**: DB lookups for names are wrapped in try-catch with sensible fallbacks ("Patient", "Doctor", "Consultation")
- **Minimal footprint**: 104 lines added across 4 files, no new dependencies

## Verification
- ✅ `tsc --noEmit` — zero errors
- ✅ `npm run lint` — clean
- ✅ `npm test` — 249/249 tests pass

---
*[Devin session](https://app.devin.ai/sessions/ee48ad7dc59744fda2955152c4725b30)*