### PR TITLE
fix: complete remaining audit items #7, #45, #46, #55, #56

### DIFF
--- a/src/app/(specialist)/parapharmacy/sales/page.tsx
+++ b/src/app/(specialist)/parapharmacy/sales/page.tsx
@@ -289,14 +289,14 @@ export default function ParapharmacySalesPage() {
                     </div>
                     <div className="flex items-center gap-2">
                       <Button size="icon" variant="outline" className="h-6 w-6" aria-label="Decrease quantity" onClick={() => updateCartQty(item.productId, -1)}>
-                        <Minus className="h-3 w-3" />
+                        <Minus className="h-3 w-3" aria-hidden="true" />
                       </Button>
                       <span className="w-6 text-center">{item.quantity}</span>
                       <Button size="icon" variant="outline" className="h-6 w-6" aria-label="Increase quantity" onClick={() => updateCartQty(item.productId, 1)}>
-                        <Plus className="h-3 w-3" />
+                        <Plus className="h-3 w-3" aria-hidden="true" />
                       </Button>
                       <Button size="icon" variant="ghost" className="h-6 w-6 text-red-500" aria-label="Remove from cart" onClick={() => removeFromCart(item.productId)}>
-                        <Trash2 className="h-3 w-3" />
+                        <Trash2 className="h-3 w-3" aria-hidden="true" />
                       </Button>
                       <span className="w-16 text-right font-medium">{(item.quantity * item.unitPrice).toFixed(2)}</span>
                     </div>

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -105,7 +105,12 @@ export function BookingForm() {
   // Honeypot field for basic bot protection (invisible to real users)
   const [honeypot, setHoneypot] = useState("");
   const [confirmChecked, setConfirmChecked] = useState(false);
-  // Issue 7: Track whether the user attempted to proceed so inline errors show
+  // Issue 7: Track per-field touched state for inline real-time validation
+  const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
+  const markTouched = useCallback((field: string) => {
+    setTouchedFields((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+  // Also keep stepAttempted for "Next" button press fallback
   const [stepAttempted, setStepAttempted] = useState(false);
 
   // Refs for focus management on step transitions (Issue 25)
@@ -205,17 +210,21 @@ export function BookingForm() {
     return true;
   };
 
-  // Issue 7: Inline validation error messages per step field
+  // Issue 7: Inline validation error messages per step field.
+  // Errors show when a field is touched (blur/interaction) OR when the user
+  // clicks "Next" without completing required fields (stepAttempted fallback).
   const stepErrors = useMemo(() => {
-    if (!stepAttempted) return { doctor: null, service: null, date: null, time: null, confirm: null };
+    const show = (field: string) => touchedFields[field] || stepAttempted;
     return {
-      doctor: step === 0 && !selectedDoctor ? "Veuillez choisir un médecin" : null,
-      service: step === 0 && selectedDoctor && !selectedService ? "Veuillez choisir un service" : null,
-      date: step === 1 && !selectedDate ? "Veuillez sélectionner une date" : null,
-      time: step === 1 && selectedDate && !selectedTime ? "Veuillez sélectionner un créneau" : null,
-      confirm: step === 2 && !confirmChecked ? "Veuillez confirmer vos informations" : null,
+      doctor: show("doctor") && step === 0 && !selectedDoctor ? "Veuillez choisir un médecin" : null,
+      service: show("service") && step === 0 && selectedDoctor && !selectedService ? "Veuillez choisir un service" : null,
+      date: show("date") && step === 1 && !selectedDate ? "Veuillez sélectionner une date" : null,
+      time: show("time") && step === 1 && selectedDate && !selectedTime ? "Veuillez sélectionner un créneau" : null,
+      phone: show("phone") && step === 2 && patientPhone.trim() !== "" && !isValidMoroccanPhone(patientPhone) ? "Numéro de téléphone invalide" : null,
+      phoneRequired: show("phone") && step === 2 && patientPhone.trim() === "" ? "Le numéro de téléphone est obligatoire" : null,
+      confirm: show("confirm") && step === 2 && !confirmChecked ? "Veuillez confirmer vos informations" : null,
     };
-  }, [stepAttempted, step, selectedDoctor, selectedService, selectedDate, selectedTime, confirmChecked]);
+  }, [touchedFields, stepAttempted, step, selectedDoctor, selectedService, selectedDate, selectedTime, patientPhone, confirmChecked]);
 
   const handleJoinWaitingList = async (slot: string) => {
     // Require a valid phone before joining the waiting list (Issue 17)
@@ -602,9 +611,13 @@ export function BookingForm() {
                     setPatientPhone(e.target.value);
                     if (phoneError) setPhoneError(null);
                     onValidationChange("phone", e.target.value);
+                    // Issue 7: Mark field as touched on first input so
+                    // real-time validation feedback appears immediately
+                    markTouched("phone");
                   }}
                   onBlur={() => {
                     onValidationBlur("phone", patientPhone);
+                    markTouched("phone");
                     if (patientPhone.trim() && !isValidMoroccanPhone(patientPhone)) {
                       setPhoneError(t("fr", "booking.invalidPhone"));
                     }
@@ -613,12 +626,12 @@ export function BookingForm() {
                   type="tel"
                   required
                   autoFocus
-                  className={phoneError ? "border-destructive" : ""}
+                  className={phoneError || stepErrors.phone || stepErrors.phoneRequired ? "border-destructive" : patientPhone.trim() && isValidMoroccanPhone(patientPhone) ? "border-green-500" : ""}
                   aria-invalid={!!phoneError}
                   aria-describedby={phoneError ? "phone-error" : undefined}
                 />
-                {(phoneError || getFieldError("phone")) ? (
-                  <p id="phone-error" className="text-xs text-destructive">{phoneError || getFieldError("phone")}</p>
+                {(phoneError || getFieldError("phone") || stepErrors.phone || stepErrors.phoneRequired) ? (
+                  <p id="phone-error" className="text-xs text-destructive">{phoneError || getFieldError("phone") || stepErrors.phone || stepErrors.phoneRequired}</p>
                 ) : (
                   <p className="text-xs text-muted-foreground">
                     Vous recevrez la confirmation par WhatsApp. Aucun compte requis.
@@ -657,7 +670,7 @@ export function BookingForm() {
                   id="b-confirm"
                   type="checkbox"
                   checked={confirmChecked}
-                  onChange={(e) => setConfirmChecked(e.target.checked)}
+                  onChange={(e) => { setConfirmChecked(e.target.checked); markTouched("confirm"); }}
                   className="h-4 w-4 mt-0.5 rounded border-gray-300 text-primary focus:ring-primary"
                 />
                 <Label htmlFor="b-confirm" className="text-sm cursor-pointer leading-snug">

--- a/src/components/booking/calendar.tsx
+++ b/src/components/booking/calendar.tsx
@@ -162,13 +162,13 @@ export function BookingCalendar({ selectedDate, onSelectDate }: BookingCalendarP
     <div>
       <div className="flex items-center justify-between mb-4">
         <Button variant="ghost" size="icon" onClick={prevMonth} aria-label="Mois précédent">
-          <ChevronLeft className="h-4 w-4" />
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
         </Button>
         <h3 id="calendar-heading" className="font-semibold" aria-live="polite">
           {monthNames[currentMonth]} {currentYear}
         </h3>
         <Button variant="ghost" size="icon" onClick={nextMonth} aria-label="Mois suivant">
-          <ChevronRight className="h-4 w-4" />
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
 

--- a/src/components/receptionist/manual-booking-dialog.tsx
+++ b/src/components/receptionist/manual-booking-dialog.tsx
@@ -29,6 +29,7 @@ import {
   type ServiceView,
   type PatientView,
 } from "@/lib/data/client";
+import { maskPhone } from "@/lib/mask";
 
 interface ManualBookingDialogProps {
   trigger?: React.ReactNode;
@@ -142,7 +143,7 @@ export function ManualBookingDialog({ trigger, onBook }: ManualBookingDialogProp
                 <SelectContent>
                   {patients.map((p) => (
                     <SelectItem key={p.id} value={p.id}>
-                      {p.name} - {p.phone}
+                      {p.name} - {maskPhone(p.phone)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/components/receptionist/walk-in-dialog.tsx
+++ b/src/components/receptionist/walk-in-dialog.tsx
@@ -29,6 +29,7 @@ import {
   type ServiceView,
   type PatientView,
 } from "@/lib/data/client";
+import { maskPhone } from "@/lib/mask";
 
 interface WalkInDialogProps {
   trigger?: React.ReactNode;
@@ -172,7 +173,7 @@ export function WalkInDialog({ trigger, onRegister }: WalkInDialogProps) {
                   <SelectContent>
                     {patients.map((p) => (
                       <SelectItem key={p.id} value={p.id}>
-                        {p.name} - {p.phone}
+                        {p.name} - {maskPhone(p.phone)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -16,9 +16,9 @@ export function ThemeToggle() {
       className="h-8 w-8"
     >
       {theme === "dark" ? (
-        <Sun className="h-4 w-4" />
+        <Sun className="h-4 w-4" aria-hidden="true" />
       ) : (
-        <Moon className="h-4 w-4" />
+        <Moon className="h-4 w-4" aria-hidden="true" />
       )}
     </Button>
   );

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -16,19 +16,19 @@ describe("extractClientIp", () => {
     expect(extractClientIp(req as never)).toBe("1.2.3.4");
   });
 
-  it("returns 'unknown' when only X-Real-IP is present (not trusted)", () => {
+  it("falls back to X-Real-IP when CF-Connecting-IP is absent", () => {
     const req = createMockRequest({ "x-real-ip": "5.6.7.8" });
-    expect(extractClientIp(req as never)).toBe("unknown");
+    expect(extractClientIp(req as never)).toBe("5.6.7.8");
   });
 
-  it("returns 'unknown' when only X-Forwarded-For is present (not trusted)", () => {
+  it("falls back to X-Forwarded-For (first IP) when CF-Connecting-IP is absent", () => {
     const req = createMockRequest({ "x-forwarded-for": "10.0.0.1, 10.0.0.2" });
-    expect(extractClientIp(req as never)).toBe("unknown");
+    expect(extractClientIp(req as never)).toBe("10.0.0.1");
   });
 
-  it("ignores X-Forwarded-For even with whitespace", () => {
+  it("trims whitespace in X-Forwarded-For entries", () => {
     const req = createMockRequest({ "x-forwarded-for": "  10.0.0.1  , 10.0.0.2" });
-    expect(extractClientIp(req as never)).toBe("unknown");
+    expect(extractClientIp(req as never)).toBe("10.0.0.1");
   });
 
   it("returns 'unknown' when no headers present", () => {
@@ -45,12 +45,12 @@ describe("extractClientIp", () => {
     expect(extractClientIp(req as never)).toBe("1.1.1.1");
   });
 
-  it("ignores X-Real-IP and X-Forwarded-For without CF-Connecting-IP", () => {
+  it("prefers X-Forwarded-For over X-Real-IP when CF-Connecting-IP is absent", () => {
     const req = createMockRequest({
       "x-real-ip": "2.2.2.2",
       "x-forwarded-for": "3.3.3.3",
     });
-    expect(extractClientIp(req as never)).toBe("unknown");
+    expect(extractClientIp(req as never)).toBe("3.3.3.3");
   });
 });
 

--- a/src/lib/data/client/mutations.ts
+++ b/src/lib/data/client/mutations.ts
@@ -14,7 +14,7 @@ import type { Database } from "@/lib/types/database";
 export async function updateAppointmentStatus(
   appointmentId: string,
   status: string,
-): Promise<MutationResult> {
+): Promise<MutationResult<{ id: string; status: string }>> {
   const supabase = createClient();
   // Explicit mapping from UI status names to DB column values (Issue 40).
   // Using a lookup object instead of fragile string replace.
@@ -29,13 +29,19 @@ export async function updateAppointmentStatus(
   if (dbStatus === "cancelled") {
     updateData.cancelled_at = new Date().toISOString();
   }
-  const { error } = await supabase.from("appointments").update(updateData).eq("id", appointmentId);
+  // Issue 45: Return updated entity data via .select()
+  const { data: updated, error } = await supabase
+    .from("appointments")
+    .update(updateData)
+    .eq("id", appointmentId)
+    .select("id, status")
+    .single();
   if (error) {
     logger.warn("Query failed", { context: "data/client", error });
     return { success: false, error: { code: error.code, message: error.message } };
   }
   clearLookupCache();
-  return { success: true, data: undefined };
+  return { success: true, data: { id: updated.id, status: updated.status } };
 }
 
 export async function createPayment(data: {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -30,21 +30,31 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
 
 /**
- * Extract the real client IP from a request.
+ * Extract the real client IP from a request (Issue 55).
  *
- * Priority order (HIGH-02 hardened):
- *   1. CF-Connecting-IP — set by Cloudflare's edge, cannot be spoofed by
- *      the client when traffic goes through Cloudflare.
- *   2. "unknown" fallback — groups all unidentified requests together,
- *      which is safe behind a trusted proxy.
+ * Priority order:
+ *   1. CF-Connecting-IP — set by Cloudflare's edge, most trustworthy.
+ *   2. X-Forwarded-For  — first IP in the chain (client IP when behind
+ *      a trusted reverse proxy). Only the left-most entry is used.
+ *   3. X-Real-IP        — set by some proxies (e.g. Nginx) to the real
+ *      client address.
+ *   4. "unknown"        — safe fallback that groups unidentified requests.
  *
- * X-Forwarded-For and X-Real-IP are intentionally NOT used because they
- * are attacker-controlled when the request does not pass through a trusted
- * proxy that overwrites them.  Since this app runs behind Cloudflare,
- * CF-Connecting-IP is the only trustworthy source of client IP.
+ * Note: X-Forwarded-For / X-Real-IP can be spoofed when requests bypass
+ * the trusted proxy.  For Cloudflare deployments CF-Connecting-IP is
+ * authoritative, but the fallbacks improve dev/staging accuracy.
  */
 export function extractClientIp(request: NextRequest): string {
-  return request.headers.get("cf-connecting-ip") ?? "unknown";
+  const cfIp = request.headers.get("cf-connecting-ip");
+  if (cfIp) return cfIp;
+
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  return request.headers.get("x-real-ip") ?? "unknown";
 }
 
 interface RateLimitEntry {


### PR DESCRIPTION
## Audit Checklist Fixes

Completes all remaining items from the 62-item audit checklist.

### Changes Made

**#7 (HIGH) — Inline real-time validation on booking form**
- Added per-field `touchedFields` state tracking so validation errors appear immediately on blur/change, not just when clicking "Next"
- Phone field shows green border when valid, red when invalid
- Combined `stepErrors` now include phone validation and required-field checks

**#45 (LOW) — `updateAppointmentStatus` returns entity data**
- Added `.select("id, status").single()` to the update query
- Returns `{ id, status }` in `MutationResult` instead of `undefined`

**#46 (LOW) — DataMask coverage for PHI display**
- Added `maskPhone()` to patient phone display in `walk-in-dialog.tsx` and `manual-booking-dialog.tsx`
- Patient phones in receptionist dropdowns are now masked per the configured masking level

**#55 (LOW) — `extractClientIp` X-Forwarded-For/X-Real-IP fallback**
- Added X-Forwarded-For (first IP only) and X-Real-IP as fallback headers
- Priority: CF-Connecting-IP > X-Forwarded-For > X-Real-IP > "unknown"
- Updated tests to match new fallback behavior (all 40 tests pass)

**#56 (LOW) — SVG icon accessibility**
- Added `aria-hidden="true"` to Lucide icons inside icon-only buttons
- Icons in theme toggle, calendar nav, and parapharmacy cart buttons

### Items Verified Already Complete
- #8 — Branding contrast validation (admin UI + server-side fallback)
- #21 — Auto-save coverage (all 7 clinical forms + consultation page)
- #22 — Optimistic UI (consultation page + doctor dashboard both have rollback)
- #37 — Command palette live search (usePatientSearch + PatientSearchPalette)
- #51 — Waiting list rate limiting (per-IP + per-phone + honeypot)
- #53 — Reviews show all ratings unfiltered

### Testing
- TypeScript: 0 errors
- ESLint: 0 errors (57 pre-existing warnings)
- Vitest: 40/40 tests pass
- Pre-commit hooks pass (lint-staged + tsc + vitest)