### PR TITLE
fix: address issues 20-24 (onboarding persistence, auto-save drafts, optimistic UI, CSP, rate limiter logging)

### DIFF
--- a/src/app/(doctor)/doctor/consultation/page.tsx
+++ b/src/app/(doctor)/doctor/consultation/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { FileEdit, CheckCircle, XCircle, Save, Eye, EyeOff, Plus } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { FileEdit, CheckCircle, XCircle, Save, Eye, EyeOff, Plus, CloudOff, Cloud, Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,7 @@ import {
   type ConsultationNoteView,
 } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
+import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
 
 interface ConsultationNote {
   id: string;
@@ -69,6 +70,31 @@ export default function ConsultationNotesPage() {
     plan: "",
     privateNotes: "",
   });
+  const [savingNote, setSavingNote] = useState(false);
+
+  // Auto-save drafts for the currently editing note
+  const draftKey = editingApptId ? `consultation-note-${editingApptId}` : "consultation-note-none";
+  const {
+    draft,
+    saveDraft,
+    clearDraft,
+    isSynced,
+    hasDraft,
+  } = useOfflineDrafts<typeof formData>(draftKey, { autoSaveMs: 5000 });
+
+  // Track whether we've shown the restore prompt for this editing session
+  const [draftRestoreOffered, setDraftRestoreOffered] = useState(false);
+
+  const updateFormField = useCallback(
+    (field: string, value: string) => {
+      setFormData((prev) => {
+        const updated = { ...prev, [field]: value };
+        saveDraft(updated);
+        return updated;
+      });
+    },
+    [saveDraft],
+  );
 
   useEffect(() => {
     const controller = new AbortController();
@@ -93,6 +119,13 @@ export default function ConsultationNotesPage() {
     });
     return () => { controller.abort(); };
   }, []);
+
+  // Check for unsaved draft when editor opens
+  useEffect(() => {
+    if (editingApptId && hasDraft && draft && !isSynced && !draftRestoreOffered) {
+      setDraftRestoreOffered(true);
+    }
+  }, [editingApptId, hasDraft, draft, isSynced, draftRestoreOffered]);
 
   if (loading) {
     return <PageLoader message="Loading consultation notes..." />;
@@ -128,6 +161,7 @@ export default function ConsultationNotesPage() {
     } else {
       setFormData({ chiefComplaint: "", examination: "", diagnosis: "", plan: "", privateNotes: "" });
     }
+    setDraftRestoreOffered(false);
     setEditingApptId(appointmentId);
   };
 
