### PR TITLE
feat: Phase 2 SEO — structured data, Twitter Cards, hreflang tags

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -23,6 +23,7 @@ import {
   BlogSection,
   LocationSection,
 } from "@/components/public/sections";
+import { safeJsonLdStringify } from "@/lib/json-ld";
 
 export async function generateMetadata(): Promise<Metadata> {
   const tenant = await getTenant();
@@ -59,14 +60,26 @@ export async function generateMetadata(): Promise<Metadata> {
     description,
     alternates: {
       canonical: canonicalUrl,
+      languages: {
+        "fr": canonicalUrl,
+        "ar": `${canonicalUrl}?lang=ar`,
+        "en": `${canonicalUrl}?lang=en`,
+        "x-default": canonicalUrl,
+      },
     },
     openGraph: {
       title,
       description,
       type: "website",
       locale: "fr_MA",
+      alternateLocale: ["ar_MA", "en_US"],
       siteName: clinicName,
       url: canonicalUrl,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
     },
   };
 }
@@ -95,8 +108,51 @@ export default async function HomePage() {
 
   const topReviews = reviews.filter((r) => r.rating >= 4).slice(0, 3);
 
+  // Build LocalBusiness + MedicalOrganization structured data
+  const rootDomain = process.env.ROOT_DOMAIN ?? "oltigo.com";
+  const canonicalUrl = `https://${tenant.subdomain}.${rootDomain}`;
+  const clinicSchema = {
+    "@context": "https://schema.org",
+    "@type": ["LocalBusiness", "MedicalOrganization"],
+    "@id": `${canonicalUrl}/#organization`,
+    name: branding.clinicName || tenant.clinicName,
+    url: canonicalUrl,
+    ...(branding.phone ? { telephone: branding.phone } : {}),
+    ...(branding.email ? { email: branding.email } : {}),
+    ...(branding.address
+      ? {
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: branding.address,
+            addressCountry: "MA",
+          },
+        }
+      : {}),
+    ...(branding.logoUrl ? { logo: branding.logoUrl } : {}),
+    ...(avgRating > 0 && reviews.length > 0
+      ? {
+          aggregateRating: {
+            "@type": "AggregateRating",
+            ratingValue: avgRating,
+            reviewCount: reviews.length,
+            bestRating: 5,
+            worstRating: 1,
+          },
+        }
+      : {}),
+    potentialAction: {
+      "@type": "ReserveAction",
+      target: `${canonicalUrl}/book`,
+      name: "Prendre rendez-vous en ligne",
+    },
+  };
+
   return (
     <div className={template.wrapperClass} dir={template.rtl ? "rtl" : "ltr"}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(clinicSchema) }}
+      />
       {/* Hero — always visible */}
       {sections.hero && <HeroSection />}
 


### PR DESCRIPTION
## Changes

Completes Tasks 1.6 + 2.1–2.5 from the Oltigo Platform task breakdown. Audited all 6 tasks — most were already implemented. This PR adds the remaining gaps.

### Task 2.2: Structured Data + Twitter Cards (remaining work)
- Added `LocalBusiness` + `MedicalOrganization` JSON-LD structured data to the clinic homepage
  - Includes clinic name, phone, email, postal address, logo, aggregate rating, and booking action
- Added Twitter Card meta tags (`summary_large_image`) to clinic homepage metadata
- Added `alternateLocale` (`ar_MA`, `en_US`) to OpenGraph metadata

### Task 2.3: Hreflang Tags (remaining work)
- Added `hreflang` tags (`fr`, `ar`, `en`, `x-default`) to clinic homepage metadata via `alternates.languages`

### Already Complete (verified, no changes needed)
- **Task 1.6 (Chatbot scoping):** Chatbot only in `(public)/layout.tsx`, component returns `null` without tenant context
- **Task 2.1 (Dynamic sitemap):** `sitemap.ts` already queries DB for active clinics with real `updated_at` timestamps
- **Task 2.4 (Per-clinic analytics):** `AnalyticsScript` already supports GA4 + GTM, reads from branding config JSONB
- **Task 2.5 (Platform analytics):** `PlausibleScript` already in root layout, activated by `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` env var

---

Session: https://app.devin.ai/sessions/9d30616bb24d4b86b61153d544f18d06