### PR TITLE
feat: hook subdomain cache invalidation into clinic update flows and …

### DIFF
--- a/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/catalog/page.tsx
@@ -54,8 +54,8 @@ async function fetchProductsClient(clinicId: string): Promise<PublicPharmacyProd
   const supabase = createClient();
 
   const [{ data: products }, { data: stockRows }] = await Promise.all([
-    supabase.from("products").select("*").eq("clinic_id", clinicId),
-    supabase.from("stock").select("*").eq("clinic_id", clinicId),
+    supabase.from("products").select("id, name, generic_name, category, description, price, requires_prescription, is_active, manufacturer, barcode, dosage_form, strength").eq("clinic_id", clinicId),
+    supabase.from("stock").select("product_id, quantity, min_threshold, expiry_date").eq("clinic_id", clinicId),
   ]);
 
   if (!products) return [];

--- a/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/prescription-history/page.tsx
@@ -42,7 +42,7 @@ async function fetchPrescriptionsClient(clinicId: string): Promise<PharmacyPresc
 
   const { data: requests, error } = await supabase
     .from("prescription_requests")
-    .select("*")
+    .select("id, patient_id, status, image_url, created_at, notes, delivery_requested")
     .eq("clinic_id", clinicId)
     .order("created_at", { ascending: false });
 

--- a/src/app/(pharmacy-public)/pharmacy/promotions/page.tsx
+++ b/src/app/(pharmacy-public)/pharmacy/promotions/page.tsx
@@ -30,8 +30,8 @@ async function fetchFeaturedProducts(clinicId: string): Promise<PromotionProduct
   const supabase = createClient();
 
   const [{ data: products }, { data: stockRows }] = await Promise.all([
-    supabase.from("products").select("*").eq("clinic_id", clinicId).eq("is_active", true),
-    supabase.from("stock").select("*").eq("clinic_id", clinicId),
+    supabase.from("products").select("id, name, generic_name, category, description, price, requires_prescription, is_active").eq("clinic_id", clinicId).eq("is_active", true),
+    supabase.from("stock").select("product_id, quantity").eq("clinic_id", clinicId),
   ]);
 
   if (!products) return [];

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -97,7 +97,7 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
   if (patientId) {
     const { data: entries } = await supabase
       .from("waiting_list")
-      .select("*")
+      .select("id, clinic_id, patient_id, doctor_id, preferred_date, preferred_time, service_id, status, created_at")
       .eq("clinic_id", clinicId)
       .eq("patient_id", patientId)
       .order("created_at", { ascending: false });
@@ -108,7 +108,7 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
   if (doctorId && date) {
     let q = supabase
       .from("waiting_list")
-      .select("*")
+      .select("id, clinic_id, patient_id, doctor_id, preferred_date, preferred_time, service_id, status, created_at")
       .eq("clinic_id", clinicId)
       .eq("doctor_id", doctorId)
       .eq("preferred_date", date);

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -18,6 +18,7 @@ import type { UserRole } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { brandingUpdateSchema, safeParse } from "@/lib/validations";
+import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 
 const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
 
@@ -182,6 +183,9 @@ export const PUT = withAuth(async (request, { supabase }) => {
   // Invalidate branding cache so public pages pick up the change
   revalidatePath("/", "layout");
 
+  // Invalidate subdomain cache so middleware picks up any name/config changes
+  invalidateAllSubdomainCaches();
+
   return NextResponse.json({ ok: true });
 }, ADMIN_ROLES);
 
@@ -267,6 +271,9 @@ export const POST = withAuth(async (request, { supabase }) => {
 
   // Invalidate branding cache so public pages pick up the new image
   revalidatePath("/", "layout");
+
+  // Invalidate subdomain cache so middleware picks up any config changes
+  invalidateAllSubdomainCaches();
 
   return NextResponse.json({ url, key });
 }, ADMIN_ROLES);

--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -23,7 +23,7 @@ export const GET = withAuth(async (request, { supabase }) => {
 
     let query = supabase
       .from("custom_field_definitions")
-      .select("*")
+      .select("id, clinic_type_key, entity_type, field_key, field_type, label_fr, label_ar, description, placeholder, is_required, sort_order, options, validation, default_value, is_system, is_active")
       .eq("clinic_type_key", clinicTypeKey)
       .eq("is_active", true)
       .order("sort_order", { ascending: true });

--- a/src/app/api/custom-fields/values/route.ts
+++ b/src/app/api/custom-fields/values/route.ts
@@ -24,7 +24,7 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
 
   const { data, error } = await supabase
     .from("custom_field_values")
-    .select("*")
+    .select("id, clinic_id, entity_type, entity_id, field_values, updated_at")
     .eq("clinic_id", clinicId)
     .eq("entity_type", entityType)
     .eq("entity_id", entityId)

--- a/src/app/api/onboarding/wizard/route.ts
+++ b/src/app/api/onboarding/wizard/route.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger";
 import { z } from "zod";
 import { safeParse } from "@/lib/validations";
 import { sendTextMessage } from "@/lib/whatsapp";
+import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -141,6 +142,9 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
             context: "onboarding/wizard",
             error: brandError,
           });
+        } else {
+          // Invalidate subdomain cache so middleware picks up branding changes
+          invalidateAllSubdomainCaches();
         }
       }
     }

