### PR TITLE
fix: ensure new clinics are fully accessible at their subdomain automatically

### DIFF
--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, ArrowRight, Check, Building2 } from "lucide-react";
+import { ArrowLeft, ArrowRight, Check, Building2, CheckCircle2, ExternalLink } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -46,6 +46,8 @@ export default function OnboardingPage() {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [completed, setCompleted] = useState(false);
+  const [createdSubdomain, setCreatedSubdomain] = useState<string | null>(null);
 
   const currentCategory = selectedCategory
     ? CLINIC_CATEGORIES.find((c) => c.key === selectedCategory)
@@ -105,7 +107,9 @@ export default function OnboardingPage() {
         throw new Error(data?.error ?? "Registration failed");
       }
 
-      router.push("/login");
+      const result = await res.json().catch(() => null);
+      setCreatedSubdomain(result?.subdomain ?? null);
+      setCompleted(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
@@ -120,6 +124,46 @@ export default function OnboardingPage() {
     { key: "details", label: "Détails" },
   ];
   const stepIndex = steps.findIndex((s) => s.key === step);
+
+  if (completed) {
+    const clinicUrl = createdSubdomain ? `https://${createdSubdomain}.oltigo.com` : null;
+    return (
+      <div className="w-full max-w-md mx-auto">
+        <Card>
+          <CardContent className="p-8 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 mx-auto mb-4">
+              <CheckCircle2 className="h-8 w-8 text-green-600" />
+            </div>
+            <h2 className="text-2xl font-bold mb-2">Établissement créé !</h2>
+            <p className="text-muted-foreground mb-6">
+              <strong>{details.clinicName}</strong> est maintenant en ligne.
+            </p>
+            {clinicUrl && (
+              <div className="bg-muted/50 rounded-lg p-4 text-left text-sm mb-6">
+                <p className="font-semibold mb-2">Votre site est accessible :</p>
+                <a
+                  href={clinicUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline font-mono flex items-center gap-1"
+                >
+                  {createdSubdomain}.oltigo.com
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+                <p className="text-muted-foreground mt-2">
+                  Votre site est automatiquement accessible — aucune action supplémentaire requise.
+                </p>
+              </div>
+            )}
+            <Button className="w-full" size="lg" onClick={() => router.push("/login")}>
+              Se connecter
+              <ArrowRight className="h-4 w-4 ml-1" />
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full max-w-2xl mx-auto">

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -125,7 +125,7 @@ async function getClinicId(): Promise<string | null> {
     const { data } = await supabase
       .from("clinics")
       .select("id")
-      .eq("is_active", true)
+      .eq("status", "active")
       .order("created_at", { ascending: true })
       .limit(1)
       .single();
@@ -168,7 +168,7 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
 
   const { data, error } = await supabase
     .from("clinics")
-    .select("name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, phone, address, owner_email")
+    .select("name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, phone, address, owner_email, config")
     .eq("id", clinicId)
     .single();
 
@@ -192,6 +192,9 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
     };
   }
 
+  // Fallback to config JSONB for phone/address/email when direct columns are null
+  const cfg = (data.config as Record<string, unknown> | null) ?? {};
+
   return {
     logoUrl: data.logo_url ?? null,
     faviconUrl: data.favicon_url ?? null,
@@ -205,9 +208,9 @@ export async function getPublicBranding(): Promise<ClinicBranding> {
     coverPhotoUrl: (data.cover_photo_url as string | null) ?? null,
     templateId: (data.template_id as string | null) ?? "modern",
     sectionVisibility: (data.section_visibility as Record<string, boolean> | null) ?? {},
-    phone: (data.phone as string | null) ?? null,
-    address: (data.address as string | null) ?? null,
-    email: (data.owner_email as string | null) ?? null,
+    phone: (data.phone as string | null) ?? (cfg.phone as string | null) ?? null,
+    address: (data.address as string | null) ?? (cfg.address as string | null) ?? null,
+    email: (data.owner_email as string | null) ?? (cfg.email as string | null) ?? null,
   };
 }
 

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -111,14 +111,22 @@ export interface CreateTimeSlotInput {
 
 export async function createClinic(input: CreateClinicInput): Promise<ClinicRow> {
   const supabase = await rawClient();
+  const cfg = input.config ?? {};
   const { data, error } = await supabase
     .from("clinics")
     .insert({
       name: input.name,
       type: input.type,
       tier: input.tier,
-      config: (input.config ?? {}) as Json,
+      config: cfg as Json,
       subdomain: input.subdomain ?? null,
+      // Also set direct columns so public branding queries work
+      phone: (cfg.phone as string) || null,
+      address: (cfg.address as string) || null,
+      owner_email: (cfg.email as string) || null,
+      owner_name: (cfg.owner_name as string) || null,
+      city: (cfg.city as string) || null,
+      domain: (cfg.domain as string) || null,
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary

Fixes multiple issues preventing new clinics from being fully functional after onboarding:

### Changes

1. **`createClinic` (super-admin-actions.ts)**: Populate direct columns (`phone`, `address`, `owner_email`, `city`, `owner_name`, `domain`) alongside the `config` JSONB so public branding queries return complete data.

2. **`getPublicBranding` (public.ts)**: Fallback to `config` JSONB for phone/address/email when direct columns are null — fixes existing clinics that only stored data in config.

3. **`getClinicId` (public.ts)**: Fix root domain fallback query — was using `.eq("is_active", true)` but the clinics table uses `status = 'active'`.

4. **User-facing onboarding (onboarding/page.tsx)**: Show success page with the live clinic URL (`{subdomain}.oltigo.com`) instead of silently redirecting to `/login`. Users now see their site is immediately accessible.

### Verification

- `ahhhhhe.oltigo.com` confirmed live and rendering correctly (HTTP 200, correct tenant headers)
- Lint and typecheck pass locally

Session: https://app.devin.ai/sessions/3ea7b0f70d7e43ab8ab68209b236d85b