### PR TITLE
fix: add Turnstile domain to CSP script-src directive

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -155,7 +155,7 @@ function buildCsp(nonce: string): string {
   const isDev = process.env.NODE_ENV === "development";
   return [
     "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}' https://static.cloudflareinsights.com${isDev ? " 'unsafe-eval'" : ""}`,
+    `script-src 'self' 'nonce-${nonce}' https://static.cloudflareinsights.com https://challenges.cloudflare.com${isDev ? " 'unsafe-eval'" : ""}`,
     // Styles: self + inline (Tailwind, shadcn) — see ACCEPTED RISK above
     "style-src 'self' 'unsafe-inline'",
     // Images: self + R2 storage + Supabase storage + data URIs + blobs


### PR DESCRIPTION
## Problem

The Turnstile captcha widget was blocked by Content Security Policy on login/register pages:

> Refused to load the script `https://challenges.cloudflare.com/turnstile/v0/api.js` because it violates the following Content Security Policy directive: `script-src 'self' 'nonce-...' https://static.cloudflareinsights.com`

## Fix

Added `https://challenges.cloudflare.com` to the `script-src` directive in `buildCsp()` (middleware.ts line 158).

The `frame-src` directive already allowed `https://challenges.cloudflare.com` for the Turnstile iframe, but the script that bootstraps the widget also needs to be in `script-src`.

## Testing

- Verified the CSP error in browser DevTools console on `dr-ahmed.oltigo.com/login`
- Lint and type check pass locally