### PR TITLE
feat: migrate all API routes to use withValidation/withAuthValidation…

### DIFF
--- a/src/app/api/booking/cancel/route.ts
+++ b/src/app/api/booking/cancel/route.ts
@@ -5,7 +5,8 @@ import { APPOINTMENT_STATUS, WAITING_LIST_STATUS } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
 import { clinicDateTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
-import { bookingCancelSchema, safeParse } from "@/lib/validations";
+import { bookingCancelSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { dispatchNotification } from "@/lib/notifications";
 import type { TemplateVariables } from "@/lib/notifications";
 import { STAFF_ROLES } from "@/lib/auth-roles";
@@ -17,14 +18,7 @@ const CANCEL_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
  *
  * Cancel an appointment if within the cancellation window.
  */
-export const POST = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(bookingCancelSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(bookingCancelSchema, async (body, request, { supabase, profile }) => {
 
     const { tenant, config: tenantConfig } = await requireTenantWithConfig();
     const clinicId = tenant.clinicId;
@@ -150,10 +144,6 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     }
 
     return NextResponse.json({ status: APPOINTMENT_STATUS.CANCELLED, message: "Appointment cancelled successfully" });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/cancel", error: err });
-    return NextResponse.json({ error: "Failed to cancel appointment" }, { status: 500 });
-  }
 }, CANCEL_ROLES);
 
 /**

--- a/src/app/api/booking/emergency-slot/route.ts
+++ b/src/app/api/booking/emergency-slot/route.ts
@@ -7,20 +7,14 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { computeEndTime } from "@/lib/timezone";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { emergencySlotSchema, safeParse } from "@/lib/validations";
+import { emergencySlotSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 /**
  * POST /api/booking/emergency-slot
  *
  * Create an emergency slot (doctor only) or book an existing one.
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(emergencySlotSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(emergencySlotSchema, async (body, request, { supabase }) => {
 
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
@@ -176,10 +170,6 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ error: "action must be 'create' or 'book'" }, { status: 400 });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/emergency-slot", error: err });
-    return NextResponse.json({ error: "Failed to process emergency slot request" }, { status: 500 });
-  }
 }, STAFF_ROLES);
 
 /**

--- a/src/app/api/booking/payment/confirm/route.ts
+++ b/src/app/api/booking/payment/confirm/route.ts
@@ -2,23 +2,16 @@ import { NextResponse } from "next/server";
 import { logAuditEvent } from "@/lib/audit-log";
 import { requireTenant } from "@/lib/tenant";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { paymentConfirmSchema, safeParse } from "@/lib/validations";
+import { paymentConfirmSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 /**
  * POST /api/booking/payment/confirm
  *
  * Confirm a pending payment.
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(paymentConfirmSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(paymentConfirmSchema, async (body, request, { supabase }) => {
 
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
@@ -68,8 +61,4 @@ export const POST = withAuth(async (request, { supabase }) => {
     });
 
     return NextResponse.json({ status: "confirmed", message: "Payment confirmed" });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/payment/confirm", error: err });
-    return NextResponse.json({ error: "Failed to confirm payment" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/booking/payment/initiate/route.ts
+++ b/src/app/api/booking/payment/initiate/route.ts
@@ -2,23 +2,16 @@ import { NextResponse } from "next/server";
 import { logAuditEvent } from "@/lib/audit-log";
 import { requireTenant } from "@/lib/tenant";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { paymentInitiateSchema, safeParse } from "@/lib/validations";
+import { paymentInitiateSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 /**
  * POST /api/booking/payment/initiate
  *
  * Initiate a payment for an appointment.
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(paymentInitiateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(paymentInitiateSchema, async (body, request, { supabase }) => {
 
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
@@ -103,8 +96,4 @@ export const POST = withAuth(async (request, { supabase }) => {
       paymentId: payment.id,
       gatewaySessionId,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/payment/initiate", error: err });
-    return NextResponse.json({ error: "Failed to initiate payment" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { logAuditEvent } from "@/lib/audit-log";
 import { requireTenant } from "@/lib/tenant";
 import type { UserRole } from "@/lib/types/database";
-import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { paymentRefundSchema, safeParse } from "@/lib/validations";
+import { paymentRefundSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
 
 /**
@@ -12,14 +12,7 @@ const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
  *
  * Refund a completed payment (full or partial).
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(paymentRefundSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(paymentRefundSchema, async (body, request, { supabase }) => {
 
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
@@ -89,8 +82,4 @@ export const POST = withAuth(async (request, { supabase }) => {
     });
 
     return NextResponse.json({ status: "refunded", message: "Payment refunded" });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/payment/refund", error: err });
-    return NextResponse.json({ error: "Failed to refund payment" }, { status: 500 });
-  }
 }, ADMIN_ROLES);

--- a/src/app/api/booking/recurring/route.ts
+++ b/src/app/api/booking/recurring/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from "next/server";
 import { requireTenantWithConfig } from "@/lib/tenant";
 import { getPublicServices } from "@/lib/data/public";
-import { withAuth } from "@/lib/with-auth";
 import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
 import type { TablesInsert } from "@/lib/types/database";
 import { computeEndTime } from "@/lib/timezone";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { recurringSchema, safeParse } from "@/lib/validations";
+import { recurringSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 function addInterval(date: Date, pattern: "weekly" | "biweekly" | "monthly"): Date {
   const next = new Date(date);
   if (pattern === "weekly") {
@@ -33,14 +33,7 @@ function addInterval(date: Date, pattern: "weekly" | "biweekly" | "monthly"): Da
  *
  * Create a recurring booking series or cancel one.
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(recurringSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(recurringSchema, async (body, request, { supabase }) => {
 
     const { tenant, config: tenantConfig } = await requireTenantWithConfig();
     const clinicId = tenant.clinicId;
@@ -235,8 +228,4 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ error: "action must be 'create' or 'cancel'" }, { status: 400 });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/recurring", error: err });
-    return NextResponse.json({ error: "Failed to process recurring booking" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/booking/reschedule/route.ts
+++ b/src/app/api/booking/reschedule/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-import { withAuth } from "@/lib/with-auth";
 import { requireTenantWithConfig } from "@/lib/tenant";
 import { getPublicAvailableSlots } from "@/lib/data/public";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { logAuditEvent } from "@/lib/audit-log";
 import { computeEndTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
-import { rescheduleSchema, safeParse } from "@/lib/validations";
+import { rescheduleSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { dispatchNotification } from "@/lib/notifications";
 import type { TemplateVariables } from "@/lib/notifications";
 import { STAFF_ROLES } from "@/lib/auth-roles";
@@ -20,14 +20,7 @@ const RESCHEDULE_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
  * Validates working hours, slot availability, and prevents
  * rescheduling to past dates or double-booking conflicts.
  */
-export const POST = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(rescheduleSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(rescheduleSchema, async (body, request, { supabase, profile }) => {
 
     const { tenant, config: tenantConfig } = await requireTenantWithConfig();
     const clinicId = tenant.clinicId;
@@ -220,8 +213,4 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       message: "Appointment rescheduled successfully",
       newAppointmentId: body.appointmentId,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/reschedule", error: err });
-    return NextResponse.json({ error: "Failed to reschedule appointment" }, { status: 500 });
-  }
 }, RESCHEDULE_ROLES);

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -18,7 +18,7 @@ import { logAuditEvent } from "@/lib/audit-log";
 import { computeEndTime } from "@/lib/timezone";
 import { logger } from "@/lib/logger";
 import { bookingLimiter, extractClientIp } from "@/lib/rate-limit";
-import { safeParse } from "@/lib/validations";
+import { withValidation } from "@/lib/api-validate";
 import { dispatchNotification } from "@/lib/notifications";
 import type { TemplateVariables } from "@/lib/notifications";
 import { z } from "zod";
@@ -175,8 +175,7 @@ async function validateBookingRequest(
  * Validates slot availability, enforces max capacity per slot and buffer time,
  * and sends confirmation via WhatsApp.
  */
-export async function POST(request: NextRequest) {
-  try {
+export const POST = withValidation(bookingRequestSchema, async (body, request: NextRequest) => {
     // Defence-in-depth: per-IP rate limit for the booking endpoint.
     // The middleware also applies bookingLimiter, but checking here guards
     // against deployment configs that skip the middleware layer.
@@ -209,13 +208,6 @@ export async function POST(request: NextRequest) {
         { status: 403 },
       );
     }
-
-    const raw = await request.json();
-    const parsed = safeParse(bookingRequestSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
 
     const { tenant, config: tenantConfig } = await requireTenantWithConfig();
     const clinicId = tenant.clinicId;
@@ -417,14 +409,7 @@ export async function POST(request: NextRequest) {
         hasInsurance: body.hasInsurance,
       },
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/route", error: err });
-    return NextResponse.json(
-      { error: "Failed to create booking" },
-      { status: 500 },
-    );
-  }
-}
+});
 
 /**
  * GET /api/booking

--- a/src/app/api/booking/verify/route.ts
+++ b/src/app/api/booking/verify/route.ts
@@ -16,8 +16,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireTenantWithConfig } from "@/lib/tenant";
+import { withValidation } from "@/lib/api-validate";
 import { logger } from "@/lib/logger";
-import { safeParse } from "@/lib/validations";
 import { z } from "zod";
 const bookingVerifySchema = z.object({
   phone: z.string().min(6).max(30),
@@ -26,60 +26,44 @@ const bookingVerifySchema = z.object({
 /** Token validity period: 15 minutes. */
 const TOKEN_TTL_MS = 15 * 60 * 1000;
 
-export async function POST(request: NextRequest) {
-  try {
-    // Ensure we are in a valid tenant context (subdomain resolved)
-    await requireTenantWithConfig();
+export const POST = withValidation(bookingVerifySchema, async (data, request: NextRequest) => {
+  // Ensure we are in a valid tenant context (subdomain resolved)
+  await requireTenantWithConfig();
 
-    const raw = await request.json();
-    const parsed = safeParse(bookingVerifySchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { phone } = parsed.data;
+  const { phone } = data;
 
-    const secret = process.env.BOOKING_TOKEN_SECRET;
-    if (!secret) {
-      logger.error(
-        "BOOKING_TOKEN_SECRET is not configured — cannot issue booking tokens",
-        { context: "booking/verify" },
-      );
-      return NextResponse.json(
-        { error: "Booking verification is not available. Contact the clinic." },
-        { status: 503 },
-      );
-    }
-
-    // Build the token: phone:expiryTimestamp:hmacSignature
-    const expiry = Date.now() + TOKEN_TTL_MS;
-    const encoder = new TextEncoder();
-    const key = await crypto.subtle.importKey(
-      "raw",
-      encoder.encode(secret),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign"],
+  const secret = process.env.BOOKING_TOKEN_SECRET;
+  if (!secret) {
+    logger.error(
+      "BOOKING_TOKEN_SECRET is not configured — cannot issue booking tokens",
+      { context: "booking/verify" },
     );
-    const data = encoder.encode(`${phone}:${expiry}`);
-    const sig = await crypto.subtle.sign("HMAC", key, data);
-    const signature = Array.from(new Uint8Array(sig))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-
-    const token = `${phone}:${expiry}:${signature}`;
-
-    return NextResponse.json({
-      token,
-      expiresAt: new Date(expiry).toISOString(),
-    });
-  } catch (err) {
-    logger.warn("Operation failed", {
-      context: "booking/verify",
-      error: err,
-    });
     return NextResponse.json(
-      { error: "Failed to verify booking" },
-      { status: 500 },
+      { error: "Booking verification is not available. Contact the clinic." },
+      { status: 503 },
     );
   }
-}
+
+  // Build the token: phone:expiryTimestamp:hmacSignature
+  const expiry = Date.now() + TOKEN_TTL_MS;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sigData = encoder.encode(`${phone}:${expiry}`);
+  const sig = await crypto.subtle.sign("HMAC", key, sigData);
+  const signature = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  const token = `${phone}:${expiry}:${signature}`;
+
+  return NextResponse.json({
+    token,
+    expiresAt: new Date(expiry).toISOString(),
+  });
+});

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -5,7 +5,8 @@ import { findOrCreatePatient } from "@/lib/find-or-create-patient";
 import { logAuditEvent } from "@/lib/audit-log";
 import { WAITING_LIST_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
-import { waitingListSchema, safeParse } from "@/lib/validations";
+import { waitingListSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import type { UserRole } from "@/lib/types/database";
 
@@ -15,14 +16,7 @@ const WAITING_LIST_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
  *
  * Add a patient to the waiting list.
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(waitingListSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(waitingListSchema, async (body, request, { supabase }) => {
 
     // Find or create patient (prefer phone-based lookup to avoid name collisions)
     const tenant = await requireTenant();
@@ -69,10 +63,6 @@ export const POST = withAuth(async (request, { supabase }) => {
       message: "Added to waiting list",
       entryId: entry.id,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "booking/waiting-list", error: err });
-    return NextResponse.json({ error: "Failed to add to waiting list" }, { status: 500 });
-  }
 }, WAITING_LIST_ROLES);
 
 /**

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -17,7 +17,8 @@ import {
 import type { UserRole } from "@/lib/types/database";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { brandingUpdateSchema, safeParse } from "@/lib/validations";
+import { brandingUpdateSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 
 const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
@@ -126,15 +127,9 @@ export async function GET() {
 
 // ── PUT — update text branding fields (colors, fonts) ──
 
-export const PUT = withAuth(async (request, { supabase }) => {
+export const PUT = withAuthValidation(brandingUpdateSchema, async (body, request, { supabase }) => {
   const tenant = await requireTenant();
   const clinicId = tenant.clinicId;
-  const raw = await request.json();
-  const parsed = safeParse(brandingUpdateSchema, raw);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error }, { status: 400 });
-  }
-  const body = parsed.data;
 
   const updates: Record<string, unknown> = {};
   const stringKeys = [

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,7 +4,8 @@ import { requireTenant } from "@/lib/tenant";
 import { createClient } from "@/lib/supabase-server";
 import { chatLimiter, extractClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
-import { chatRequestSchema, safeParse } from "@/lib/validations";
+import { chatRequestSchema } from "@/lib/validations";
+import { withValidation } from "@/lib/api-validate";
 /**
  * POST /api/chat
  *
@@ -54,8 +55,7 @@ function sanitizeUserInput(text: string): string {
   );
 }
 
-export async function POST(request: NextRequest) {
-  try {
+export const POST = withValidation(chatRequestSchema, async (body, request: NextRequest) => {
     // Defence-in-depth: per-IP rate limit for the chat endpoint.
     // The middleware also applies chatLimiter, but checking here guards
     // against deployment configs that skip the middleware layer.
@@ -71,12 +71,6 @@ export async function POST(request: NextRequest) {
     // Resolve clinic ID strictly from tenant context (middleware headers)
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
-    const raw = await request.json();
-    const parsed = safeParse(chatRequestSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
 
     const lastMessage = body.messages[body.messages.length - 1];
     if (!lastMessage || lastMessage.role !== "user" || !lastMessage.content.trim()) {
@@ -289,11 +283,4 @@ export async function POST(request: NextRequest) {
         Connection: "keep-alive",
       },
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "chat", error: err });
-    return NextResponse.json(
-      { error: "Failed to process chat message" },
-      { status: 500 },
-    );
-  }
-}
+});

--- a/src/app/api/consent/route.ts
+++ b/src/app/api/consent/route.ts
@@ -11,9 +11,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { extractClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
-import { consentSchema, safeParse } from "@/lib/validations";
+import { consentSchema } from "@/lib/validations";
+import { withValidation } from "@/lib/api-validate";
 
-export async function POST(request: NextRequest) {
+export const POST = withValidation(consentSchema, async (data, request: NextRequest) => {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -24,25 +25,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: 400 },
-    );
-  }
-
-  const parsed = safeParse(consentSchema, body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error },
-      { status: 400 },
-    );
-  }
-
-  const { consentType, granted } = parsed.data;
+  const { consentType, granted } = data;
 
   const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
@@ -87,4 +70,4 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ ok: true, logged: true });
-}
+});

--- a/src/app/api/custom-fields/route.ts
+++ b/src/app/api/custom-fields/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { customFieldCreateSchema, customFieldUpdateSchema, safeParse } from "@/lib/validations";
+import { customFieldCreateSchema, customFieldUpdateSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import type { Json } from "@/lib/types/database";
 /**
  * GET /api/custom-fields?clinic_type_key=...&entity_type=...
@@ -57,13 +58,7 @@ export const GET = withAuth(async (request, { supabase }) => {
  * Create a new custom field definition.
  * Only super admins can create definitions.
  */
-export const POST = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(customFieldCreateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
+export const POST = withAuthValidation(customFieldCreateSchema, async (body, request, { supabase }) => {
     const {
       clinic_type_key,
       entity_type,
@@ -78,7 +73,7 @@ export const POST = withAuth(async (request, { supabase }) => {
       options,
       validation,
       default_value,
-    } = parsed.data;
+    } = body;
 
     const { data, error } = await supabase
       .from("custom_field_definitions")
@@ -110,13 +105,6 @@ export const POST = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ definition: data }, { status: 201 });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "custom-fields", error: err });
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 },
-    );
-  }
 }, ["super_admin"]);
 
 /**
@@ -125,14 +113,8 @@ export const POST = withAuth(async (request, { supabase }) => {
  * Update an existing custom field definition.
  * Body must include `id` and any fields to update.
  */
-export const PATCH = withAuth(async (request, { supabase }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(customFieldUpdateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { id, ...updates } = parsed.data;
+export const PATCH = withAuthValidation(customFieldUpdateSchema, async (body, request, { supabase }) => {
+    const { id, ...updates } = body;
 
     // Prevent modifying system field keys
     const allowedUpdates: Record<string, unknown> = {};
@@ -164,13 +146,6 @@ export const PATCH = withAuth(async (request, { supabase }) => {
     }
 
     return NextResponse.json({ definition: data });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "custom-fields", error: err });
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 },
-    );
-  }
 }, ["super_admin"]);
 
 /**

--- a/src/app/api/custom-fields/values/route.ts
+++ b/src/app/api/custom-fields/values/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { customFieldValuesSchema, safeParse } from "@/lib/validations";
+import { customFieldValuesSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import type { Json } from "@/lib/types/database";
 /**
  * GET /api/custom-fields/values?entity_type=...&entity_id=...
@@ -49,14 +50,8 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
  *
  * Save (upsert) custom field values for a specific entity instance.
  */
-export const POST = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(customFieldValuesSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { entity_type, entity_id, field_values } = parsed.data;
+export const POST = withAuthValidation(customFieldValuesSchema, async (body, request, { supabase, profile }) => {
+    const { entity_type, entity_id, field_values } = body;
     // Always derive clinic_id from the authenticated user's profile
     const clinic_id = profile.clinic_id;
     if (!clinic_id) {
@@ -141,13 +136,6 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     }
 
     return NextResponse.json({ values: data });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "custom-fields/values", error: err });
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 },
-    );
-  }
 }, STAFF_ROLES);
 
 /**
@@ -155,14 +143,8 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
  *
  * Partially update custom field values (merge with existing).
  */
