### PR TITLE
fix: launch blocker fixes — payment webhook validation & auth i18n

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -58,7 +58,7 @@ export default function LoginPage() {
         setError(
           isRateLimitError
             ? result.error
-            : "Identifiants de connexion invalides.",
+            : t("fr", "auth.invalidCredentials"),
         );
         setLoading(false);
       }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -44,7 +44,7 @@ export default function RegisterPage() {
     setError(null);
 
     if (!PHONE_AUTH_ENABLED) {
-      setError("L'inscription par t\u00e9l\u00e9phone est temporairement d\u00e9sactiv\u00e9e. Veuillez r\u00e9essayer plus tard.");
+      setError(t("fr", "auth.phoneDisabled"));
       return;
     }
 

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -5,6 +5,7 @@ import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { logger } from "@/lib/logger";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 import { apiError, apiInternalError } from "@/lib/api-response";
+import { cmiCallbackFieldsSchema } from "@/lib/validations";
 
 /**
  * POST /api/payments/cmi/callback
@@ -21,6 +22,16 @@ export async function POST(request: NextRequest) {
     formData.forEach((value, key) => {
       params[key] = String(value);
     });
+
+    // Validate callback fields before HMAC verification
+    const fieldResult = cmiCallbackFieldsSchema.safeParse(params);
+    if (!fieldResult.success) {
+      logger.warn("CMI callback fields failed validation", {
+        context: "payments/cmi/callback",
+        error: fieldResult.error.issues,
+      });
+      return apiError("Invalid callback fields");
+    }
 
     const callbackData = await verifyCmiCallback(params);
 

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -6,6 +6,8 @@ import { logger } from "@/lib/logger";
 import { assertClinicId } from "@/lib/assert-tenant";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 import { apiError, apiSuccess, apiInternalError } from "@/lib/api-response";
+import { stripeWebhookEventSchema } from "@/lib/validations";
+import type { StripeWebhookEvent } from "@/lib/validations";
 
 /**
  * POST /api/payments/webhook
@@ -47,19 +49,21 @@ export async function POST(request: NextRequest) {
       return apiError("Invalid signature");
     }
 
-    const event = JSON.parse(rawBody) as {
-      type: string;
-      data: {
-        object: {
-          id: string;
-          metadata?: Record<string, string>;
-          amount_total?: number;
-          currency?: string;
-          payment_status?: string;
-          customer_email?: string;
-        };
-      };
-    };
+    let event: StripeWebhookEvent;
+    try {
+      const parsed = JSON.parse(rawBody);
+      const result = stripeWebhookEventSchema.safeParse(parsed);
+      if (!result.success) {
+        logger.warn("Stripe webhook event failed validation", {
+          context: "payments/webhook",
+          error: result.error.issues,
+        });
+        return apiError("Invalid webhook event payload");
+      }
+      event = result.data;
+    } catch {
+      return apiError("Invalid JSON in webhook body");
+    }
 
     const supabase = await createClient();
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -253,6 +253,8 @@ export const translations = {
     "auth.rateLimitOtp": "Trop de demandes de code. Veuillez réessayer dans quelques minutes.",
     "auth.rateLimitGeneric": "Trop de demandes. Veuillez réessayer dans quelques minutes.",
     "auth.genericError": "Une erreur est survenue",
+    "auth.invalidCredentials": "Identifiants de connexion invalides.",
+    "auth.phoneDisabled": "L'inscription par téléphone est temporairement désactivée. Veuillez réessayer plus tard.",
 
     // Chatbot
     "chatbot.error": "Désolé, une erreur est survenue. Veuillez réessayer.",
@@ -530,6 +532,8 @@ export const translations = {
     "auth.rateLimitOtp": "طلبات كثيرة للرمز. يرجى المحاولة بعد بضع دقائق.",
     "auth.rateLimitGeneric": "طلبات كثيرة. يرجى المحاولة بعد بضع دقائق.",
     "auth.genericError": "حدث خطأ",
+    "auth.invalidCredentials": "بيانات تسجيل الدخول غير صحيحة.",
+    "auth.phoneDisabled": "التسجيل عبر الهاتف معطّل مؤقتاً. يرجى المحاولة لاحقاً.",
 
     // Chatbot
     "chatbot.error": "عذراً، حدث خطأ. يرجى المحاولة مرة أخرى.",
@@ -807,6 +811,8 @@ export const translations = {
     "auth.rateLimitOtp": "Too many code requests. Please try again in a few minutes.",
     "auth.rateLimitGeneric": "Too many requests. Please try again in a few minutes.",
     "auth.genericError": "An error occurred",
+    "auth.invalidCredentials": "Invalid login credentials.",
+    "auth.phoneDisabled": "Phone registration is temporarily disabled. Please try again later.",
 
     // Chatbot
     "chatbot.error": "Sorry, an error occurred. Please try again.",

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -111,6 +111,52 @@ export const paymentRefundSchema = z.object({
 
 // ── Payments ────────────────────────────────────────────────────────────
 
+/**
+ * Stripe webhook event schema — validates the parsed JSON body after
+ * signature verification for defense-in-depth on payment events.
+ */
+const stripeWebhookEventObjectSchema = z.object({
+  id: z.string().min(1),
+  metadata: z.record(z.string(), z.string()).optional(),
+  amount_total: z.number().optional(),
+  currency: z.string().optional(),
+  payment_status: z.string().optional(),
+  customer_email: z.string().optional(),
+});
+
+export const stripeWebhookEventSchema = z.object({
+  type: z.string().min(1),
+  data: z.object({
+    object: stripeWebhookEventObjectSchema,
+  }),
+});
+
+export type StripeWebhookEvent = z.infer<typeof stripeWebhookEventSchema>;
+
+/**
+ * CMI callback form data schema — validates the parsed form fields after
+ * HMAC signature verification for defense-in-depth on payment callbacks.
+ */
+export const cmiCallbackFieldsSchema = z.object({
+  oid: z.string().optional(),
+  OID: z.string().optional(),
+  amount: z.string().optional(),
+  AMOUNT: z.string().optional(),
+  ProcReturnCode: z.string().optional(),
+  procreturncode: z.string().optional(),
+  TransId: z.string().optional(),
+  transid: z.string().optional(),
+  AuthCode: z.string().optional(),
+  authcode: z.string().optional(),
+  HASH: z.string().optional(),
+  hash: z.string().optional(),
+}).passthrough().refine(
+  (data) => Boolean(data.HASH || data.hash),
+  { message: "Missing required HASH field" },
+);
+
+export type CmiCallbackFields = z.infer<typeof cmiCallbackFieldsSchema>;
+
 export const cmiPaymentSchema = z.object({
   amount: z.number().positive().finite(),
   description: z.string().max(500).optional(),


### PR DESCRIPTION
## Launch Blocker Fixes

Addresses the 3 must-fix launch blockers from the launch readiness audit.

### Fix 1: Payment Webhook/Callback Body Validation

- Added `stripeWebhookEventSchema` Zod schema to validate parsed Stripe webhook event payloads after signature verification (defense-in-depth)
- Added `cmiCallbackFieldsSchema` Zod schema to validate CMI callback form data fields before HMAC verification
- Both schemas reject malformed payloads with structured logging before any business logic runs

### Fix 2: Hardcoded French Strings in Auth Pages

- Replaced hardcoded `"Identifiants de connexion invalides."` in login page with `t("fr", "auth.invalidCredentials")`
- Replaced hardcoded phone disabled error in register page with `t("fr", "auth.phoneDisabled")`
- Added `auth.invalidCredentials` and `auth.phoneDisabled` translation keys to all 3 locales (fr, ar, en)

### Fix 3: GDPR Routes Already Use `withAuth`

- Verified that both `/api/patient/export` and `/api/patient/delete-account` already use the `withAuth` wrapper from `@/lib/with-auth` — no changes needed (this was fixed in a prior PR)

### Verification

- 0 TypeScript errors
- 0 ESLint errors
- 87 tests passing
- All pre-commit hooks pass (lint-staged + typecheck + changed tests)

---

[Devin session](https://app.devin.ai/sessions/61dbbe174c4a41a49f8095d496ccd111)