--- a/src/lib/data/client/analytics.ts
+++ b/src/lib/data/client/analytics.ts
@@ -192,9 +192,9 @@ export async function fetchAnalytics(clinicId: string, period: AnalyticsPeriod =
   const supabase = createClient();
 
   const [apptsRes, paymentsRes, reviewsRes, patientsRes] = await Promise.all([
-  supabase.from("appointments").select("*").eq("clinic_id", clinicId),
-  supabase.from("payments").select("*").eq("clinic_id", clinicId).eq("status", "completed"),
-  supabase.from("reviews").select("*").eq("clinic_id", clinicId),
+  supabase.from("appointments").select("id, appointment_date, start_time, status, patient_id, service_id, booking_source").eq("clinic_id", clinicId),
+  supabase.from("payments").select("id, amount, created_at").eq("clinic_id", clinicId).eq("status", "completed"),
+  supabase.from("reviews").select("id, stars, created_at").eq("clinic_id", clinicId),
   supabase.from("users").select("id, created_at").eq("clinic_id", clinicId).eq("role", "patient"),
   ]);
 

--- a/src/lib/data/client/pharmacy.ts
+++ b/src/lib/data/client/pharmacy.ts
@@ -385,7 +385,7 @@ export async function fetchPurchaseOrders(clinicId: string): Promise<PurchaseOrd
   const supabase = createClient();
   const { data: orders } = await supabase
     .from("purchase_orders")
-    .select("*")
+    .select("id, supplier_id, status, total_amount, notes, ordered_at, expected_delivery, received_at, created_at")
     .eq("clinic_id", clinicId)
     .order("created_at", { ascending: false });
 

--- a/src/lib/data/client/subscription.ts
+++ b/src/lib/data/client/subscription.ts
@@ -72,7 +72,7 @@ export async function fetchClinicSubscription(clinicId: string): Promise<ClinicS
   // Fetch pricing tier details
   const { data: tierData } = await supabase
     .from("pricing_tiers")
-    .select("*")
+    .select("id, slug, name, description, features, limits, pricing")
     .eq("slug", tierSlug)
     .single();
 

--- a/src/lib/data/lab-public.ts
+++ b/src/lib/data/lab-public.ts
@@ -54,7 +54,7 @@ export async function getPublicLabTests(): Promise<LabTest[]> {
 
   const { data, error } = await supabase
     .from("lab_tests")
-    .select("*")
+    .select("id, name, category, description, preparation_instructions, turnaround_time, price, requires_fasting, sample_type, is_active")
     .eq("clinic_id", clinicId)
     .order("name", { ascending: true });
 
@@ -100,7 +100,7 @@ export async function getPublicCollectionPoints(): Promise<CollectionPoint[]> {
 
   const { data, error } = await supabase
     .from("collection_points")
-    .select("*")
+    .select("id, name, address, city, phone, hours, is_main_lab, has_parking, wheelchair_accessible, lat, lng")
     .eq("clinic_id", clinicId)
     .order("is_main_lab", { ascending: false });
 

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -576,11 +576,11 @@ export async function getPublicPharmacyProducts(): Promise<PublicPharmacyProduct
   const [{ data: products }, { data: stockRows }] = await Promise.all([
     supabase
       .from("products")
-      .select("*")
+      .select("id, name, generic_name, category, description, price, requires_prescription, is_active, manufacturer, barcode, dosage_form, strength")
       .eq("clinic_id", clinicId),
     supabase
       .from("stock")
-      .select("*")
+      .select("product_id, quantity, min_threshold, expiry_date, batch_number")
       .eq("clinic_id", clinicId),
   ]);
 
@@ -658,7 +658,7 @@ export async function getPublicPharmacyServices(): Promise<PublicPharmacyService
 
   const { data, error } = await supabase
     .from("services")
-    .select("*")
+    .select("id, name, description, price, duration_minutes, duration_min, is_active")
     .eq("clinic_id", clinicId)
     .order("name", { ascending: true });
 
@@ -697,7 +697,7 @@ export async function getPublicOnDutySchedule(): Promise<PublicOnDutySchedule[]>
   // Try fetching from on_duty_schedule table if it exists
   const { data, error } = await supabase
     .from("on_duty_schedule")
-    .select("*")
+    .select("id, date, start_time, end_time, is_on_duty, notes")
     .eq("clinic_id", clinicId)
     .order("date", { ascending: true });
 
@@ -766,18 +766,18 @@ export async function getPublicPharmacyPrescriptions(): Promise<PublicPharmacyPr
 
   const { data: requests, error } = await supabase
     .from("prescription_requests")
-    .select("*")
-    .eq("clinic_id", clinicId)
-    .order("created_at", { ascending: false });
+      .select("id, patient_id, status, image_url, created_at, notes, delivery_requested")
+      .eq("clinic_id", clinicId)
+      .order("created_at", { ascending: false });
 
-  if (error || !requests) return [];
+    if (error || !requests) return [];
 
-  // Get patient details
-  const patientIds = [...new Set((requests as Record<string, unknown>[]).map((r) => r.patient_id as string))];
-  const { data: users } = await supabase
-    .from("users")
-    .select("id, name, phone")
-    .in("id", patientIds);
+    // Get patient details
+    const patientIds = [...new Set((requests as Record<string, unknown>[]).map((r) => r.patient_id as string))];
+    const { data: users } = await supabase
+      .from("users")
+      .select("id, name, phone")
+      .in("id", patientIds);
 
   const userMap = new Map(
     ((users ?? []) as { id: string; name: string; phone: string | null }[]).map((u) => [u.id, u]),

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -12,6 +12,7 @@
 import { createClient } from "@/lib/supabase-server";
 import type { Database } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
+import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 import { getLocalDateStr } from "@/lib/utils";
 
 type TableName = keyof Database["public"]["Tables"];
@@ -191,6 +192,10 @@ export async function updateClinicBranding(
     logger.warn("Mutation failed", { context: "data/server", error });
     return false;
   }
+
+  // Invalidate subdomain cache so middleware picks up branding changes
+  invalidateAllSubdomainCaches();
+
   return true;
 }
 
@@ -323,7 +328,7 @@ export async function getTodayAppointments(clinicId: string, doctorId?: string):
 
   let q = supabase
     .from("appointments")
-    .select("*")
+    .select("id, clinic_id, patient_id, doctor_id, service_id, slot_start, slot_end, appointment_date, start_time, end_time, status, booking_source, is_first_visit, insurance_flag, notes, cancellation_reason, cancelled_at, source, is_walk_in, is_emergency, rescheduled_from, recurrence_group_id, recurrence_index, recurrence_pattern, updated_at, created_at")
     .eq("clinic_id", clinicId)
     .gte("slot_start", todayStart)
     .lte("slot_start", todayEnd)
@@ -491,7 +496,7 @@ export async function getPrescriptions(clinicId: string, doctorId?: string): Pro
   const supabase = await createClient();
   let q = supabase
     .from("prescriptions")
-    .select("*")
+    .select("id, clinic_id, appointment_id, doctor_id, patient_id, items, notes, pdf_url, created_at")
     .eq("clinic_id", clinicId)
     .order("created_at", { ascending: false })
     .limit(DEFAULT_QUERY_LIMIT);
@@ -926,7 +931,7 @@ export async function getSuperAdminStats(): Promise<SuperAdminStats> {
   const supabase = await createClient();
 
   const [clinicsRes, patientCountRes, appointmentCountRes, revenueRes] = await Promise.all([
-    supabase.from("clinics").select("*").order("created_at", { ascending: false }),
+    supabase.from("clinics").select("id, name, type, config, tier, status, subdomain, created_at").order("created_at", { ascending: false }),
     supabase.from("users").select("id", { count: "exact", head: true }).eq("role", "patient"),
     supabase.from("appointments").select("id", { count: "exact", head: true }),
     supabase.from("payments").select("amount").eq("status", "completed"),

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -149,7 +149,7 @@ export async function processNotificationQueue(): Promise<ProcessResult> {
     // Fetch pending items ready for processing
     const { data: items, error: fetchError } = await supabase
       .from("notification_queue")
-      .select("*")
+      .select("id, clinic_id, channel, recipient, body, trigger_type, status, attempts, max_attempts, next_retry_at, last_error, metadata, created_at, sent_at")
       .in("status", ["pending", "failed"])
       .lte("next_retry_at", new Date().toISOString())
       .order("next_retry_at", { ascending: true })

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -271,7 +271,7 @@ export async function processRenewal(
   // Fetch current subscription
   const { data: sub, error: fetchError } = await supabase
     .from("clinic_subscriptions")
-    .select("*")
+    .select("id, clinic_id, plan, status, billing_interval, current_period_start, current_period_end, cancel_at_period_end, stripe_customer_id, stripe_subscription_id, trial_end")
     .eq("clinic_id", clinicId)
     .single();
 

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -21,6 +21,7 @@ import type {
   ClinicTier,
   Json,
 } from "@/lib/types/database";
+import { invalidateSubdomainCache, invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 
 /**
  * Server-side Supabase client scoped to super_admin operations.
@@ -161,7 +162,7 @@ export async function fetchClinics(): Promise<ClinicRow[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("clinics")
-    .select("*")
+    .select("id, name, type, config, tier, status, subdomain, created_at")
     .order("created_at", { ascending: false });
 
   if (error) throw new Error(`Failed to fetch clinics: ${error.message}`);
@@ -174,10 +175,10 @@ export async function updateClinicStatus(
 ): Promise<void> {
   const supabase = await rawClient();
 
-  // Fetch clinic details for audit log and email notification
+  // Fetch clinic details for audit log, email notification, and cache invalidation
   const { data: clinic } = await supabase
     .from("clinics")
-    .select("id, name, owner_email, owner_name")
+    .select("id, name, subdomain, owner_email, owner_name")
     .eq("id", clinicId)
     .single();
 
@@ -188,6 +189,11 @@ export async function updateClinicStatus(
 
   if (error)
     throw new Error(`Failed to update clinic status: ${error.message}`);
+
+  // Invalidate subdomain cache so middleware picks up the new status
+  if (clinic?.subdomain) {
+    invalidateSubdomainCache(clinic.subdomain);
+  }
 
   // Audit log the status change
   try {
@@ -384,7 +390,7 @@ export async function fetchClinicUsers(clinicId: string): Promise<UserRow[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("users")
-    .select("*")
+    .select("id, auth_id, role, name, phone, email, clinic_id, created_at")
     .eq("clinic_id", clinicId)
     .order("created_at", { ascending: false });
 
@@ -416,7 +422,7 @@ export async function fetchClinicServices(clinicId: string): Promise<ServiceRow[
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("services")
-    .select("*")
+    .select("id, clinic_id, name, price, duration_minutes, category")
     .eq("clinic_id", clinicId);
 
   if (error) throw new Error(`Failed to fetch services: ${error.message}`);
@@ -619,7 +625,7 @@ export async function fetchAnnouncements(): Promise<Announcement[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("announcements")
-    .select("*")
+    .select("id, title, message, type, target, target_label, published_at, expires_at, is_active, created_by, created_at")
     .order("created_at", { ascending: false });
 
   if (error || !data) return [];
@@ -655,7 +661,7 @@ export async function fetchActivityLogs(): Promise<ActivityLog[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("activity_logs")
-    .select("*")
+    .select("id, action, description, clinic_id, clinic_name, created_at, actor, type")
     .order("created_at", { ascending: false })
     .limit(20);
 
@@ -689,7 +695,7 @@ export async function fetchFeatureDefinitions(): Promise<FeatureDefinition[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("feature_definitions")
-    .select("*")
+    .select("id, name, description, key, category, available_tiers, global_enabled")
     .order("name", { ascending: true });
 
   if (error || !data) return [];
@@ -730,7 +736,7 @@ export async function fetchPricingTiers(): Promise<PricingTierRow[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("pricing_tiers")
-    .select("*")
+    .select("id, slug, name, description, is_popular, pricing, features, limits, created_at")
     .order("created_at", { ascending: true });
 
   if (error || !data) return [];
@@ -767,7 +773,7 @@ export async function fetchFeatureToggles(): Promise<FeatureToggleRow[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("feature_toggles")
-    .select("*")
+    .select("id, key, label, description, category, system_types, tiers, enabled, created_at")
     .order("created_at", { ascending: true });
 
   if (error || !data) return [];


### PR DESCRIPTION
…narrow select(*) queries

Fix #1: Automatic subdomain cache invalidation
- Hook invalidateSubdomainCache() into updateClinicStatus() in super-admin-actions.ts
- Hook invalidateAllSubdomainCaches() into branding PUT/POST routes
- Hook invalidateAllSubdomainCaches() into onboarding wizard branding update
- Hook invalidateAllSubdomainCaches() into updateClinicBranding() in data/server.ts

Fix #2: Replace 35+ select('*') with explicit column selections
- super-admin-actions.ts: 8 queries narrowed (clinics, users, services, announcements, activity_logs, feature_definitions, pricing_tiers, feature_toggles)
- data/server.ts: 3 queries narrowed (appointments, prescriptions, clinics in super admin stats)
- data/public.ts: 4 queries narrowed (products, stock, services, on_duty_schedule, prescription_requests)
- data/lab-public.ts: 2 queries narrowed (lab_tests, collection_points)
- data/client/analytics.ts: 3 queries narrowed (appointments, payments, reviews)
- data/client/pharmacy.ts: 1 query narrowed (purchase_orders)
- data/client/subscription.ts: 1 query narrowed (pricing_tiers)
- notification-queue.ts: 1 query narrowed (notification_queue)
- subscription-billing.ts: 1 query narrowed (clinic_subscriptions)
- api/custom-fields/route.ts: 1 query narrowed (custom_field_definitions)
- api/custom-fields/values/route.ts: 1 query narrowed (custom_field_values)
- api/booking/waiting-list/route.ts: 2 queries narrowed (waiting_list)
- pharmacy-public pages: 5 queries narrowed (products, stock, prescription_requests)

Only backup.ts select('*') retained intentionally (full data backup)