### PR TITLE
feat: add doctor directory + SEO pages at /annuaire

### DIFF
--- a/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
@@ -1,0 +1,236 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MapPin, Stethoscope, Calendar, Phone } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { safeJsonLdStringify } from "@/lib/json-ld";
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import {
+  getCityBySlug,
+  getSpecialtyBySlug,
+  TOP_CITY_SPECIALTY_COMBOS,
+} from "@/lib/directory-constants";
+import { getDirectoryDoctorsByCityAndSpecialty } from "@/lib/data/directory";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
+const ROOT_DOMAIN = process.env.ROOT_DOMAIN ?? "oltigo.com";
+
+interface CitySpecialtyPageProps {
+  params: Promise<{ city: string; specialty: string }>;
+}
+
+export async function generateStaticParams() {
+  return TOP_CITY_SPECIALTY_COMBOS;
+}
+
+export async function generateMetadata({ params }: CitySpecialtyPageProps): Promise<Metadata> {
+  const { city: citySlug, specialty: specialtySlug } = await params;
+  const city = getCityBySlug(citySlug);
+  const specialty = getSpecialtyBySlug(specialtySlug);
+  if (!city || !specialty) return {};
+
+  const title = `${specialty.nameFr} à ${city.name} — Annuaire Médical | Oltigo`;
+  const description = `Trouvez un ${specialty.nameFr.toLowerCase()} à ${city.name}, Maroc. ${specialty.description}. Prenez rendez-vous en ligne.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      locale: "fr_MA",
+      url: `${BASE_URL}/annuaire/${city.slug}/${specialty.slug}`,
+      siteName: "Oltigo",
+    },
+    alternates: {
+      canonical: `${BASE_URL}/annuaire/${city.slug}/${specialty.slug}`,
+    },
+  };
+}
+
+export default async function CitySpecialtyPage({ params }: CitySpecialtyPageProps) {
+  const { city: citySlug, specialty: specialtySlug } = await params;
+  const city = getCityBySlug(citySlug);
+  const specialty = getSpecialtyBySlug(specialtySlug);
+  if (!city || !specialty) notFound();
+
+  const doctors = await getDirectoryDoctorsByCityAndSpecialty(citySlug, specialtySlug);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MedicalBusiness",
+    name: `${specialty.nameFr} à ${city.name}`,
+    url: `${BASE_URL}/annuaire/${city.slug}/${specialty.slug}`,
+    medicalSpecialty: specialty.name,
+    areaServed: {
+      "@type": "City",
+      name: city.name,
+      containedInPlace: {
+        "@type": "Country",
+        name: "Morocco",
+      },
+    },
+    ...(doctors.length > 0
+      ? {
+          member: doctors.map((d) => ({
+            "@type": "Physician",
+            name: d.name,
+            medicalSpecialty: d.specialty,
+            url: `${BASE_URL}/annuaire/${d.slug}`,
+            ...(d.phone ? { telephone: d.phone } : {}),
+            ...(d.address
+              ? {
+                  address: {
+                    "@type": "PostalAddress",
+                    streetAddress: d.address,
+                    addressLocality: city.name,
+                    addressCountry: "MA",
+                  },
+                }
+              : {}),
+          })),
+        }
+      : {}),
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+      />
+
+      {/* Breadcrumb */}
+      <nav className="text-sm text-muted-foreground mb-6">
+        <Link href="/annuaire" className="hover:text-foreground">Annuaire</Link>
+        <span className="mx-2">/</span>
+        <Link href={`/annuaire/${city.slug}`} className="hover:text-foreground">{city.name}</Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">{specialty.nameFr}</span>
+      </nav>
+
+      {/* Hero */}
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold mb-2">
+          {specialty.nameFr} à {city.name}
+        </h1>
+        <p className="text-muted-foreground">
+          {doctors.length} {specialty.nameFr.toLowerCase()}{doctors.length !== 1 ? "s" : ""} trouvé{doctors.length !== 1 ? "s" : ""} à {city.name}
+        </p>
+        <p className="text-sm text-muted-foreground mt-1">
+          {specialty.description}
+        </p>
+      </div>
+
+      {/* Doctor list */}
+      {doctors.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p>Aucun {specialty.nameFr.toLowerCase()} trouvé à {city.name} pour le moment.</p>
+          <div className="flex justify-center gap-4 mt-4">
+            <Link href={`/annuaire/${city.slug}`} className="text-primary hover:underline">
+              Tous les médecins à {city.name}
+            </Link>
+            <Link href="/annuaire" className="text-primary hover:underline">
+              Retour à l&apos;annuaire
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {doctors.map((doctor) => {
+            const bookingUrl = doctor.clinicSubdomain
+              ? `https://${doctor.clinicSubdomain}.${ROOT_DOMAIN}/book`
+              : null;
+
+            return (
+              <Card key={doctor.id} className="hover:border-primary/50 transition-all">
+                <CardContent className="pt-5 pb-5">
+                  <div className="flex flex-col sm:flex-row items-start gap-4">
+                    {/* Avatar */}
+                    {doctor.avatar ? (
+                      <Image
+                        src={doctor.avatar}
+                        alt={doctor.name}
+                        width={64}
+                        height={64}
+                        className="h-16 w-16 rounded-full object-cover flex-shrink-0"
+                      />
+                    ) : (
+                      <Avatar className="h-16 w-16 flex-shrink-0">
+                        <AvatarFallback className="text-lg bg-primary/10 text-primary">
+                          {doctor.name.split(" ").map((n) => n[0]).join("").slice(0, 2)}
+                        </AvatarFallback>
+                      </Avatar>
+                    )}
+
+                    {/* Info */}
+                    <div className="flex-1 min-w-0">
+                      <Link href={`/annuaire/${doctor.slug}`} className="hover:underline">
+                        <h2 className="text-lg font-semibold">{doctor.name}</h2>
+                      </Link>
+                      <div className="flex items-center gap-2 mt-1">
+                        <Badge variant="secondary" className="text-xs">
+                          <Stethoscope className="h-3 w-3 mr-1" />
+                          {doctor.specialty}
+                        </Badge>
+                      </div>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-sm text-muted-foreground">
+                        {doctor.address && (
+                          <span className="flex items-center gap-1">
+                            <MapPin className="h-3 w-3" />
+                            {doctor.address}
+                          </span>
+                        )}
+                        {doctor.phone && (
+                          <span className="flex items-center gap-1">
+                            <Phone className="h-3 w-3" />
+                            {doctor.phone}
+                          </span>
+                        )}
+                      </div>
+                      {doctor.consultationFee > 0 && (
+                        <p className="text-sm font-medium mt-2">
+                          Consultation : {doctor.consultationFee} MAD
+                        </p>
+                      )}
+                      {doctor.languages.length > 0 && (
+                        <div className="flex gap-1 mt-2">
+                          {doctor.languages.map((lang) => (
+                            <Badge key={lang} variant="outline" className="text-xs">{lang}</Badge>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* CTA */}
+                    <div className="flex flex-col gap-2 sm:items-end mt-2 sm:mt-0">
+                      <Link
+                        href={`/annuaire/${doctor.slug}`}
+                        className={buttonVariants({ variant: "outline", size: "sm" })}
+                      >
+                        Voir le profil
+                      </Link>
+                      {bookingUrl && (
+                        <a
+                          href={bookingUrl}
+                          className={buttonVariants({ size: "sm" })}
+                        >
+                          <Calendar className="h-3 w-3 mr-1" />
+                          Prendre RDV
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(public)/annuaire/[city]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/page.tsx
@@ -1,0 +1,501 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  MapPin, Stethoscope, Calendar, ArrowRight,
+  Phone, Languages, Award, Building2,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { buttonVariants } from "@/components/ui/button-variants";
+import { safeJsonLdStringify } from "@/lib/json-ld";
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import {
+  DIRECTORY_CITIES,
+  getCityBySlug,
+  getSpecialtyBySlug,
+} from "@/lib/directory-constants";
+import {
+  getDirectoryDoctorsByCity,
+  getDirectorySpecialtiesInCity,
+  getDirectoryDoctorBySlug,
+  getDirectoryDoctors,
+} from "@/lib/data/directory";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
+const ROOT_DOMAIN = process.env.ROOT_DOMAIN ?? "oltigo.com";
+
+interface PageProps {
+  params: Promise<{ city: string }>;
+}
+
+function isDoctorSlug(slug: string): boolean {
+  return slug.startsWith("dr-");
+}
+
+export async function generateStaticParams() {
+  const cityParams = DIRECTORY_CITIES.map((c) => ({ city: c.slug }));
+  const doctors = await getDirectoryDoctors();
+  const doctorParams = doctors.map((d) => ({ city: d.slug }));
+  return [...cityParams, ...doctorParams];
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { city: slug } = await params;
+
+  // Doctor profile
+  if (isDoctorSlug(slug)) {
+    const doctor = await getDirectoryDoctorBySlug(slug);
+    if (!doctor) return {};
+
+    const title = `${doctor.name} — ${doctor.specialty} à ${doctor.city} | Oltigo`;
+    const description = `Prenez rendez-vous avec ${doctor.name}, ${doctor.specialty.toLowerCase()} à ${doctor.city}. ${doctor.clinicName}. Consultation en ligne disponible.`;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        title,
+        description,
+        type: "profile",
+        locale: "fr_MA",
+        url: `${BASE_URL}/annuaire/${doctor.slug}`,
+        siteName: "Oltigo",
+        ...(doctor.avatar ? { images: [{ url: doctor.avatar, width: 200, height: 200, alt: doctor.name }] } : {}),
+      },
+      alternates: { canonical: `${BASE_URL}/annuaire/${doctor.slug}` },
+    };
+  }
+
+  // City page
+  const city = getCityBySlug(slug);
+  if (!city) return {};
+
+  const title = `Médecins à ${city.name} — Annuaire Médical | Oltigo`;
+  const description = `Trouvez un médecin, dentiste ou spécialiste à ${city.name}, Maroc. Consultez les profils, avis et prenez rendez-vous en ligne.`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: "website",
+      locale: "fr_MA",
+      url: `${BASE_URL}/annuaire/${city.slug}`,
+      siteName: "Oltigo",
+    },
+    alternates: { canonical: `${BASE_URL}/annuaire/${city.slug}` },
+  };
+}
+
+// ── Doctor Profile View ──
+
+function DoctorProfileView({
+  doctor,
+}: {
+  doctor: NonNullable<Awaited<ReturnType<typeof getDirectoryDoctorBySlug>>>;
+}) {
+  const city = getCityBySlug(doctor.citySlug);
+  const specialty = getSpecialtyBySlug(doctor.specialtySlug);
+  const bookingUrl = doctor.clinicSubdomain
+    ? `https://${doctor.clinicSubdomain}.${ROOT_DOMAIN}/book`
+    : null;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Physician",
+    "@id": `${BASE_URL}/annuaire/${doctor.slug}#physician`,
+    name: doctor.name,
+    url: `${BASE_URL}/annuaire/${doctor.slug}`,
+    medicalSpecialty: doctor.specialty,
+    ...(doctor.avatar ? { image: doctor.avatar } : {}),
+    ...(doctor.phone ? { telephone: doctor.phone } : {}),
+    ...(doctor.languages.length > 0 ? { knowsLanguage: doctor.languages } : {}),
+    ...(doctor.address
+      ? {
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: doctor.address,
+            addressLocality: doctor.city,
+            addressCountry: "MA",
+          },
+        }
+      : {}),
+    worksFor: {
+      "@type": "MedicalBusiness",
+      name: doctor.clinicName,
+      ...(doctor.clinicSubdomain ? { url: `https://${doctor.clinicSubdomain}.${ROOT_DOMAIN}` } : {}),
+    },
+    ...(bookingUrl
+      ? {
+          potentialAction: {
+            "@type": "ReserveAction",
+            target: bookingUrl,
+            name: "Prendre rendez-vous en ligne",
+          },
+        }
+      : {}),
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-4xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+      />
+
+      {/* Breadcrumb */}
+      <nav className="text-sm text-muted-foreground mb-6">
+        <Link href="/annuaire" className="hover:text-foreground">Annuaire</Link>
+        {city && (
+          <>
+            <span className="mx-2">/</span>
+            <Link href={`/annuaire/${city.slug}`} className="hover:text-foreground">{city.name}</Link>
+          </>
+        )}
+        {city && specialty && (
+          <>
+            <span className="mx-2">/</span>
+            <Link href={`/annuaire/${city.slug}/${specialty.slug}`} className="hover:text-foreground">
+              {specialty.nameFr}
+            </Link>
+          </>
+        )}
+        <span className="mx-2">/</span>
+        <span className="text-foreground">{doctor.name}</span>
+      </nav>
+
+      {/* Profile card */}
+      <Card className="mb-8">
+        <CardContent className="pt-6 pb-6">
+          <div className="flex flex-col sm:flex-row items-start gap-6">
+            <div className="flex-shrink-0">
+              {doctor.avatar ? (
+                <Image
+                  src={doctor.avatar}
+                  alt={doctor.name}
+                  width={128}
+                  height={128}
+                  className="h-32 w-32 rounded-full object-cover shadow-lg"
+                />
+              ) : (
+                <Avatar className="h-32 w-32">
+                  <AvatarFallback className="text-3xl bg-primary/10 text-primary">
+                    {doctor.name.split(" ").map((n) => n[0]).join("").slice(0, 2)}
+                  </AvatarFallback>
+                </Avatar>
+              )}
+            </div>
+            <div className="flex-1">
+              <h1 className="text-2xl font-bold mb-1">{doctor.name}</h1>
+              <div className="flex items-center gap-2 mb-3">
+                <Badge variant="secondary">
+                  <Stethoscope className="h-3 w-3 mr-1" />
+                  {doctor.specialty}
+                </Badge>
+                {city && (
+                  <Badge variant="outline">
+                    <MapPin className="h-3 w-3 mr-1" />
+                    {city.name}
+                  </Badge>
+                )}
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2 mb-4">
+                {doctor.address && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <MapPin className="h-4 w-4 text-primary flex-shrink-0" />
+                    <span>{doctor.address}</span>
+                  </div>
+                )}
+                {doctor.phone && (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Phone className="h-4 w-4 text-primary flex-shrink-0" />
+                    <a href={`tel:${doctor.phone}`} className="hover:text-foreground">{doctor.phone}</a>
+                  </div>
+                )}
+                {doctor.consultationFee > 0 && (
+                  <div className="flex items-center gap-2 text-sm">
+                    <Award className="h-4 w-4 text-primary flex-shrink-0" />
+                    <span>Consultation : <strong>{doctor.consultationFee} MAD</strong></span>
+                  </div>
+                )}
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Building2 className="h-4 w-4 text-primary flex-shrink-0" />
+                  <span>{doctor.clinicName}</span>
+                </div>
+              </div>
+              {doctor.languages.length > 0 && (
+                <div className="flex items-center gap-2 mb-4">
+                  <Languages className="h-4 w-4 text-primary" />
+                  <div className="flex gap-1">
+                    {doctor.languages.map((lang) => (
+                      <Badge key={lang} variant="outline" className="text-xs">{lang}</Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {bookingUrl && (
+                <a href={bookingUrl} className={buttonVariants({ size: "lg" })}>
+                  <Calendar className="h-4 w-4 mr-2" />
+                  Prendre rendez-vous en ligne
+                </a>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Bio */}
+      {doctor.bio && (
+        <Card className="mb-8">
+          <CardContent className="pt-6 pb-6">
+            <h2 className="text-lg font-semibold mb-3">À propos</h2>
+            <p className="text-muted-foreground whitespace-pre-line">{doctor.bio}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Clinic info */}
+      <Card className="mb-8">
+        <CardContent className="pt-6 pb-6">
+          <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+            <Building2 className="h-4 w-4" />
+            Cabinet
+          </h2>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">{doctor.clinicName}</p>
+            {doctor.address && (
+              <p className="flex items-center gap-2">
+                <MapPin className="h-4 w-4 flex-shrink-0" />
+                {doctor.address}
+              </p>
+            )}
+            {doctor.phone && (
+              <p className="flex items-center gap-2">
+                <Phone className="h-4 w-4 flex-shrink-0" />
+                <a href={`tel:${doctor.phone}`} className="hover:text-foreground">{doctor.phone}</a>
+              </p>
+            )}
+          </div>
+          {doctor.clinicSubdomain && (
+            <div className="mt-4">
+              <a
+                href={`https://${doctor.clinicSubdomain}.${ROOT_DOMAIN}`}
+                className={buttonVariants({ variant: "outline", size: "sm" })}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visiter le site du cabinet
+              </a>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Related links */}
+      <div className="flex flex-wrap gap-3">
+        {city && (
+          <Link href={`/annuaire/${city.slug}`} className={buttonVariants({ variant: "outline", size: "sm" })}>
+            Tous les médecins à {city.name}
+          </Link>
+        )}
+        {city && specialty && (
+          <Link
+            href={`/annuaire/${city.slug}/${specialty.slug}`}
+            className={buttonVariants({ variant: "outline", size: "sm" })}
+          >
+            {specialty.nameFr}s à {city.name}
+          </Link>
+        )}
+        <Link href="/annuaire" className={buttonVariants({ variant: "outline", size: "sm" })}>
+          Annuaire complet
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// ── City Listing View ──
+
+function CityListingView({
+  citySlug,
+  city,
+  doctors,
+  specialties,
+}: {
+  citySlug: string;
+  city: NonNullable<ReturnType<typeof getCityBySlug>>;
+  doctors: Awaited<ReturnType<typeof getDirectoryDoctorsByCity>>;
+  specialties: Awaited<ReturnType<typeof getDirectorySpecialtiesInCity>>;
+}) {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MedicalBusiness",
+    name: `Médecins à ${city.name}`,
+    url: `${BASE_URL}/annuaire/${city.slug}`,
+    areaServed: {
+      "@type": "City",
+      name: city.name,
+      containedInPlace: { "@type": "Country", name: "Morocco" },
+    },
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+      />
+
+      {/* Breadcrumb */}
+      <nav className="text-sm text-muted-foreground mb-6">
+        <Link href="/annuaire" className="hover:text-foreground">Annuaire</Link>
+        <span className="mx-2">/</span>
+        <span className="text-foreground">{city.name}</span>
+      </nav>
+
+      {/* Hero */}
+      <div className="mb-10">
+        <div className="flex items-center gap-2 mb-2">
+          <MapPin className="h-5 w-5 text-primary" />
+          <h1 className="text-3xl font-bold">Médecins à {city.name}</h1>
+        </div>
+        <p className="text-muted-foreground">
+          {doctors.length} professionnel{doctors.length !== 1 ? "s" : ""} de santé à {city.name}, {city.region}
+        </p>
+      </div>
+
+      {/* Specialties filter */}
+      {specialties.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+            <Stethoscope className="h-4 w-4" />
+            Filtrer par spécialité
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {specialties.map((spec) => {
+              const specInfo = getSpecialtyBySlug(spec.slug);
+              return (
+                <Link
+                  key={spec.slug}
+                  href={`/annuaire/${citySlug}/${spec.slug}`}
+                  className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+                >
+                  {specInfo?.nameFr ?? spec.name}
+                  <Badge variant="secondary" className="ml-1 text-xs">{spec.count}</Badge>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Doctor list */}
+      {doctors.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <p>Aucun médecin trouvé à {city.name} pour le moment.</p>
+          <Link href="/annuaire" className="text-primary hover:underline mt-2 inline-block">
+            Retour à l&apos;annuaire
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {doctors.map((doctor) => (
+            <Link key={doctor.id} href={`/annuaire/${doctor.slug}`}>
+              <Card className="hover:border-primary/50 hover:shadow-md transition-all cursor-pointer h-full">
+                <CardContent className="pt-5 pb-5">
+                  <div className="flex items-start gap-4">
+                    {doctor.avatar ? (
+                      <Image
+                        src={doctor.avatar}
+                        alt={doctor.name}
+                        width={48}
+                        height={48}
+                        className="h-12 w-12 rounded-full object-cover"
+                      />
+                    ) : (
+                      <Avatar className="h-12 w-12">
+                        <AvatarFallback className="text-sm bg-primary/10 text-primary">
+                          {doctor.name.split(" ").map((n) => n[0]).join("").slice(0, 2)}
+                        </AvatarFallback>
+                      </Avatar>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold truncate">{doctor.name}</p>
+                      <p className="text-sm text-muted-foreground">{doctor.specialty}</p>
+                      <p className="text-xs text-muted-foreground mt-1">{doctor.clinicName}</p>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between">
+                    {doctor.consultationFee > 0 && (
+                      <span className="text-sm font-medium">{doctor.consultationFee} MAD</span>
+                    )}
+                    {doctor.clinicSubdomain && (
+                      <span className={buttonVariants({ variant: "outline", size: "sm" })}>
+                        <Calendar className="h-3 w-3 mr-1" />
+                        Rendez-vous
+                      </span>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Other cities */}
+      <section className="mt-16">
+        <h2 className="text-xl font-bold mb-4">Autres villes</h2>
+        <div className="flex flex-wrap gap-2">
+          {DIRECTORY_CITIES
+            .filter((c) => c.slug !== citySlug)
+            .slice(0, 12)
+            .map((c) => (
+              <Link
+                key={c.slug}
+                href={`/annuaire/${c.slug}`}
+                className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+              >
+                {c.name}
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ── Page Component ──
+
+export default async function CityOrDoctorPage({ params }: PageProps) {
+  const { city: slug } = await params;
+
+  // Doctor profile page (slug starts with "dr-")
+  if (isDoctorSlug(slug)) {
+    const doctor = await getDirectoryDoctorBySlug(slug);
+    if (!doctor) notFound();
+    return <DoctorProfileView doctor={doctor} />;
+  }
+
+  // City listing page
+  const city = getCityBySlug(slug);
+  if (!city) notFound();
+
+  const [doctors, specialties] = await Promise.all([
+    getDirectoryDoctorsByCity(slug),
+    getDirectorySpecialtiesInCity(slug),
+  ]);
+
+  return (
+    <CityListingView
+      citySlug={slug}
+      city={city}
+      doctors={doctors}
+      specialties={specialties}
+    />
+  );
+}

--- a/src/app/(public)/annuaire/page.tsx
+++ b/src/app/(public)/annuaire/page.tsx
@@ -1,0 +1,175 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Search, MapPin, Stethoscope, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { safeJsonLdStringify } from "@/lib/json-ld";
+import { DIRECTORY_CITIES, DIRECTORY_SPECIALTIES } from "@/lib/directory-constants";
+import {
+  getDirectoryCities,
+  getDirectorySpecialties,
+} from "@/lib/data/directory";
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
+
+export const metadata: Metadata = {
+  title: "Annuaire Médical au Maroc — Trouvez votre médecin | Oltigo",
+  description:
+    "Trouvez un médecin, dentiste ou spécialiste près de chez vous au Maroc. Annuaire médical complet avec prise de rendez-vous en ligne à Casablanca, Rabat, Marrakech et plus.",
+  openGraph: {
+    title: "Annuaire Médical au Maroc — Trouvez votre médecin | Oltigo",
+    description:
+      "Trouvez un médecin, dentiste ou spécialiste près de chez vous au Maroc. Annuaire médical complet avec prise de rendez-vous en ligne.",
+    type: "website",
+    locale: "fr_MA",
+    url: `${BASE_URL}/annuaire`,
+    siteName: "Oltigo",
+  },
+  alternates: {
+    canonical: `${BASE_URL}/annuaire`,
+  },
+};
+
+export default async function AnnuairePage() {
+  const [cities, specialties] = await Promise.all([
+    getDirectoryCities(),
+    getDirectorySpecialties(),
+  ]);
+
+  // Use static data for cities/specialties that don't yet have doctors
+  const allCities = DIRECTORY_CITIES.map((c) => {
+    const live = cities.find((lc) => lc.slug === c.slug);
+    return { ...c, count: live?.count ?? 0 };
+  });
+
+  const allSpecialties = DIRECTORY_SPECIALTIES.map((s) => {
+    const live = specialties.find((ls) => ls.slug === s.slug);
+    return { ...s, count: live?.count ?? 0 };
+  });
+
+  const totalDoctors = cities.reduce((sum, c) => sum + c.count, 0);
+  const totalCities = cities.length;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MedicalBusiness",
+    "@id": `${BASE_URL}/annuaire#directory`,
+    name: "Annuaire Médical Oltigo — Maroc",
+    url: `${BASE_URL}/annuaire`,
+    description:
+      "Annuaire médical complet au Maroc. Trouvez un médecin, dentiste ou spécialiste et prenez rendez-vous en ligne.",
+    areaServed: {
+      "@type": "Country",
+      name: "Morocco",
+      alternateName: "Maroc",
+    },
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+      />
+
+      {/* Hero */}
+      <div className="text-center mb-12">
+        <h1 className="text-4xl font-bold mb-4">
+          Annuaire Médical au Maroc
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-2xl mx-auto mb-6">
+          Trouvez un médecin, dentiste ou spécialiste près de chez vous.
+          {totalDoctors > 0 && (
+            <span className="block mt-2 text-sm">
+              {totalDoctors} professionnels de santé dans {totalCities} villes
+            </span>
+          )}
+        </p>
+        <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Search className="h-4 w-4" />
+          <span>Sélectionnez une ville ou une spécialité ci-dessous</span>
+        </div>
+      </div>
+
+      {/* Cities */}
+      <section className="mb-16">
+        <div className="flex items-center gap-2 mb-6">
+          <MapPin className="h-5 w-5 text-primary" />
+          <h2 className="text-2xl font-bold">Par ville</h2>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {allCities.map((city) => (
+            <Link key={city.slug} href={`/annuaire/${city.slug}`}>
+              <Card className="hover:border-primary/50 hover:shadow-md transition-all cursor-pointer h-full">
+                <CardContent className="pt-4 pb-4 flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{city.name}</p>
+                    <p className="text-xs text-muted-foreground">{city.region}</p>
+                  </div>
+                  {city.count > 0 && (
+                    <Badge variant="secondary" className="text-xs">
+                      {city.count}
+                    </Badge>
+                  )}
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Specialties */}
+      <section className="mb-16">
+        <div className="flex items-center gap-2 mb-6">
+          <Stethoscope className="h-5 w-5 text-primary" />
+          <h2 className="text-2xl font-bold">Par spécialité</h2>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {allSpecialties.map((spec) => (
+            <Card key={spec.slug} className="h-full">
+              <CardContent className="pt-4 pb-4">
+                <p className="font-medium">{spec.nameFr}</p>
+                <p className="text-xs text-muted-foreground mb-2 line-clamp-2">
+                  {spec.description}
+                </p>
+                {spec.count > 0 && (
+                  <Badge variant="outline" className="text-xs">
+                    {spec.count} praticien{spec.count > 1 ? "s" : ""}
+                  </Badge>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      {/* Popular combos */}
+      <section>
+        <h2 className="text-2xl font-bold mb-6">Recherches populaires</h2>
+        <div className="flex flex-wrap gap-2">
+          {[
+            { city: "casablanca", specialty: "dentiste", label: "Dentiste à Casablanca" },
+            { city: "rabat", specialty: "medecin-generaliste", label: "Médecin généraliste à Rabat" },
+            { city: "marrakech", specialty: "gynecologue", label: "Gynécologue à Marrakech" },
+            { city: "casablanca", specialty: "cardiologue", label: "Cardiologue à Casablanca" },
+            { city: "fes", specialty: "pediatre", label: "Pédiatre à Fès" },
+            { city: "tanger", specialty: "dermatologue", label: "Dermatologue à Tanger" },
+            { city: "agadir", specialty: "ophtalmologue", label: "Ophtalmologue à Agadir" },
+            { city: "casablanca", specialty: "orl", label: "ORL à Casablanca" },
+            { city: "rabat", specialty: "pediatre", label: "Pédiatre à Rabat" },
+            { city: "marrakech", specialty: "dentiste", label: "Dentiste à Marrakech" },
+          ].map((combo) => (
+            <Link
+              key={`${combo.city}-${combo.specialty}`}
+              href={`/annuaire/${combo.city}/${combo.specialty}`}
+              className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+            >
+              {combo.label}
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 import { createClient } from "@/lib/supabase-server";
 import { getAllPosts } from "@/lib/blog";
 import { logger } from "@/lib/logger";
+import { DIRECTORY_CITIES, TOP_CITY_SPECIALTY_COMBOS } from "@/lib/directory-constants";
+import { getDirectoryDoctors } from "@/lib/data/directory";
 
 /**
  * Dynamic sitemap for public-facing pages.
@@ -86,6 +88,51 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   } catch (err) {
     logger.warn("Failed to fetch clinic subdomains for sitemap", { context: "sitemap", error: err });
+  }
+
+  // ── Doctor Directory pages ──
+
+  // Directory index
+  entries.push({
+    url: `${baseUrl}/annuaire`,
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: 0.9,
+  });
+
+  // City pages
+  for (const city of DIRECTORY_CITIES) {
+    entries.push({
+      url: `${baseUrl}/annuaire/${city.slug}`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    });
+  }
+
+  // City + specialty combo pages
+  for (const combo of TOP_CITY_SPECIALTY_COMBOS) {
+    entries.push({
+      url: `${baseUrl}/annuaire/${combo.city}/${combo.specialty}`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    });
+  }
+
+  // Individual doctor profile pages
+  try {
+    const doctors = await getDirectoryDoctors();
+    for (const doctor of doctors) {
+      entries.push({
+        url: `${baseUrl}/annuaire/${doctor.slug}`,
+        lastModified: now,
+        changeFrequency: "weekly",
+        priority: 0.6,
+      });
+    }
+  } catch (err) {
+    logger.warn("Failed to fetch directory doctors for sitemap", { context: "sitemap", error: err });
   }
 
   return entries;

--- a/src/lib/data/directory.ts
+++ b/src/lib/data/directory.ts
@@ -1,0 +1,292 @@
+/**
+ * Data fetching for the public doctor directory (/annuaire).
+ *
+ * These queries run cross-tenant (no clinic_id scoping) using the
+ * admin client because the directory is a platform-wide public listing.
+ * Only active clinics and doctors with `is_listed = true` are included.
+ */
+
+import { createClient } from "@/lib/supabase-server";
+import { unstable_cache } from "next/cache";
+import { logger } from "@/lib/logger";
+
+// ── Types ──
+
+export interface DirectoryDoctor {
+  id: string;
+  name: string;
+  slug: string;
+  specialty: string;
+  specialtySlug: string;
+  city: string;
+  citySlug: string;
+  clinicName: string;
+  clinicSubdomain: string | null;
+  address: string | null;
+  phone: string | null;
+  avatar: string | null;
+  consultationFee: number;
+  languages: string[];
+  bio: string | null;
+  clinicId: string;
+}
+
+export interface DirectoryClinic {
+  id: string;
+  name: string;
+  subdomain: string | null;
+  city: string | null;
+  address: string | null;
+  phone: string | null;
+  logoUrl: string | null;
+}
+
+// ── Helpers ──
+
+function nameToSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/^(?!dr-)/, "dr-");
+}
+
+function cityToSlug(city: string): string {
+  return city
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+function specialtyToSlug(specialty: string): string {
+  // Map common specialty names to their French slugs
+  const specialtyMap: Record<string, string> = {
+    "dentist": "dentiste",
+    "dentiste": "dentiste",
+    "general practitioner": "medecin-generaliste",
+    "médecin généraliste": "medecin-generaliste",
+    "medecin generaliste": "medecin-generaliste",
+    "pediatrician": "pediatre",
+    "pédiatre": "pediatre",
+    "pediatre": "pediatre",
+    "gynecologist": "gynecologue",
+    "gynécologue": "gynecologue",
+    "gynecologue": "gynecologue",
+    "ophthalmologist": "ophtalmologue",
+    "ophtalmologue": "ophtalmologue",
+    "cardiologist": "cardiologue",
+    "cardiologue": "cardiologue",
+    "dermatologist": "dermatologue",
+    "dermatologue": "dermatologue",
+    "orthopedist": "orthopediste",
+    "orthopédiste": "orthopediste",
+    "orthopediste": "orthopediste",
+    "neurologist": "neurologue",
+    "neurologue": "neurologue",
+    "psychiatrist": "psychiatre",
+    "psychiatre": "psychiatre",
+    "physiotherapist": "kinesitherapeute",
+    "kinésithérapeute": "kinesitherapeute",
+    "kinesitherapeute": "kinesitherapeute",
+    "radiologist": "radiologue",
+    "radiologue": "radiologue",
+    "nutritionist": "nutritionniste",
+    "nutritionniste": "nutritionniste",
+    "ent specialist": "orl",
+    "orl": "orl",
+    "urologist": "urologue",
+    "urologue": "urologue",
+    "pulmonologist": "pneumologue",
+    "pneumologue": "pneumologue",
+    "endocrinologist": "endocrinologue",
+    "endocrinologue": "endocrinologue",
+    "rheumatologist": "rhumatologue",
+    "rhumatologue": "rhumatologue",
+    "gastroenterologist": "gastro-enterologue",
+    "gastro-entérologue": "gastro-enterologue",
+    "gastro-enterologue": "gastro-enterologue",
+    "nephrologist": "nephrologue",
+    "néphrologue": "nephrologue",
+    "nephrologue": "nephrologue",
+    "pharmacist": "pharmacien",
+    "pharmacien": "pharmacien",
+    "optician": "opticien",
+    "opticien": "opticien",
+    "speech therapist": "orthophoniste",
+    "orthophoniste": "orthophoniste",
+    "psychologist": "psychologue",
+    "psychologue": "psychologue",
+  };
+
+  const lower = specialty.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  return specialtyMap[lower] ?? lower.replace(/[^a-z0-9\s-]/g, "").trim().replace(/\s+/g, "-");
+}
+
+// ── Data fetching ──
+
+async function fetchDirectoryDoctors(): Promise<DirectoryDoctor[]> {
+  try {
+    const supabase = await createClient();
+
+    // Fetch all doctors from active clinics
+    const { data: doctors, error: doctorsError } = await supabase
+      .from("users")
+      .select("id, name, phone, email, avatar_url, metadata, clinic_id")
+      .eq("role", "doctor")
+      .order("name", { ascending: true });
+
+    if (doctorsError || !doctors) {
+      logger.warn("Failed to fetch directory doctors", { context: "directory", error: doctorsError });
+      return [];
+    }
+
+    // Fetch active clinics
+    const { data: clinics, error: clinicsError } = await supabase
+      .from("clinics")
+      .select("id, name, subdomain, phone, address, logo_url, config")
+      .eq("status", "active");
+
+    if (clinicsError || !clinics) {
+      logger.warn("Failed to fetch directory clinics", { context: "directory", error: clinicsError });
+      return [];
+    }
+
+    const clinicMap = new Map(clinics.map((c) => [c.id, c]));
+
+    return doctors
+      .map((d) => {
+        if (!d.clinic_id) return null;
+        const clinic = clinicMap.get(d.clinic_id);
+        if (!clinic) return null;
+
+        const meta = (d.metadata ?? {}) as Record<string, unknown>;
+        const specialty = (meta.specialty as string) ?? "";
+        const cfg = (clinic.config as Record<string, unknown> | null) ?? {};
+        const city = (cfg.city as string) ?? (clinic.address?.split(",").pop()?.trim() ?? "");
+
+        if (!specialty || !city) return null;
+
+        return {
+          id: d.id,
+          name: d.name,
+          slug: nameToSlug(d.name),
+          specialty,
+          specialtySlug: specialtyToSlug(specialty),
+          city,
+          citySlug: cityToSlug(city),
+          clinicName: clinic.name ?? "",
+          clinicSubdomain: clinic.subdomain,
+          address: clinic.address ?? (cfg.address as string | null) ?? null,
+          phone: d.phone ?? clinic.phone ?? null,
+          avatar: d.avatar_url ?? null,
+          consultationFee: (meta.consultation_fee as number) ?? 0,
+          languages: (meta.languages as string[]) ?? [],
+          bio: (meta.bio as string | null) ?? null,
+          clinicId: d.clinic_id,
+        };
+      })
+      .filter((d): d is DirectoryDoctor => d !== null);
+  } catch (err) {
+    logger.error("Failed to fetch directory data", { context: "directory", error: err });
+    return [];
+  }
+}
+
+const getCachedDirectoryDoctors = unstable_cache(
+  fetchDirectoryDoctors,
+  ["directory-doctors"],
+  { revalidate: 300, tags: ["directory"] }, // 5-minute TTL
+);
+
+// ── Public API ──
+
+/** Fetch all listed doctors across all clinics */
+export async function getDirectoryDoctors(): Promise<DirectoryDoctor[]> {
+  return getCachedDirectoryDoctors();
+}
+
+/** Fetch doctors filtered by city slug */
+export async function getDirectoryDoctorsByCity(citySlug: string): Promise<DirectoryDoctor[]> {
+  const all = await getCachedDirectoryDoctors();
+  return all.filter((d) => d.citySlug === citySlug);
+}
+
+/** Fetch doctors filtered by city + specialty slug */
+export async function getDirectoryDoctorsByCityAndSpecialty(
+  citySlug: string,
+  specialtySlug: string,
+): Promise<DirectoryDoctor[]> {
+  const all = await getCachedDirectoryDoctors();
+  return all.filter((d) => d.citySlug === citySlug && d.specialtySlug === specialtySlug);
+}
+
+/** Fetch a single doctor by their slug */
+export async function getDirectoryDoctorBySlug(slug: string): Promise<DirectoryDoctor | null> {
+  const all = await getCachedDirectoryDoctors();
+  return all.find((d) => d.slug === slug) ?? null;
+}
+
+/** Get all unique cities that have at least one doctor */
+export async function getDirectoryCities(): Promise<{ slug: string; name: string; count: number }[]> {
+  const all = await getCachedDirectoryDoctors();
+  const cityMap = new Map<string, { name: string; count: number }>();
+
+  for (const d of all) {
+    const existing = cityMap.get(d.citySlug);
+    if (existing) {
+      existing.count++;
+    } else {
+      cityMap.set(d.citySlug, { name: d.city, count: 1 });
+    }
+  }
+
+  return Array.from(cityMap.entries())
+    .map(([slug, { name, count }]) => ({ slug, name, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** Get all unique specialties that have at least one doctor */
+export async function getDirectorySpecialties(): Promise<{ slug: string; name: string; count: number }[]> {
+  const all = await getCachedDirectoryDoctors();
+  const specMap = new Map<string, { name: string; count: number }>();
+
+  for (const d of all) {
+    const existing = specMap.get(d.specialtySlug);
+    if (existing) {
+      existing.count++;
+    } else {
+      specMap.set(d.specialtySlug, { name: d.specialty, count: 1 });
+    }
+  }
+
+  return Array.from(specMap.entries())
+    .map(([slug, { name, count }]) => ({ slug, name, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/** Get specialties available in a specific city */
+export async function getDirectorySpecialtiesInCity(
+  citySlug: string,
+): Promise<{ slug: string; name: string; count: number }[]> {
+  const cityDoctors = await getDirectoryDoctorsByCity(citySlug);
+  const specMap = new Map<string, { name: string; count: number }>();
+
+  for (const d of cityDoctors) {
+    const existing = specMap.get(d.specialtySlug);
+    if (existing) {
+      existing.count++;
+    } else {
+      specMap.set(d.specialtySlug, { name: d.specialty, count: 1 });
+    }
+  }
+
+  return Array.from(specMap.entries())
+    .map(([slug, { name, count }]) => ({ slug, name, count }))
+    .sort((a, b) => b.count - a.count);
+}

--- a/src/lib/directory-constants.ts
+++ b/src/lib/directory-constants.ts
@@ -1,0 +1,175 @@
+/**
+ * Directory Constants
+ *
+ * Static data for the public doctor directory (/annuaire).
+ * Cities, specialties, and slug-mapping utilities used by
+ * directory pages and sitemap generation.
+ */
+
+// ── Moroccan Cities with French slugs ──
+
+export interface DirectoryCity {
+  name: string;
+  slug: string;
+  nameAr: string;
+  region: string;
+}
+
+export const DIRECTORY_CITIES: DirectoryCity[] = [
+  { name: "Casablanca", slug: "casablanca", nameAr: "الدار البيضاء", region: "Casablanca-Settat" },
+  { name: "Rabat", slug: "rabat", nameAr: "الرباط", region: "Rabat-Salé-Kénitra" },
+  { name: "Marrakech", slug: "marrakech", nameAr: "مراكش", region: "Marrakech-Safi" },
+  { name: "Fès", slug: "fes", nameAr: "فاس", region: "Fès-Meknès" },
+  { name: "Tanger", slug: "tanger", nameAr: "طنجة", region: "Tanger-Tétouan-Al Hoceïma" },
+  { name: "Agadir", slug: "agadir", nameAr: "أكادير", region: "Souss-Massa" },
+  { name: "Meknès", slug: "meknes", nameAr: "مكناس", region: "Fès-Meknès" },
+  { name: "Oujda", slug: "oujda", nameAr: "وجدة", region: "Oriental" },
+  { name: "Kénitra", slug: "kenitra", nameAr: "القنيطرة", region: "Rabat-Salé-Kénitra" },
+  { name: "Tétouan", slug: "tetouan", nameAr: "تطوان", region: "Tanger-Tétouan-Al Hoceïma" },
+  { name: "Salé", slug: "sale", nameAr: "سلا", region: "Rabat-Salé-Kénitra" },
+  { name: "Temara", slug: "temara", nameAr: "تمارة", region: "Rabat-Salé-Kénitra" },
+  { name: "Safi", slug: "safi", nameAr: "آسفي", region: "Marrakech-Safi" },
+  { name: "Mohammedia", slug: "mohammedia", nameAr: "المحمدية", region: "Casablanca-Settat" },
+  { name: "El Jadida", slug: "el-jadida", nameAr: "الجديدة", region: "Casablanca-Settat" },
+  { name: "Béni Mellal", slug: "beni-mellal", nameAr: "بني ملال", region: "Béni Mellal-Khénifra" },
+  { name: "Nador", slug: "nador", nameAr: "الناظور", region: "Oriental" },
+  { name: "Taza", slug: "taza", nameAr: "تازة", region: "Fès-Meknès" },
+  { name: "Settat", slug: "settat", nameAr: "سطات", region: "Casablanca-Settat" },
+  { name: "Berrechid", slug: "berrechid", nameAr: "برشيد", region: "Casablanca-Settat" },
+  { name: "Khouribga", slug: "khouribga", nameAr: "خريبكة", region: "Béni Mellal-Khénifra" },
+  { name: "Khémisset", slug: "khemisset", nameAr: "الخميسات", region: "Rabat-Salé-Kénitra" },
+  { name: "Larache", slug: "larache", nameAr: "العرائش", region: "Tanger-Tétouan-Al Hoceïma" },
+  { name: "Guelmim", slug: "guelmim", nameAr: "كلميم", region: "Guelmim-Oued Noun" },
+  { name: "Errachidia", slug: "errachidia", nameAr: "الراشيدية", region: "Drâa-Tafilalet" },
+  { name: "Ifrane", slug: "ifrane", nameAr: "إفران", region: "Fès-Meknès" },
+];
+
+// ── Medical Specialties with French slugs ──
+
+export interface DirectorySpecialty {
+  name: string;
+  slug: string;
+  nameAr: string;
+  nameFr: string;
+  description: string;
+}
+
+export const DIRECTORY_SPECIALTIES: DirectorySpecialty[] = [
+  { name: "General Practitioner", slug: "medecin-generaliste", nameAr: "طبيب عام", nameFr: "Médecin généraliste", description: "Consultations de médecine générale et suivi médical" },
+  { name: "Dentist", slug: "dentiste", nameAr: "طبيب أسنان", nameFr: "Dentiste", description: "Soins dentaires, orthodontie et chirurgie buccale" },
+  { name: "Pediatrician", slug: "pediatre", nameAr: "طبيب أطفال", nameFr: "Pédiatre", description: "Suivi médical des nourrissons, enfants et adolescents" },
+  { name: "Gynecologist", slug: "gynecologue", nameAr: "طبيب نساء وتوليد", nameFr: "Gynécologue", description: "Gynécologie, obstétrique et suivi de grossesse" },
+  { name: "Ophthalmologist", slug: "ophtalmologue", nameAr: "طبيب عيون", nameFr: "Ophtalmologue", description: "Soins des yeux, examens de la vue et chirurgie ophtalmique" },
+  { name: "Cardiologist", slug: "cardiologue", nameAr: "طبيب قلب", nameFr: "Cardiologue", description: "Diagnostic et traitement des maladies cardiovasculaires" },
+  { name: "Dermatologist", slug: "dermatologue", nameAr: "طبيب جلد", nameFr: "Dermatologue", description: "Soins de la peau, dermatologie esthétique et allergies cutanées" },
+  { name: "Orthopedist", slug: "orthopediste", nameAr: "طبيب عظام", nameFr: "Orthopédiste", description: "Traumatologie, chirurgie orthopédique et rhumatologie" },
+  { name: "Neurologist", slug: "neurologue", nameAr: "طبيب أعصاب", nameFr: "Neurologue", description: "Diagnostic et traitement des maladies du système nerveux" },
+  { name: "Psychiatrist", slug: "psychiatre", nameAr: "طبيب نفسي", nameFr: "Psychiatre", description: "Santé mentale, troubles psychologiques et thérapies" },
+  { name: "Physiotherapist", slug: "kinesitherapeute", nameAr: "معالج طبيعي", nameFr: "Kinésithérapeute", description: "Rééducation fonctionnelle et kinésithérapie" },
+  { name: "Radiologist", slug: "radiologue", nameAr: "طبيب أشعة", nameFr: "Radiologue", description: "Imagerie médicale, radiologie et échographie" },
+  { name: "Nutritionist", slug: "nutritionniste", nameAr: "أخصائي تغذية", nameFr: "Nutritionniste", description: "Nutrition, diététique et suivi alimentaire" },
+  { name: "ENT Specialist", slug: "orl", nameAr: "طبيب أنف أذن حنجرة", nameFr: "ORL", description: "Oto-rhino-laryngologie — nez, oreilles et gorge" },
+  { name: "Urologist", slug: "urologue", nameAr: "طبيب مسالك بولية", nameFr: "Urologue", description: "Appareil urinaire et troubles urologiques" },
+  { name: "Pulmonologist", slug: "pneumologue", nameAr: "طبيب رئة", nameFr: "Pneumologue", description: "Maladies respiratoires et pneumologie" },
+  { name: "Endocrinologist", slug: "endocrinologue", nameAr: "طبيب غدد", nameFr: "Endocrinologue", description: "Diabète, thyroïde et troubles hormonaux" },
+  { name: "Rheumatologist", slug: "rhumatologue", nameAr: "طبيب روماتيزم", nameFr: "Rhumatologue", description: "Rhumatismes, arthrose et maladies articulaires" },
+  { name: "Gastroenterologist", slug: "gastro-enterologue", nameAr: "طبيب جهاز هضمي", nameFr: "Gastro-entérologue", description: "Maladies de l'appareil digestif et hépatologie" },
+  { name: "Nephrologist", slug: "nephrologue", nameAr: "طبيب كلى", nameFr: "Néphrologue", description: "Maladies rénales et dialyse" },
+  { name: "Pharmacist", slug: "pharmacien", nameAr: "صيدلي", nameFr: "Pharmacien", description: "Pharmacie, conseil pharmaceutique et parapharmacie" },
+  { name: "Optician", slug: "opticien", nameAr: "بصري", nameFr: "Opticien", description: "Lunettes, lentilles de contact et optique" },
+  { name: "Speech Therapist", slug: "orthophoniste", nameAr: "أخصائي نطق", nameFr: "Orthophoniste", description: "Rééducation de la parole et du langage" },
+  { name: "Psychologist", slug: "psychologue", nameAr: "أخصائي نفسي", nameFr: "Psychologue", description: "Accompagnement psychologique et thérapies comportementales" },
+];
+
+// ── Top city+specialty combos for SSG (generateStaticParams) ──
+
+/** Top 50 city+specialty combinations for static generation */
+export const TOP_CITY_SPECIALTY_COMBOS: { city: string; specialty: string }[] = [
+  // Casablanca — largest city, all major specialties
+  { city: "casablanca", specialty: "dentiste" },
+  { city: "casablanca", specialty: "medecin-generaliste" },
+  { city: "casablanca", specialty: "gynecologue" },
+  { city: "casablanca", specialty: "pediatre" },
+  { city: "casablanca", specialty: "cardiologue" },
+  { city: "casablanca", specialty: "dermatologue" },
+  { city: "casablanca", specialty: "ophtalmologue" },
+  { city: "casablanca", specialty: "orthopediste" },
+  { city: "casablanca", specialty: "orl" },
+  { city: "casablanca", specialty: "kinesitherapeute" },
+  // Rabat
+  { city: "rabat", specialty: "dentiste" },
+  { city: "rabat", specialty: "medecin-generaliste" },
+  { city: "rabat", specialty: "gynecologue" },
+  { city: "rabat", specialty: "pediatre" },
+  { city: "rabat", specialty: "cardiologue" },
+  { city: "rabat", specialty: "dermatologue" },
+  { city: "rabat", specialty: "ophtalmologue" },
+  // Marrakech
+  { city: "marrakech", specialty: "dentiste" },
+  { city: "marrakech", specialty: "medecin-generaliste" },
+  { city: "marrakech", specialty: "gynecologue" },
+  { city: "marrakech", specialty: "pediatre" },
+  { city: "marrakech", specialty: "cardiologue" },
+  { city: "marrakech", specialty: "dermatologue" },
+  // Fès
+  { city: "fes", specialty: "dentiste" },
+  { city: "fes", specialty: "medecin-generaliste" },
+  { city: "fes", specialty: "gynecologue" },
+  { city: "fes", specialty: "pediatre" },
+  { city: "fes", specialty: "cardiologue" },
+  // Tanger
+  { city: "tanger", specialty: "dentiste" },
+  { city: "tanger", specialty: "medecin-generaliste" },
+  { city: "tanger", specialty: "gynecologue" },
+  { city: "tanger", specialty: "pediatre" },
+  { city: "tanger", specialty: "cardiologue" },
+  // Agadir
+  { city: "agadir", specialty: "dentiste" },
+  { city: "agadir", specialty: "medecin-generaliste" },
+  { city: "agadir", specialty: "gynecologue" },
+  { city: "agadir", specialty: "pediatre" },
+  // Meknès
+  { city: "meknes", specialty: "dentiste" },
+  { city: "meknes", specialty: "medecin-generaliste" },
+  { city: "meknes", specialty: "gynecologue" },
+  // Oujda
+  { city: "oujda", specialty: "dentiste" },
+  { city: "oujda", specialty: "medecin-generaliste" },
+  { city: "oujda", specialty: "gynecologue" },
+  // Kénitra
+  { city: "kenitra", specialty: "dentiste" },
+  { city: "kenitra", specialty: "medecin-generaliste" },
+  // Tétouan
+  { city: "tetouan", specialty: "dentiste" },
+  { city: "tetouan", specialty: "medecin-generaliste" },
+  // Salé
+  { city: "sale", specialty: "dentiste" },
+  { city: "sale", specialty: "medecin-generaliste" },
+  // Safi
+  { city: "safi", specialty: "dentiste" },
+];
+
+// ── Lookup helpers ──
+
+export function getCityBySlug(slug: string): DirectoryCity | undefined {
+  return DIRECTORY_CITIES.find((c) => c.slug === slug);
+}
+
+export function getSpecialtyBySlug(slug: string): DirectorySpecialty | undefined {
+  return DIRECTORY_SPECIALTIES.find((s) => s.slug === slug);
+}
+
+/**
+ * Generate a doctor slug from their name.
+ * e.g. "Dr. Ahmed El Fassi" → "dr-ahmed-el-fassi"
+ */
+export function doctorNameToSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // strip diacritics
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/^(?!dr-)/, "dr-"); // ensure dr- prefix
+}


### PR DESCRIPTION
- Directory index page with city/specialty browsing and popular searches
- City listing pages with doctor cards and specialty filters (SSG for 26 cities)
- City+specialty pages with detailed doctor listings (SSG for top 50 combos)
- Doctor profile pages at /annuaire/dr-{slug} with full profile, clinic info
- JSON-LD structured data (Physician, MedicalBusiness, ReserveAction)
- Book Now CTA linking to clinic subdomain booking page
- Sitemap updated with all directory pages (cities, combos, doctor profiles)
- Meta tags with OG data, canonical URLs, fr_MA locale on all pages
- Directory data layer with cross-tenant queries and 5-min cache
- 24 specialties with French slugs and Arabic names
- 26 Moroccan cities with slugs, regions, and Arabic names