### PR TITLE
fix: add skip-to-content link, main-content IDs, and fix unused varia…

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -129,7 +129,7 @@ export default function AdminLayout({
     <div className="flex min-h-screen">
       {/* Skip to content link for keyboard accessibility */}
       <a
-        href="#admin-main-content"
+        href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:text-sm focus:font-medium"
       >
         Aller au contenu principal
@@ -175,7 +175,7 @@ export default function AdminLayout({
         <SidebarContent pathname={pathname} />
       </aside>
 
-      <main id="admin-main-content" className="flex-1 p-6 pt-16 md:pt-6">
+      <main id="main-content" className="flex-1 p-6 pt-16 md:pt-6">
         <AutoBreadcrumb />
         {children}
       </main>

--- a/src/app/(doctor)/layout.tsx
+++ b/src/app/(doctor)/layout.tsx
@@ -448,7 +448,7 @@ export default function DoctorLayout({
           </div>
         )}
 
-        <main className="flex-1 p-4 md:p-6">
+        <main id="main-content" className="flex-1 p-4 md:p-6">
           <AutoBreadcrumb />
           {children}
         </main>

--- a/src/app/(patient)/layout.tsx
+++ b/src/app/(patient)/layout.tsx
@@ -161,7 +161,7 @@ export default function PatientLayout({
           </div>
         )}
 
-        <main className="flex-1 p-4 md:p-6">
+        <main id="main-content" className="flex-1 p-4 md:p-6">
           <AutoBreadcrumb />
           {children}
         </main>

--- a/src/app/(receptionist)/layout.tsx
+++ b/src/app/(receptionist)/layout.tsx
@@ -117,7 +117,7 @@ export default function ReceptionistLayout({
           </div>
         )}
 
-        <main className="flex-1 p-4 md:p-6">
+        <main id="main-content" className="flex-1 p-4 md:p-6">
           <AutoBreadcrumb />
           {children}
         </main>

--- a/src/app/(specialist)/equipment/layout.tsx
+++ b/src/app/(specialist)/equipment/layout.tsx
@@ -163,7 +163,7 @@ export default function EquipmentLayout({
           <SidebarContent pathname={pathname} locale={locale} />
         </aside>
 
-        <main className="flex-1 p-6 pt-16 md:pt-6">
+        <main id="main-content" className="flex-1 p-6 pt-16 md:pt-6">
           <FeatureGate featureKey="equipment_rentals" moduleName="Medical Equipment">
             {children}
           </FeatureGate>

--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -344,7 +344,7 @@ export default function SuperAdminLayout({
           </DropdownMenu>
         </header>
 
-        <main className="flex-1 p-4 md:p-6">
+        <main id="main-content" className="flex-1 p-4 md:p-6">
           {children}
         </main>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -88,6 +88,13 @@ export default async function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} ${notoSansArabic.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
+        {/* Skip-to-content link for keyboard / screen-reader accessibility (WCAG 2.4.1) */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        >
+          Aller au contenu principal
+        </a>
         {/* JSON-LD structured data is rendered on public pages only (Issue 59).
             See src/app/(public)/page.tsx for clinic-specific schema. */}
         <ThemeProvider>

--- a/src/components/layouts/clinic-dashboard-layout.tsx
+++ b/src/components/layouts/clinic-dashboard-layout.tsx
@@ -149,7 +149,7 @@ export function ClinicDashboardLayout({
         <SidebarContent config={config} pathname={pathname} />
       </aside>
 
-      <main className="flex-1 p-6 pt-16 md:pt-6">
+      <main id="main-content" className="flex-1 p-6 pt-16 md:pt-6">
         {content}
       </main>
     </div>

--- a/src/components/layouts/clinic-public-layout.tsx
+++ b/src/components/layouts/clinic-public-layout.tsx
@@ -31,7 +31,7 @@ export async function ClinicPublicLayout({
         logoUrl={branding.logoUrl}
         clinicName={branding.clinicName}
       />
-      <main className="flex-1">{children}</main>
+      <main id="main-content" className="flex-1">{children}</main>
       <PublicFooter clinicName={branding.clinicName} />
     </div>
   );

--- a/src/lib/data/client/booking.ts
+++ b/src/lib/data/client/booking.ts
@@ -1,10 +1,9 @@
 "use client";
 
-import { fetchRows, clearLookupCache, type ClientBookingConfig } from "./_core";
+import { clearLookupCache, type ClientBookingConfig } from "./_core";
 import { createClient } from "@/lib/supabase-client";
 import { logger } from "@/lib/logger";
 import type { Database } from "@/lib/types/database";
-import { getLocalDateStr } from "@/lib/utils";
 import { fetchTimeSlots } from "./clinical";
 import { fetchServices } from "./services";
 

--- a/src/lib/data/client/clinic.ts
+++ b/src/lib/data/client/clinic.ts
@@ -1,8 +1,6 @@
 "use client";
 
 import { fetchRows, ensureLookups, _activeUserMap, _activeServiceMap, type TableName } from "./_core";
-import { createClient } from "@/lib/supabase-client";
-import { getLocalDateStr } from "@/lib/utils";
 import { fetchTodayAppointments } from "./appointments";
 
 // ─────────────────────────────────────────────

--- a/src/lib/data/client/medical-equipment.ts
+++ b/src/lib/data/client/medical-equipment.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { fetchRows, ensureLookups, _activeUserMap } from "./_core";
+import { fetchRows, _activeUserMap } from "./_core";
 import { createClient } from "@/lib/supabase-client";
 import { logger } from "@/lib/logger";
 import type { Database } from "@/lib/types/database";

--- a/src/lib/data/client/ophthalmologist.ts
+++ b/src/lib/data/client/ophthalmologist.ts
@@ -3,7 +3,6 @@
 import { fetchRows, ensureLookups, _activeUserMap } from "./_core";
 import { createClient } from "@/lib/supabase-client";
 import { logger } from "@/lib/logger";
-import type { Database } from "@/lib/types/database";
 
 // OPHTHALMOLOGIST — Vision Tests
 // ─────────────────────────────────────────────

--- a/src/lib/hooks/use-clinic-features.tsx
+++ b/src/lib/hooks/use-clinic-features.tsx
@@ -200,7 +200,7 @@ export const SPECIALTY_FEATURES: Record<string, ClinicFeatureKey[]> = {
  * Get the user's specialty from their profile
  * This could be extended to read from user metadata or a profile table
  */
-function getUserSpecialty(): string | null {
+function _getUserSpecialty(): string | null {
   // In a real implementation, this would read from the user's session/profile
   // For now, we'll return null to fall back to clinic features only
   // The sidebar can be enhanced to accept a specialty prop from the user context

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -21,7 +21,7 @@ import type {
   ClinicTier,
   Json,
 } from "@/lib/types/database";
-import { invalidateSubdomainCache, invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
+import { invalidateSubdomainCache } from "@/lib/subdomain-cache";
 
 /**
  * Server-side Supabase client scoped to super_admin operations.


### PR DESCRIPTION
…ble warnings

- Add WCAG 2.4.1 skip-to-content link in root layout
- Add id='main-content' to all 8 layout files for keyboard navigation
- Standardize admin layout from 'admin-main-content' to 'main-content'
- Remove unused imports in booking.ts, clinic.ts, medical-equipment.ts, ophthalmologist.ts, super-admin-actions.ts
- Prefix unused function with underscore in use-clinic-features.tsx