### PR TITLE
feat: Issues #45, #46, #47 — MutationResult discriminated union, PHI data masking, Supabase singleton docs

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -67,6 +67,13 @@ SUPABASE_DB_URL=postgresql://postgres:password@db.xxx.supabase.co:5432/postgres
 # When "false", phone/OTP login and registration are disabled.
 NEXT_PUBLIC_PHONE_AUTH_ENABLED=false
 
+# Data Masking (Patient PHI)
+# Controls masking of sensitive patient data (phone, email, CIN) in the UI.
+# "full" — aggressive masking for demos / public screens
+# "partial" — moderate masking for staff who need partial visibility
+# "none" — no masking (authorized personnel, default)
+NEXT_PUBLIC_DATA_MASKING=none
+
 # Seed Password Rotation
 # Migration 00019 creates seed users with a default password.
 # After rotating all seed passwords in production, set this to "true"

--- a/src/components/doctor/doctor-dashboard-view.tsx
+++ b/src/components/doctor/doctor-dashboard-view.tsx
@@ -16,6 +16,7 @@ import { updateAppointmentStatus } from "@/lib/data/client";
 import { useOptimisticUpdate } from "@/lib/hooks/use-optimistic-update";
 import { PageLoader } from "@/components/ui/page-loader";
 import { EmptyState } from "@/components/ui/empty-state";
+import { DataMask } from "@/components/ui/data-mask";
 import { logger } from "@/lib/logger";
 import { getLocalDateStr, formatDisplayDate } from "@/lib/utils";
 import { useToast } from "@/components/ui/toast";
@@ -481,7 +482,7 @@ export function DoctorDashboardView({
                         </Avatar>
                         <div className="flex-1 min-w-0">
                           <p className="font-medium truncate">{p.name}</p>
-                          <p className="text-xs text-muted-foreground">{p.phone}</p>
+                          <DataMask value={p.phone} type="phone" className="text-xs text-muted-foreground" />
                         </div>
                       </div>
                     ))

--- a/src/components/doctor/patient-card.tsx
+++ b/src/components/doctor/patient-card.tsx
@@ -15,6 +15,7 @@ import {
   type AppointmentView,
 } from "@/lib/data/client";
 import { PageLoader } from "@/components/ui/page-loader";
+import { DataMask } from "@/components/ui/data-mask";
 import { formatDisplayDate } from "@/lib/utils";
 
 type TabKey = "overview" | "history" | "prescriptions" | "notes";