@@ -136,10 +170,11 @@ export default function ConsultationNotesPage() {
     const appt = apptList.find((a) => a.id === editingApptId);
     if (!appt) return;
 
+    setSavingNote(true);
     const existing = getNoteForAppointment(editingApptId);
     const now = new Date().toISOString();
     const user = await getCurrentUser();
-    if (!user?.clinic_id) return;
+    if (!user?.clinic_id) { setSavingNote(false); return; }
 
     const content = {
       chiefComplaint: formData.chiefComplaint,
@@ -163,6 +198,7 @@ export default function ConsultationNotesPage() {
               : n
           )
         );
+        clearDraft();
       }
     } else {
       const newId = await createConsultationNote({
@@ -187,23 +223,43 @@ export default function ConsultationNotesPage() {
           updatedAt: now,
         };
         setNotes((prev) => [...prev, newNote]);
+        clearDraft();
       }
     }
+    setSavingNote(false);
     setEditingApptId(null);
   };
 
   const handleMarkDone = async (appointmentId: string) => {
-    await updateAppointmentStatus(appointmentId, "completed");
+    const apt = apptList.find((a) => a.id === appointmentId);
+    const previousStatus = apt?.status ?? "in-progress";
+    // Optimistic update
     setApptList((prev) =>
       prev.map((a) => (a.id === appointmentId ? { ...a, status: "completed" } : a))
     );
+    const result = await updateAppointmentStatus(appointmentId, "completed");
+    if (!result.success) {
+      // Roll back on failure
+      setApptList((prev) =>
+        prev.map((a) => (a.id === appointmentId ? { ...a, status: previousStatus } : a))
+      );
+    }
   };
 
   const handleNoShow = async (appointmentId: string) => {
-    await updateAppointmentStatus(appointmentId, "no-show");
+    const apt = apptList.find((a) => a.id === appointmentId);
+    const previousStatus = apt?.status ?? "scheduled";
+    // Optimistic update
     setApptList((prev) =>
       prev.map((a) => (a.id === appointmentId ? { ...a, status: "no-show" } : a))
     );
+    const result = await updateAppointmentStatus(appointmentId, "no-show");
+    if (!result.success) {
+      // Roll back on failure
+      setApptList((prev) =>
+        prev.map((a) => (a.id === appointmentId ? { ...a, status: previousStatus } : a))
+      );
+    }
   };
 
   const togglePrivate = (noteId: string) => {
@@ -329,7 +385,7 @@ export default function ConsultationNotesPage() {
               <Textarea
                 placeholder="What is the patient's main concern?"
                 value={formData.chiefComplaint}
-                onChange={(e) => setFormData((p) => ({ ...p, chiefComplaint: e.target.value }))}
+                onChange={(e) => updateFormField("chiefComplaint", e.target.value)}
               />
             </div>
             <div className="space-y-2">
@@ -337,7 +393,7 @@ export default function ConsultationNotesPage() {
               <Textarea
                 placeholder="Physical examination findings..."
                 value={formData.examination}
-                onChange={(e) => setFormData((p) => ({ ...p, examination: e.target.value }))}
+                onChange={(e) => updateFormField("examination", e.target.value)}
               />
             </div>
             <div className="space-y-2">
@@ -345,7 +401,7 @@ export default function ConsultationNotesPage() {
               <Input
                 placeholder="Diagnosis..."
                 value={formData.diagnosis}
-                onChange={(e) => setFormData((p) => ({ ...p, diagnosis: e.target.value }))}
+                onChange={(e) => updateFormField("diagnosis", e.target.value)}
               />
             </div>
             <div className="space-y-2">
@@ -353,7 +409,7 @@ export default function ConsultationNotesPage() {
               <Textarea
                 placeholder="Treatment plan and next steps..."
                 value={formData.plan}
-                onChange={(e) => setFormData((p) => ({ ...p, plan: e.target.value }))}
+                onChange={(e) => updateFormField("plan", e.target.value)}
               />
             </div>
             <div className="space-y-2">
@@ -364,16 +420,60 @@ export default function ConsultationNotesPage() {
               <Textarea
                 placeholder="Private observations, reminders..."
                 value={formData.privateNotes}
-                onChange={(e) => setFormData((p) => ({ ...p, privateNotes: e.target.value }))}
+                onChange={(e) => updateFormField("privateNotes", e.target.value)}
                 className="border-yellow-200 dark:border-yellow-800"
               />
             </div>
-            <div className="flex gap-2 justify-end">
-              <Button variant="outline" onClick={() => setEditingApptId(null)}>Cancel</Button>
-              <Button onClick={handleSaveNote}>
-                <Save className="h-4 w-4 mr-1" />
-                Save Notes
-              </Button>
+            {/* Draft restore banner */}
+            {draftRestoreOffered && hasDraft && draft && !isSynced && (
+              <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/20 p-3">
+                <CloudOff className="h-4 w-4 text-amber-600 shrink-0" />
+                <p className="text-xs text-amber-800 dark:text-amber-200 flex-1">
+                  An unsaved draft was found. Restore it?
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  onClick={() => {
+                    setFormData(draft);
+                    setDraftRestoreOffered(false);
+                  }}
+                >
+                  Restore
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-xs"
+                  onClick={() => {
+                    clearDraft();
+                    setDraftRestoreOffered(false);
+                  }}
+                >
+                  Discard
+                </Button>
+              </div>
+            )}
+
+            {/* Draft status indicator + actions */}
+            <div className="flex items-center gap-2 justify-between">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                {savingNote ? (
+                  <><Loader2 className="h-3 w-3 animate-spin" /> Saving...</>
+                ) : isSynced ? (
+                  <><Cloud className="h-3 w-3 text-green-500" /> Draft saved</>
+                ) : (
+                  <><CloudOff className="h-3 w-3 text-amber-500" /> Unsaved changes</>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={() => setEditingApptId(null)}>Cancel</Button>
+                <Button onClick={handleSaveNote} disabled={savingNote}>
+                  <Save className="h-4 w-4 mr-1" />
+                  Save Notes
+                </Button>
+              </div>
             </div>
           </div>
         </DialogContent>

--- a/src/components/doctor/doctor-dashboard-view.tsx
+++ b/src/components/doctor/doctor-dashboard-view.tsx
@@ -169,12 +169,14 @@ export function DoctorDashboardView({
     newStatus: string,
     previousStatus: string,
   ) => {
+    // Optimistic update: reflect the change immediately
+    setAppointmentList((prev) =>
+      prev.map((a) => (a.id === appointmentId ? { ...a, status: newStatus } : a))
+    );
+
     try {
       const result = await updateAppointmentStatus(appointmentId, newStatus);
       if (!result.success) throw new Error(result.error?.message ?? "Failed to update status");
-      setAppointmentList((prev) =>
-        prev.map((a) => (a.id === appointmentId ? { ...a, status: newStatus } : a))
-      );
       addToast(
         t(locale, "dashboard.statusChanged"),
         "success",
@@ -183,14 +185,19 @@ export function DoctorDashboardView({
           label: t(locale, "dashboard.undo"),
           onClick: () => {
             void (async () => {
+              // Optimistic undo
+              setAppointmentList((prev) =>
+                prev.map((a) => (a.id === appointmentId ? { ...a, status: previousStatus } : a))
+              );
               try {
                 const undo = await updateAppointmentStatus(appointmentId, previousStatus);
                 if (!undo.success) throw new Error(undo.error?.message ?? "Undo failed");
-                setAppointmentList((prev) =>
-                  prev.map((a) => (a.id === appointmentId ? { ...a, status: previousStatus } : a))
-                );
                 addToast(t(locale, "dashboard.undone"), "info");
               } catch (err) {
+                // Revert the undo — restore the new status
+                setAppointmentList((prev) =>
+                  prev.map((a) => (a.id === appointmentId ? { ...a, status: newStatus } : a))
+                );
                 logger.warn("Undo failed", { context: "doctor-dashboard", error: err });
                 addToast(t(locale, "error.updateFailed"), "error");
               }
@@ -199,8 +206,12 @@ export function DoctorDashboardView({
         },
       );
     } catch (err) {
+      // Roll back optimistic update on failure
+      setAppointmentList((prev) =>
+        prev.map((a) => (a.id === appointmentId ? { ...a, status: previousStatus } : a))
+      );
       logger.warn("Failed to update appointment status", { context: "doctor-dashboard", error: err });
-      setError(new Error(t(locale, "error.updateFailed")));
+      addToast(t(locale, "error.updateFailed"), "error");
     }
   }, [addToast, locale]);
 
@@ -221,15 +232,22 @@ export function DoctorDashboardView({
   };
 
   const handleStartConsultation = async (appointmentId: string) => {
+    const apt = appointmentList.find((a) => a.id === appointmentId);
+    const previousStatus = apt?.status ?? "scheduled";
+    // Optimistic update
+    setAppointmentList((prev) =>
+      prev.map((a) => (a.id === appointmentId ? { ...a, status: "in-progress" } : a))
+    );
     try {
       const result = await updateAppointmentStatus(appointmentId, "in-progress");
       if (!result.success) throw new Error(result.error?.message ?? "Failed to start consultation");
-      setAppointmentList((prev) =>
-        prev.map((a) => (a.id === appointmentId ? { ...a, status: "in-progress" } : a))
-      );
     } catch (err) {
+      // Roll back on failure
+      setAppointmentList((prev) =>
+        prev.map((a) => (a.id === appointmentId ? { ...a, status: previousStatus } : a))
+      );
       logger.warn("Failed to start consultation", { context: "doctor-dashboard", error: err });
-      setError(new Error(t(locale, "error.updateFailed")));
+      addToast(t(locale, "error.updateFailed"), "error");
     }
   };
 

--- a/src/components/onboarding/getting-started-checklist.tsx
+++ b/src/components/onboarding/getting-started-checklist.tsx
@@ -10,8 +10,6 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   ONBOARDING_STEPS,
-  dismissTour,
-  resetTour,
   type OnboardingStepId,
 } from "@/lib/data/client/onboarding";
 
@@ -49,10 +47,7 @@ export function GettingStartedChecklist({
     return (
       <button
         type="button"
-        onClick={async () => {
-          await resetTour();
-          onReshow();
-        }}
+        onClick={() => onReshow()}
         className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors px-3 py-2 rounded-lg hover:bg-muted w-full"
       >
         <RotateCcw className="h-3 w-3" />
@@ -84,10 +79,7 @@ export function GettingStartedChecklist({
             </button>
             <button
               type="button"
-              onClick={async () => {
-                await dismissTour();
-                onDismiss();
-              }}
+              onClick={() => onDismiss()}
               className="rounded p-0.5 hover:bg-muted transition-colors"
               aria-label="Dismiss checklist"
             >

--- a/src/components/onboarding/onboarding-provider.tsx
+++ b/src/components/onboarding/onboarding-provider.tsx
@@ -5,6 +5,9 @@ import {
   fetchOnboardingState,
   autoDetectCompletedSteps,
   updateOnboardingState,
+  markStepComplete,
+  dismissTour,
+  resetTour,
   type OnboardingState,
   type OnboardingStepId,
 } from "@/lib/data/client/onboarding";
@@ -82,16 +85,20 @@ export function OnboardingProvider({ children }: { children: React.ReactNode }) 
       const completedSteps = [...prev.completedSteps, stepId];
       return { ...prev, completedSteps };
     });
+    // Persist to database so progress survives refresh/browser switch
+    void markStepComplete(stepId);
   }, []);
 
   const dismiss = useCallback(() => {
     setShowTour(false);
     setState((prev) => (prev ? { ...prev, tourDismissed: true } : prev));
+    void dismissTour();
   }, []);
 
   const reshow = useCallback(() => {
     setShowTour(true);
     setState((prev) => (prev ? { ...prev, tourDismissed: false } : prev));
+    void resetTour();
   }, []);
 
   return (

--- a/src/lib/middleware/security-headers.ts
+++ b/src/lib/middleware/security-headers.ts
@@ -8,7 +8,7 @@ export function buildCsp(nonce: string): string {
   return [
     "default-src 'self'",
     `script-src 'self' 'nonce-${nonce}' https://static.cloudflareinsights.com${isDev ? " 'unsafe-eval'" : ""}`,
-    `style-src 'self' 'unsafe-inline' 'nonce-${nonce}'`,
+    `style-src 'self' 'nonce-${nonce}'`,
     "img-src 'self' data: blob: *.supabase.co *.r2.cloudflarestorage.com *.r2.dev",
     "font-src 'self' data:",
     "connect-src 'self' *.supabase.co wss://*.supabase.co graph.facebook.com api.twilio.com api.cloudflare.com *.googleapis.com https://cloudflareinsights.com https://static.cloudflareinsights.com",

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -403,7 +403,11 @@ function createMemoryRateLimiter(options: RateLimiterOptions): RateLimiter {
       // know the rate-limit state was reset (all previous counters lost).
       if (!coldStartWarned) {
         coldStartWarned = true;
-        // In-memory fallback active — counters not shared across isolates
+        logger.warn(
+          "In-memory rate limiter active — counters are not shared across isolates and will reset on cold starts. " +
+          "Configure RATE_LIMIT_BACKEND=kv or RATE_LIMIT_BACKEND=supabase for production use.",
+          { context: "rate-limit" },
+        );
       }
 
       prune(now);
@@ -439,6 +443,13 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
   if (shouldUseSupabase()) {
     return createSupabaseRateLimiter(options);
   }
+  logger.warn(
+    "Rate limiter falling back to in-memory backend. " +
+    "This is unsuitable for production serverless deployments — " +
+    "counters reset on cold starts and are not shared across isolates. " +
+    "Set RATE_LIMIT_BACKEND=kv or configure NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.",
+    { context: "rate-limit" },
+  );
   return createMemoryRateLimiter(options);
 }
 


### PR DESCRIPTION
## Summary

Fixes 5 medium-priority issues in the webs-alots healthcare SaaS application.

### Issue 20: Admin Dashboard Missing Onboarding Progress Persistence
- `markComplete` now calls `markStepComplete()` to persist progress to Supabase
- `dismiss`/`reshow` callbacks persist via `dismissTour()`/`resetTour()`
- Removed duplicate persistence calls from checklist component

### Issue 21: No Form Auto-Save for Clinical Notes
- Integrated `useOfflineDrafts` hook into consultation note editor with `autoSaveMs: 5000`
- Shows draft restore banner when unsaved draft is detected on editor open
- Displays sync status indicator (saved/unsaved/syncing) near the form
- Clears draft on successful save

### Issue 22: Appointment Status Update Has No Optimistic UI
- Doctor dashboard: immediately updates UI on status change, reverts on failure
- Added undo capability in toast with optimistic rollback
- Consultation page: optimistic updates for mark done/no-show actions

### Issue 23: CSP Allows Unsafe-Inline Styles Permanently
- Removed `unsafe-inline` from `style-src` CSP directive
- Now relies solely on nonce for style-src protection

### Issue 24: In-Memory Rate Limiter State Lost on Serverless Cold Start
- Added warning log at factory level when in-memory backend is selected
- Added warning log on first request after cold start
- Includes actionable configuration guidance in log messages

### Validation
- 0 lint errors (55 pre-existing warnings unchanged)
- TypeScript typecheck passes
- All 29 tests pass