### PR TITLE
fix: auto-set subdomain in API onboarding route

### DIFF
--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -83,6 +83,14 @@ export const POST = withAuth(async (request, { supabase, user }) => {
       .limit(1)
       .maybeSingle();
 
+    // Auto-generate subdomain from clinic name (lowercase, alphanumeric + hyphens)
+    const subdomain = body.clinic_name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .replace(/--+/g, "-");
+
     let clinicId: string;
 
     if (orphanedClinic) {
@@ -114,6 +122,7 @@ export const POST = withAuth(async (request, { supabase, user }) => {
           clinic_type_key: body.clinic_type_key,
           tier: "pro",
           status: "active",
+          subdomain: subdomain || null,
           config: {
             city: body.city ?? null,
             phone: body.phone,
@@ -176,6 +185,7 @@ export const POST = withAuth(async (request, { supabase, user }) => {
       status: "created",
       message: "Clinic registered successfully",
       clinic_id: clinicId,
+      subdomain: subdomain || null,
     });
   } catch (err) {
     logger.warn("Operation failed", { context: "onboarding/route", error: err });


### PR DESCRIPTION
## What

The self-service `/api/onboarding` endpoint also creates clinics without setting subdomain. This is the companion fix to PR #242 which fixed the super-admin onboarding.

## Changes

- Auto-generates subdomain from clinic name (lowercase, alphanumeric + hyphens)
- Saves subdomain to clinics table on creation
- Returns subdomain in the API response

Without this fix, clinics created via the self-service onboarding flow would be inaccessible because the middleware requires a subdomain to resolve the clinic.

---

[Devin session](https://app.devin.ai/sessions/2ea14f31b990400287ebabcf712a012d)