@@ -103,7 +104,7 @@ export function PatientCard({ patientId }: { patientId?: string }) {
               <div className="flex flex-wrap gap-3 mt-1 text-sm text-muted-foreground">
                 <span className="flex items-center gap-1">
                   <Phone className="h-3 w-3" />
-                  {patient.phone}
+                  <DataMask value={patient.phone} type="phone" />
                 </span>
                 <span className="flex items-center gap-1">
                   <Calendar className="h-3 w-3" />

--- a/src/components/receptionist/daily-report.tsx
+++ b/src/components/receptionist/daily-report.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/data/client";
 import { exportAppointments, exportInvoices } from "@/lib/export-data";
 import { PageLoader } from "@/components/ui/page-loader";
+import { DataMask } from "@/components/ui/data-mask";
 
 const statusVariant: Record<string, "default" | "success" | "warning" | "destructive" | "secondary" | "outline"> = {
   scheduled: "outline",
@@ -292,8 +293,8 @@ export function DailyReport() {
                                     <Badge variant="secondary" className="ml-2 text-[10px]">New</Badge>
                                   )}
                                 </div>
-                                {patient && (
-                                  <span className="text-xs text-muted-foreground">{patient.phone}</span>
+                                {patient?.phone && (
+                                  <DataMask value={patient.phone} type="phone" className="text-xs text-muted-foreground" />
                                 )}
                               </td>
                               <td className="py-2 px-3">{apt.serviceName}</td>

--- a/src/components/ui/data-mask.tsx
+++ b/src/components/ui/data-mask.tsx
@@ -3,53 +3,69 @@
 import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { mask, getMaskLevel, type MaskLevel } from "@/lib/mask";
 
 interface DataMaskProps {
   /** The sensitive value to mask */
   value: string;
-  /** Number of characters to show at the end (default: 4) */
-  visibleChars?: number;
-  /** Mask character (default: "•") */
-  maskChar?: string;
+  /** Type of data — determines the masking strategy */
+  type: "phone" | "email" | "cin";
+  /** Override the environment-level masking level for this instance */
+  level?: MaskLevel;
   /** Label for accessibility */
   label?: string;
   className?: string;
 }
 
 /**
- * Data masking component for sensitive information (CIN, phone numbers, etc.).
- * Shows masked value by default with a toggle to reveal.
+ * Masks sensitive patient data based on user role and environment.
+ *
+ * Masking level is controlled by `NEXT_PUBLIC_DATA_MASKING` (full | partial | none).
+ * When masking is active, a reveal/hide toggle is shown.
+ *
+ * - Full mask for demo:  `"06 *** *** 78"`
+ * - Partial mask for staff:  `"0612 *** 78"`
+ * - No mask for authorized doctors
  *
  * Usage:
  * ```tsx
- * <DataMask value="AB123456" label="CIN" />
- * // Displays: ••••3456 [eye icon]
+ * <DataMask value="0612345678" type="phone" />
+ * <DataMask value="ahmed@example.com" type="email" />
+ * <DataMask value="AB123456" type="cin" />
  * ```
+ *
+ * Issue 46
  */
 export function DataMask({
   value,
-  visibleChars = 4,
-  maskChar = "\u2022",
-  label = "Donnée sensible",
+  type,
+  level,
+  label,
   className,
 }: DataMaskProps) {
+  const effectiveLevel = level ?? getMaskLevel();
   const [revealed, setRevealed] = useState(false);
 
-  const masked =
-    value.length <= visibleChars
-      ? maskChar.repeat(value.length)
-      : maskChar.repeat(value.length - visibleChars) +
-        value.slice(-visibleChars);
+  // When masking is disabled, render the value directly — no toggle needed.
+  if (effectiveLevel === "none") {
+    return <span className={className}>{value}</span>;
+  }
+
+  const masked = mask(value, type, effectiveLevel);
+
+  const defaultLabel =
+    type === "phone" ? "Téléphone" : type === "email" ? "Email" : "CIN";
+  const a11yLabel = label ?? defaultLabel;
 
   return (
     <span
       className={cn("inline-flex items-center gap-1.5", className)}
-      aria-label={`${label}: ${revealed ? value : "masqué"}`}
+      aria-label={`${a11yLabel}: ${revealed ? value : "masqué"}`}
     >
       <span
         className={cn(
           "font-mono text-sm transition-all",
-          !revealed && "select-none blur-[1px]"
+          !revealed && "select-none blur-[1px]",
         )}
         aria-hidden={!revealed}
       >

--- a/src/lib/data/client/_core.ts
+++ b/src/lib/data/client/_core.ts
@@ -164,8 +164,23 @@ export function clearLookupCache() {
 
 // ── Mutation result type ──
 
-export interface MutationResult<T = void> {
-  success: boolean;
-  data?: T;
-  error?: { code: string; message: string };
-}
+/**
+ * Discriminated union for mutation outcomes.
+ *
+ * On success the result carries `data` of type `T` (defaults to `void` for
+ * mutations that don't return a payload).  On failure it carries a structured
+ * `error` object.  Using a discriminated union (`success: true` vs
+ * `success: false`) lets callers narrow the type with a simple `if` check:
+ *
+ * ```ts
+ * const res = await createPayment({ ... });
+ * if (res.success) {
+ *   console.log(res.data.id); // TS knows `data` exists
+ * } else {
+ *   console.error(res.error.message); // TS knows `error` exists
+ * }
+ * ```
+ */
+export type MutationResult<T = void> =
+  | { success: true; data: T }
+  | { success: false; error: { code: string; message: string } };

--- a/src/lib/data/client/mutations.ts
+++ b/src/lib/data/client/mutations.ts
@@ -35,7 +35,7 @@ export async function updateAppointmentStatus(
     return { success: false, error: { code: error.code, message: error.message } };
   }
   clearLookupCache();
-  return { success: true };
+  return { success: true, data: undefined };
 }
 
 export async function createPayment(data: {

--- a/src/lib/hooks/use-patient-search.ts
+++ b/src/lib/hooks/use-patient-search.ts
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase-client";
 import type { CommandPaletteItem } from "@/components/command-palette";
 import { CommandIcons } from "@/components/command-palette";
 import { logger } from "@/lib/logger";
+import { maskPhone, maskCIN } from "@/lib/mask";
 
 /**
  * Hook that performs a debounced Supabase patient search and returns
@@ -59,8 +60,8 @@ export function usePatientSearch(
           return {
             id: p.id,
             label: p.name,
-            description: p.phone ?? undefined,
-            badge: cin ?? undefined,
+            description: p.phone ? maskPhone(p.phone) : undefined,
+            badge: cin ? maskCIN(cin) : undefined,
             icon: CommandIcons.patient,
             onSelect: () => onSelect(p.id),
           };


### PR DESCRIPTION
## Summary

Implements issues #45, #46, and #47.

### #45 — Mutation Functions Return Created Entity
- Updated `MutationResult` type in `_core.ts` to a proper **discriminated union** (`{ success: true; data: T } | { success: false; error: ... }`), enabling type-safe narrowing with `if (res.success)`.
- `createPayment()` and `upsertReview()` already had `.select().single()` and returned data — no changes needed there.
- Updated `updateAppointmentStatus()` to conform to the new union shape.

### #46 — Data Masking for Patient PHI
- Enhanced `DataMask` component (`src/components/ui/data-mask.tsx`) to accept a `type` prop (`phone | email | cin`) and integrate with `src/lib/mask.ts` utilities.
- Applied `DataMask` to patient-facing views:
  - `patient-card.tsx` — phone in patient header
  - `doctor-dashboard-view.tsx` — phone in quick patient search
  - `daily-report.tsx` — phone in appointment table
  - `use-patient-search.ts` — phone/CIN in search palette results
- Added `NEXT_PUBLIC_DATA_MASKING` env var (`full | partial | none`) to `.env.local.example`.
- When `none` (default), data renders normally with no toggle.

### #47 — Supabase Client Singleton
- Verified `createBrowserClient` from `@supabase/ssr` already returns a **singleton** — calling `createClient()` multiple times is safe and intended.
- JSDoc in `supabase-client.ts` already documents this behavior (added in a prior PR).
- **No code changes needed** for this issue.