### PR TITLE
feat: implement issues #49, #50, #51 (isFirstVisit i18n, print letterhead, waiting-list rate limiting)

### DIFF
--- a/src/app/(doctor)/doctor/certificates/page.tsx
+++ b/src/app/(doctor)/doctor/certificates/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { clinicConfig } from "@/config/clinic.config";
 
 export default function DoctorCertificatesPage() {
   const [certificates, setCertificates] = useState<MedicalCertificateView[]>([]);
@@ -96,6 +97,7 @@ export default function DoctorCertificatesPage() {
       <CertificateGenerator
         certificates={certificates}
         patients={patients.map((p) => ({ id: p.id, name: p.name }))}
+        clinic={{ name: clinicConfig.name, address: clinicConfig.contact.address, phone: clinicConfig.contact.phone }}
         onCreateCertificate={handleCreateCertificate}
       />
     </div>

--- a/src/app/(doctor)/doctor/consultation/page.tsx
+++ b/src/app/(doctor)/doctor/consultation/page.tsx
@@ -23,6 +23,7 @@ import {
 import { PageLoader } from "@/components/ui/page-loader";
 import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { clinicConfig } from "@/config/clinic.config";
 
 interface ConsultationNote {
   id: string;
@@ -58,10 +59,17 @@ function mapDbNoteToLocal(n: ConsultationNoteView): ConsultationNote {
 }
 
 function printConsultationNote(apt: AppointmentView, note: ConsultationNote): void {
+  const clinicName = clinicConfig.name || "";
+  const clinicAddress = clinicConfig.contact.address || "";
+  const clinicPhone = clinicConfig.contact.phone || "";
+
   const html = `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Consultation – ${apt.patientName}</title>
 <style>
   body{font-family:Helvetica,Arial,sans-serif;font-size:11pt;line-height:1.6;color:#000;margin:0;padding:20mm}
+  .letterhead{text-align:center;margin-bottom:12pt}
+  .letterhead h2{font-size:14pt;margin:0 0 2pt;color:#333}
+  .letterhead p{font-size:9pt;color:#555;margin:0}
   .header{text-align:center;border-bottom:2px solid #333;padding-bottom:12pt;margin-bottom:18pt}
   .header h1{font-size:16pt;margin:0 0 4pt}
   .header p{font-size:9pt;color:#555;margin:0}
@@ -70,14 +78,15 @@ function printConsultationNote(apt: AppointmentView, note: ConsultationNote): vo
   .signature{margin-top:48pt;text-align:right;border-top:1px solid #999;padding-top:8pt;width:40%;margin-left:auto}
   @page{size:A4;margin:20mm}
 </style></head><body>
-<div class="header"><h1>CONSULTATION NOTES</h1><p>${apt.serviceName} — ${apt.date}</p></div>
-<div class="field"><span class="field-label">Patient:</span> ${apt.patientName}</div>
-<div class="field"><span class="field-label">Date:</span> ${apt.date} at ${apt.time}</div>
-<div class="field"><span class="field-label">Chief Complaint:</span> ${note.chiefComplaint}</div>
-<div class="field"><span class="field-label">Examination:</span> ${note.examination}</div>
-<div class="field"><span class="field-label">Diagnosis:</span> ${note.diagnosis}</div>
-<div class="field"><span class="field-label">Plan:</span> ${note.plan}</div>
-<div class="signature">Doctor's Signature</div>
+${clinicName ? `<div class="letterhead"><h2>${clinicName}</h2>${clinicAddress ? `<p>${clinicAddress}</p>` : ""}${clinicPhone ? `<p>Tél : ${clinicPhone}</p>` : ""}</div>` : ""}
+<div class="header"><h1>NOTES DE CONSULTATION</h1><p>${apt.serviceName} — ${apt.date}</p></div>
+<div class="field"><span class="field-label">Patient :</span> ${apt.patientName}</div>
+<div class="field"><span class="field-label">Date :</span> ${apt.date} à ${apt.time}</div>
+<div class="field"><span class="field-label">Motif de consultation :</span> ${note.chiefComplaint}</div>
+<div class="field"><span class="field-label">Examen :</span> ${note.examination}</div>
+<div class="field"><span class="field-label">Diagnostic :</span> ${note.diagnosis}</div>
+<div class="field"><span class="field-label">Plan :</span> ${note.plan}</div>
+<div class="signature">Signature du médecin</div>
 </body></html>`;
 
   const win = window.open("", "_blank");

--- a/src/app/api/booking/waiting-list/route.ts
+++ b/src/app/api/booking/waiting-list/route.ts
@@ -8,7 +8,8 @@ import { waitingListSchema } from "@/lib/validations";
 import { withAuthValidation } from "@/lib/api-validate";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import type { UserRole } from "@/lib/types/database";
-import { apiError, apiForbidden, apiInternalError, apiSuccess } from "@/lib/api-response";
+import { apiError, apiForbidden, apiInternalError, apiRateLimited, apiSuccess } from "@/lib/api-response";
+import { waitingListLimiter, extractClientIp } from "@/lib/rate-limit";
 
 const WAITING_LIST_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
 /**
@@ -17,6 +18,28 @@ const WAITING_LIST_ROLES: UserRole[] = [...STAFF_ROLES, "patient"];
  * Add a patient to the waiting list.
  */
 export const POST = withAuthValidation(waitingListSchema, async (body, request, { supabase }) => {
+
+    // Honeypot check: if the hidden field was filled, silently reject (Issue 51)
+    if (body.website) {
+      return apiSuccess({ status: "added", message: "Added to waiting list", entryId: "ok" });
+    }
+
+    // Defence-in-depth: per-IP rate limit (Issue 51).
+    // The middleware also applies waitingListLimiter, but checking here
+    // guards against deployment configs that skip the middleware layer.
+    const clientIp = extractClientIp(request);
+    const ipAllowed = await waitingListLimiter.check(`waiting-list:${clientIp}`);
+    if (!ipAllowed) {
+      return apiRateLimited("Trop de demandes. Veuillez réessayer plus tard.");
+    }
+
+    // Per-phone rate limit: 3 requests per phone number per hour (Issue 51)
+    if (body.patientPhone) {
+      const phoneAllowed = await waitingListLimiter.check(`waiting-list-phone:${body.patientPhone}`);
+      if (!phoneAllowed) {
+        return apiRateLimited("Trop de demandes pour ce numéro. Veuillez réessayer plus tard.");
+      }
+    }
 
     // Find or create patient (prefer phone-based lookup to avoid name collisions)
     const tenant = await requireTenant();

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -222,6 +222,7 @@ export function BookingForm() {
           preferredDate: selectedDate,
           preferredTime: slot,
           serviceId: selectedService,
+          website: honeypot,
         }),
       });
       const data = await res.json();
@@ -619,7 +620,7 @@ export function BookingForm() {
                   className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary"
                 />
                 <Label htmlFor="b-first-visit" className="text-sm cursor-pointer">
-                  Est-ce votre premi\u00e8re visite ?
+                  {t("fr", "booking.isFirstVisit")}
                 </Label>
               </div>
 

--- a/src/components/medical/certificate-generator.tsx
+++ b/src/components/medical/certificate-generator.tsx
@@ -24,6 +24,7 @@ const CERTIFICATE_TYPES: { value: CertificateType; label: string }[] = [
 interface CertificateGeneratorProps {
   certificates: MedicalCertificateView[];
   patients: { id: string; name: string }[];
+  clinic?: { name: string; address?: string; phone?: string };
   onCreateCertificate?: (data: {
     patientId: string;
     type: CertificateType;
@@ -109,14 +110,20 @@ function generateCertificateSVG(cert: MedicalCertificateView): void {
   URL.revokeObjectURL(url);
 }
 
-function printCertificate(cert: MedicalCertificateView): void {
+function printCertificate(cert: MedicalCertificateView, clinic?: { name: string; address?: string; phone?: string }): void {
   const content = cert.content as Record<string, string>;
   const typeLabel = CERTIFICATE_TYPES.find((t) => t.value === cert.type)?.label ?? cert.type;
+  const clinicName = clinic?.name || "";
+  const clinicAddress = clinic?.address || "";
+  const clinicPhone = clinic?.phone || "";
 
   const html = `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><title>Certificate – ${cert.patientName}</title>
 <style>
   body{font-family:Helvetica,Arial,sans-serif;font-size:11pt;line-height:1.6;color:#000;margin:0;padding:20mm}
+  .letterhead{text-align:center;margin-bottom:12pt}
+  .letterhead h2{font-size:14pt;margin:0 0 2pt;color:#333}
+  .letterhead p{font-size:9pt;color:#555;margin:0}
   .header{text-align:center;border-bottom:2px solid #333;padding-bottom:12pt;margin-bottom:18pt}
   .header h1{font-size:16pt;margin:0 0 4pt}
   .header p{font-size:9pt;color:#555;margin:0}
@@ -125,15 +132,16 @@ function printCertificate(cert: MedicalCertificateView): void {
   .signature{margin-top:48pt;text-align:right;border-top:1px solid #999;padding-top:8pt;width:40%;margin-left:auto}
   @page{size:A4;margin:20mm}
 </style></head><body>
-<div class="header"><h1>MEDICAL CERTIFICATE</h1><p>${typeLabel}</p></div>
-<div class="field"><span class="field-label">Patient:</span> ${cert.patientName}</div>
-<div class="field"><span class="field-label">Doctor:</span> ${cert.doctorName}</div>
-<div class="field"><span class="field-label">Date:</span> ${cert.issuedDate}</div>
-${content.reason ? `<div class="field"><span class="field-label">Reason:</span> ${content.reason}</div>` : ""}
-${content.startDate && content.endDate ? `<div class="field"><span class="field-label">Period:</span> ${content.startDate} to ${content.endDate}</div>` : ""}
-${content.details ? `<div class="field"><span class="field-label">Details:</span><br/>${content.details.replace(/\n/g, "<br/>")}</div>` : ""}
-${content.recommendations ? `<div class="field"><span class="field-label">Recommendations:</span> ${content.recommendations}</div>` : ""}
-<div class="signature">Doctor's Signature</div>
+${clinicName ? `<div class="letterhead"><h2>${clinicName}</h2>${clinicAddress ? `<p>${clinicAddress}</p>` : ""}${clinicPhone ? `<p>Tél : ${clinicPhone}</p>` : ""}</div>` : ""}
+<div class="header"><h1>CERTIFICAT MÉDICAL</h1><p>${typeLabel}</p></div>
+<div class="field"><span class="field-label">Patient :</span> ${cert.patientName}</div>
+<div class="field"><span class="field-label">Médecin :</span> ${cert.doctorName}</div>
+<div class="field"><span class="field-label">Date :</span> ${cert.issuedDate}</div>
+${content.reason ? `<div class="field"><span class="field-label">Motif :</span> ${content.reason}</div>` : ""}
+${content.startDate && content.endDate ? `<div class="field"><span class="field-label">Période :</span> du ${content.startDate} au ${content.endDate}</div>` : ""}
+${content.details ? `<div class="field"><span class="field-label">Détails :</span><br/>${content.details.replace(/\n/g, "<br/>")}</div>` : ""}
+${content.recommendations ? `<div class="field"><span class="field-label">Recommandations :</span> ${content.recommendations}</div>` : ""}
+<div class="signature">Signature du médecin</div>
 </body></html>`;
 
   const win = window.open("", "_blank");
@@ -146,6 +154,7 @@ ${content.recommendations ? `<div class="field"><span class="field-label">Recomm
 export function CertificateGenerator({
   certificates,
   patients,
+  clinic,
   onCreateCertificate,
 }: CertificateGeneratorProps) {
   const [showForm, setShowForm] = useState(false);
@@ -215,7 +224,7 @@ export function CertificateGenerator({
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => printCertificate(cert)}
+                        onClick={() => printCertificate(cert, clinic)}
                       >
                         <Printer className="h-3.5 w-3.5 mr-1" />
                         Print

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -360,6 +360,7 @@ export const translations = {
     "booking.invalidPhone": "Veuillez entrer un numéro marocain valide (+212 6XX XX XX XX)",
     "booking.verifyingPhone": "Vérification de votre numéro…",
     "booking.creatingAppointment": "Création du rendez-vous…",
+    "booking.isFirstVisit": "Est-ce votre première visite ?",
 
     // Error pages
     "error.title": "Une erreur est survenue",
@@ -987,6 +988,7 @@ export const translations = {
     "booking.next": "التالي",
     "booking.verifyingPhone": "جاري التحقق من رقمك…",
     "booking.creatingAppointment": "جاري إنشاء الموعد…",
+    "booking.isFirstVisit": "هل هذه زيارتك الأولى؟",
 
     // Error pages
     "error.title": "حدث خطأ",
@@ -1614,6 +1616,7 @@ export const translations = {
     "booking.next": "Next",
     "booking.verifyingPhone": "Verifying your number…",
     "booking.creatingAppointment": "Creating appointment…",
+    "booking.isFirstVisit": "Is this your first visit?",
 
     // Error pages
     "error.title": "An error occurred",

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -89,6 +89,8 @@ export const waitingListSchema = z.object({
   preferredDate: isoDate,
   preferredTime: timeHHMM.optional(),
   serviceId: z.string().optional(),
+  /** Honeypot field – hidden from real users, filled only by bots (Issue 51) */
+  website: z.string().max(200).optional(),
 });
 
 export const paymentConfirmSchema = z.object({


### PR DESCRIPTION
## Summary

Implements three issues:

### Issue #49 — Booking Form isFirstVisit i18n
- Added `booking.isFirstVisit` i18n key in all 3 locales (French, Arabic, English)
- Replaced hardcoded French label in booking form with `t("fr", "booking.isFirstVisit")`

### Issue #50 — Print Styles for Clinical Documents
- Enhanced `printCertificate()` with clinic letterhead (name, address, phone) from `clinicConfig`
- Enhanced `printConsultationNote()` with clinic letterhead from `clinicConfig`
- Translated print labels to French (Certificat Médical, Notes de Consultation, etc.)
- `CertificateGenerator` component now accepts optional `clinic` prop

### Issue #51 — handleJoinWaitingList Rate Limiting
- Added server-side per-IP rate limiting using existing `waitingListLimiter`
- Added per-phone rate limiting (3 req/phone/hour) using `waitingListLimiter`
- Added honeypot field (`website`) to waiting list schema and client request
- Server silently returns success for honeypot-filled requests

## Files Changed
- `src/lib/i18n.ts` — Added booking.isFirstVisit keys
- `src/components/booking/booking-form.tsx` — Use i18n key, pass honeypot to waiting list
- `src/components/medical/certificate-generator.tsx` — Clinic letterhead in print
- `src/app/(doctor)/doctor/consultation/page.tsx` — Clinic letterhead in print
- `src/app/(doctor)/doctor/certificates/page.tsx` — Pass clinic info to CertificateGenerator
- `src/app/api/booking/waiting-list/route.ts` — Rate limiting + honeypot
- `src/lib/validations.ts` — Added website honeypot field to schema

Closes #49, #50, #51