### PR TITLE
feat: Darija WhatsApp templates with clinic locale preference

### DIFF
--- a/docs/whatsapp-template-approval.md
+++ b/docs/whatsapp-template-approval.md
@@ -1,0 +1,248 @@
+# WhatsApp Template Approval — Meta Business API
+
+This guide documents how to submit WhatsApp message templates for approval through the Meta (Facebook) Business API. All templates **must** be approved by Meta before they can be sent via the WhatsApp Business API.
+
+## Prerequisites
+
+1. **Meta Business Account** — [business.facebook.com](https://business.facebook.com)
+2. **WhatsApp Business Account (WABA)** linked to your Meta Business Account
+3. **Phone Number** registered and verified in the WABA
+4. **System User Token** with `whatsapp_business_management` permission
+
+## Template Categories
+
+Meta classifies templates into three categories:
+
+| Category | Description | Approval Speed |
+|---|---|---|
+| **UTILITY** | Transaction-related (confirmations, reminders, receipts) | Usually fast (minutes to hours) |
+| **MARKETING** | Promotions, offers, re-engagement | Slower (hours to days) |
+| **AUTHENTICATION** | OTP / verification codes | Fast |
+
+Most clinic templates fall under **UTILITY** (appointment confirmations, reminders, prescriptions, payments).
+
+## Submission Methods
+
+### Method 1: WhatsApp Manager (Recommended for first-time setup)
+
+1. Go to [business.facebook.com/wa/manage/message-templates](https://business.facebook.com/wa/manage/message-templates)
+2. Select your WhatsApp Business Account
+3. Click **Create Template**
+4. Fill in:
+   - **Category**: Select `Utility` for transactional messages
+   - **Name**: Use the `metaTemplateName` from `whatsapp-templates-darija.ts` (e.g., `booking_confirmation_darija`)
+   - **Language**: Select **Arabic** (`ar`) — Meta does not have a "Darija" option, so Arabic is used as the base language
+5. Add template body with variables:
+   - Use `{{1}}`, `{{2}}`, etc. as positional parameters (Meta format)
+   - Map these to the `{{variable_name}}` placeholders in our code
+6. Add sample values for each variable (required for review)
+7. Submit for review
+
+### Method 2: WhatsApp Business Management API
+
+Submit templates programmatically via the API:
+
+```bash
+curl -X POST \
+  "https://graph.facebook.com/v21.0/<WABA_ID>/message_templates" \
+  -H "Authorization: Bearer <ACCESS_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "booking_confirmation_darija",
+    "category": "UTILITY",
+    "language": "ar",
+    "components": [
+      {
+        "type": "BODY",
+        "text": "السلام {{1}} 👋\n\nالموعد ديالك تأكد ✅\n\n🩺 دكتور: {{2}}\n📅 نهار: {{3}}\n🕐 الوقت: {{4}}\n💼 الخدمة: {{5}}\n📍 العنوان: {{6}}\n\nإلا بغيتي تبدل ولا تلغي: {{7}}\n\n{{8}}",
+        "example": {
+          "body_text": [
+            ["كريم", "أحمد بنعلي", "2026-03-20", "09:00", "استشارة عامة", "123 شارع الحسن الثاني، الدار البيضاء", "https://clinic.ma/manage/123", "عيادة الصحة"]
+          ]
+        }
+      }
+    ]
+  }'
+```
+
+## Template-to-API Variable Mapping
+
+Our code uses named `{{variable_name}}` placeholders, but Meta requires positional `{{1}}`, `{{2}}`, etc. Here is the mapping for each Darija template:
+
+### 1. `booking_confirmation_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `date` | 2026-03-20 |
+| `{{4}}` | `time` | 09:00 |
+| `{{5}}` | `service_name` | استشارة عامة |
+| `{{6}}` | `clinic_address` | 123 شارع الحسن الثاني |
+| `{{7}}` | `manage_url` | https://clinic.ma/manage/123 |
+| `{{8}}` | `clinic_name` | عيادة الصحة |
+
+### 2. `reminder_24h_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `time` | 09:00 |
+| `{{4}}` | `clinic_name` | عيادة الصحة |
+| `{{5}}` | `clinic_address` | 123 شارع الحسن الثاني |
+
+### 3. `cancellation_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `date` | 2026-03-20 |
+| `{{4}}` | `time` | 09:00 |
+| `{{5}}` | `clinic_phone` | +212 6 00 00 00 00 |
+| `{{6}}` | `clinic_name` | عيادة الصحة |
+
+### 4. `prescription_ready_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `clinic_name` | عيادة الصحة |
+| `{{4}}` | `clinic_address` | 123 شارع الحسن الثاني |
+
+### 5. `payment_received_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `amount` | 200 |
+| `{{3}}` | `currency` | MAD |
+| `{{4}}` | `payment_method` | بطاقة |
+| `{{5}}` | `invoice_id` | INV-001 |
+| `{{6}}` | `clinic_name` | عيادة الصحة |
+
+### 6. `welcome_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `clinic_name` | عيادة الصحة |
+| `{{3}}` | `clinic_phone` | +212 6 00 00 00 00 |
+| `{{4}}` | `clinic_address` | 123 شارع الحسن الثاني |
+
+### 7. `review_request_darija` (MARKETING)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `booking_url` | https://clinic.ma/review |
+| `{{4}}` | `clinic_name` | عيادة الصحة |
+
+> **Note**: Review requests are categorized as **MARKETING** and may take longer to approve.
+
+### 8. `rescheduled_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `date` | 2026-03-25 |
+| `{{4}}` | `time` | 10:00 |
+| `{{5}}` | `clinic_phone` | +212 6 00 00 00 00 |
+| `{{6}}` | `clinic_name` | عيادة الصحة |
+
+### 9. `waiting_room_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `time` | 15 دقيقة |
+| `{{4}}` | `clinic_name` | عيادة الصحة |
+
+### 10. `follow_up_darija` (UTILITY)
+
+| Position | Variable | Example |
+|---|---|---|
+| `{{1}}` | `patient_name` | كريم |
+| `{{2}}` | `doctor_name` | أحمد بنعلي |
+| `{{3}}` | `booking_url` | https://clinic.ma/book |
+| `{{4}}` | `clinic_name` | عيادة الصحة |
+
+## Approval Tips
+
+1. **Use clear sample content** — provide realistic Moroccan names, addresses, and amounts
+2. **Avoid promotional language** in UTILITY templates — keep them transactional
+3. **Include opt-out instructions** if sending marketing messages
+4. **Don't use URL shorteners** — Meta may reject templates with shortened URLs
+5. **Emojis are allowed** — they help engagement and are accepted by Meta
+6. **Review times**: UTILITY templates typically take minutes to a few hours; MARKETING templates can take up to 24 hours
+
+## Checking Template Status
+
+### Via API
+
+```bash
+curl -X GET \
+  "https://graph.facebook.com/v21.0/<WABA_ID>/message_templates?name=booking_confirmation_darija" \
+  -H "Authorization: Bearer <ACCESS_TOKEN>"
+```
+
+### Via WhatsApp Manager
+
+Go to [business.facebook.com/wa/manage/message-templates](https://business.facebook.com/wa/manage/message-templates) and check the **Status** column.
+
+Possible statuses:
+- **APPROVED** — Ready to use
+- **PENDING** — Under review
+- **REJECTED** — Fix issues and resubmit
+
+## Handling Rejections
+
+Common rejection reasons:
+
+| Reason | Fix |
+|---|---|
+| Missing sample values | Add realistic example values for every variable |
+| URL in body without URL button | Use a URL button component or remove the URL |
+| Promotional content in UTILITY | Change category to MARKETING or remove promotional language |
+| Duplicate template name | Use a unique name (our templates use `_darija` suffix) |
+
+## Integration with Codebase
+
+The Darija templates are defined in `src/lib/whatsapp-templates-darija.ts`. Each template has a `metaTemplateName` field that corresponds to the name used when submitting to Meta.
+
+The `sendNotificationWhatsApp()` function in `src/lib/whatsapp.ts` accepts a `locale` parameter. When set to `"darija"`, it automatically uses the Darija template set.
+
+The clinic's preferred locale is stored in the `patient_message_locale` column of the `clinics` table and can be configured in **Admin > Settings > WhatsApp Templates**.
+
+## Bulk Submission Script
+
+To submit all 10 Darija templates at once, you can use the following script pattern:
+
+```bash
+# Set your credentials
+WABA_ID="your_waba_id"
+TOKEN="your_access_token"
+
+# Submit each template
+for template in booking_confirmation_darija reminder_24h_darija cancellation_darija \
+  prescription_ready_darija payment_received_darija welcome_darija \
+  review_request_darija rescheduled_darija waiting_room_darija follow_up_darija; do
+
+  echo "Submitting $template..."
+  curl -s -X POST \
+    "https://graph.facebook.com/v21.0/$WABA_ID/message_templates" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d @"templates/${template}.json"
+
+  echo ""
+  sleep 2  # Rate limit safety
+done
+```
+
+Create individual JSON files for each template in a `templates/` directory with the appropriate body text and sample values.

--- a/src/app/(admin)/admin/settings/page.tsx
+++ b/src/app/(admin)/admin/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CreditCard, MessageCircle, Calendar, Save, Edit, Ban, Building2, Phone, MapPin, Globe, RefreshCw } from "lucide-react";
+import { CreditCard, MessageCircle, Calendar, Save, Edit, Ban, Building2, Phone, MapPin, Globe, RefreshCw, Languages } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -151,6 +151,7 @@ export default function ClinicSettingsPage() {
   const [templates, setTemplates] = useState<WhatsAppTemplate[]>(defaultTemplates);
   const [editingTemplate, setEditingTemplate] = useState<string | null>(null);
   const [savedSection, setSavedSection] = useState<string | null>(null);
+  const [patientMessageLocale, setPatientMessageLocale] = useState<"fr" | "ar" | "darija">("fr");
 
   const handleSave = (section: string) => {
     setSavedSection(section);
@@ -511,6 +512,26 @@ export default function ClinicSettingsPage() {
               </div>
             </CardHeader>
             <CardContent>
+              {/* Patient Message Locale Preference */}
+              <div className="border rounded-lg p-4 mb-6 bg-muted/30">
+                <div className="flex items-center gap-2 mb-3">
+                  <Languages className="h-4 w-4" />
+                  <h4 className="text-sm font-medium">Patient Message Language</h4>
+                </div>
+                <p className="text-xs text-muted-foreground mb-3">
+                  Choose the language for patient-facing WhatsApp notifications. Darija (Moroccan Arabic) is recommended for higher engagement.
+                </p>
+                <select
+                  value={patientMessageLocale}
+                  onChange={(e) => setPatientMessageLocale(e.target.value as "fr" | "ar" | "darija")}
+                  className="flex h-10 w-full max-w-xs rounded-md border border-input bg-background px-3 py-2 text-sm"
+                >
+                  <option value="fr">Fran\u00e7ais (French)</option>
+                  <option value="ar">\u0627\u0644\u0639\u0631\u0628\u064a\u0629 (Arabic)</option>
+                  <option value="darija">\u0627\u0644\u062f\u0627\u0631\u062c\u0629 (Darija / Moroccan Arabic)</option>
+                </select>
+              </div>
+
               <p className="text-sm text-muted-foreground mb-4">
                 Customize the message templates sent via WhatsApp. Use placeholders like{" "}
                 <code className="bg-muted px-1 rounded text-xs">{"{{patient_name}}"}</code>,{" "}

--- a/src/config/clinic.config.ts
+++ b/src/config/clinic.config.ts
@@ -68,6 +68,9 @@ export interface ClinicConfig {
   /** Default locale */
   locale: "fr" | "ar" | "en";
 
+  /** Locale for patient-facing WhatsApp/SMS messages */
+  patientMessageLocale: "fr" | "ar" | "darija";
+
   /** Currency code */
   currency: string;
 
@@ -171,6 +174,7 @@ export const clinicConfig: ClinicConfig = {
   tier: "pro",
   domain: undefined,
   locale: "fr",
+  patientMessageLocale: "fr",
   currency: "MAD",
   timezone: "Africa/Casablanca",
 

--- a/src/lib/whatsapp-templates-darija.ts
+++ b/src/lib/whatsapp-templates-darija.ts
@@ -1,0 +1,261 @@
+/**
+ * WhatsApp Message Templates — Darija (Moroccan Arabic)
+ *
+ * 10 patient-facing message templates written in Darija for higher
+ * engagement with Moroccan patients. These map to the same
+ * `NotificationTrigger` types and use the same `{{variable}}`
+ * placeholders as the default (French/formal) templates in
+ * `notifications.ts`.
+ *
+ * Each template is pre-approved-ready for Meta WhatsApp Business API
+ * submission. See `docs/whatsapp-template-approval.md` for the
+ * approval workflow.
+ */
+
+import type {
+  NotificationTrigger,
+  NotificationTemplate,
+  NotificationChannel,
+  NotificationPriority,
+} from "./notifications";
+
+// ---- Darija Template Definitions ----
+
+export interface DarijaTemplate {
+  id: string;
+  trigger: NotificationTrigger;
+  name: string;
+  label: string;
+  labelDarija: string;
+  channels: NotificationChannel[];
+  subject: string;
+  body: string;
+  whatsappBody: string;
+  enabled: boolean;
+  priority: NotificationPriority;
+  recipientRoles: ("patient" | "doctor" | "receptionist" | "clinic_admin")[];
+  /** Meta template name for API submission (lowercase, underscores) */
+  metaTemplateName: string;
+}
+
+/**
+ * 10 Darija WhatsApp templates for patient notifications.
+ *
+ * These are designed to feel conversational and warm — the way
+ * Moroccans actually communicate on WhatsApp — rather than using
+ * formal Modern Standard Arabic.
+ */
+export const darijaWhatsAppTemplates: DarijaTemplate[] = [
+  // 1. Appointment Confirmation
+  {
+    id: "darija_booking_confirmation",
+    trigger: "booking_confirmation",
+    name: "booking_confirmation_darija",
+    label: "Appointment Confirmation (Darija)",
+    labelDarija: "تأكيد الموعد",
+    channels: ["whatsapp", "in_app"],
+    subject: "تأكيد الموعد ديالك",
+    body: "السلام {{patient_name}}، الموعد ديالك مع {{doctor_name}} تأكد. نهار {{date}} على {{time}}. الخدمة: {{service_name}}. العنوان: {{clinic_address}}. إلا بغيتي تبدل ولا تلغي: {{manage_url}}. {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nالموعد ديالك تأكد ✅\n\n🩺 دكتور: {{doctor_name}}\n📅 نهار: {{date}}\n🕐 الوقت: {{time}}\n💼 الخدمة: {{service_name}}\n📍 العنوان: {{clinic_address}}\n\nإلا بغيتي تبدل ولا تلغي: {{manage_url}}\n\n{{clinic_name}}",
+    enabled: true,
+    priority: "high",
+    recipientRoles: ["patient"],
+    metaTemplateName: "booking_confirmation_darija",
+  },
+
+  // 2. Reminder (24h)
+  {
+    id: "darija_reminder_24h",
+    trigger: "reminder_24h",
+    name: "reminder_24h_darija",
+    label: "24-Hour Reminder (Darija)",
+    labelDarija: "تذكير 24 ساعة",
+    channels: ["whatsapp", "in_app"],
+    subject: "تذكير: الموعد ديالك غدا",
+    body: "السلام {{patient_name}}، تذكير بلي عندك موعد غدا مع {{doctor_name}} على {{time}} ف {{clinic_name}}. العنوان: {{clinic_address}}. جاوب ب نعم للتأكيد ولا لا للإلغاء.",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nما تنساش! عندك موعد غدا ⏰\n\n🩺 دكتور: {{doctor_name}}\n🕐 الوقت: {{time}}\n📍 {{clinic_name}} — {{clinic_address}}\n\nجاوبنا ب ✅ نعم للتأكيد ولا ❌ لا للإلغاء",
+    enabled: true,
+    priority: "high",
+    recipientRoles: ["patient"],
+    metaTemplateName: "reminder_24h_darija",
+  },
+
+  // 3. Cancellation
+  {
+    id: "darija_cancellation",
+    trigger: "cancellation",
+    name: "cancellation_darija",
+    label: "Cancellation Notice (Darija)",
+    labelDarija: "إلغاء الموعد",
+    channels: ["whatsapp", "in_app"],
+    subject: "الموعد ديالك تلغا",
+    body: "السلام {{patient_name}}، الموعد ديالك مع {{doctor_name}} نهار {{date}} على {{time}} تلغا. عيط لينا على {{clinic_phone}} باش تاخد موعد جديد. {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nالموعد ديالك تلغا ❌\n\n🩺 دكتور: {{doctor_name}}\n📅 نهار: {{date}}\n🕐 الوقت: {{time}}\n\nإلا بغيتي تاخد موعد جديد عيط لينا على: {{clinic_phone}}\n\n{{clinic_name}}",
+    enabled: true,
+    priority: "high",
+    recipientRoles: ["patient"],
+    metaTemplateName: "cancellation_darija",
+  },
+
+  // 4. Prescription Ready
+  {
+    id: "darija_prescription_ready",
+    trigger: "prescription_ready",
+    name: "prescription_ready_darija",
+    label: "Prescription Ready (Darija)",
+    labelDarija: "الوصفة جاهزة",
+    channels: ["whatsapp", "in_app"],
+    subject: "الوصفة ديالك جاهزة",
+    body: "السلام {{patient_name}}، الوصفة ديالك من عند {{doctor_name}} جاهزة. يمكن ليك تجيبها من {{clinic_name}}. العنوان: {{clinic_address}}.",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nالوصفة ديالك جاهزة 📋✅\n\n🩺 دكتور: {{doctor_name}}\n📍 جيبها من: {{clinic_name}}\n📍 العنوان: {{clinic_address}}\n\nصحتك تهمنا! 🙏",
+    enabled: true,
+    priority: "normal",
+    recipientRoles: ["patient"],
+    metaTemplateName: "prescription_ready_darija",
+  },
+
+  // 5. Payment Received
+  {
+    id: "darija_payment_received",
+    trigger: "payment_received",
+    name: "payment_received_darija",
+    label: "Payment Received (Darija)",
+    labelDarija: "تأكيد الدفع",
+    channels: ["whatsapp", "in_app"],
+    subject: "الدفع توصل",
+    body: "السلام {{patient_name}}، توصلنا بالخلاص ديالك {{amount}} {{currency}} عن طريق {{payment_method}}. رقم الفاتورة: {{invoice_id}}. شكرا! — {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nتوصلنا بالخلاص ديالك ✅\n\n💰 المبلغ: {{amount}} {{currency}}\n💳 طريقة الدفع: {{payment_method}}\n🧾 رقم الفاتورة: {{invoice_id}}\n\nشكرا ليك! 🙏\n{{clinic_name}}",
+    enabled: true,
+    priority: "normal",
+    recipientRoles: ["patient"],
+    metaTemplateName: "payment_received_darija",
+  },
+
+  // 6. Welcome (New Patient Registered)
+  {
+    id: "darija_welcome",
+    trigger: "new_patient_registered",
+    name: "welcome_darija",
+    label: "Welcome Message (Darija)",
+    labelDarija: "مرحبا بيك",
+    channels: ["whatsapp", "in_app"],
+    subject: "مرحبا بيك ف {{clinic_name}}",
+    body: "مرحبا بيك {{patient_name}} ف {{clinic_name}}! حنا هنا باش نعتانيو بصحتك. إلا عندك شي سؤال عيط لينا على {{clinic_phone}}.",
+    whatsappBody:
+      "مرحبا بيك {{patient_name}} 👋🎉\n\nتسجلتي ف {{clinic_name}} بنجاح ✅\n\nحنا هنا باش نعتانيو بصحتك 🏥\n\nإلا بغيتي تاخد موعد ولا عندك شي سؤال:\n📞 {{clinic_phone}}\n📍 {{clinic_address}}\n\nصحتك تهمنا! 🙏",
+    enabled: true,
+    priority: "normal",
+    recipientRoles: ["patient"],
+    metaTemplateName: "welcome_darija",
+  },
+
+  // 7. Review Request
+  {
+    id: "darija_review_request",
+    trigger: "follow_up",
+    name: "review_request_darija",
+    label: "Review Request (Darija)",
+    labelDarija: "طلب تقييم",
+    channels: ["whatsapp"],
+    subject: "شاركنا رأيك",
+    body: "السلام {{patient_name}}، كيفاش لقيتي الزيارة ديالك عند {{doctor_name}}؟ شاركنا رأيك باش نحسنو الخدمة ديالنا. شكرا! — {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nكيفاش لقيتي الزيارة ديالك عند {{doctor_name}}؟ 🩺\n\nرأيك مهم لينا باش نحسنو الخدمة ديالنا ⭐\n\nشاركنا تقييمك هنا: {{booking_url}}\n\nشكرا ليك! 🙏\n{{clinic_name}}",
+    enabled: true,
+    priority: "low",
+    recipientRoles: ["patient"],
+    metaTemplateName: "review_request_darija",
+  },
+
+  // 8. Reschedule
+  {
+    id: "darija_rescheduled",
+    trigger: "rescheduled",
+    name: "rescheduled_darija",
+    label: "Appointment Rescheduled (Darija)",
+    labelDarija: "تغيير الموعد",
+    channels: ["whatsapp", "in_app"],
+    subject: "الموعد ديالك تبدل",
+    body: "السلام {{patient_name}}، الموعد ديالك مع {{doctor_name}} تبدل لنهار {{date}} على {{time}}. إلا عندك شي سؤال عيط لينا على {{clinic_phone}}. {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nالموعد ديالك تبدل 📅\n\n🩺 دكتور: {{doctor_name}}\n📅 النهار الجديد: {{date}}\n🕐 الوقت الجديد: {{time}}\n\nإلا عندك شي سؤال عيط لينا على: {{clinic_phone}}\n\n{{clinic_name}}",
+    enabled: true,
+    priority: "high",
+    recipientRoles: ["patient"],
+    metaTemplateName: "rescheduled_darija",
+  },
+
+  // 9. Waiting Room Update
+  {
+    id: "darija_waiting_room",
+    trigger: "reminder_1h",
+    name: "waiting_room_darija",
+    label: "Waiting Room Update (Darija)",
+    labelDarija: "تحديث قاعة الانتظار",
+    channels: ["whatsapp"],
+    subject: "الدور ديالك قرب",
+    body: "السلام {{patient_name}}، الدور ديالك قرب عند {{doctor_name}}. بقاو {{time}} تقريبا. كون مستاعد. {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nالدور ديالك قرب عند {{doctor_name}} 🏥\n\n🕐 بقات تقريبا: {{time}}\n\nكون مستاعد! 🙏\n{{clinic_name}}",
+    enabled: true,
+    priority: "urgent",
+    recipientRoles: ["patient"],
+    metaTemplateName: "waiting_room_darija",
+  },
+
+  // 10. Follow-up Reminder
+  {
+    id: "darija_follow_up",
+    trigger: "follow_up",
+    name: "follow_up_darija",
+    label: "Follow-up Reminder (Darija)",
+    labelDarija: "تذكير بالمراجعة",
+    channels: ["whatsapp", "in_app"],
+    subject: "وقت المراجعة",
+    body: "السلام {{patient_name}}، جا الوقت ديال المراجعة ديالك عند {{doctor_name}}. خود موعد جديد من هنا: {{booking_url}}. {{clinic_name}}",
+    whatsappBody:
+      "السلام {{patient_name}} 👋\n\nجا الوقت ديال المراجعة ديالك 📋\n\n🩺 دكتور: {{doctor_name}}\n\nخود موعد جديد من هنا: {{booking_url}}\n\nصحتك تهمنا! 🙏\n{{clinic_name}}",
+    enabled: true,
+    priority: "normal",
+    recipientRoles: ["patient"],
+    metaTemplateName: "follow_up_darija",
+  },
+];
+
+/**
+ * Convert Darija templates to the standard `NotificationTemplate` format
+ * used by the notification engine, so they can be passed directly to
+ * `dispatchNotification()` and `sendNotificationWhatsApp()`.
+ */
+export function toDarijaNotificationTemplates(): NotificationTemplate[] {
+  return darijaWhatsAppTemplates.map((t) => ({
+    id: t.id,
+    trigger: t.trigger,
+    name: t.name,
+    label: t.label,
+    channels: t.channels,
+    subject: t.subject,
+    body: t.body,
+    whatsappBody: t.whatsappBody,
+    enabled: t.enabled,
+    priority: t.priority,
+    recipientRoles: t.recipientRoles,
+  }));
+}
+
+/**
+ * Look up a single Darija template by its notification trigger.
+ * Returns `undefined` if no enabled template exists for that trigger.
+ */
+export function getDarijaTemplate(
+  trigger: NotificationTrigger,
+): DarijaTemplate | undefined {
+  return darijaWhatsAppTemplates.find(
+    (t) => t.trigger === trigger && t.enabled,
+  );
+}

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -12,6 +12,15 @@ import {
   type NotificationTemplate,
   defaultNotificationTemplates,
 } from "./notifications";
+import { toDarijaNotificationTemplates } from "./whatsapp-templates-darija";
+
+/**
+ * Supported locales for patient-facing WhatsApp messages.
+ * - `fr`     – French / formal (default, uses `defaultNotificationTemplates`)
+ * - `ar`     – Arabic (same as default for now, can be extended)
+ * - `darija` – Moroccan Arabic (uses Darija-specific templates)
+ */
+export type PatientMessageLocale = "fr" | "ar" | "darija";
 
 // ---- Types ----
 
@@ -346,16 +355,44 @@ export async function sendTextMessage(
 }
 
 /**
+ * Return the correct template set for the given patient message locale.
+ * Falls back to the default (French) templates when no locale-specific
+ * set exists.
+ */
+export function getTemplatesForLocale(
+  locale: PatientMessageLocale = "fr",
+): NotificationTemplate[] {
+  switch (locale) {
+    case "darija":
+      return toDarijaNotificationTemplates();
+    case "ar":
+      // Arabic templates can be added later; fall back to default for now
+      return defaultNotificationTemplates;
+    case "fr":
+    default:
+      return defaultNotificationTemplates;
+  }
+}
+
+/**
  * Send a notification-triggered WhatsApp message with variable substitution.
  * Looks up the template for the given trigger, substitutes variables, and sends.
+ *
+ * When a `locale` is provided the function selects the matching template set
+ * (e.g. Darija) automatically. The explicit `templates` parameter still takes
+ * precedence if supplied so existing call-sites are unaffected.
  */
 export async function sendNotificationWhatsApp(
   trigger: NotificationTrigger,
   to: string,
   variables: TemplateVariables,
-  templates: NotificationTemplate[] = defaultNotificationTemplates,
+  templates?: NotificationTemplate[],
+  locale?: PatientMessageLocale,
 ): Promise<WhatsAppSendResult> {
-  const template = templates.find(
+  const resolvedTemplates =
+    templates ?? getTemplatesForLocale(locale);
+
+  const template = resolvedTemplates.find(
     (t) => t.trigger === trigger && t.enabled && t.channels.includes("whatsapp"),
   );
 

--- a/supabase/migrations/00054_clinic_patient_message_locale.sql
+++ b/supabase/migrations/00054_clinic_patient_message_locale.sql
@@ -1,0 +1,11 @@
+-- Add patient_message_locale to clinics table
+-- Controls which language templates are used for patient-facing
+-- WhatsApp / SMS notifications: 'fr' (French), 'ar' (Arabic), 'darija' (Moroccan Arabic).
+-- Defaults to 'fr' to match existing behaviour.
+
+ALTER TABLE clinics
+  ADD COLUMN IF NOT EXISTS patient_message_locale TEXT NOT NULL DEFAULT 'fr'
+    CHECK (patient_message_locale IN ('fr', 'ar', 'darija'));
+
+COMMENT ON COLUMN clinics.patient_message_locale IS
+  'Locale for patient-facing WhatsApp messages: fr | ar | darija';


### PR DESCRIPTION
## Summary

Adds 10 WhatsApp message templates in **Darija (Moroccan Arabic)** for patient notifications, with a clinic-level locale preference so clinics can choose between French, Arabic, or Darija for patient-facing messages.

## Changes

### 5.1 — Darija Templates (`src/lib/whatsapp-templates-darija.ts`)
- 10 templates: appointment confirmation, 24h reminder, cancellation, prescription ready, payment received, welcome, review request, reschedule, waiting room update, follow-up reminder
- Written in conversational Darija (not formal Arabic) for higher patient engagement
- Each template includes a `metaTemplateName` for Meta Business API submission

### 5.3 — Locale Preference
- **DB migration** (`00054`): adds `patient_message_locale` column to `clinics` table (`fr` / `ar` / `darija`)
- **Config**: adds `patientMessageLocale` to `ClinicConfig` interface
- **Settings UI**: adds language selector in Admin > Settings > WhatsApp Templates tab

### 5.4 — Locale-aware Message Sending
- `sendNotificationWhatsApp()` now accepts an optional `locale` parameter
- New `getTemplatesForLocale()` helper resolves the correct template set
- Existing call-sites are unaffected (backward compatible)

### 5.5 — Documentation
- `docs/whatsapp-template-approval.md`: full guide for Meta Business API template submission, variable mapping, approval tips, and bulk submission script