### PR TITLE
fix: auto-set Worker runtime secrets during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,21 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
+      - name: Set Worker Secrets (Production)
+        if: github.ref_name == 'main'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: secret bulk
+          stdin: |
+            {
+              "SUPABASE_SERVICE_ROLE_KEY": "${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}",
+              "RESEND_API_KEY": "${{ secrets.RESEND_API_KEY }}",
+              "BOOKING_TOKEN_SECRET": "${{ secrets.BOOKING_TOKEN_SECRET }}",
+              "CRON_SECRET": "${{ secrets.CRON_SECRET }}"
+            }
+
       - name: Deploy to Cloudflare Workers (Staging)
         if: github.ref_name == 'staging'
         uses: cloudflare/wrangler-action@v3
@@ -68,3 +83,18 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --env staging
+
+      - name: Set Worker Secrets (Staging)
+        if: github.ref_name == 'staging'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: secret bulk --env staging
+          stdin: |
+            {
+              "SUPABASE_SERVICE_ROLE_KEY": "${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}",
+              "RESEND_API_KEY": "${{ secrets.RESEND_API_KEY }}",
+              "BOOKING_TOKEN_SECRET": "${{ secrets.BOOKING_TOKEN_SECRET }}",
+              "CRON_SECRET": "${{ secrets.CRON_SECRET }}"
+            }


### PR DESCRIPTION
## What this does

Adds `wrangler secret bulk` steps after deploy for both production and staging environments.

This ensures runtime secrets (`SUPABASE_SERVICE_ROLE_KEY`, `RESEND_API_KEY`, `BOOKING_TOKEN_SECRET`, `CRON_SECRET`) are automatically synced to the Cloudflare Workers on every deploy — no more manually setting them via the dashboard or CLI.

## Why

The staging Worker was missing runtime secrets (especially `RESEND_API_KEY`) because they were only set manually on production. This caused email notifications and other server-side features to silently fail on staging.

## Also done in this session (no code changes needed)

- Synced `staging` branch with `main` (was 11 commits behind) and pushed — staging auto-deployed successfully
- Added `RESEND_API_KEY` to GitHub Actions secrets
- Added `RESEND_API_KEY` to Cloudflare Pages preview environment

---

*Devin session: https://app.devin.ai/sessions/950d75093dbe4a0d95c2c43c32757169*