### PR TITLE
fix: fix backup verify step and R2 replication skip logic

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -199,18 +199,39 @@ jobs:
           sudo -u postgres createuser -s runner 2>/dev/null || true
           createdb backup_verify_test 2>/dev/null || true
 
+      - name: Install Supabase-compatible extensions
+        run: |
+          # Supabase dumps reference extensions that aren't in default PostgreSQL.
+          # Install common ones so the restore can create tables that depend on them.
+          PG_VERSION=$(pg_config --version | grep -oP '\d+' | head -1)
+          sudo apt-get install -y \
+            postgresql-${PG_VERSION}-pgcrypto 2>/dev/null || true
+
+          # Pre-create extensions that Supabase uses so CREATE EXTENSION doesn't fail
+          psql backup_verify_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;" 2>/dev/null || true
+          psql backup_verify_test -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" 2>/dev/null || true
+
       - name: Test restore
         run: |
           # The dump uses --clean which generates DROP/ALTER for objects that
           # don't exist in a fresh database. Pipe through psql with ON_ERROR_STOP
           # disabled so those harmless errors don't abort the restore.
-          gunzip -c /tmp/verify_backup.sql.gz | psql -v ON_ERROR_STOP=0 backup_verify_test 2>&1 | tail -5
+          gunzip -c /tmp/verify_backup.sql.gz \
+            | psql -v ON_ERROR_STOP=0 backup_verify_test 2>&1 \
+            | tail -20
 
-          # Verify key tables exist
-          TABLES=$(psql backup_verify_test -t -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" | tr -d ' ')
+          # Verify key tables exist in public schema
+          TABLES=$(psql backup_verify_test -t -c \
+            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';" \
+            | tr -d '[:space:]')
           echo "Tables restored: ${TABLES}"
 
-          if [ -z "${TABLES}" ] || [ "${TABLES}" -lt 5 ]; then
+          if [ -z "${TABLES}" ] || [ "${TABLES}" = "" ]; then
+            echo "ERROR: Could not count tables. Backup may be corrupt."
+            exit 1
+          fi
+
+          if [ "${TABLES}" -lt 5 ] 2>/dev/null; then
             echo "ERROR: Too few tables restored (${TABLES}). Backup may be corrupt."
             exit 1
           fi

--- a/.github/workflows/r2-replication.yml
+++ b/.github/workflows/r2-replication.yml
@@ -7,9 +7,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Check Replica Configuration
+    outputs:
+      skip: ${{ steps.check_replica.outputs.skip }}
+    steps:
+      - name: Check replica configuration
+        id: check_replica
+        env:
+          REPLICA_ACCOUNT_ID: ${{ secrets.R2_REPLICA_ACCOUNT_ID }}
+          REPLICA_BUCKET_NAME: ${{ secrets.R2_REPLICA_BUCKET_NAME }}
+        run: |
+          if [ -z "${REPLICA_ACCOUNT_ID}" ] || [ -z "${REPLICA_BUCKET_NAME}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::notice::R2 replica not configured — skipping replication. Set R2_REPLICA_ACCOUNT_ID, R2_REPLICA_ACCESS_KEY_ID, R2_REPLICA_SECRET_ACCESS_KEY, and R2_REPLICA_BUCKET_NAME secrets to enable."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
   replicate:
     runs-on: ubuntu-latest
     name: Replicate R2 to Secondary Bucket
+    needs: check
+    if: needs.check.outputs.skip != 'true'
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -20,26 +41,14 @@ jobs:
       R2_REPLICA_SECRET_ACCESS_KEY: ${{ secrets.R2_REPLICA_SECRET_ACCESS_KEY }}
       R2_REPLICA_BUCKET_NAME: ${{ secrets.R2_REPLICA_BUCKET_NAME }}
     steps:
-      - name: Check replica configuration
-        id: check_replica
-        run: |
-          if [ -z "${{ secrets.R2_REPLICA_ACCOUNT_ID }}" ] || [ -z "${{ secrets.R2_REPLICA_BUCKET_NAME }}" ]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "::warning::R2 replica not configured. Set R2_REPLICA_ACCOUNT_ID, R2_REPLICA_ACCESS_KEY_ID, R2_REPLICA_SECRET_ACCESS_KEY, and R2_REPLICA_BUCKET_NAME secrets to enable replication."
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Checkout
-        if: steps.check_replica.outputs.skip != 'true'
         uses: actions/checkout@v4
 
       - name: Install AWS CLI
-        if: steps.check_replica.outputs.skip != 'true'
         run: pip install awscli
 
       - name: Configure primary R2 credentials
-        if: steps.check_replica.outputs.skip != 'true'
         run: |
           mkdir -p ~/.aws
           cat > ~/.aws/credentials << EOF
@@ -58,7 +67,6 @@ jobs:
           EOF
 
       - name: Sync primary to replica bucket
-        if: steps.check_replica.outputs.skip != 'true'
         run: |
           PRIMARY_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           REPLICA_ENDPOINT="https://${R2_REPLICA_ACCOUNT_ID}.r2.cloudflarestorage.com"
@@ -88,7 +96,6 @@ jobs:
           echo "Replication complete: ${FILE_COUNT} files synced"
 
       - name: Verify replica integrity
-        if: steps.check_replica.outputs.skip != 'true'
         run: |
           PRIMARY_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           REPLICA_ENDPOINT="https://${R2_REPLICA_ACCOUNT_ID}.r2.cloudflarestorage.com"
@@ -110,5 +117,5 @@ jobs:
           echo "Replication verification PASSED"
 
       - name: Cleanup
-        if: always() && steps.check_replica.outputs.skip != 'true'
+        if: always()
         run: rm -rf /tmp/r2-sync


### PR DESCRIPTION
## What

Fixes two failing GitHub Actions workflows:

### R2 Backup Replication (`r2-replication.yml`)
- **Problem**: Workflow reported as failed even when replica bucket is not configured (no `R2_REPLICA_*` secrets set). The skip logic was inside the same job, so the job still showed as failed.
- **Fix**: Split into two jobs — a lightweight `check` job that outputs `skip=true/false`, and a `replicate` job that only runs when replica is configured. When skipped, the workflow shows as passed (not failed).

### Database Backup Verify (`backup.yml`)
- **Problem**: The `Test restore` step failed because the Supabase dump references extensions (`pgcrypto`, `uuid-ossp`) not available in the default GitHub Actions PostgreSQL.
- **Fix**: Added a step to pre-create Supabase-compatible extensions before restoring. Also improved whitespace handling in the table count check to prevent false failures.

## Testing
- No application code changes — only CI workflow files
- Lint and typecheck pass locally

---

[Devin session](https://app.devin.ai/sessions/fac17b1317db421d9de3d38a5961ab5f)