### PR TITLE
feat: auto-create Supabase Auth accounts for staff during onboarding

### DIFF
--- a/src/app/(super-admin)/super-admin/onboarding/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/page.tsx
@@ -20,10 +20,10 @@ import {
   createUser,
   createService,
   createTimeSlotsForDoctor,
-  STAFF_DEFAULT_PASSWORD,
   type CreateUserInput,
   type CreateServiceInput,
 } from "@/lib/super-admin-actions";
+import { STAFF_DEFAULT_PASSWORD } from "@/lib/constants";
 import {
   OnboardingStepClinic,
   type ClinicFormData,

--- a/src/app/(super-admin)/super-admin/onboarding/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/page.tsx
@@ -20,6 +20,7 @@ import {
   createUser,
   createService,
   createTimeSlotsForDoctor,
+  STAFF_DEFAULT_PASSWORD,
   type CreateUserInput,
   type CreateServiceInput,
 } from "@/lib/super-admin-actions";
@@ -86,7 +87,7 @@ export default function OnboardingPage() {
     { role: "clinic_admin", name: "", phone: "", email: "" },
   ]);
   const [createdUsers, setCreatedUsers] = useState<
-    { id: string; name: string; role: string }[]
+    { id: string; name: string; role: string; email?: string }[]
   >([]);
 
   // Step 3: Services
