### PR TITLE
fix: fix backup verify and R2 replication workflows

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -201,13 +201,16 @@ jobs:
 
       - name: Test restore
         run: |
-          gunzip -c /tmp/verify_backup.sql.gz | psql backup_verify_test
+          # The dump uses --clean which generates DROP/ALTER for objects that
+          # don't exist in a fresh database. Pipe through psql with ON_ERROR_STOP
+          # disabled so those harmless errors don't abort the restore.
+          gunzip -c /tmp/verify_backup.sql.gz | psql -v ON_ERROR_STOP=0 backup_verify_test 2>&1 | tail -5
 
           # Verify key tables exist
-          TABLES=$(psql backup_verify_test -t -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
+          TABLES=$(psql backup_verify_test -t -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" | tr -d ' ')
           echo "Tables restored: ${TABLES}"
 
-          if [ "${TABLES}" -lt 5 ]; then
+          if [ -z "${TABLES}" ] || [ "${TABLES}" -lt 5 ]; then
             echo "ERROR: Too few tables restored (${TABLES}). Backup may be corrupt."
             exit 1
           fi

--- a/.github/workflows/r2-replication.yml
+++ b/.github/workflows/r2-replication.yml
@@ -20,13 +20,26 @@ jobs:
       R2_REPLICA_SECRET_ACCESS_KEY: ${{ secrets.R2_REPLICA_SECRET_ACCESS_KEY }}
       R2_REPLICA_BUCKET_NAME: ${{ secrets.R2_REPLICA_BUCKET_NAME }}
     steps:
+      - name: Check replica configuration
+        id: check_replica
+        run: |
+          if [ -z "${{ secrets.R2_REPLICA_ACCOUNT_ID }}" ] || [ -z "${{ secrets.R2_REPLICA_BUCKET_NAME }}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::warning::R2 replica not configured. Set R2_REPLICA_ACCOUNT_ID, R2_REPLICA_ACCESS_KEY_ID, R2_REPLICA_SECRET_ACCESS_KEY, and R2_REPLICA_BUCKET_NAME secrets to enable replication."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
+        if: steps.check_replica.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Install AWS CLI
+        if: steps.check_replica.outputs.skip != 'true'
         run: pip install awscli
 
       - name: Configure primary R2 credentials
+        if: steps.check_replica.outputs.skip != 'true'
         run: |
           mkdir -p ~/.aws
           cat > ~/.aws/credentials << EOF
@@ -45,6 +58,7 @@ jobs:
           EOF
 
       - name: Sync primary to replica bucket
+        if: steps.check_replica.outputs.skip != 'true'
         run: |
           PRIMARY_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           REPLICA_ENDPOINT="https://${R2_REPLICA_ACCOUNT_ID}.r2.cloudflarestorage.com"
@@ -74,6 +88,7 @@ jobs:
           echo "Replication complete: ${FILE_COUNT} files synced"
 
       - name: Verify replica integrity
+        if: steps.check_replica.outputs.skip != 'true'
         run: |
           PRIMARY_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           REPLICA_ENDPOINT="https://${R2_REPLICA_ACCOUNT_ID}.r2.cloudflarestorage.com"
@@ -95,5 +110,5 @@ jobs:
           echo "Replication verification PASSED"
 
       - name: Cleanup
-        if: always()
+        if: always() && steps.check_replica.outputs.skip != 'true'
         run: rm -rf /tmp/r2-sync


### PR DESCRIPTION
## Summary
Fixes two failing GitHub Actions workflows.

### 1. Backup verify step (`backup.yml`)
**Problem:** The verify job restored the backup into a fresh local PostgreSQL database, but `pg_dump --clean` generates `DROP`/`ALTER` statements for objects that don't exist in a fresh DB. These errors caused the restore to silently fail, resulting in 0 tables and a failed verification.

**Fix:** Use `psql -v ON_ERROR_STOP=0` to allow harmless DROP errors to pass, and `tr -d ' '` to trim whitespace from the table count comparison.

### 2. R2 replication (`r2-replication.yml`)
**Problem:** Workflow fails with `Invalid endpoint: https://.r2.cloudflarestorage.com` because `R2_REPLICA_*` secrets are not configured (no replica bucket exists).

**Fix:** Add a check step that gracefully skips all replication steps when replica secrets are not configured, with a warning annotation instead of a failure.