### PR TITLE
feat: Issues #37, #41, #42, #43, #44 — Command palette data source, perf monitor gate, external links, calendar tooltips, breadcrumbs

### DIFF
--- a/src/app/(receptionist)/layout.tsx
+++ b/src/app/(receptionist)/layout.tsx
@@ -12,6 +12,7 @@ import { SignOutButton } from "@/components/sign-out-button";
 import { SessionTimeoutWarning } from "@/components/session-timeout-warning";
 import { signOut } from "@/lib/auth";
 import { AutoBreadcrumb } from "@/components/ui/auto-breadcrumb";
+import { PatientSearchPalette } from "@/components/patient-search-palette";
 
 const navItems = [
   { href: "/receptionist/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -122,6 +123,7 @@ export default function ReceptionistLayout({
         </main>
       </div>
       <SessionTimeoutWarning onLogout={() => signOut()} />
+      <PatientSearchPalette basePath="/receptionist/patients" />
     </div>
   );
 }

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -31,6 +31,8 @@ interface CommandPaletteProps {
   onClose?: () => void;
   /** Whether the palette is open */
   open: boolean;
+  /** Relay query changes to the parent (e.g. for server-side search). */
+  onQueryChange?: (query: string) => void;
 }
 
 /**
@@ -49,6 +51,7 @@ export function CommandPalette({
   placeholder,
   onClose,
   open,
+  onQueryChange,
 }: CommandPaletteProps) {
   const [query, setQuery] = useState("");
   const [locale] = useLocale();
@@ -66,11 +69,19 @@ export function CommandPalette({
     );
   });
 
+  const updateQuery = useCallback(
+    (value: string) => {
+      setQuery(value);
+      onQueryChange?.(value);
+    },
+    [onQueryChange],
+  );
+
   const handleClose = useCallback(() => {
-    setQuery("");
+    updateQuery("");
     setSelectedIndex(0);
     onClose?.();
-  }, [onClose]);
+  }, [onClose, updateQuery]);
 
   useEffect(() => {
     if (open) {
@@ -149,7 +160,7 @@ export function CommandPalette({
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => updateQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={effectivePlaceholder}
             className="flex-1 bg-transparent px-3 py-3 text-sm outline-none placeholder:text-muted-foreground"
@@ -165,7 +176,7 @@ export function CommandPalette({
           {query && (
             <button
               type="button"
-              onClick={() => setQuery("")}
+              onClick={() => updateQuery("")}
               className="p-1 text-muted-foreground hover:text-foreground"
               aria-label={t(locale, "commandPalette.clearSearch")}
             >

--- a/src/components/patient-search-palette.tsx
+++ b/src/components/patient-search-palette.tsx
@@ -41,6 +41,7 @@ export function PatientSearchPalette({ basePath = "/doctor/patients" }: { basePa
       }}
       items={items}
       placeholder="Rechercher un patient (nom, tél, CIN)..."
+      onQueryChange={setQuery}
     />
   );
 }


### PR DESCRIPTION
## Summary

Addresses issues #37, #41, #42, #43, and #44.

### #37 — Command Palette Connected to Data Source
- Added `onQueryChange` callback prop to `CommandPalette` so parents can react to search input changes.
- Wired `PatientSearchPalette` to relay query changes to `usePatientSearch` hook via `onQueryChange`, enabling debounced Supabase patient search on keystroke.
- Mounted `PatientSearchPalette` in the **receptionist layout** (was already in the doctor layout). Receptionists now have Ctrl+K patient search.

### #41 — Performance Monitor in Production (already implemented)
- Verified: `layout.tsx` already gates `<PerformanceMonitor />` behind `NEXT_PUBLIC_ENABLE_PERF_MONITORING === "true"`. No changes needed.

### #42 — External Links rel="noopener noreferrer" (already implemented)
- Verified: `ExternalLink` component exists and is already used for all external `<a>` tags. No bare `target="_blank"` links found. No changes needed.

### #43 — Booking Calendar Disabled Days Feedback (already implemented)
- Verified: `calendar.tsx` already has `getDateStatus()` returning disable reasons ("Date passée", "Fermé"), `Tooltip` wrapping disabled days, and aria-labels including the reason. No changes needed.

### #44 — Breadcrumb Navigation (already implemented)
- Verified: `AutoBreadcrumb` component exists with French labels for all route segments. Already mounted in all four dashboard layouts (doctor, receptionist, admin, patient). No changes needed.