-export const PATCH = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(customFieldValuesSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { entity_type, entity_id, field_values } = parsed.data;
+export const PATCH = withAuthValidation(customFieldValuesSchema, async (body, request, { supabase, profile }) => {
+    const { entity_type, entity_id, field_values } = body;
     // Always derive clinic_id from the authenticated user's profile
     const clinic_id = profile.clinic_id;
     if (!clinic_id) {
@@ -259,11 +241,4 @@ export const PATCH = withAuth(async (request, { supabase, profile }) => {
     }
 
     return NextResponse.json({ values: data });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "custom-fields/values", error: err });
-    return NextResponse.json(
-      { error: "Invalid request body" },
-      { status: 400 },
-    );
-  }
 }, STAFF_ROLES);

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { impersonateSchema, safeParse } from "@/lib/validations";
+import { impersonateSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { createClient } from "@/lib/supabase-server";
 import { logSecurityEvent } from "@/lib/audit-log";
 
@@ -17,14 +18,8 @@ import { logSecurityEvent } from "@/lib/audit-log";
  *
  * Ends the impersonation session by clearing the cookie.
  */
-export const POST = withAuth(async (request, { supabase, user }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(impersonateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { clinicId, clinicName, password, reason } = parsed.data;
+export const POST = withAuthValidation(impersonateSchema, async (body, request, { supabase, user }) => {
+    const { clinicId, clinicName, password, reason } = body;
 
     const reauthClient = await createClient();
     const { error: reauthError } = await reauthClient.auth.signInWithPassword({
@@ -95,10 +90,6 @@ export const POST = withAuth(async (request, { supabase, user }) => {
     });
 
     return response;
-  } catch (err) {
-    logger.warn("Operation failed", { context: "impersonate/route", error: err });
-    return NextResponse.json({ error: "Failed to start impersonation" }, { status: 500 });
-  }
 }, ["super_admin"]);
 
 export const DELETE = withAuth(async (_request, { supabase, user }) => {

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -11,11 +11,11 @@
 import { NextResponse } from "next/server";
 import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
 import { updateLabOrderPdfUrl } from "@/lib/data/server";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { escapeHtml } from "@/lib/escape-html";
-import { labReportSchema, safeParse } from "@/lib/validations";
+import { labReportSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 
 interface LabResultItem {
   testName: string;
@@ -116,14 +116,8 @@ function generateLabReportHtml(data: {
 </html>`;
 }
 
-export const POST = withAuth(async (request, { profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(labReportSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { orderId, patientName, orderNumber, results } = parsed.data;
+export const POST = withAuthValidation(labReportSchema, async (body, request, { profile }) => {
+    const { orderId, patientName, orderNumber, results } = body;
     // Derive clinic_id from the authenticated user's profile — never from the request body
     const clinicId = profile.clinic_id;
     if (!clinicId) {
@@ -166,8 +160,4 @@ export const POST = withAuth(async (request, { profile }) => {
     await updateLabOrderPdfUrl(orderId, url);
 
     return NextResponse.json({ pdfUrl: url });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "lab/report-html", error: err });
-    return NextResponse.json({ error: "Failed to generate lab report" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -9,7 +9,8 @@ import type { NotificationChannel as DBNotificationChannel } from "@/lib/types/d
 import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { notificationDispatchSchema, safeParse } from "@/lib/validations";
+import { notificationDispatchSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 /**
  * POST /api/notifications
  *
@@ -17,14 +18,8 @@ import { notificationDispatchSchema, safeParse } from "@/lib/validations";
  * Body: { trigger, variables, recipientId, channels }
  */
 
-export const POST = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(notificationDispatchSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { trigger, variables, recipientId, channels } = parsed.data as {
+export const POST = withAuthValidation(notificationDispatchSchema, async (body, request, { supabase, profile }) => {
+    const { trigger, variables, recipientId, channels } = body as {
       trigger: NotificationTrigger;
       variables: TemplateVariables;
       recipientId: string;
@@ -56,13 +51,6 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
     );
 
     return NextResponse.json({ results });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "notifications", error: err });
-    return NextResponse.json(
-      { error: "Failed to dispatch notification" },
-      { status: 500 },
-    );
-  }
 }, STAFF_ROLES);
 
 /**

--- a/src/app/api/notifications/trigger/route.ts
+++ b/src/app/api/notifications/trigger/route.ts
@@ -5,10 +5,10 @@ import {
   type NotificationTrigger,
   type TemplateVariables,
 } from "@/lib/notifications";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { notificationTriggerSchema, safeParse } from "@/lib/validations";
+import { notificationTriggerSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 /**
  * POST /api/notifications/trigger
  *
@@ -34,14 +34,8 @@ import { notificationTriggerSchema, safeParse } from "@/lib/validations";
  * - payment_received: When a payment is confirmed
  * - new_patient_registered: When a new patient registers
  */
-export const POST = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(notificationTriggerSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { trigger, variables, recipients } = parsed.data as {
+export const POST = withAuthValidation(notificationTriggerSchema, async (body, request, { supabase, profile }) => {
+    const { trigger, variables, recipients } = body as {
       trigger: NotificationTrigger;
       variables: TemplateVariables;
       recipients: Array<{ id: string; channels: ("whatsapp" | "in_app")[] }>;
@@ -104,11 +98,4 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
       template: template.name,
       dispatched: allResults,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "notifications/trigger", error: err });
-    return NextResponse.json(
-      { error: "Failed to trigger notification" },
-      { status: 500 },
-    );
-  }
 }, STAFF_ROLES);

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { onboardingSchema, safeParse } from "@/lib/validations";
+import { onboardingSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 /**
  * POST /api/onboarding
  *
@@ -9,8 +10,7 @@ import { onboardingSchema, safeParse } from "@/lib/validations";
  * Inserts a clinic row with the clinic_type_key FK and creates the
  * clinic_admin user record.
  */
-export const POST = withAuth(async (request, { supabase, user }) => {
-  try {
+export const POST = withAuthValidation(onboardingSchema, async (body, request, { supabase, user }) => {
     // Require email verification before allowing clinic creation
     if (!user.email_confirmed_at) {
       return NextResponse.json(
@@ -41,13 +41,6 @@ export const POST = withAuth(async (request, { supabase, user }) => {
         { status: 403 },
       );
     }
-
-    const raw = await request.json();
-    const parsed = safeParse(onboardingSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
 
     // Map category to the legacy clinic type field
     const legacyTypeMap: Record<string, string> = {
@@ -192,11 +185,4 @@ export const POST = withAuth(async (request, { supabase, user }) => {
       clinic_id: clinicId,
       subdomain: subdomain || null,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "onboarding/route", error: err });
-    return NextResponse.json(
-      { error: "Failed to process onboarding" },
-      { status: 500 },
-    );
-  }
 }, null); // null is intentional: new users don't have a profile/role yet during onboarding; the handler performs its own authorization checks (email verification, no existing profile)

--- a/src/app/api/onboarding/wizard/route.ts
+++ b/src/app/api/onboarding/wizard/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
-import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { z } from "zod";
-import { safeParse } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { sendTextMessage } from "@/lib/whatsapp";
 import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 
@@ -46,14 +45,7 @@ const wizardSchema = z.object({
 // welcome message when go_live is true.
 // ---------------------------------------------------------------------------
 
-export const POST = withAuth(async (request, { supabase, profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(wizardSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const POST = withAuthValidation(wizardSchema, async (body, request, { supabase, profile }) => {
 
     // Verify the authenticated user owns the clinic
     if (profile.clinic_id !== body.clinic_id) {
@@ -189,14 +181,4 @@ export const POST = withAuth(async (request, { supabase, profile }) => {
         ? "Clinic is live — congratulations!"
         : "Wizard data saved",
     });
-  } catch (err) {
-    logger.warn("Operation failed", {
-      context: "onboarding/wizard",
-      error: err,
-    });
-    return NextResponse.json(
-      { error: "Failed to save wizard data" },
-      { status: 500 },
-    );
-  }
 }, null);

--- a/src/app/api/payments/cmi/route.ts
+++ b/src/app/api/payments/cmi/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { createCmiPayment, isCmiConfigured } from "@/lib/cmi";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { cmiPaymentSchema, safeParse } from "@/lib/validations";
+import { cmiPaymentSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 
 /**
  * Validate that a redirect URL is same-origin to prevent open redirects.
@@ -41,7 +41,7 @@ function validateRedirectUrl(
  *
  * Requires: CMI_MERCHANT_ID, CMI_SECRET_KEY env vars
  */
-export const POST = withAuth(async (request, { user }) => {
+export const POST = withAuthValidation(cmiPaymentSchema, async (body, request, { user }) => {
   if (!isCmiConfigured()) {
     return NextResponse.json(
       { error: "CMI payment gateway is not configured. Set CMI_MERCHANT_ID and CMI_SECRET_KEY." },
@@ -49,12 +49,6 @@ export const POST = withAuth(async (request, { user }) => {
     );
   }
 
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(cmiPaymentSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
     const {
       amount,
       description = "Paiement",
@@ -62,7 +56,7 @@ export const POST = withAuth(async (request, { user }) => {
       appointmentId,
       successUrl,
       failUrl,
-    } = parsed.data;
+    } = body;
 
     const origin = request.nextUrl.origin;
     const orderId = `ord_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
@@ -94,8 +88,4 @@ export const POST = withAuth(async (request, { user }) => {
       formUrl: result.formUrl,
       formFields: result.formFields,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "payments/cmi", error: err });
-    return NextResponse.json({ error: "Failed to create CMI payment" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/payments/create-checkout/route.ts
+++ b/src/app/api/payments/create-checkout/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { stripeCheckoutSchema, safeParse } from "@/lib/validations";
+import { stripeCheckoutSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 
 /**
  * HIGH-03: Validate that a redirect URL is same-origin to prevent open redirects.
@@ -42,7 +42,7 @@ function validateRedirectUrl(
  *
  * Requires: STRIPE_SECRET_KEY env var
  */
-export const POST = withAuth(async (request, { user, profile }) => {
+export const POST = withAuthValidation(stripeCheckoutSchema, async (body, request, { user, profile }) => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
 
   if (!stripeSecretKey) {
@@ -52,12 +52,6 @@ export const POST = withAuth(async (request, { user, profile }) => {
     );
   }
 
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(stripeCheckoutSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
     const {
       amount,
       currency = "mad",
@@ -67,7 +61,7 @@ export const POST = withAuth(async (request, { user, profile }) => {
       successUrl,
       cancelUrl,
       metadata = {},
-    } = parsed.data;
+    } = body;
 
     const origin = request.nextUrl.origin;
 
@@ -122,8 +116,4 @@ export const POST = withAuth(async (request, { user, profile }) => {
       sessionId: session.id,
       url: session.url,
     });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "payments/create-checkout", error: err });
-    return NextResponse.json({ error: "Failed to process payment" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/radiology/orders/route.ts
+++ b/src/app/api/radiology/orders/route.ts
@@ -14,19 +14,13 @@ import {
   updateRadiologyOrderStatus,
   saveRadiologyReport,
 } from "@/lib/data/server";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
-import { radiologyOrderCreateSchema, radiologyOrderPatchSchema, safeParse } from "@/lib/validations";
+import { radiologyOrderCreateSchema, radiologyOrderPatchSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 
-export const POST = withAuth(async (request, { profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(radiologyOrderCreateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const { patientId, modality, bodyPart, clinicalIndication, priority, scheduledAt, orderingDoctorId } = parsed.data;
+export const POST = withAuthValidation(radiologyOrderCreateSchema, async (body, request, { profile }) => {
+    const { patientId, modality, bodyPart, clinicalIndication, priority, scheduledAt, orderingDoctorId } = body;
     // Derive clinic_id from the authenticated user's profile — never from the request body
     const clinicId = profile.clinic_id;
     if (!clinicId) {
@@ -55,20 +49,9 @@ export const POST = withAuth(async (request, { profile }) => {
     }
 
     return NextResponse.json(result, { status: 201 });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "radiology/orders", error: err });
-    return NextResponse.json({ error: "Failed to create radiology order" }, { status: 500 });
-  }
 }, STAFF_ROLES);
 
-export const PATCH = withAuth(async (request) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(radiologyOrderPatchSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
-    const body = parsed.data;
+export const PATCH = withAuthValidation(radiologyOrderPatchSchema, async (body, request) => {
     const { orderId, action } = body;
 
     if (action === "status") {
@@ -111,8 +94,4 @@ export const PATCH = withAuth(async (request) => {
       { error: `Unknown action: ${action}` },
       { status: 400 },
     );
-  } catch (err) {
-    logger.warn("Operation failed", { context: "radiology/orders", error: err });
-    return NextResponse.json({ error: "Failed to update radiology order" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/radiology/report-pdf/route.ts
+++ b/src/app/api/radiology/report-pdf/route.ts
@@ -11,11 +11,11 @@
 import { NextResponse } from "next/server";
 import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
 import { updateRadiologyOrderPdfUrl } from "@/lib/data/server";
-import { withAuth } from "@/lib/with-auth";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { logger } from "@/lib/logger";
 import { escapeHtml } from "@/lib/escape-html";
-import { radiologyReportPdfSchema, safeParse } from "@/lib/validations";
+import { radiologyReportPdfSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 
 function generateReportHtml(data: {
   patientName: string;
@@ -65,13 +65,7 @@ function generateReportHtml(data: {
 </html>`;
 }
 
-export const POST = withAuth(async (request, { profile }) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(radiologyReportPdfSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error }, { status: 400 });
-    }
+export const POST = withAuthValidation(radiologyReportPdfSchema, async (body, request, { profile }) => {
     const {
       orderId,
       patientName,
@@ -81,7 +75,7 @@ export const POST = withAuth(async (request, { profile }) => {
       impression,
       reportText,
       radiologistName,
-    } = parsed.data;
+    } = body;
     // Derive clinic_id from the authenticated user's profile — never from the request body
     const clinicId = profile.clinic_id;
     if (!clinicId) {
@@ -138,8 +132,4 @@ export const POST = withAuth(async (request, { profile }) => {
     await updateRadiologyOrderPdfUrl(orderId, url);
 
     return NextResponse.json({ pdfUrl: url });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "radiology/report-pdf", error: err });
-    return NextResponse.json({ error: "Failed to generate radiology report" }, { status: 500 });
-  }
 }, STAFF_ROLES);

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -30,7 +30,8 @@ import { encryptAndUpload } from "@/lib/r2-encrypted";
 import { requiresEncryption } from "@/lib/encryption";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { uploadConfirmSchema, safeParse } from "@/lib/validations";
+import { uploadConfirmSchema } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
 
@@ -142,7 +143,7 @@ export const POST = withAuth(async (request, { profile }) => {
  * Body: { key: string, contentType: string }
  * Returns: { valid: true } or { error: string } (with 400 status + deletion)
  */
-export const PUT = withAuth(async (request, { profile }) => {
+export const PUT = withAuthValidation(uploadConfirmSchema, async (body, request, { profile }) => {
   if (!isR2Configured()) {
     return NextResponse.json(
       { error: "File storage is not configured" },
@@ -150,16 +151,7 @@ export const PUT = withAuth(async (request, { profile }) => {
     );
   }
 
-  const raw = await request.json();
-  const parsed = safeParse(uploadConfirmSchema, raw);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error },
-      { status: 400 },
-    );
-  }
-
-  const { key, contentType } = parsed.data;
+  const { key, contentType } = body;
 
   // Tenant isolation: verify the R2 key belongs to this user's clinic.
   // Keys follow the pattern: {clinicId}/{category}/{filename}

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -13,8 +13,9 @@ import { authenticateApiKey } from "@/lib/api-auth";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 import { logger } from "@/lib/logger";
-import { v1AppointmentCreateSchema, safeParse } from "@/lib/validations";
+import { v1AppointmentCreateSchema } from "@/lib/validations";
 import { logTenantContext } from "@/lib/tenant-context";
+import { withValidation } from "@/lib/api-validate";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -65,7 +66,7 @@ export async function GET(request: NextRequest) {
   }, { headers: getCorsHeaders(request) });
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withValidation(v1AppointmentCreateSchema, async (body, request: NextRequest) => {
   const auth = await authenticateApiKey(request);
   if (!auth) {
     return NextResponse.json(
@@ -73,17 +74,6 @@ export async function POST(request: NextRequest) {
       { status: 401, headers: getCorsHeaders(request) },
     );
   }
-
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(v1AppointmentCreateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error },
-        { status: 400, headers: getCorsHeaders(request) },
-      );
-    }
-    const body = parsed.data;
 
     // Build slot_start / slot_end from appointment_date + start_time / end_time.
     // These are required NOT NULL columns in the appointments table.
@@ -119,8 +109,4 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ data }, { status: 201, headers: getCorsHeaders(request) });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "v1/appointments", error: err });
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400, headers: getCorsHeaders(request) });
-  }
-}
+});

--- a/src/app/api/v1/cache/invalidate/route.ts
+++ b/src/app/api/v1/cache/invalidate/route.ts
@@ -10,10 +10,9 @@
  */
 
 import { NextRequest } from "next/server";
-import { withAuth } from "@/lib/with-auth";
-import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
+import { apiSuccess } from "@/lib/api-response";
 import { invalidateSubdomainCache } from "@/lib/subdomain-cache";
-import { safeParse } from "@/lib/validations";
+import { withAuthValidation } from "@/lib/api-validate";
 import { z } from "zod";
 import { logger } from "@/lib/logger";
 
@@ -21,24 +20,13 @@ const cacheInvalidateSchema = z.object({
   subdomain: z.string().min(1).max(100),
 });
 
-export const POST = withAuth(async (request: NextRequest) => {
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(cacheInvalidateSchema, raw);
-    if (!parsed.success) {
-      return apiValidationError(parsed.error);
-    }
-
-    invalidateSubdomainCache(parsed.data.subdomain);
+export const POST = withAuthValidation(cacheInvalidateSchema, async (data, _request: NextRequest) => {
+    invalidateSubdomainCache(data.subdomain);
 
     logger.info("Subdomain cache invalidated", {
       context: "cache/invalidate",
-      subdomain: parsed.data.subdomain,
+      subdomain: data.subdomain,
     });
 
-    return apiSuccess({ invalidated: parsed.data.subdomain });
-  } catch (err) {
-    logger.error("Cache invalidation failed", { context: "cache/invalidate", error: err });
-    return apiError("Failed to invalidate cache", 500, "INTERNAL_ERROR");
-  }
+    return apiSuccess({ invalidated: data.subdomain });
 }, ["clinic_admin", "super_admin"]);

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -13,8 +13,9 @@ import { authenticateApiKey } from "@/lib/api-auth";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 import { logger } from "@/lib/logger";
 import type { TablesInsert } from "@/lib/types/database";
-import { v1PatientCreateSchema, safeParse } from "@/lib/validations";
+import { v1PatientCreateSchema } from "@/lib/validations";
 import { logTenantContext } from "@/lib/tenant-context";
+import { withValidation } from "@/lib/api-validate";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -67,7 +68,7 @@ export async function GET(request: NextRequest) {
   }, { headers: getCorsHeaders(request) });
 }
 
-export async function POST(request: NextRequest) {
+export const POST = withValidation(v1PatientCreateSchema, async (body, request: NextRequest) => {
   const auth = await authenticateApiKey(request);
   if (!auth) {
     return NextResponse.json(
@@ -75,17 +76,6 @@ export async function POST(request: NextRequest) {
       { status: 401, headers: getCorsHeaders(request) },
     );
   }
-
-  try {
-    const raw = await request.json();
-    const parsed = safeParse(v1PatientCreateSchema, raw);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error },
-        { status: 400, headers: getCorsHeaders(request) },
-      );
-    }
-    const body = parsed.data;
 
     logTenantContext(auth.clinicId, "v1/patients:POST");
     const supabase = await createTenantClient(auth.clinicId);
@@ -115,8 +105,4 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ data }, { status: 201, headers: getCorsHeaders(request) });
-  } catch (err) {
-    logger.warn("Operation failed", { context: "v1/patients", error: err });
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400, headers: getCorsHeaders(request) });
-  }
-}
+});

--- a/src/app/api/verify-email/route.ts
+++ b/src/app/api/verify-email/route.ts
@@ -11,7 +11,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { logger } from "@/lib/logger";
-import { verifyEmailSendSchema, verifyEmailConfirmSchema, safeParse } from "@/lib/validations";
+import { verifyEmailSendSchema, verifyEmailConfirmSchema } from "@/lib/validations";
+import { withValidation } from "@/lib/api-validate";
 
 /**
  * Generate a 6-digit numeric verification code.
@@ -23,7 +24,7 @@ function generateCode(): string {
 /**
  * POST — Send a verification code to the provided email.
  */
-export async function POST(request: NextRequest) {
+export const POST = withValidation(verifyEmailSendSchema, async (data, request: NextRequest) => {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -34,25 +35,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  let raw: unknown;
-  try {
-    raw = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: 400 },
-    );
-  }
-
-  const parsed = safeParse(verifyEmailSendSchema, raw);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error },
-      { status: 400 },
-    );
-  }
-
-  const { email } = parsed.data;
+  const { email } = data;
 
   const code = generateCode();
   const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString(); // 10 min
@@ -102,12 +85,12 @@ export async function POST(request: NextRequest) {
     message: "Verification code sent. Check your email.",
     expiresInMinutes: 10,
   });
-}
+});
 
 /**
  * PUT — Verify a code submitted by the patient.
  */
-export async function PUT(request: NextRequest) {
+export const PUT = withValidation(verifyEmailConfirmSchema, async (data, request: NextRequest) => {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
@@ -118,25 +101,7 @@ export async function PUT(request: NextRequest) {
     );
   }
 
-  let raw: unknown;
-  try {
-    raw = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "Invalid JSON body" },
-      { status: 400 },
-    );
-  }
-
-  const parsed = safeParse(verifyEmailConfirmSchema, raw);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error },
-      { status: 400 },
-    );
-  }
-
-  const { email, code } = parsed.data;
+  const { email, code } = data;
 
   const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
     cookies: {
@@ -190,4 +155,4 @@ export async function PUT(request: NextRequest) {
     ok: true,
     message: "Email verified successfully",
   });
-}
+});

--- a/src/lib/api-validate.ts
+++ b/src/lib/api-validate.ts
@@ -1,10 +1,10 @@
 /**
- * API route validation wrapper.
+ * API route validation wrappers.
  *
- * Provides a higher-order function that wraps API route handlers with
+ * Provides higher-order functions that wrap API route handlers with
  * automatic Zod validation, error handling, and structured logging.
  *
- * @example
+ * @example Standalone route (no auth):
  *   import { withValidation } from "@/lib/api-validate";
  *   import { bookingCancelSchema } from "@/lib/validations";
  *
@@ -12,6 +12,15 @@
  *     // `data` is typed and validated
  *     return apiSuccess({ cancelled: true });
  *   });
+ *
+ * @example Authenticated route:
+ *   import { withAuthValidation } from "@/lib/api-validate";
+ *   import { bookingCancelSchema } from "@/lib/validations";
+ *
+ *   export const POST = withAuthValidation(bookingCancelSchema, async (data, request, auth) => {
+ *     // `data` is typed and validated, `auth` has supabase/user/profile
+ *     return apiSuccess({ cancelled: true });
+ *   }, ["clinic_admin", "doctor"]);
  */
 
 import { type NextRequest, NextResponse } from "next/server";
@@ -19,6 +28,8 @@ import { type ZodType } from "zod";
 import { safeParse } from "@/lib/validations";
 import { apiValidationError, apiInternalError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+import type { UserRole } from "@/lib/types/database";
 
 /**
  * Wrap an API route handler with Zod request body validation.
@@ -30,9 +41,9 @@ import { logger } from "@/lib/logger";
  */
 export function withValidation<T>(
   schema: ZodType<T>,
-  handler: (data: T, request: NextRequest) => Promise<NextResponse>,
-): (request: NextRequest) => Promise<NextResponse> {
-  return async (request: NextRequest): Promise<NextResponse> => {
+  handler: (data: T, request: NextRequest) => Promise<NextResponse | Response>,
+): (request: NextRequest) => Promise<NextResponse | Response> {
+  return async (request: NextRequest): Promise<NextResponse | Response> => {
     let body: unknown;
     try {
       body = await request.json();
@@ -55,4 +66,46 @@ export function withValidation<T>(
       return apiInternalError();
     }
   };
+}
+
+/**
+ * Wrap an authenticated API route handler with Zod request body validation.
+ *
+ * Combines `withAuth` (authentication + role checking) with `withValidation`
+ * (JSON body parsing + Zod schema validation) in a single wrapper.
+ *
+ * - Authenticates the user and checks role permissions (via withAuth)
+ * - Parses the JSON body with the given schema
+ * - Returns a 422 with a descriptive message on validation failure
+ * - Catches unhandled errors and returns a 500
+ * - Logs errors with structured context
+ */
+export function withAuthValidation<T>(
+  schema: ZodType<T>,
+  handler: (data: T, request: NextRequest, auth: AuthContext) => Promise<NextResponse>,
+  allowedRoles: UserRole[] | null,
+): (request: NextRequest) => Promise<NextResponse> {
+  return withAuth(async (request: NextRequest, auth: AuthContext) => {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return apiValidationError("Invalid JSON body");
+    }
+
+    const result = safeParse(schema, body);
+    if (!result.success) {
+      return apiValidationError(result.error);
+    }
+
+    try {
+      return await handler(result.data, request, auth);
+    } catch (err) {
+      logger.error("Unhandled API route error", {
+        context: `api${request.nextUrl.pathname}`,
+        error: err,
+      });
+      return apiInternalError();
+    }
+  }, allowedRoles);
 }


### PR DESCRIPTION
… wrappers

- Add withAuthValidation helper to api-validate.ts for auth+validation composition
- Migrate 26 route files from inline safeParse to withValidation/withAuthValidation
- Standalone routes (booking/verify, consent, verify-email, chat, booking POST, v1/appointments POST, v1/patients POST) use withValidation
- Authenticated routes use withAuthValidation (booking/cancel, emergency-slot, payment/*, recurring, reschedule, waiting-list, branding PUT, custom-fields, impersonate, lab/report-html, notifications, onboarding, radiology/*, upload PUT, payments/cmi, payments/create-checkout, v1/cache/invalidate)
- Widen withValidation return type to accept Response | NextResponse for SSE streaming
- Remove all inline safeParse usage from route files