### PR TITLE
fix: use shell pipe for wrangler secret bulk (fixes stuck deploy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,18 +63,11 @@ jobs:
 
       - name: Set Worker Secrets (Production)
         if: github.ref_name == 'main'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: secret bulk
-          stdin: |
-            {
-              "SUPABASE_SERVICE_ROLE_KEY": "${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}",
-              "RESEND_API_KEY": "${{ secrets.RESEND_API_KEY }}",
-              "BOOKING_TOKEN_SECRET": "${{ secrets.BOOKING_TOKEN_SECRET }}",
-              "CRON_SECRET": "${{ secrets.CRON_SECRET }}"
-            }
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo '{"SUPABASE_SERVICE_ROLE_KEY":"${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}","RESEND_API_KEY":"${{ secrets.RESEND_API_KEY }}","BOOKING_TOKEN_SECRET":"${{ secrets.BOOKING_TOKEN_SECRET }}","CRON_SECRET":"${{ secrets.CRON_SECRET }}"}' | npx wrangler secret bulk
 
       - name: Deploy to Cloudflare Workers (Staging)
         if: github.ref_name == 'staging'
@@ -86,15 +79,8 @@ jobs:
 
       - name: Set Worker Secrets (Staging)
         if: github.ref_name == 'staging'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: secret bulk --env staging
-          stdin: |
-            {
-              "SUPABASE_SERVICE_ROLE_KEY": "${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}",
-              "RESEND_API_KEY": "${{ secrets.RESEND_API_KEY }}",
-              "BOOKING_TOKEN_SECRET": "${{ secrets.BOOKING_TOKEN_SECRET }}",
-              "CRON_SECRET": "${{ secrets.CRON_SECRET }}"
-            }
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo '{"SUPABASE_SERVICE_ROLE_KEY":"${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}","RESEND_API_KEY":"${{ secrets.RESEND_API_KEY }}","BOOKING_TOKEN_SECRET":"${{ secrets.BOOKING_TOKEN_SECRET }}","CRON_SECRET":"${{ secrets.CRON_SECRET }}"}' | npx wrangler secret bulk --env staging


### PR DESCRIPTION
## Fix

The `cloudflare/wrangler-action` `stdin` parameter hangs when used with `secret bulk`. This switches to a direct shell `echo | npx wrangler secret bulk` pipe which is reliable.

Replaces the approach from PR #234 that caused the staging deploy to hang on the "Set Worker Secrets" step.

---

*Devin session: https://app.devin.ai/sessions/950d75093dbe4a0d95c2c43c32757169*