### PR TITLE
feat: add Turnstile site key to .env.production for captcha support

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,5 @@
+# Public build-time variables (safe to commit — these are embedded in client HTML)
+# See: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
+
+# Cloudflare Turnstile CAPTCHA — public site key for oltigo.com
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=0x4AAAAAACvd2Wv1I_bf4FHk

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 .env*
 !.env.example
 !.env.local.example
+!.env.production
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
## Summary

Adds the Cloudflare Turnstile site key (`0x4AAAAAACvd2Wv1I_bf4FHk`) as a build-time environment variable so captcha works on login/register pages.

### Changes
- **`.env.production`** (new): Contains `NEXT_PUBLIC_TURNSTILE_SITE_KEY` — this is a public site key (embedded in client HTML by design), safe to commit per Next.js conventions
- **`.gitignore`**: Added `!.env.production` exception so the file is tracked

### Why
- The Turnstile site key was missing from builds, so captcha was silently disabled on login/register
- This ensures it works on both GitHub Actions deploys and Cloudflare Pages builds without needing a separate secret
- Also set as Cloudflare Pages env var for redundancy

### Notes
- Turnstile site keys are public by design (like reCAPTCHA site keys) — only the secret key needs protection
- The secret key (`TURNSTILE_SECRET_KEY`) is already configured in GitHub Actions secrets