@@ -259,7 +260,7 @@ export default function OnboardingPage() {
     setLoading(true);
     setError(null);
     try {
-      const created: { id: string; name: string; role: string }[] = [];
+      const created: { id: string; name: string; role: string; email?: string }[] = [];
       for (const u of validUsers) {
         const input: CreateUserInput = {
           clinic_id: createdClinicId,
@@ -269,7 +270,7 @@ export default function OnboardingPage() {
           email: u.email || undefined,
         };
         const user = await createUser(input);
-        created.push({ id: user.id, name: user.name, role: user.role });
+        created.push({ id: user.id, name: user.name, role: user.role, email: user.email ?? undefined });
       }
       setCreatedUsers(created);
 
@@ -393,6 +394,37 @@ export default function OnboardingPage() {
               <p>{services.filter((s) => s.name.trim()).length} service(s) added</p>
             </div>
             <Separator className="my-6" />
+            {/* Staff Login Credentials */}
+            {createdUsers.filter((u) => u.email).length > 0 && (
+              <div className="bg-muted/50 rounded-lg p-4 text-left text-sm mb-6">
+                <h3 className="font-semibold mb-3">Staff Login Credentials:</h3>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="text-left py-2 pr-4 font-medium">Role</th>
+                        <th className="text-left py-2 pr-4 font-medium">Name</th>
+                        <th className="text-left py-2 pr-4 font-medium">Email</th>
+                        <th className="text-left py-2 font-medium">Password</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {createdUsers.filter((u) => u.email).map((u) => (
+                        <tr key={u.id} className="border-b last:border-0">
+                          <td className="py-2 pr-4 capitalize">{u.role.replace("_", " ")}</td>
+                          <td className="py-2 pr-4">{u.name}</td>
+                          <td className="py-2 pr-4 font-mono text-xs">{u.email}</td>
+                          <td className="py-2 font-mono text-xs">{STAFF_DEFAULT_PASSWORD}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <p className="text-xs text-amber-600 mt-3">
+                  Please change the passwords after first login.
+                </p>
+              </div>
+            )}
             <div className="bg-muted/50 rounded-lg p-4 text-left text-sm mb-6">
               <h3 className="font-semibold mb-2">Clinic is Live:</h3>
               <div className="space-y-2 text-muted-foreground">
@@ -410,7 +442,20 @@ export default function OnboardingPage() {
                   </p>
                 )}
                 <p>The clinic is automatically accessible — no deployment needed.</p>
-                <p>Staff can log in at the clinic URL above using their credentials.</p>
+                {clinicForm.subdomain && (
+                  <p>
+                    Staff can log in at{" "}
+                    <a
+                      href={`https://${clinicForm.subdomain}.oltigo.com/login`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline font-mono"
+                    >
+                      {clinicForm.subdomain}.oltigo.com/login
+                    </a>
+                    {" "}using the credentials above.
+                  </p>
+                )}
                 <p>Branding, colors, and website content can be customized from <strong>Admin → Branding</strong>.</p>
               </div>
             </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,2 @@
+/** Default password assigned to staff accounts created during onboarding. */
+export const STAFF_DEFAULT_PASSWORD = "Oltigo-Staff-2026!";

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,4 +1,5 @@
 import { createServerClient } from "@supabase/ssr";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/lib/types/database";
 import { setTenantContext, isValidClinicId } from "@/lib/tenant-context";
 import { logger } from "@/lib/logger";
@@ -108,4 +109,23 @@ export async function createTenantClient(clinicId: string) {
   }
 
   return client;
+}
+
+/**
+ * Create a Supabase admin client using the service role key.
+ *
+ * This client bypasses RLS and can perform admin operations such as
+ * creating auth users via `supabase.auth.admin.createUser()`.
+ *
+ * Only use this for privileged server-side operations (e.g. super-admin
+ * onboarding staff accounts). Never expose this client to the browser.
+ *
+ * @throws Error if SUPABASE_SERVICE_ROLE_KEY is not configured
+ */
+export function createAdminClient() {
+  return createSupabaseClient<Database>(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
 }

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -13,6 +13,7 @@
 import { createClient, createAdminClient } from "@/lib/supabase-server";
 import { requireRole } from "@/lib/auth";
 import { logger } from "@/lib/logger";
+import { STAFF_DEFAULT_PASSWORD } from "@/lib/constants";
 import type {
   ClinicType,
   ClinicTier,
@@ -89,8 +90,6 @@ export interface CreateUserInput {
   email?: string;
 }
 
-/** Default password assigned to staff accounts created during onboarding. */
-export const STAFF_DEFAULT_PASSWORD = "Oltigo-Staff-2026!";
 
 export interface CreateServiceInput {
   clinic_id: string;

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -10,8 +10,9 @@
  * All operations require the authenticated user to have role = "super_admin".
  */
 
-import { createClient } from "@/lib/supabase-server";
+import { createClient, createAdminClient } from "@/lib/supabase-server";
 import { requireRole } from "@/lib/auth";
+import { logger } from "@/lib/logger";
 import type {
   ClinicType,
   ClinicTier,
@@ -88,6 +89,9 @@ export interface CreateUserInput {
   email?: string;
 }
 
+/** Default password assigned to staff accounts created during onboarding. */
+export const STAFF_DEFAULT_PASSWORD = "Oltigo-Staff-2026!";
+
 export interface CreateServiceInput {
   clinic_id: string;
   name: string;
@@ -162,8 +166,64 @@ export async function updateClinicStatus(
 
 // ---------- User CRUD ----------
 
+/**
+ * Create a staff user with a real Supabase Auth login account.
+ *
+ * When a valid email is provided and SUPABASE_SERVICE_ROLE_KEY is configured,
+ * this function:
+ *   1. Creates a Supabase Auth user (email + default password, auto-confirmed)
+ *   2. Inserts a row in public.users linked via auth_id
+ *
+ * If the service role key is missing or auth creation fails, the user is still
+ * inserted into public.users (without auth_id) so onboarding doesn't break.
+ * A warning is logged in that case.
+ */
 export async function createUser(input: CreateUserInput): Promise<UserRow> {
   const supabase = await rawClient();
+  let authId: string | null = null;
+
+  // Attempt to create a Supabase Auth account if email is provided
+  if (input.email && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    try {
+      const admin = createAdminClient();
+      const { data: authUser, error: authError } = await admin.auth.admin.createUser({
+        email: input.email,
+        password: STAFF_DEFAULT_PASSWORD,
+        email_confirm: true,
+        user_metadata: {
+          name: input.name,
+          role: input.role,
+          clinic_id: input.clinic_id,
+        },
+      });
+
+      if (authError) {
+        // If user already exists, try to look up their auth_id
+        if (authError.message?.includes("already been registered")) {
+          const { data: listData } = await admin.auth.admin.listUsers();
+          const existing = listData?.users?.find((u) => u.email === input.email);
+          if (existing) {
+            authId = existing.id;
+          }
+        } else {
+          logger.warn("Failed to create auth account for staff — user will be created without login", {
+            context: "super-admin-actions",
+            email: input.email,
+            error: authError.message,
+          });
+        }
+      } else if (authUser?.user) {
+        authId = authUser.user.id;
+      }
+    } catch (err) {
+      logger.warn("Auth account creation threw — user will be created without login", {
+        context: "super-admin-actions",
+        email: input.email,
+        error: err,
+      });
+    }
+  }
+
   const { data, error } = await supabase
     .from("users")
     .insert({
@@ -172,6 +232,7 @@ export async function createUser(input: CreateUserInput): Promise<UserRow> {
       name: input.name,
       phone: input.phone ?? null,
       email: input.email ?? null,
+      ...(authId ? { auth_id: authId } : {}),
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary

When staff are added during clinic onboarding, real Supabase Auth login accounts are now created automatically. Staff can immediately log in at `{subdomain}.oltigo.com/login` after onboarding.

## Changes

- **`src/lib/supabase-server.ts`**: Added `createAdminClient()` — a Supabase client using the service role key for admin operations like creating auth users
- **`src/lib/super-admin-actions.ts`**: Modified `createUser()` to call `auth.admin.createUser()` with a default password (`Oltigo-Staff-2026!`) and auto-confirm email. Falls back gracefully if service role key is not configured.
- **`src/lib/constants.ts`**: New file — exports `STAFF_DEFAULT_PASSWORD` constant (separated from server actions file for Next.js compatibility)
- **`src/app/(super-admin)/super-admin/onboarding/page.tsx`**: Updated completion screen to show a credentials table (role, name, email, password) and a direct link to the clinic login page

## How it works

1. During onboarding Step 2 (Add Staff), when a staff member has an email:
   - A Supabase Auth account is created via `auth.admin.createUser()`
   - The `auth_id` is linked to the `public.users` row
   - Email is auto-confirmed (no verification email needed)
   - Default password: `Oltigo-Staff-2026!`
2. Completion screen shows all staff credentials in a table
3. If `SUPABASE_SERVICE_ROLE_KEY` is not set, staff are still created in the DB but without login accounts (graceful fallback)

## Testing

1. Go to Super Admin → Onboarding
2. Create a clinic with staff members (use real emails)
3. Complete onboarding — credentials table should appear
4. Try logging in at `{subdomain}.oltigo.com/login` with the shown credentials