### PR TITLE
feat: add loading/error/404 states for public pages & fix API cache security

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -82,12 +82,14 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Cache API responses for 5 minutes
+        // Default: prevent caching of API responses (authentication, patient
+        // data, mutations, etc.).  Individual routes that serve truly public
+        // data can override this with their own Cache-Control header.
         source: "/api/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, max-age=300, s-maxage=300",
+            value: "private, no-store",
           },
         ],
       },

--- a/src/app/(public)/error.tsx
+++ b/src/app/(public)/error.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, RefreshCw, Home } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { logger } from "@/lib/logger";
 import { t } from "@/lib/i18n";
 import { useLocale } from "@/components/locale-switcher";
+import Link from "next/link";
 
 export default function PublicError({
   error,
@@ -37,10 +38,19 @@ export default function PublicError({
               Error ID: {error.digest}
             </p>
           )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
+          <div className="flex items-center justify-center gap-3">
+            <Button onClick={reset} size="lg">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              {t(locale, "error.retry")}
+            </Button>
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <Home className="mr-2 h-4 w-4" />
+              {t(locale, "notFound.backHome")}
+            </Link>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/app/(public)/loading.tsx
+++ b/src/app/(public)/loading.tsx
@@ -2,24 +2,71 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export default function PublicLoading() {
   return (
-    <div className="min-h-[60vh] container mx-auto px-4 py-12 space-y-8">
-      {/* Hero skeleton */}
-      <div className="space-y-4 text-center">
-        <Skeleton className="h-10 w-2/3 mx-auto" />
-        <Skeleton className="h-5 w-1/2 mx-auto" />
-        <Skeleton className="h-10 w-40 mx-auto rounded-lg" />
-      </div>
-      {/* Content cards skeleton */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 mt-12">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-xl border p-6 space-y-4">
-            <Skeleton className="h-6 w-2/3" />
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-4/5" />
-            <Skeleton className="h-32 w-full rounded-lg" />
+    <div className="min-h-screen">
+      {/* Hero section skeleton */}
+      <section className="relative py-20 lg:py-28">
+        <div className="container mx-auto px-4 text-center space-y-6">
+          <Skeleton className="h-12 w-3/4 mx-auto rounded-lg" />
+          <Skeleton className="h-6 w-1/2 mx-auto" />
+          <div className="flex items-center justify-center gap-4 pt-4">
+            <Skeleton className="h-12 w-44 rounded-lg" />
+            <Skeleton className="h-12 w-36 rounded-lg" />
           </div>
-        ))}
-      </div>
+        </div>
+      </section>
+
+      {/* Services section skeleton */}
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <div className="text-center mb-12 space-y-3">
+            <Skeleton className="h-8 w-48 mx-auto" />
+            <Skeleton className="h-5 w-72 mx-auto" />
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="rounded-xl border p-6 space-y-4">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <Skeleton className="h-6 w-2/3" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-4/5" />
+                <Skeleton className="h-9 w-28 rounded-lg mt-2" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Reviews section skeleton */}
+      <section className="py-16">
+        <div className="container mx-auto px-4">
+          <div className="text-center mb-12 space-y-3">
+            <Skeleton className="h-8 w-64 mx-auto" />
+            <div className="flex items-center justify-center gap-2">
+              <Skeleton className="h-8 w-12" />
+              <div className="flex gap-0.5">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-5 w-5 rounded-sm" />
+                ))}
+              </div>
+              <Skeleton className="h-4 w-16" />
+            </div>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="rounded-xl border p-6 space-y-4">
+                <div className="flex gap-0.5">
+                  {Array.from({ length: 5 }).map((_, j) => (
+                    <Skeleton key={j} className="h-4 w-4 rounded-sm" />
+                  ))}
+                </div>
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-24 mt-2" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/(public)/not-found.tsx
+++ b/src/app/(public)/not-found.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { t, type Locale } from "@/lib/i18n";
+import { clinicConfig } from "@/config/clinic.config";
+
+export default function PublicNotFound() {
+  const locale: Locale = (clinicConfig.locale as Locale) ?? "fr";
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <div className="w-full max-w-md text-center">
+        <p className="text-6xl font-bold text-muted-foreground">404</p>
+        <h1 className="mt-4 text-xl font-semibold">
+          {t(locale, "notFound.title")}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t(locale, "notFound.description")}
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          {t(locale, "notFound.backHome")}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -23,6 +23,24 @@ import {
   LocationSection,
 } from "@/components/public/sections";
 import { safeJsonLdStringify } from "@/lib/json-ld";
