### PR TITLE
feat: Phase 1 remaining tasks — CI unit tests, French error page, landing page a11y

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,22 @@ jobs:
 
       - name: Type check
         run: npx tsc --noEmit
+
+  test:
+    runs-on: ubuntu-latest
+    name: Unit Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -40,10 +40,10 @@ export default function GlobalError({
             </svg>
           </div>
           <h1 className="text-xl font-semibold mb-2">
-            Something went wrong
+            Une erreur est survenue
           </h1>
           <p className="text-sm text-gray-500 mb-6">
-            A critical error occurred. Please try refreshing the page.
+            Une erreur critique s&apos;est produite. Veuillez rafraîchir la page.
           </p>
           {error.digest && (
             <p className="text-xs text-gray-400 mb-4">
@@ -68,7 +68,7 @@ export default function GlobalError({
                 d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
               />
             </svg>
-            Try Again
+            Réessayer
           </button>
         </div>
       </body>

--- a/src/components/landing/landing-footer.tsx
+++ b/src/components/landing/landing-footer.tsx
@@ -26,7 +26,7 @@ export function LandingFooter() {
             Oltigo
           </Link>
 
-          <nav className="flex flex-wrap items-center justify-center gap-6">
+          <nav role="navigation" aria-label="Liens du pied de page" className="flex flex-wrap items-center justify-center gap-6">
             {links.map(({ key, href }) => (
               <Link
                 key={href}

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -20,8 +20,14 @@ export function LandingPage() {
   return (
     <LandingLocaleProvider>
       <div className="flex min-h-screen flex-col bg-white">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:bg-blue-600 focus:px-4 focus:py-2 focus:text-white focus:text-sm focus:font-medium"
+        >
+          Aller au contenu principal
+        </a>
         <LandingHeader />
-        <main className="flex-1">
+        <main id="main-content" className="flex-1">
           <HeroSection />
           <TrustSection />
           <FeaturesSection />

--- a/src/components/public/contact-form.tsx
+++ b/src/components/public/contact-form.tsx
@@ -46,7 +46,7 @@ export function ContactForm() {
 
   if (submitted) {
     return (
-      <Card>
+      <Card role="status" aria-live="polite">
         <CardContent className="py-12 text-center">
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
             <Check className="h-8 w-8 text-green-600" />


### PR DESCRIPTION
## Changes

Completes remaining Phase 1 tasks from the Oltigo Platform task breakdown.

### Task 1.3: Add Unit Tests to CI Pipeline
- Added a new `test` job to `.github/workflows/ci.yml` that runs `npm run test` (Vitest)
- 20 test files with 249 tests are now executed on every PR
- Runs in parallel with the existing lint+typecheck job

### Task 1.4: Translate Error Page to French
- Translated `global-error.tsx` from English to French ("Something went wrong" → "Une erreur est survenue", "Try Again" → "Réessayer")
- `error.tsx` was already translated in a previous PR

### Task 1.5: Landing Page Accessibility (ARIA)
- Added skip-to-content link (`Aller au contenu principal`) to the SaaS landing page
- Added `id="main-content"` landmark to landing page `<main>` element
- Added `role="navigation"` and `aria-label` to landing footer nav
- Added `aria-live="polite"` to contact form success confirmation
- Previous PR already handled: `aria-expanded` on mobile menu, `aria-label` on header nav, skip-to-content in public (tenant) layout

### Already Complete (verified, no changes needed)
- **Task 1.1 (Sentry):** Client, server, and edge configs exist; `next.config.ts` wraps with `withSentryConfig`
- **Task 1.2 (i18n):** All landing page components use `useLandingLocale()` + `t()` calls with translations from `i18n.ts`

---

Session: https://app.devin.ai/sessions/9d30616bb24d4b86b61153d544f18d06