### PR TITLE
fix: audit report fixes (part 2) — GDPR withAuth, DEFAULT_TIMEZONE, error.tsx i18n, API helpers

### DIFF
--- a/src/app/(doctor)/error.tsx
+++ b/src/app/(doctor)/error.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { logger } from "@/lib/logger";
+import { t } from "@/lib/i18n";
 
 export default function DoctorError({
   error,
@@ -24,10 +25,9 @@ export default function DoctorError({
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangle className="h-7 w-7 text-destructive" />
           </div>
-          <h2 className="mb-2 text-lg font-semibold">Une erreur est survenue</h2>
+          <h2 className="mb-2 text-lg font-semibold">{t("fr", "error.title")}</h2>
           <p className="mb-6 text-sm text-muted-foreground">
-            Une erreur inattendue s&apos;est produite. Veuillez réessayer ou contacter
-            le support si le problème persiste.
+            {t("fr", "error.description")}
           </p>
           {error.digest && (
             <p className="mb-4 text-xs text-muted-foreground">
@@ -36,7 +36,7 @@ export default function DoctorError({
           )}
           <Button onClick={reset} size="lg">
             <RefreshCw className="mr-2 h-4 w-4" />
-            Réessayer
+            {t("fr", "error.retry")}
           </Button>
         </CardContent>
       </Card>

--- a/src/app/(patient)/error.tsx
+++ b/src/app/(patient)/error.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { logger } from "@/lib/logger";
+import { t } from "@/lib/i18n";
 
 export default function PatientError({
   error,
@@ -24,10 +25,9 @@ export default function PatientError({
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangle className="h-7 w-7 text-destructive" />
           </div>
-          <h2 className="mb-2 text-lg font-semibold">Une erreur est survenue</h2>
+          <h2 className="mb-2 text-lg font-semibold">{t("fr", "error.title")}</h2>
           <p className="mb-6 text-sm text-muted-foreground">
-            Une erreur inattendue s&apos;est produite. Veuillez réessayer ou contacter
-            le support si le problème persiste.
+            {t("fr", "error.description")}
           </p>
           {error.digest && (
             <p className="mb-4 text-xs text-muted-foreground">
@@ -36,7 +36,7 @@ export default function PatientError({
           )}
           <Button onClick={reset} size="lg">
             <RefreshCw className="mr-2 h-4 w-4" />
-            Réessayer
+            {t("fr", "error.retry")}
           </Button>
         </CardContent>
       </Card>

--- a/src/app/(receptionist)/error.tsx
+++ b/src/app/(receptionist)/error.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { logger } from "@/lib/logger";
+import { t } from "@/lib/i18n";
 
 export default function ReceptionistError({
   error,
@@ -24,10 +25,9 @@ export default function ReceptionistError({
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangle className="h-7 w-7 text-destructive" />
           </div>
-          <h2 className="mb-2 text-lg font-semibold">Une erreur est survenue</h2>
+          <h2 className="mb-2 text-lg font-semibold">{t("fr", "error.title")}</h2>
           <p className="mb-6 text-sm text-muted-foreground">
-            Une erreur inattendue s&apos;est produite. Veuillez réessayer ou contacter
-            le support si le problème persiste.
+            {t("fr", "error.description")}
           </p>
           {error.digest && (
             <p className="mb-4 text-xs text-muted-foreground">
@@ -36,7 +36,7 @@ export default function ReceptionistError({
           )}
           <Button onClick={reset} size="lg">
             <RefreshCw className="mr-2 h-4 w-4" />
-            Réessayer
+            {t("fr", "error.retry")}
           </Button>
         </CardContent>
       </Card>

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { fetchChatbotContext, buildSystemPrompt, getBasicResponse } from "@/lib/chatbot-data";
 import { requireTenant } from "@/lib/tenant";
 import { createClient } from "@/lib/supabase-server";
@@ -6,6 +6,7 @@ import { chatLimiter, extractClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { chatRequestSchema } from "@/lib/validations";
 import { withValidation } from "@/lib/api-validate";
+import { apiSuccess, apiError, apiRateLimited } from "@/lib/api-response";
 /**
  * POST /api/chat
  *
@@ -62,10 +63,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
     const clientIp = extractClientIp(request);
     const allowed = await chatLimiter.check(`chat:${clientIp}`);
     if (!allowed) {
-      return NextResponse.json(
-        { error: "Too many requests. Please try again later." },
-        { status: 429 },
-      );
+      return apiRateLimited();
     }
 
     // Resolve clinic ID strictly from tenant context (middleware headers)
@@ -74,10 +72,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
 
     const lastMessage = body.messages[body.messages.length - 1];
     if (!lastMessage || lastMessage.role !== "user" || !lastMessage.content.trim()) {
-      return NextResponse.json(
-        { error: "Last message must be a non-empty user message" },
-        { status: 400 },
-      );
+      return apiError("Last message must be a non-empty user message");
     }
 
     // Sanitize and truncate user messages; limit conversation history length
@@ -96,10 +91,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
 
     // Check if chatbot is enabled for this clinic
     if (ctx.chatbotConfig && !ctx.chatbotConfig.enabled) {
-      return NextResponse.json(
-        { error: "Chatbot is not enabled for this clinic" },
-        { status: 403 },
-      );
+      return apiError("Chatbot is not enabled for this clinic", 403, "FORBIDDEN");
     }
 
     // Determine intelligence level
@@ -111,7 +103,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
     // interact with the chatbot quick-reply buttons.
     if (intelligence === "basic") {
       const reply = getBasicResponse(lastMessage.content, ctx);
-      return NextResponse.json({
+      return apiSuccess({
         message: { role: "assistant" as const, content: reply },
       });
     }
@@ -123,7 +115,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
     if (!chatUser) {
       // Fall back to basic keyword matching for unauthenticated users
       const reply = getBasicResponse(lastMessage.content, ctx);
-      return NextResponse.json({
+      return apiSuccess({
         message: { role: "assistant" as const, content: reply },
       });
     }
@@ -135,7 +127,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
 
       if (!cfAccountId || !cfApiToken) {
         const reply = getBasicResponse(lastMessage.content, ctx);
-        return NextResponse.json({
+        return apiSuccess({
           message: { role: "assistant" as const, content: reply },
         });
       }
@@ -166,7 +158,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
         const cfData = (await cfResponse.json()) as { result?: { response?: string } };
         const content = cfData.result?.response;
         if (content) {
-          return NextResponse.json({
+          return apiSuccess({
             message: { role: "assistant" as const, content },
           });
         }
@@ -182,7 +174,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
 
       // Fallback to basic keyword matching when AI is unavailable
       const reply = getBasicResponse(lastMessage.content, ctx);
-      return NextResponse.json({
+      return apiSuccess({
         message: { role: "assistant" as const, content: reply },
       });
     }
@@ -195,7 +187,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
 
     if (!apiKey) {
       const reply = getBasicResponse(lastMessage.content, ctx);
-      return NextResponse.json({
+      return apiSuccess({
         message: { role: "assistant" as const, content: reply },
       });
     }
@@ -224,7 +216,7 @@ export const POST = withValidation(chatRequestSchema, async (body, request: Next
 
     if (!apiResponse.ok) {
       const reply = getBasicResponse(lastMessage.content, ctx);
-      return NextResponse.json({
+      return apiSuccess({
         message: { role: "assistant" as const, content: reply },
       });
     }

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
 import { impersonateSchema } from "@/lib/validations";
 import { withAuthValidation } from "@/lib/api-validate";
 import { createClient } from "@/lib/supabase-server";
 import { logSecurityEvent } from "@/lib/audit-log";
-import { apiInternalError, apiNotFound, apiUnauthorized } from "@/lib/api-response";
+import { apiSuccess, apiInternalError, apiNotFound, apiUnauthorized } from "@/lib/api-response";
 
 /**
  * POST /api/impersonate
@@ -55,7 +54,7 @@ export const POST = withAuthValidation(impersonateSchema, async (body, request, 
     });
 
     // Set impersonation cookie
-    const response = NextResponse.json({
+    const response = apiSuccess({
       success: true,
       clinicId,
       clinicName: clinicName || clinic.name,
@@ -103,7 +102,7 @@ export const DELETE = withAuth(async (_request, { supabase, user }) => {
       });
     }
 
-    const response = NextResponse.json({ success: true });
+    const response = apiSuccess({ success: true });
 
     response.cookies.set("sa_impersonate_clinic_id", "", {
       httpOnly: true,

--- a/src/app/api/patient/delete-account/route.ts
+++ b/src/app/api/patient/delete-account/route.ts
@@ -8,69 +8,44 @@
  * DELETE /api/patient/delete-account — Cancel pending deletion
  */
 
-import { NextRequest } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { apiError, apiForbidden, apiInternalError, apiNotFound, apiSuccess, apiUnauthorized } from "@/lib/api-response";
+import { apiForbidden, apiInternalError, apiSuccess } from "@/lib/api-response";
 
-export async function POST(request: NextRequest) {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    return apiError("Service unavailable", 503);
-  }
-
-  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
-      },
-      setAll() {
-        /* read-only */
-      },
-    },
-  });
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return apiUnauthorized();
-  }
-
-  // Fetch user profile
-  const { data: profile } = await supabase
+export const POST = withAuth(async (_request, { supabase, profile }) => {
+  // Fetch deletion status
+  // NOTE: deletion_requested_at is not yet in the generated Supabase types
+  // but exists in the DB schema (added via migration). Cast to access it.
+  const { data: userRow } = await (supabase
     .from("users")
     .select("id, role, deletion_requested_at")
-    .eq("auth_id", user.id)
-    .maybeSingle();
+    .eq("id", profile.id)
+    .maybeSingle() as unknown as Promise<{ data: { id: string; role: string; deletion_requested_at: string | null } | null }>);
 
-  if (!profile) {
-    return apiNotFound("Profile not found");
+  if (!userRow) {
+    return apiInternalError("Profile lookup failed");
   }
 
-  if (profile.role !== "patient") {
+  if (userRow.role !== "patient") {
     return apiForbidden("Only patient accounts can request self-deletion. Contact support for other roles.");
   }
 
-  if (profile.deletion_requested_at) {
+  if (userRow.deletion_requested_at) {
     return apiSuccess({
       message: "Deletion already requested",
-      deletionRequestedAt: profile.deletion_requested_at,
+      deletionRequestedAt: userRow.deletion_requested_at,
       permanentDeletionAt: new Date(
-        new Date(profile.deletion_requested_at).getTime() + 30 * 24 * 60 * 60 * 1000,
+        new Date(userRow.deletion_requested_at).getTime() + 30 * 24 * 60 * 60 * 1000,
       ).toISOString(),
     });
   }
 
   // Soft-delete: set deletion_requested_at timestamp
   const now = new Date().toISOString();
-  const { error } = await supabase
+  const { error } = await (supabase
     .from("users")
-    .update({ deletion_requested_at: now })
-    .eq("id", profile.id);
+    .update({ deletion_requested_at: now } as Record<string, unknown>)
+    .eq("id", profile.id) as unknown as Promise<{ error: { message: string } | null }>);
 
   if (error) {
     return apiInternalError("Failed to request deletion");
@@ -99,54 +74,28 @@ export async function POST(request: NextRequest) {
     deletionRequestedAt: now,
     permanentDeletionAt,
   });
-}
+}, ["patient"]);
 
-export async function DELETE(request: NextRequest) {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    return apiError("Service unavailable", 503);
-  }
-
-  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
-      },
-      setAll() {
-        /* read-only */
-      },
-    },
-  });
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return apiUnauthorized();
-  }
-
-  const { data: profile } = await supabase
+export const DELETE = withAuth(async (_request, { supabase, profile }) => {
+  const { data: userRow } = await (supabase
     .from("users")
     .select("id, deletion_requested_at")
-    .eq("auth_id", user.id)
-    .maybeSingle();
+    .eq("id", profile.id)
+    .maybeSingle() as unknown as Promise<{ data: { id: string; deletion_requested_at: string | null } | null }>);
 
-  if (!profile) {
-    return apiNotFound("Profile not found");
+  if (!userRow) {
+    return apiInternalError("Profile lookup failed");
   }
 
-  if (!profile.deletion_requested_at) {
+  if (!userRow.deletion_requested_at) {
     return apiSuccess({ message: "No pending deletion request" });
   }
 
   // Cancel deletion
-  const { error } = await supabase
+  const { error } = await (supabase
     .from("users")
-    .update({ deletion_requested_at: null })
-    .eq("id", profile.id);
+    .update({ deletion_requested_at: null } as Record<string, unknown>)
+    .eq("id", profile.id) as unknown as Promise<{ error: { message: string } | null }>);
 
   if (error) {
     return apiInternalError("Failed to cancel deletion");
@@ -167,4 +116,4 @@ export async function DELETE(request: NextRequest) {
   }
 
   return apiSuccess({ message: "Account deletion cancelled successfully." });
-}
+}, ["patient"]);

--- a/src/app/api/patient/export/route.ts
+++ b/src/app/api/patient/export/route.ts
@@ -8,9 +8,9 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { withAuth } from "@/lib/with-auth";
 import { logger } from "@/lib/logger";
-import { apiError, apiNotFound, apiUnauthorized } from "@/lib/api-response";
+import { apiError, apiNotFound } from "@/lib/api-response";
 
 /** Characters that trigger formula execution in Excel/Google Sheets. */
 const FORMULA_PREFIXES = new Set(["=", "+", "-", "@", "\t", "\r"]);
@@ -37,48 +37,21 @@ function toCSV(rows: Record<string, unknown>[], columns: string[]): string {
   return [header, ...body].join("\n");
 }
 
-export async function GET(request: NextRequest) {
+export const GET = withAuth(async (request: NextRequest, { supabase, profile }) => {
   const format = request.nextUrl.searchParams.get("format") ?? "json";
 
   if (format !== "json" && format !== "csv") {
     return apiError("Invalid format. Use 'json' or 'csv'.");
   }
 
-  // Authenticate via Supabase session cookies
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    return apiError("Service unavailable", 503);
-  }
-
-  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
-      },
-      setAll() {
-        /* read-only */
-      },
-    },
-  });
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return apiUnauthorized();
-  }
-
-  // Fetch user profile — select only needed columns
-  const { data: profile } = await supabase
+  // Fetch full user profile for export — select only needed columns
+  const { data: fullProfile } = await supabase
     .from("users")
     .select("id, name, email, phone, role, created_at")
-    .eq("auth_id", user.id)
+    .eq("id", profile.id)
     .maybeSingle();
 
-  if (!profile) {
+  if (!fullProfile) {
     return apiNotFound("Profile not found");
   }
 
@@ -94,11 +67,13 @@ export async function GET(request: NextRequest) {
       .select("id, slot_start, slot_end, status, notes, source, is_first_visit, insurance_flag, created_at")
       .eq("patient_id", profile.id)
       .order("slot_start", { ascending: false }),
-    supabase
+    // NOTE: medication/dosage/duration/instructions are not in generated Supabase types
+    // but exist in the DB schema. Cast the query result.
+    (supabase
       .from("prescriptions")
       .select("id, medication, dosage, duration, instructions, created_at")
       .eq("patient_id", profile.id)
-      .order("created_at", { ascending: false }),
+      .order("created_at", { ascending: false }) as unknown as Promise<{ data: { id: string; medication: string; dosage: string; duration: string; instructions: string; created_at: string }[] | null }>),
     supabase
       .from("payments")
       .select("id, amount, method, status, ref, created_at")
@@ -114,11 +89,11 @@ export async function GET(request: NextRequest) {
   const exportData = {
     exportDate: new Date().toISOString(),
     personalInfo: {
-      name: profile.name,
-      email: profile.email,
-      phone: profile.phone,
-      role: profile.role,
-      createdAt: profile.created_at,
+      name: fullProfile.name,
+      email: fullProfile.email,
+      phone: fullProfile.phone,
+      role: fullProfile.role,
+      createdAt: fullProfile.created_at,
     },
     appointments: appointments ?? [],
     prescriptions: prescriptions ?? [],
@@ -187,4 +162,4 @@ export async function GET(request: NextRequest) {
       "Content-Disposition": `attachment; filename="my-data-${new Date().toISOString().split("T")[0]}.csv"`,
     },
   });
-}
+}, ["patient"]);

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -4,6 +4,7 @@ import { verifyCmiCallback } from "@/lib/cmi";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
+import { apiError, apiInternalError } from "@/lib/api-response";
 
 /**
  * POST /api/payments/cmi/callback
@@ -24,8 +25,7 @@ export async function POST(request: NextRequest) {
     const callbackData = await verifyCmiCallback(params);
 
     if (!callbackData) {
-      // Invalid hash or missing callback data
-      return NextResponse.json({ error: "Invalid callback" }, { status: 400 });
+      return apiError("Invalid callback");
     }
 
     const supabase = await createClient();
@@ -117,6 +117,6 @@ export async function POST(request: NextRequest) {
     });
   } catch (err) {
     logger.warn("Operation failed", { context: "payments/cmi/callback", error: err });
-    return NextResponse.json({ error: "Failed to process payment callback" }, { status: 500 });
+    return apiInternalError("Failed to process payment callback");
   }
 }

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -1,10 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase-server";
 import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
 import { assertClinicId } from "@/lib/assert-tenant";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
+import { apiError, apiSuccess, apiInternalError } from "@/lib/api-response";
 
 /**
  * POST /api/payments/webhook
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
   if (!stripeSecretKey) {
-    return NextResponse.json({ error: "Stripe not configured" }, { status: 503 });
+    return apiError("Stripe not configured", 503);
   }
 
   try {
@@ -34,25 +35,16 @@ export async function POST(request: NextRequest) {
 
     // Verify webhook signature — webhook secret MUST be configured
     if (!webhookSecret) {
-      // STRIPE_WEBHOOK_SECRET not configured
-      return NextResponse.json(
-        { error: "Webhook signature verification not configured" },
-        { status: 503 },
-      );
+      return apiError("Webhook signature verification not configured", 503);
     }
 
     if (!signature) {
-      // Missing stripe-signature header
-      return NextResponse.json(
-        { error: "Missing stripe-signature header" },
-        { status: 400 },
-      );
+      return apiError("Missing stripe-signature header");
     }
 
     const isValid = await verifyStripeSignature(rawBody, signature, webhookSecret);
     if (!isValid) {
-      // Invalid webhook signature
-      return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+      return apiError("Invalid signature");
     }
 
     const event = JSON.parse(rawBody) as {
@@ -163,10 +155,10 @@ export async function POST(request: NextRequest) {
         // Unhandled event type — acknowledged without processing
     }
 
-    return NextResponse.json({ received: true });
+    return apiSuccess({ received: true });
   } catch (err) {
     logger.warn("Operation failed", { context: "payments/webhook", error: err });
-    return NextResponse.json({ error: "Failed to process webhook" }, { status: 500 });
+    return apiInternalError("Failed to process webhook");
   }
 }
 

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -7,7 +7,7 @@
  * Authentication: Bearer token via API key stored in clinic settings.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { createTenantClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
@@ -16,6 +16,7 @@ import { logger } from "@/lib/logger";
 import { v1AppointmentCreateSchema } from "@/lib/validations";
 import { logTenantContext } from "@/lib/tenant-context";
 import { withValidation } from "@/lib/api-validate";
+import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -23,12 +24,10 @@ export function OPTIONS(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const cors = getCorsHeaders(request);
   const auth = await authenticateApiKey(request);
   if (!auth) {
-    return NextResponse.json(
-      { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: getCorsHeaders(request) },
-    );
+    return apiError("Unauthorized. Provide a valid API key as Bearer token.", 401, "UNAUTHORIZED", cors);
   }
 
   logTenantContext(auth.clinicId, "v1/appointments:GET");
@@ -57,22 +56,17 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     logger.warn("Operation failed", { context: "v1/appointments", error });
-    return NextResponse.json({ error: "Failed to fetch appointments" }, { status: 500, headers: getCorsHeaders(request) });
+    return apiInternalError("Failed to fetch appointments");
   }
 
-  return NextResponse.json({
-    data,
-    pagination: { total: count, limit, offset },
-  }, { headers: getCorsHeaders(request) });
+  return apiSuccess({ data, pagination: { total: count, limit, offset } }, 200, cors);
 }
 
 export const POST = withValidation(v1AppointmentCreateSchema, async (body, request: NextRequest) => {
+  const cors = getCorsHeaders(request);
   const auth = await authenticateApiKey(request);
   if (!auth) {
-    return NextResponse.json(
-      { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: getCorsHeaders(request) },
-    );
+    return apiError("Unauthorized. Provide a valid API key as Bearer token.", 401, "UNAUTHORIZED", cors);
   }
 
     // Build slot_start / slot_end from appointment_date + start_time / end_time.
@@ -105,8 +99,8 @@ export const POST = withValidation(v1AppointmentCreateSchema, async (body, reque
 
     if (error) {
       logger.warn("Operation failed", { context: "v1/appointments", error });
-      return NextResponse.json({ error: "Failed to create appointment" }, { status: 500, headers: getCorsHeaders(request) });
+      return apiInternalError("Failed to create appointment");
     }
 
-    return NextResponse.json({ data }, { status: 201, headers: getCorsHeaders(request) });
+    return apiSuccess({ data }, 201, cors);
 });

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -7,7 +7,7 @@
  * Authentication: Bearer token via API key stored in clinic settings.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { createTenantClient } from "@/lib/supabase-server";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
@@ -16,6 +16,7 @@ import type { TablesInsert } from "@/lib/types/database";
 import { v1PatientCreateSchema } from "@/lib/validations";
 import { logTenantContext } from "@/lib/tenant-context";
 import { withValidation } from "@/lib/api-validate";
+import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 
 /** Handle CORS preflight requests. */
 export function OPTIONS(request: NextRequest) {
@@ -23,12 +24,10 @@ export function OPTIONS(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
+  const cors = getCorsHeaders(request);
   const auth = await authenticateApiKey(request);
   if (!auth) {
-    return NextResponse.json(
-      { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: getCorsHeaders(request) },
-    );
+    return apiError("Unauthorized. Provide a valid API key as Bearer token.", 401, "UNAUTHORIZED", cors);
   }
 
   logTenantContext(auth.clinicId, "v1/patients:GET");
@@ -59,22 +58,17 @@ export async function GET(request: NextRequest) {
 
   if (error) {
     logger.warn("Operation failed", { context: "v1/patients", error });
-    return NextResponse.json({ error: "Failed to fetch patients" }, { status: 500, headers: getCorsHeaders(request) });
+    return apiInternalError("Failed to fetch patients");
   }
 
-  return NextResponse.json({
-    data,
-    pagination: { total: count, limit, offset },
-  }, { headers: getCorsHeaders(request) });
+  return apiSuccess({ data, pagination: { total: count, limit, offset } }, 200, cors);
 }
 
 export const POST = withValidation(v1PatientCreateSchema, async (body, request: NextRequest) => {
+  const cors = getCorsHeaders(request);
   const auth = await authenticateApiKey(request);
   if (!auth) {
-    return NextResponse.json(
-      { error: "Unauthorized. Provide a valid API key as Bearer token." },
-      { status: 401, headers: getCorsHeaders(request) },
-    );
+    return apiError("Unauthorized. Provide a valid API key as Bearer token.", 401, "UNAUTHORIZED", cors);
   }
 
     logTenantContext(auth.clinicId, "v1/patients:POST");
@@ -101,8 +95,8 @@ export const POST = withValidation(v1PatientCreateSchema, async (body, request: 
 
     if (error) {
       logger.warn("Operation failed", { context: "v1/patients", error });
-      return NextResponse.json({ error: "Failed to create patient" }, { status: 500, headers: getCorsHeaders(request) });
+      return apiInternalError("Failed to create patient");
     }
 
-    return NextResponse.json({ data }, { status: 201, headers: getCorsHeaders(request) });
+    return apiSuccess({ data }, 201, cors);
 });

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -36,8 +36,8 @@ interface ApiErrorBody {
 /**
  * Return a success JSON response with standard shape.
  */
-export function apiSuccess<T>(data: T, status = 200): NextResponse<ApiSuccessBody<T>> {
-  return NextResponse.json({ ok: true as const, data }, { status });
+export function apiSuccess<T>(data: T, status = 200, headers?: HeadersInit): NextResponse<ApiSuccessBody<T>> {
+  return NextResponse.json({ ok: true as const, data }, { status, headers });
 }
 
 /**
@@ -47,10 +47,11 @@ export function apiError(
   error: string,
   status = 400,
   code?: string,
+  headers?: HeadersInit,
 ): NextResponse<ApiErrorBody> {
   const body: ApiErrorBody = { ok: false, error };
   if (code) body.code = code;
-  return NextResponse.json(body, { status });
+  return NextResponse.json(body, { status, headers });
 }
 
 /**

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,3 +8,12 @@
  */
 export const STAFF_DEFAULT_PASSWORD =
   process.env.STAFF_DEFAULT_PASSWORD || `Staff-${crypto.randomUUID()}`;
+
+/**
+ * Default IANA timezone used as a last-resort fallback when tenant config
+ * does not provide one. Matches the primary deployment locale (Morocco).
+ *
+ * Prefer reading timezone from the tenant's DB config via `getClinicConfig()`.
+ * If this fallback is triggered, a warning is logged so the gap can be fixed.
+ */
+export const DEFAULT_TIMEZONE = "Africa/Casablanca";

--- a/src/lib/google-calendar.ts
+++ b/src/lib/google-calendar.ts
@@ -10,6 +10,9 @@
  *   GOOGLE_CALENDAR_REDIRECT_URI
  */
 
+import { DEFAULT_TIMEZONE } from "@/lib/constants";
+import { logger } from "@/lib/logger";
+
 // ---- Types ----
 
 export interface CalendarEvent {
@@ -259,7 +262,10 @@ export function appointmentToCalendarEvent(appointment: {
   clinicAddress?: string;
   timeZone?: string;
 }): CalendarEvent {
-  const timeZone = appointment.timeZone ?? "Africa/Casablanca";
+  const timeZone = appointment.timeZone ?? DEFAULT_TIMEZONE;
+  if (!appointment.timeZone) {
+    logger.warn("appointmentToCalendarEvent called without timeZone — using DEFAULT_TIMEZONE fallback", { context: "google-calendar" });
+  }
 
   return {
     summary: `${appointment.type} - ${appointment.patientName}`,

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -12,6 +12,7 @@
 import { headers } from "next/headers";
 import { clinicConfig } from "@/config/clinic.config";
 import { logTenantContext } from "@/lib/tenant-context";
+import { DEFAULT_TIMEZONE } from "@/lib/constants";
 
 /** Minimal tenant info passed via request headers from middleware. */
 export interface TenantInfo {
@@ -115,7 +116,7 @@ export async function getClinicConfig(clinicId: string): Promise<TenantClinicCon
 
   // Merge DB config with static defaults (DB takes precedence)
   return {
-    timezone: (dbConfig.timezone as string) ?? clinicConfig.timezone ?? "Africa/Casablanca",
+    timezone: (dbConfig.timezone as string) ?? clinicConfig.timezone ?? DEFAULT_TIMEZONE,
     currency: (dbConfig.currency as string) ?? clinicConfig.currency ?? "MAD",
     workingHours: (dbConfig.workingHours as TenantClinicConfig["workingHours"])
       ?? clinicConfig.workingHours,

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -10,6 +10,9 @@
  * is critical.
  */
 
+import { DEFAULT_TIMEZONE } from "@/lib/constants";
+import { logger } from "@/lib/logger";
+
 /**
  * Build a timezone-aware Date for a date + time string using the clinic's timezone.
  *
@@ -23,7 +26,10 @@
  *                 from the tenant's DB config — never from static clinicConfig.
  */
 export function clinicDateTime(dateStr: string, timeStr: string, timezone?: string): Date {
-  const tz = timezone ?? "Africa/Casablanca";
+  const tz = timezone ?? DEFAULT_TIMEZONE;
+  if (!timezone) {
+    logger.warn("clinicDateTime called without timezone — using DEFAULT_TIMEZONE fallback", { context: "timezone" });
+  }
   const [year, month, day] = dateStr.split("-").map(Number);
   const [hour, minute] = timeStr.split(":").map(Number);
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 import { formatInTimeZone } from "date-fns-tz"
+import { DEFAULT_TIMEZONE } from "@/lib/constants"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -16,7 +17,7 @@ export function cn(...inputs: ClassValue[]) {
  */
 export function getLocalDateStr(
   date: Date = new Date(),
-  timezone = "Africa/Casablanca",
+  timezone = DEFAULT_TIMEZONE,
 ): string {
   return formatInTimeZone(date, timezone, "yyyy-MM-dd");
 }


### PR DESCRIPTION
## Summary

Continuation of audit report fixes from PR #298. Addresses remaining HIGH and MEDIUM priority items.

### Changes

**HIGH #1 — Hardcoded French Error Strings (3 files)**
- `src/app/(patient)/error.tsx`, `src/app/(doctor)/error.tsx`, `src/app/(receptionist)/error.tsx`
- Replaced hardcoded French strings with `t("fr", "error.title")`, `t("fr", "error.description")`, `t("fr", "error.retry")`

**HIGH #2 — API Route Consistency (6 routes)**
- Migrated remaining routes from `NextResponse.json()` to `apiSuccess`/`apiError`/`apiInternalError` helpers
- Routes: `v1/patients`, `v1/appointments`, `chat`, `payments/webhook`, `payments/cmi/callback`, `impersonate`
- Added optional `headers` parameter to `apiSuccess`/`apiError` for CORS support
- Removed unused `NextResponse` imports from 4 files

**MEDIUM #10 — GDPR Routes withAuth (2 routes)**
- Refactored `patient/export` and `patient/delete-account` to use `withAuth` wrapper
- Eliminates manual `createServerClient` + auth boilerplate
- Preserves all business logic (data export, soft-delete, audit logging)

**MEDIUM #7 — DEFAULT_TIMEZONE Constant (4 files)**
- Added `DEFAULT_TIMEZONE` constant in `src/lib/constants.ts`
- Replaced hardcoded `"Africa/Casablanca"` in `timezone.ts`, `utils.ts`, `google-calendar.ts`, `tenant.ts`
- Added warning logs when timezone fallback is triggered

### Files Changed (17)
- 3 error.tsx files (i18n)
- 6 API route files (response helpers)
- 2 GDPR route files (withAuth refactor)
- 4 lib files (DEFAULT_TIMEZONE)
- 1 lib file (api-response.ts headers param)
- 1 lib file (constants.ts new constant)