+import { logger } from "@/lib/logger";
+import { notFound } from "next/navigation";
+
+/** Default timeout (ms) for Supabase data-fetching on public pages. */
+const DATA_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Race a promise against a timeout. Rejects with a descriptive error
+ * if the promise does not settle within `ms` milliseconds.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Timeout: ${label} did not respond within ${ms}ms`)), ms),
+    ),
+  ]);
+}
 
 export async function generateMetadata(): Promise<Metadata> {
   const tenant = await getTenant();
@@ -95,11 +113,32 @@ export default async function HomePage() {
   }
 
   // Subdomain → show clinic homepage with tenant data
-  const [branding, reviews, avgRating] = await Promise.all([
-    getPublicBranding(),
-    getPublicReviews(),
-    getPublicAverageRating(),
-  ]);
+  let branding;
+  let reviews;
+  let avgRating;
+
+  try {
+    [branding, reviews, avgRating] = await withTimeout(
+      Promise.all([
+        getPublicBranding(),
+        getPublicReviews(),
+        getPublicAverageRating(),
+      ]),
+      DATA_FETCH_TIMEOUT_MS,
+      "clinic public data",
+    );
+  } catch (err) {
+    logger.error("Failed to fetch public clinic data", {
+      context: "public-page",
+      clinicId: tenant.clinicId,
+      error: err,
+    });
+    throw err;
+  }
+
+  if (!branding) {
+    notFound();
+  }
   const sections = mergeSectionVisibility(
     branding.sectionVisibility as Record<string, boolean>,
   );

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -414,14 +414,18 @@ export async function GET(request: NextRequest) {
       getPublicSlotBookingCounts(date, doctorId),
     ]);
 
-    return apiSuccess({
-      slots: availableSlots,
-      allSlots,
-      bookedCounts,
-      maxPerSlot: tenantCfg.booking.maxPerSlot,
-      slotDuration: tenantCfg.booking.slotDuration,
-      bufferTime: tenantCfg.booking.bufferTime,
-    });
+    return apiSuccess(
+      {
+        slots: availableSlots,
+        allSlots,
+        bookedCounts,
+        maxPerSlot: tenantCfg.booking.maxPerSlot,
+        slotDuration: tenantCfg.booking.slotDuration,
+        bufferTime: tenantCfg.booking.bufferTime,
+      },
+      200,
+      { "Cache-Control": "public, max-age=60" },
+    );
   } catch (err) {
     logger.warn("Operation failed", { context: "booking/route", error: err });
     return apiInternalError("Failed to fetch available slots");

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -105,7 +105,7 @@ export async function GET() {
     // PII that should only be visible to authenticated users.
     const { phone: _phone, address: _address, ...publicData } = data;
 
-    return apiSuccess(publicData);
+    return apiSuccess(publicData, 200, { "Cache-Control": "public, max-age=300" });
   } catch (err) {
     logger.warn("Operation failed", { context: "branding", error: err });
     return apiInternalError("Failed to fetch branding");

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -83,5 +83,6 @@ export async function GET() {
       checks,
     },
     overallStatus === "down" ? 503 : 200,
+    { "Cache-Control": "public, max-age=30" },
   );
 }


### PR DESCRIPTION
## Summary

Addresses audit issues #6 (No Loading/Error States for Public Clinic Pages) and #7 (API Responses Cached with public Cache-Control).

### Issue #6: Loading/Error/404 States

- **loading.tsx**: Enhanced skeleton UI matching the actual page layout (hero, services, reviews sections) for smooth loading experience
- **error.tsx**: Added "go home" link alongside the retry button for better error recovery UX
- **not-found.tsx**: New 404 page for when a clinic is not found, with i18n support
- **page.tsx**: Added 10s timeout handling for Supabase queries via `Promise.race()`, explicit error logging, and `notFound()` call when branding data is missing

### Issue #7: API Cache Security Fix (HIPAA/Compliance)

- **next.config.ts**: Replaced dangerous blanket `public, max-age=300` Cache-Control on ALL `/api/*` routes with safe default `private, no-store`
- Added explicit per-route caching only to truly public endpoints:
  - `/api/health`: `public, max-age=30`
  - `/api/branding` GET: `public, max-age=300`
  - `/api/booking` GET (slot availability): `public, max-age=60`
  - `/api/docs` already had its own Cache-Control header
- All authenticated endpoints (patient data, booking mutations, admin, etc.) now correctly use `private, no-store`

### Files Changed

- `src/app/(public)/loading.tsx` - Enhanced skeleton UI
- `src/app/(public)/error.tsx` - Added home link
- `src/app/(public)/not-found.tsx` - New 404 page
- `src/app/(public)/page.tsx` - Timeout + error handling
- `next.config.ts` - Safe default API caching
- `src/app/api/health/route.ts` - Per-route cache header
- `src/app/api/branding/route.ts` - Per-route cache header
- `src/app/api/booking/route.ts` - Per-route cache header