### PR TITLE
fix: populate recentActivity in admin dashboard from activity_logs

### DIFF
--- a/src/components/admin/admin-dashboard-view.tsx
+++ b/src/components/admin/admin-dashboard-view.tsx
@@ -8,14 +8,35 @@ import { ClinicCenterDashboardKPIsComponent } from "@/components/admin/clinic-ce
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useLocale } from "@/components/locale-switcher";
 import { t } from "@/lib/i18n";
-import type { DashboardStats } from "@/lib/data/server";
+import type { DashboardStats, RecentActivityItem } from "@/lib/data/server";
 
 const activityVariant: Record<string, "default" | "success" | "warning" | "destructive"> = {
   booking: "default",
   payment: "success",
   review: "warning",
   cancel: "destructive",
+  admin: "default",
+  auth: "default",
+  security: "destructive",
+  patient: "default",
+  config: "warning",
 };
+
+/** Format an ISO timestamp into a short relative or absolute label. */
+function formatActivityTime(iso: string): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
 
 interface AdminDashboardViewProps {
   stats: DashboardStats;
@@ -40,7 +61,7 @@ export function AdminDashboardView({ stats }: AdminDashboardViewProps) {
     { icon: Star, label: t(locale, "admin.averageRating"), value: avgRating.toFixed(1), color: "text-yellow-600" },
   ];
 
-  const recentActivity: { type: string; message: string; time: string }[] = [];
+  const recentActivity: RecentActivityItem[] = stats.recentActivity;
 
   return (
     <div>
@@ -79,7 +100,7 @@ export function AdminDashboardView({ stats }: AdminDashboardViewProps) {
                       {activity.type}
                     </Badge>
                     <p className="flex-1 text-sm">{activity.message}</p>
-                    <span className="text-xs text-muted-foreground whitespace-nowrap">{activity.time}</span>
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">{formatActivityTime(activity.time)}</span>
                   </div>
                 ))}
               </div>

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -1217,6 +1217,12 @@ export async function updateLabOrderPdfUrl(
 // Dashboard Stats (server-side)
 // ────────────────────────────────────────────
 
+export interface RecentActivityItem {
+  type: string;
+  message: string;
+  time: string;
+}
+
 export interface DashboardStats {
   totalPatients: number;
   totalAppointments: number;
@@ -1226,6 +1232,7 @@ export interface DashboardStats {
   averageRating: number;
   doctorCount: number;
   insurancePatients: number;
+  recentActivity: RecentActivityItem[];
 }
 
 export async function getDashboardStats(clinicId: string): Promise<DashboardStats> {
@@ -1257,6 +1264,9 @@ export async function getDashboardStats(clinicId: string): Promise<DashboardStat
   const avgRating = reviews.length > 0 ? reviews.reduce((s, r) => s + r.stars, 0) / reviews.length : 0;
   const insuranceCount = insurancePatients.filter((p) => p.metadata && (p.metadata as Record<string, unknown>).insurance).length;
 
+  // Fetch recent activity from the audit trail
+  const recentActivity = await getRecentActivity(supabase, clinicId);
+
   return {
     totalPatients: patientCountRes.count ?? 0,
     totalAppointments: appointmentCountRes.count ?? 0,
@@ -1266,7 +1276,50 @@ export async function getDashboardStats(clinicId: string): Promise<DashboardStat
     averageRating: avgRating,
     doctorCount: doctorCountRes.count ?? 0,
     insurancePatients: insuranceCount,
+    recentActivity,
   };
+}
+
+/**
+ * Map an audit event type to a UI-friendly activity type used by the
+ * dashboard badge (see `activityVariant` in admin-dashboard-view).
+ */
+function auditTypeToActivityType(type: string, action: string): string {
+  if (type === "booking" || action.startsWith("appointment.")) return "booking";
+  if (type === "payment" || action.startsWith("payment.")) return "payment";
+  if (action.includes("cancel")) return "cancel";
+  if (type === "admin" || type === "config") return "admin";
+  if (type === "auth") return "auth";
+  if (type === "security") return "security";
+  return type;
+}
+
+/**
+ * Fetch the most recent activity log entries for a clinic.
+ * Reads from the `activity_logs` table populated by `logAuditEvent()`.
+ */
+async function getRecentActivity(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  clinicId: string,
+  limit = 10,
+): Promise<RecentActivityItem[]> {
+  const { data, error } = await supabase
+    .from("activity_logs")
+    .select("action, type, description, timestamp")
+    .eq("clinic_id", clinicId)
+    .order("timestamp", { ascending: false })
+    .limit(limit);
+
+  if (error || !data) {
+    logger.warn("Failed to fetch recent activity", { context: "data/server", error });
+    return [];
+  }
+
+  return data.map((row) => ({
+    type: auditTypeToActivityType(row.type, row.action),
+    message: row.description ?? row.action,
+    time: row.timestamp ?? "",
+  }));
 }
 
 // ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes audit issue #8: the admin dashboard's "Recent Activity" feed was always empty because `recentActivity` was hardcoded as `[]`.

### Problem

In `admin-dashboard-view.tsx` (line 43), `recentActivity` was a hardcoded empty array:
```ts
const recentActivity: { type: string; message: string; time: string }[] = [];
```
The audit logging infrastructure (`logAuditEvent()`) was already writing events to the `activity_logs` table — but nothing was reading them for the dashboard.

### Solution

- **`src/lib/data/server.ts`**:
  - Added `RecentActivityItem` interface (exported for use by the view)
  - Added `recentActivity` field to `DashboardStats` interface
  - Added `getRecentActivity()` — queries the 10 most recent entries from `activity_logs` for the clinic
  - Added `auditTypeToActivityType()` — maps audit event types to UI badge variants
  - Wired into `getDashboardStats()` so activity data flows through the existing stats pipeline

- **`src/components/admin/admin-dashboard-view.tsx`**:
  - Replaced hardcoded empty array with `stats.recentActivity`
  - Added `formatActivityTime()` for relative timestamps (e.g. "5m ago", "2h ago", "3d ago")
  - Added badge variant mappings for new activity types (admin, auth, security, patient, config)