### PR TITLE
feat: CNSS/CNOPS Insurance Billing Tables & Tariff System (Task 8)

### DIFF
--- a/src/components/__tests__/patient-registration.test.tsx
+++ b/src/components/__tests__/patient-registration.test.tsx
@@ -77,7 +77,7 @@ describe("PatientRegistrationDialog", () => {
     
     // Check form sections are present
     expect(screen.getByText("Personal Information")).toBeDefined();
-    expect(screen.getByText("Insurance")).toBeDefined();
+    expect(screen.getByText("Assurance / Insurance")).toBeDefined();
     expect(screen.getByText("Medical Information")).toBeDefined();
     expect(screen.getByText("Emergency Contact")).toBeDefined();
   });
@@ -112,11 +112,11 @@ describe("PatientRegistrationDialog", () => {
     // Open the dialog
     fireEvent.click(screen.getByText("Register New Patient"));
     
-    // Check insurance options exist
-    expect(screen.getByText("No Insurance")).toBeDefined();
-    expect(screen.getByText("CNSS")).toBeDefined();
-    expect(screen.getByText("CNOPS")).toBeDefined();
-    expect(screen.getByText("RAMED")).toBeDefined();
+    // Check insurance options exist (French labels)
+    expect(screen.getByText("Aucune assurance")).toBeDefined();
+    expect(screen.getByText("CNSS (70%)")).toBeDefined();
+    expect(screen.getByText("CNOPS (80%)")).toBeDefined();
+    expect(screen.getByText("RAMED (100%)")).toBeDefined();
   });
 
   it("has cancel and register buttons", () => {

--- a/src/components/insurance-billing-report.tsx
+++ b/src/components/insurance-billing-report.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  Shield, FileText, Download, TrendingUp,
+  Clock, CheckCircle, AlertTriangle, Search,
+  Filter,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { EmptyState } from "@/components/ui/empty-state";
+import { formatMADFormal } from "@/lib/morocco";
+import type { InsuranceTariffType } from "@/lib/insurance-billing";
+
+// ---- Types ----
+
+export interface InsuranceClaimRecord {
+  id: string;
+  patientName: string;
+  patientCIN: string;
+  affiliationNumber: string;
+  insuranceType: InsuranceTariffType;
+  dateOfTreatment: string;
+  actCodes: string[];
+  actDescriptions: string[];
+  totalCharged: number;
+  totalReimbursement: number;
+  patientShare: number;
+  depassement: number;
+  invoiceNumber: string;
+  status: "pending" | "submitted" | "approved" | "paid" | "rejected";
+  bordereauRef?: string;
+  submittedDate?: string;
+  paidDate?: string;
+  rejectionReason?: string;
+}
+
+interface InsuranceBillingReportProps {
+  claims: InsuranceClaimRecord[];
+  onGenerateBordereau?: (insuranceType: InsuranceTariffType, claimIds: string[]) => void;
+  onDownloadBordereau?: (bordereauRef: string) => void;
+}
+
+// ---- Component ----
+
+export function InsuranceBillingReport({
+  claims,
+  onGenerateBordereau,
+  onDownloadBordereau,
+}: InsuranceBillingReportProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [selectedClaims, setSelectedClaims] = useState<Set<string>>(new Set());
+
+  // ── Filtered claims ──
+  const filteredClaims = useMemo(() => {
+    return claims.filter((claim) => {
+      const matchesSearch =
+        !searchQuery.trim() ||
+        claim.patientName.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        claim.invoiceNumber.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        claim.affiliationNumber.includes(searchQuery);
+
+      const matchesStatus =
+        statusFilter === "all" || claim.status === statusFilter;
+
+      return matchesSearch && matchesStatus;
+    });
+  }, [claims, searchQuery, statusFilter]);
+
+  // ── Stats by insurance type ──
+  const cnssStats = useMemo(() => {
+    const cnssClaims = claims.filter((c) => c.insuranceType === "cnss");
+    return {
+      total: cnssClaims.length,
+      totalBilled: cnssClaims.reduce((sum, c) => sum + c.totalReimbursement, 0),
+      pending: cnssClaims.filter((c) => c.status === "pending" || c.status === "submitted").length,
+      pendingAmount: cnssClaims
+        .filter((c) => c.status === "pending" || c.status === "submitted")
+        .reduce((sum, c) => sum + c.totalReimbursement, 0),
+      paid: cnssClaims.filter((c) => c.status === "paid").length,
+      paidAmount: cnssClaims
+        .filter((c) => c.status === "paid")
+        .reduce((sum, c) => sum + c.totalReimbursement, 0),
+      rejected: cnssClaims.filter((c) => c.status === "rejected").length,
+    };
+  }, [claims]);
+
+  const cnopsStats = useMemo(() => {
+    const cnopsClaims = claims.filter((c) => c.insuranceType === "cnops");
+    return {
+      total: cnopsClaims.length,
+      totalBilled: cnopsClaims.reduce((sum, c) => sum + c.totalReimbursement, 0),
+      pending: cnopsClaims.filter((c) => c.status === "pending" || c.status === "submitted").length,
+      pendingAmount: cnopsClaims
+        .filter((c) => c.status === "pending" || c.status === "submitted")
+        .reduce((sum, c) => sum + c.totalReimbursement, 0),
+      paid: cnopsClaims.filter((c) => c.status === "paid").length,
+      paidAmount: cnopsClaims
+        .filter((c) => c.status === "paid")
+        .reduce((sum, c) => sum + c.totalReimbursement, 0),
+      rejected: cnopsClaims.filter((c) => c.status === "rejected").length,
+    };
+  }, [claims]);
+
+  // ── Selection handlers ──
+  const toggleClaim = (id: string) => {
+    setSelectedClaims((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = (checked: boolean) => {
+    if (checked) {
+      const pendingIds = filteredClaims
+        .filter((c) => c.status === "pending")
+        .map((c) => c.id);
+      setSelectedClaims(new Set(pendingIds));
+    } else {
+      setSelectedClaims(new Set());
+    }
+  };
+
+  const handleGenerateBordereau = (insuranceType: InsuranceTariffType) => {
+    const selectedIds = [...selectedClaims].filter((id) => {
+      const claim = claims.find((c) => c.id === id);
+      return claim?.insuranceType === insuranceType && claim?.status === "pending";
+    });
+    if (selectedIds.length > 0) {
+      onGenerateBordereau?.(insuranceType, selectedIds);
+      setSelectedClaims(new Set());
+    }
+  };
+
+  const statusBadge = (status: InsuranceClaimRecord["status"]) => {
+    switch (status) {
+      case "pending":
+        return <Badge variant="warning" className="text-[10px]">En attente</Badge>;
+      case "submitted":
+        return <Badge variant="default" className="text-[10px]">Soumis</Badge>;
+      case "approved":
+        return <Badge variant="outline" className="text-[10px]">Approuvé</Badge>;
+      case "paid":
+        return <Badge variant="success" className="text-[10px]">Payé</Badge>;
+      case "rejected":
+        return <Badge variant="destructive" className="text-[10px]">Rejeté</Badge>;
+    }
+  };
+
+  const statusIcon = (status: InsuranceClaimRecord["status"]) => {
+    switch (status) {
+      case "pending":
+        return <Clock className="h-3.5 w-3.5 text-yellow-600" />;
+      case "submitted":
+        return <FileText className="h-3.5 w-3.5 text-blue-600" />;
+      case "approved":
+        return <CheckCircle className="h-3.5 w-3.5 text-indigo-600" />;
+      case "paid":
+        return <CheckCircle className="h-3.5 w-3.5 text-green-600" />;
+      case "rejected":
+        return <AlertTriangle className="h-3.5 w-3.5 text-red-600" />;
+    }
+  };
+
+  const renderStatsCards = (
+    label: string,
+    stats: typeof cnssStats,
+    insuranceType: InsuranceTariffType,
+  ) => (
+    <div>
+      <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
+        <Shield className="h-4 w-4" />
+        {label}
+      </h3>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-muted-foreground">Total facturé</p>
+            <p className="text-lg font-bold text-blue-600">
+              {formatMADFormal(stats.totalBilled)}
+            </p>
+            <p className="text-xs text-muted-foreground">{stats.total} dossiers</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-muted-foreground">En attente</p>
+            <p className="text-lg font-bold text-yellow-600">
+              {formatMADFormal(stats.pendingAmount)}
+            </p>
+            <p className="text-xs text-muted-foreground">{stats.pending} dossiers</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-muted-foreground">Reçu</p>
+            <p className="text-lg font-bold text-green-600">
+              {formatMADFormal(stats.paidAmount)}
+            </p>
+            <p className="text-xs text-muted-foreground">{stats.paid} dossiers</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Rejeté</p>
+                <p className="text-lg font-bold text-red-500">{stats.rejected}</p>
+              </div>
+              {selectedClaims.size > 0 && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="text-xs"
+                  onClick={() => handleGenerateBordereau(insuranceType)}
+                >
+                  <FileText className="h-3 w-3 mr-1" />
+                  Bordereau
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Shield className="h-6 w-6" />
+            Rapport Assurance Maladie
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Suivi des remboursements CNSS / CNOPS et g&eacute;n&eacute;ration des bordereaux
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={selectedClaims.size === 0}
+            onClick={() => handleGenerateBordereau("cnss")}
+          >
+            <FileText className="h-4 w-4 mr-1" />
+            Bordereau CNSS
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={selectedClaims.size === 0}
+            onClick={() => handleGenerateBordereau("cnops")}
+          >
+            <FileText className="h-4 w-4 mr-1" />
+            Bordereau CNOPS
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats Overview */}
+      <div className="space-y-6 mb-6">
+        {renderStatsCards("CNSS — Sécurité Sociale (70%)", cnssStats, "cnss")}
+        {renderStatsCards("CNOPS — Prévoyance Sociale (80%)", cnopsStats, "cnops")}
+      </div>
+
+      <Separator className="my-6" />
+
+      {/* Claims List */}
+      <Tabs defaultValue="all">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+          <TabsList>
+            <TabsTrigger value="all">Tous</TabsTrigger>
+            <TabsTrigger value="cnss">CNSS</TabsTrigger>
+            <TabsTrigger value="cnops">CNOPS</TabsTrigger>
+          </TabsList>
+
+          <div className="flex gap-2">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Rechercher patient, facture..."
+                className="pl-10 w-64"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-40">
+                <Filter className="h-3.5 w-3.5 mr-1" />
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Tous les statuts</SelectItem>
+                <SelectItem value="pending">En attente</SelectItem>
+                <SelectItem value="submitted">Soumis</SelectItem>
+                <SelectItem value="approved">Approuvé</SelectItem>
+                <SelectItem value="paid">Payé</SelectItem>
+                <SelectItem value="rejected">Rejeté</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {["all", "cnss", "cnops"].map((tab) => (
+          <TabsContent key={tab} value={tab}>
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base flex items-center justify-between">
+                  <span className="flex items-center gap-2">
+                    <FileText className="h-4 w-4" />
+                    Dossiers de remboursement
+                    <Badge variant="outline" className="text-xs ml-2">
+                      {filteredClaims.filter(
+                        (c) => tab === "all" || c.insuranceType === tab,
+                      ).length}
+                    </Badge>
+                  </span>
+                  <label className="flex items-center gap-2 text-xs font-normal cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="rounded border-gray-300"
+                      onChange={(e) => toggleAll(e.target.checked)}
+                    />
+                    Sélectionner en attente
+                  </label>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {filteredClaims.filter(
+                  (c) => tab === "all" || c.insuranceType === tab,
+                ).length === 0 ? (
+                  <EmptyState
+                    icon={FileText}
+                    title="Aucun dossier trouvé"
+                    className="py-8"
+                  />
+                ) : (
+                  <div className="space-y-2">
+                    {filteredClaims
+                      .filter((c) => tab === "all" || c.insuranceType === tab)
+                      .map((claim) => (
+                        <div
+                          key={claim.id}
+                          className="flex items-center gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+                        >
+                          {claim.status === "pending" && (
+                            <input
+                              type="checkbox"
+                              className="rounded border-gray-300"
+                              checked={selectedClaims.has(claim.id)}
+                              onChange={() => toggleClaim(claim.id)}
+                            />
+                          )}
+
+                          <div className="flex items-center gap-2">
+                            {statusIcon(claim.status)}
+                            <Badge
+                              variant={
+                                claim.insuranceType === "cnss"
+                                  ? "default"
+                                  : "secondary"
+                              }
+                              className="text-[10px]"
+                            >
+                              {claim.insuranceType.toUpperCase()}
+                            </Badge>
+                          </div>
+
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <p className="text-sm font-medium truncate">
+                                {claim.patientName}
+                              </p>
+                              {statusBadge(claim.status)}
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                              {claim.dateOfTreatment} &middot; Facture{" "}
+                              {claim.invoiceNumber} &middot; N°{" "}
+                              {claim.affiliationNumber}
+                            </p>
+                            <p className="text-xs text-muted-foreground truncate">
+                              {claim.actDescriptions.join(", ")}
+                            </p>
+                          </div>
+
+                          <div className="text-right shrink-0">
+                            <p className="text-sm font-medium">
+                              {formatMADFormal(claim.totalReimbursement)}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              sur {formatMADFormal(claim.totalCharged)}
+                            </p>
+                            {claim.depassement > 0 && (
+                              <p className="text-[10px] text-amber-600">
+                                Dép. {formatMADFormal(claim.depassement)}
+                              </p>
+                            )}
+                          </div>
+
+                          <div className="flex gap-1 shrink-0">
+                            {claim.bordereauRef && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                title="Télécharger le bordereau"
+                                onClick={() =>
+                                  onDownloadBordereau?.(claim.bordereauRef!)
+                                }
+                              >
+                                <Download className="h-3.5 w-3.5" />
+                              </Button>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+        ))}
+      </Tabs>
+
+      {/* Monthly Summary */}
+      <div className="mt-6">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base flex items-center gap-2">
+              <TrendingUp className="h-4 w-4" />
+              Résumé mensuel
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">
+                  Total facturé aux assurances
+                </p>
+                <p className="text-lg font-bold">
+                  {formatMADFormal(
+                    cnssStats.totalBilled + cnopsStats.totalBilled,
+                  )}
+                </p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">
+                  En attente de remboursement
+                </p>
+                <p className="text-lg font-bold text-yellow-600">
+                  {formatMADFormal(
+                    cnssStats.pendingAmount + cnopsStats.pendingAmount,
+                  )}
+                </p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">
+                  Remboursements reçus
+                </p>
+                <p className="text-lg font-bold text-green-600">
+                  {formatMADFormal(
+                    cnssStats.paidAmount + cnopsStats.paidAmount,
+                  )}
+                </p>
+              </div>
+              <div className="rounded-lg border p-3">
+                <p className="text-xs text-muted-foreground">
+                  Taux de recouvrement
+                </p>
+                <p className="text-lg font-bold text-blue-600">
+                  {cnssStats.totalBilled + cnopsStats.totalBilled > 0
+                    ? (
+                        ((cnssStats.paidAmount + cnopsStats.paidAmount) /
+                          (cnssStats.totalBilled + cnopsStats.totalBilled)) *
+                        100
+                      ).toFixed(1)
+                    : "0.0"}
+                  %
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/receptionist/patient-registration-dialog.tsx
+++ b/src/components/receptionist/patient-registration-dialog.tsx
@@ -31,6 +31,9 @@ interface PatientFormData {
   cin: string;
   insurance: string;
   insuranceNumber: string;
+  mutuelleName: string;
+  mutuelleNumber: string;
+  mutuelleCoverageRate: string;
   allergies: string;
   medicalHistory: string;
   emergencyContactName: string;
@@ -52,6 +55,9 @@ const initialForm: PatientFormData = {
   cin: "",
   insurance: "",
   insuranceNumber: "",
+  mutuelleName: "",
+  mutuelleNumber: "",
+  mutuelleCoverageRate: "",
   allergies: "",
   medicalHistory: "",
   emergencyContactName: "",
@@ -165,33 +171,70 @@ export function PatientRegistrationDialog({ trigger, onRegister }: PatientRegist
             {/* Insurance */}
             <div>
               <h3 className="text-sm font-semibold mb-3 text-muted-foreground uppercase tracking-wide">
-                Insurance
+                Assurance / Insurance
               </h3>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Insurance Provider</Label>
+                  <Label>Type d&apos;assurance</Label>
                   <Select value={form.insurance} onValueChange={(v) => updateField("insurance", v)}>
                     <SelectTrigger>
-                      <SelectValue placeholder="Select insurance" />
+                      <SelectValue placeholder="Sélectionner l'assurance" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="none">No Insurance</SelectItem>
-                      <SelectItem value="CNSS">CNSS</SelectItem>
-                      <SelectItem value="CNOPS">CNOPS</SelectItem>
-                      <SelectItem value="RAMED">RAMED</SelectItem>
-                      <SelectItem value="private">Private Insurance</SelectItem>
+                      <SelectItem value="none">Aucune assurance</SelectItem>
+                      <SelectItem value="CNSS">CNSS (70%)</SelectItem>
+                      <SelectItem value="CNOPS">CNOPS (80%)</SelectItem>
+                      <SelectItem value="AMO">AMO (70%)</SelectItem>
+                      <SelectItem value="RAMED">RAMED (100%)</SelectItem>
+                      <SelectItem value="private">Assurance privée</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label>Insurance Number</Label>
+                  <Label>N° d&apos;affiliation</Label>
                   <Input
-                    placeholder="Insurance ID"
+                    placeholder="Numéro d'affiliation"
                     value={form.insuranceNumber}
                     onChange={(e) => updateField("insuranceNumber", e.target.value)}
                   />
                 </div>
               </div>
+
+              {/* Mutuelle (complementary insurance) */}
+              {form.insurance && form.insurance !== "none" && (
+                <div className="mt-4">
+                  <p className="text-xs text-muted-foreground mb-2">Mutuelle complémentaire (optionnel)</p>
+                  <div className="grid grid-cols-3 gap-4">
+                    <div className="space-y-2">
+                      <Label>Nom de la mutuelle</Label>
+                      <Input
+                        placeholder="Ex: MGPAP, OMFAM..."
+                        value={form.mutuelleName}
+                        onChange={(e) => updateField("mutuelleName", e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>N° d&apos;adhérent</Label>
+                      <Input
+                        placeholder="Numéro mutuelle"
+                        value={form.mutuelleNumber}
+                        onChange={(e) => updateField("mutuelleNumber", e.target.value)}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label>Taux de couverture (%)</Label>
+                      <Input
+                        type="number"
+                        min="0"
+                        max="100"
+                        placeholder="Ex: 20"
+                        value={form.mutuelleCoverageRate}
+                        onChange={(e) => updateField("mutuelleCoverageRate", e.target.value)}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Medical */}

--- a/src/lib/bordereau-generator.ts
+++ b/src/lib/bordereau-generator.ts
@@ -1,0 +1,337 @@
+/**
+ * Bordereau de Soins Generator
+ *
+ * Generates batch insurance claim forms (bordereaux de soins) for
+ * CNSS and CNOPS. A bordereau groups multiple patient claims into
+ * a single submission document for the insurance organism.
+ *
+ * Structure:
+ * - One bordereau per insurance type per submission period
+ * - Contains multiple patient claim rows
+ * - Each row lists the patient, acts performed, amounts, and coverage
+ * - Totals at the bottom for the entire batch
+ */
+
+import { escapeHtml } from "./escape-html";
+import { formatMADFormal } from "./morocco";
+import type { InsuranceTariffType } from "./insurance-billing";
+
+// ---- Types ----
+
+export interface BordereauPatientClaim {
+  /** Patient full name */
+  patientName: string;
+  /** Patient CIN (national ID) */
+  patientCIN: string;
+  /** Insurance affiliation number */
+  affiliationNumber: string;
+  /** Date of treatment (ISO string) */
+  dateOfTreatment: string;
+  /** List of acts performed */
+  acts: BordereauActEntry[];
+  /** Total amount charged by doctor */
+  totalCharged: number;
+  /** Total tarif de référence */
+  totalTarifReference: number;
+  /** Total amount reimbursable by insurance */
+  totalReimbursement: number;
+  /** Dépassement d'honoraires */
+  depassement: number;
+  /** Invoice number linked to this claim */
+  invoiceNumber: string;
+}
+
+export interface BordereauActEntry {
+  /** Act code (NGAP) */
+  code: string;
+  /** Act description */
+  description: string;
+  /** Quantity */
+  quantity: number;
+  /** Tarif de référence (per unit) */
+  tarifReference: number;
+  /** Amount charged by doctor (per unit) */
+  chargedPrice: number;
+  /** Reimbursement rate */
+  reimbursementRate: number;
+  /** Reimbursement amount (per unit) */
+  reimbursementAmount: number;
+}
+
+export interface BordereauData {
+  /** Insurance type */
+  insuranceType: InsuranceTariffType;
+  /** Bordereau reference number */
+  referenceNumber: string;
+  /** Submission period start (ISO date) */
+  periodStart: string;
+  /** Submission period end (ISO date) */
+  periodEnd: string;
+  /** Doctor / clinic information */
+  provider: {
+    name: string;
+    address: string;
+    city: string;
+    phone: string;
+    conventionNumber: string;
+    cnssNumber?: string;
+    ice: string;
+  };
+  /** List of patient claims */
+  claims: BordereauPatientClaim[];
+  /** Date of submission */
+  submissionDate: string;
+}
+
+export interface BordereauTotals {
+  /** Total number of claims */
+  claimCount: number;
+  /** Total number of acts across all claims */
+  actCount: number;
+  /** Total charged by doctor */
+  totalCharged: number;
+  /** Total tarif de référence */
+  totalTarifReference: number;
+  /** Total reimbursable */
+  totalReimbursement: number;
+  /** Total dépassements */
+  totalDepassement: number;
+}
+
+// ---- Calculation ----
+
+/**
+ * Calculate totals for a bordereau.
+ */
+export function calculateBordereauTotals(
+  claims: BordereauPatientClaim[],
+): BordereauTotals {
+  let actCount = 0;
+  let totalCharged = 0;
+  let totalTarifReference = 0;
+  let totalReimbursement = 0;
+  let totalDepassement = 0;
+
+  for (const claim of claims) {
+    actCount += claim.acts.reduce((sum, a) => sum + a.quantity, 0);
+    totalCharged += claim.totalCharged;
+    totalTarifReference += claim.totalTarifReference;
+    totalReimbursement += claim.totalReimbursement;
+    totalDepassement += claim.depassement;
+  }
+
+  return {
+    claimCount: claims.length,
+    actCount,
+    totalCharged: Math.round(totalCharged * 100) / 100,
+    totalTarifReference: Math.round(totalTarifReference * 100) / 100,
+    totalReimbursement: Math.round(totalReimbursement * 100) / 100,
+    totalDepassement: Math.round(totalDepassement * 100) / 100,
+  };
+}
+
+// ---- Reference Number ----
+
+/**
+ * Generate a bordereau reference number.
+ * Format: BRD-{CNSS|CNOPS}-YYYY-MM-NNNN
+ */
+export function generateBordereauNumber(
+  insuranceType: InsuranceTariffType,
+  year: number,
+  month: number,
+  sequence: number,
+): string {
+  const prefix = insuranceType.toUpperCase();
+  const monthStr = month.toString().padStart(2, "0");
+  const seqStr = sequence.toString().padStart(4, "0");
+  return `BRD-${prefix}-${year}-${monthStr}-${seqStr}`;
+}
+
+// ---- HTML Generation ----
+
+/**
+ * Generate a print-ready HTML bordereau de soins.
+ * This is the batch claim form submitted to CNSS or CNOPS.
+ */
+export function generateBordereauHTML(data: BordereauData): string {
+  const totals = calculateBordereauTotals(data.claims);
+  const insuranceLabel =
+    data.insuranceType === "cnss"
+      ? "Caisse Nationale de Sécurité Sociale (CNSS)"
+      : "Caisse Nationale des Organismes de Prévoyance Sociale (CNOPS)";
+
+  return `<!DOCTYPE html>
+<html lang="fr" dir="ltr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bordereau de Soins — ${escapeHtml(data.referenceNumber)}</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 10px; color: #333; padding: 15mm; }
+    .bordereau { max-width: 297mm; margin: 0 auto; }
+    .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 15px; padding-bottom: 10px; border-bottom: 3px solid #1e40af; }
+    .header-left h1 { font-size: 16px; color: #1e40af; margin-bottom: 4px; }
+    .header-left h2 { font-size: 12px; color: #64748b; margin-bottom: 8px; }
+    .header-left p { font-size: 9px; line-height: 1.5; color: #666; }
+    .header-right { text-align: right; }
+    .header-right .ref { font-size: 14px; font-weight: 700; color: #1e40af; }
+    .header-right p { font-size: 9px; line-height: 1.5; color: #666; }
+    .provider-info { background: #f0f4ff; border: 1px solid #bfdbfe; border-radius: 6px; padding: 10px; margin-bottom: 15px; }
+    .provider-info h3 { font-size: 10px; color: #1e40af; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.3px; }
+    .provider-info .grid { display: flex; gap: 20px; flex-wrap: wrap; }
+    .provider-info .grid div { font-size: 9px; line-height: 1.6; }
+    .provider-info .grid div strong { color: #1e3a5f; }
+    .summary-bar { display: flex; gap: 12px; margin-bottom: 15px; }
+    .summary-card { flex: 1; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 8px 10px; text-align: center; }
+    .summary-card .value { font-size: 16px; font-weight: 700; color: #1e40af; }
+    .summary-card .label { font-size: 8px; color: #64748b; text-transform: uppercase; letter-spacing: 0.3px; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 15px; font-size: 9px; }
+    thead th { background: #1e40af; color: white; padding: 6px 8px; text-align: left; font-size: 8px; text-transform: uppercase; letter-spacing: 0.3px; }
+    thead th.right { text-align: right; }
+    tbody td { padding: 5px 8px; border-bottom: 1px solid #eee; }
+    tbody td.right { text-align: right; }
+    tbody tr:nth-child(even) { background: #f8fafc; }
+    tbody tr.claim-header { background: #eff6ff; font-weight: 600; }
+    tbody tr.claim-header td { border-top: 1px solid #bfdbfe; padding-top: 8px; }
+    .acts-detail { padding-left: 20px; font-size: 8px; color: #64748b; }
+    tfoot td { padding: 8px; font-weight: 700; border-top: 2px solid #1e40af; font-size: 10px; }
+    tfoot td.right { text-align: right; }
+    .footer { margin-top: 20px; }
+    .signatures { display: flex; justify-content: space-between; margin-top: 30px; }
+    .signatures div { width: 30%; text-align: center; }
+    .signatures p { font-size: 9px; color: #666; border-top: 1px dashed #ccc; padding-top: 8px; margin-top: 50px; }
+    .legal-notice { margin-top: 20px; padding: 8px; background: #fffbeb; border: 1px solid #fde68a; border-radius: 4px; font-size: 8px; color: #92400e; }
+    @media print {
+      body { padding: 10mm; }
+      .no-print { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="bordereau">
+    <div class="header">
+      <div class="header-left">
+        <h1>BORDEREAU DE SOINS</h1>
+        <h2>${escapeHtml(insuranceLabel)}</h2>
+        <p>Période: du ${escapeHtml(data.periodStart)} au ${escapeHtml(data.periodEnd)}</p>
+        <p>Date de soumission: ${escapeHtml(data.submissionDate)}</p>
+      </div>
+      <div class="header-right">
+        <p class="ref">${escapeHtml(data.referenceNumber)}</p>
+        <p>${escapeHtml(data.insuranceType.toUpperCase())}</p>
+      </div>
+    </div>
+
+    <div class="provider-info">
+      <h3>Prestataire de soins</h3>
+      <div class="grid">
+        <div><strong>Nom:</strong> ${escapeHtml(data.provider.name)}</div>
+        <div><strong>Adresse:</strong> ${escapeHtml(data.provider.address)}, ${escapeHtml(data.provider.city)}</div>
+        <div><strong>Tél:</strong> ${escapeHtml(data.provider.phone)}</div>
+        <div><strong>N° Convention:</strong> ${escapeHtml(data.provider.conventionNumber)}</div>
+        <div><strong>ICE:</strong> ${escapeHtml(data.provider.ice)}</div>
+        ${data.provider.cnssNumber ? `<div><strong>N° CNSS:</strong> ${escapeHtml(data.provider.cnssNumber)}</div>` : ""}
+      </div>
+    </div>
+
+    <div class="summary-bar">
+      <div class="summary-card">
+        <div class="value">${totals.claimCount}</div>
+        <div class="label">Dossiers patients</div>
+      </div>
+      <div class="summary-card">
+        <div class="value">${totals.actCount}</div>
+        <div class="label">Actes médicaux</div>
+      </div>
+      <div class="summary-card">
+        <div class="value">${formatMADFormal(totals.totalCharged)}</div>
+        <div class="label">Total facturé</div>
+      </div>
+      <div class="summary-card">
+        <div class="value">${formatMADFormal(totals.totalReimbursement)}</div>
+        <div class="label">Total remboursable</div>
+      </div>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>N°</th>
+          <th>Patient</th>
+          <th>CIN</th>
+          <th>N° Affiliation</th>
+          <th>Date soins</th>
+          <th>Actes</th>
+          <th class="right">Tarif réf.</th>
+          <th class="right">Honoraires</th>
+          <th class="right">Remboursement</th>
+          <th>N° Facture</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${data.claims.map((claim, idx) => `
+          <tr class="claim-header">
+            <td>${idx + 1}</td>
+            <td>${escapeHtml(claim.patientName)}</td>
+            <td>${escapeHtml(claim.patientCIN)}</td>
+            <td>${escapeHtml(claim.affiliationNumber)}</td>
+            <td>${escapeHtml(claim.dateOfTreatment)}</td>
+            <td>${claim.acts.length} acte${claim.acts.length > 1 ? "s" : ""}</td>
+            <td class="right">${formatMADFormal(claim.totalTarifReference)}</td>
+            <td class="right">${formatMADFormal(claim.totalCharged)}</td>
+            <td class="right">${formatMADFormal(claim.totalReimbursement)}</td>
+            <td>${escapeHtml(claim.invoiceNumber)}</td>
+          </tr>
+          ${claim.acts.map((act) => `
+          <tr>
+            <td></td>
+            <td colspan="4" class="acts-detail">${escapeHtml(act.code)} — ${escapeHtml(act.description)} (x${act.quantity})</td>
+            <td class="acts-detail">${(act.reimbursementRate * 100).toFixed(0)}%</td>
+            <td class="right acts-detail">${formatMADFormal(act.tarifReference * act.quantity)}</td>
+            <td class="right acts-detail">${formatMADFormal(act.chargedPrice * act.quantity)}</td>
+            <td class="right acts-detail">${formatMADFormal(act.reimbursementAmount * act.quantity)}</td>
+            <td></td>
+          </tr>`).join("")}
+        `).join("")}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="6">TOTAUX (${totals.claimCount} dossier${totals.claimCount > 1 ? "s" : ""})</td>
+          <td class="right">${formatMADFormal(totals.totalTarifReference)}</td>
+          <td class="right">${formatMADFormal(totals.totalCharged)}</td>
+          <td class="right">${formatMADFormal(totals.totalReimbursement)}</td>
+          <td></td>
+        </tr>
+        ${totals.totalDepassement > 0 ? `
+        <tr>
+          <td colspan="6" style="color: #b45309;">Dont dépassements d'honoraires</td>
+          <td colspan="3" class="right" style="color: #b45309;">${formatMADFormal(totals.totalDepassement)}</td>
+          <td></td>
+        </tr>` : ""}
+      </tfoot>
+    </table>
+
+    <div class="signatures">
+      <div>
+        <p>Cachet et signature du prestataire</p>
+      </div>
+      <div>
+        <p>Visa du contrôleur</p>
+      </div>
+      <div>
+        <p>Cachet de l'organisme</p>
+      </div>
+    </div>
+
+    <div class="legal-notice">
+      <strong>Mentions légales:</strong> Ce bordereau est établi conformément à la réglementation
+      de l'Assurance Maladie Obligatoire (AMO). Toute fausse déclaration est passible de
+      poursuites judiciaires. Les actes nécessitant une entente préalable doivent être
+      accompagnés de l'accord de prise en charge.
+    </div>
+  </div>
+</body>
+</html>`;
+}

--- a/src/lib/cnops-tariffs.ts
+++ b/src/lib/cnops-tariffs.ts
@@ -1,0 +1,248 @@
+/**
+ * CNOPS (Caisse Nationale des Organismes de Prévoyance Sociale) Tariff Table
+ *
+ * Official conventional tariffs for medical acts covered by CNOPS.
+ * CNOPS covers public-sector employees (fonctionnaires) and typically
+ * reimburses at 80% of the tarif national de référence (TNR).
+ *
+ * CNOPS manages 8 mutual societies:
+ * - MGPAP (Mutuelle Générale du Personnel des Administrations Publiques)
+ * - OMFAM (Œuvres de Mutualité des Fonctionnaires et Agents du Maroc)
+ * - MGEN (Mutuelle Générale de l'Éducation Nationale)
+ * - MGPTT (Mutuelle Générale du Personnel des PTT)
+ * - FM6E (Fondation Mohammed VI de l'Éducation)
+ * - MODEP (Mutuelle des Douanes et Eaux et Forêts)
+ * - FAR (Forces Armées Royales)
+ * - CNSS sections fonctionnaires
+ *
+ * Key differences from CNSS:
+ * - Higher base reimbursement rate (80% vs 70%)
+ * - Generally higher tarif de référence for specialist acts
+ * - Different prior-approval thresholds
+ * - Better coverage for dental prosthetics (60% vs 50%)
+ */
+
+// ---- Types ----
+
+export interface CNOPSTariffEntry {
+  /** Unique act code (NGAP-based) */
+  code: string;
+  /** Category letter (C, CS, K, Z, B, D, etc.) */
+  category: string;
+  /** Coefficient / multiplier */
+  coefficient: number;
+  /** Description in French */
+  descriptionFr: string;
+  /** Description in Arabic */
+  descriptionAr: string;
+  /** Tarif National de Référence (TNR) in MAD */
+  tarifReference: number;
+  /** CNOPS reimbursement rate (0-1) — typically 0.80 */
+  reimbursementRate: number;
+  /** Amount reimbursed by CNOPS in MAD */
+  reimbursementAmount: number;
+  /** Patient out-of-pocket (reste à charge) in MAD */
+  patientShare: number;
+  /** Whether this act requires prior approval (entente préalable) */
+  requiresPriorApproval: boolean;
+  /** Medical specialty this act belongs to */
+  specialty: string;
+}
+
+// ---- CNOPS Base Rates ----
+
+/** CNOPS standard reimbursement rate */
+export const CNOPS_REIMBURSEMENT_RATE = 0.80;
+
+/** CNOPS letter-key base values in MAD (generally higher than CNSS) */
+export const CNOPS_LETTER_VALUES: Record<string, number> = {
+  C: 80,    // Consultation généraliste
+  CS: 150,  // Consultation spécialisée
+  K: 17,    // Chirurgie coefficient base (higher than CNSS)
+  KC: 17,   // Chirurgie coefficient base
+  KE: 17,   // Explorations fonctionnelles base
+  Z: 14,    // Radiologie coefficient base (higher than CNSS)
+  B: 1.8,   // Biologie coefficient base (higher than CNSS)
+  D: 12,    // Dentaire coefficient base (higher than CNSS)
+  P: 1,     // Prothèses (unit price)
+};
+
+// Helper to compute tariff fields
+function cnopsEntry(
+  code: string,
+  category: string,
+  coefficient: number,
+  descriptionFr: string,
+  descriptionAr: string,
+  tarifReference: number,
+  specialty: string,
+  requiresPriorApproval = false,
+  reimbursementRate = CNOPS_REIMBURSEMENT_RATE,
+): CNOPSTariffEntry {
+  const reimbursementAmount = Math.round(tarifReference * reimbursementRate * 100) / 100;
+  const patientShare = Math.round((tarifReference - reimbursementAmount) * 100) / 100;
+  return {
+    code,
+    category,
+    coefficient,
+    descriptionFr,
+    descriptionAr,
+    tarifReference,
+    reimbursementRate,
+    reimbursementAmount,
+    patientShare,
+    requiresPriorApproval,
+    specialty,
+  };
+}
+
+// ---- Tariff Table ----
+
+export const CNOPS_TARIFFS: CNOPSTariffEntry[] = [
+  // ── Consultations (C / CS) ──
+  cnopsEntry("C-001", "C", 1, "Consultation médecin généraliste", "استشارة طبيب عام", 80, "Médecine générale"),
+  cnopsEntry("CS-001", "CS", 1, "Consultation médecin spécialiste", "استشارة طبيب مختص", 150, "Spécialiste"),
+  cnopsEntry("CS-002", "CS", 1.5, "Consultation cardiologue", "استشارة طبيب القلب", 200, "Cardiologie"),
+  cnopsEntry("CS-003", "CS", 1, "Consultation pédiatre", "استشارة طبيب الأطفال", 150, "Pédiatrie"),
+  cnopsEntry("CS-004", "CS", 1.5, "Consultation gynécologue-obstétricien", "استشارة طبيب النساء والتوليد", 200, "Gynécologie"),
+  cnopsEntry("CS-005", "CS", 1, "Consultation ORL", "استشارة طبيب الأنف والأذن والحنجرة", 150, "ORL"),
+  cnopsEntry("CS-006", "CS", 1, "Consultation ophtalmologue", "استشارة طبيب العيون", 150, "Ophtalmologie"),
+  cnopsEntry("CS-007", "CS", 1, "Consultation dermatologue", "استشارة طبيب الجلد", 150, "Dermatologie"),
+  cnopsEntry("CS-008", "CS", 1, "Consultation pneumologue", "استشارة طبيب الرئة", 150, "Pneumologie"),
+  cnopsEntry("CS-009", "CS", 1, "Consultation rhumatologue", "استشارة طبيب الروماتيزم", 150, "Rhumatologie"),
+  cnopsEntry("CS-010", "CS", 1.5, "Consultation neurologie", "استشارة طبيب الأعصاب", 200, "Neurologie"),
+  cnopsEntry("CS-011", "CS", 1, "Consultation endocrinologue", "استشارة طبيب الغدد الصماء", 150, "Endocrinologie"),
+  cnopsEntry("CS-012", "CS", 1, "Consultation gastro-entérologue", "استشارة طبيب الجهاز الهضمي", 150, "Gastro-entérologie"),
+  cnopsEntry("CS-013", "CS", 1, "Consultation urologue", "استشارة طبيب المسالك البولية", 150, "Urologie"),
+  cnopsEntry("CS-014", "CS", 1, "Consultation néphrologue", "استشارة طبيب الكلى", 150, "Néphrologie"),
+  cnopsEntry("CS-015", "CS", 1, "Consultation psychiatre", "استشارة طبيب نفسي", 150, "Psychiatrie"),
+
+  // ── Actes de chirurgie (KC) ──
+  cnopsEntry("KC-001", "KC", 15, "Petite chirurgie / suture simple", "جراحة صغيرة / خياطة بسيطة", 255, "Chirurgie"),
+  cnopsEntry("KC-002", "KC", 30, "Chirurgie ambulatoire courante", "جراحة يومية عادية", 510, "Chirurgie"),
+  cnopsEntry("KC-003", "KC", 50, "Appendicectomie", "استئصال الزائدة الدودية", 850, "Chirurgie", true),
+  cnopsEntry("KC-004", "KC", 80, "Cholécystectomie", "استئصال المرارة", 1360, "Chirurgie", true),
+  cnopsEntry("KC-005", "KC", 60, "Hernie inguinale (cure)", "إصلاح الفتق الإربي", 1020, "Chirurgie", true),
+  cnopsEntry("KC-006", "KC", 120, "Césarienne", "عملية قيصرية", 2040, "Gynécologie", true),
+  cnopsEntry("KC-007", "KC", 100, "Hystérectomie", "استئصال الرحم", 1700, "Gynécologie", true),
+  cnopsEntry("KC-008", "KC", 40, "Circoncision", "ختان", 680, "Chirurgie"),
+  cnopsEntry("KC-009", "KC", 90, "Chirurgie du genou (méniscectomie)", "جراحة الركبة", 1530, "Orthopédie", true),
+  cnopsEntry("KC-010", "KC", 150, "Prothèse totale de hanche", "بدلة كاملة للورك", 2550, "Orthopédie", true),
+
+  // ── Explorations fonctionnelles (KE) ──
+  cnopsEntry("KE-001", "KE", 10, "Électrocardiogramme (ECG)", "تخطيط القلب", 170, "Cardiologie"),
+  cnopsEntry("KE-002", "KE", 25, "Échocardiographie", "تصوير القلب بالصدى", 425, "Cardiologie"),
+  cnopsEntry("KE-003", "KE", 20, "Épreuve d'effort", "اختبار الجهد", 340, "Cardiologie", true),
+  cnopsEntry("KE-004", "KE", 15, "Spirométrie", "قياس التنفس", 255, "Pneumologie"),
+  cnopsEntry("KE-005", "KE", 20, "Électromyogramme (EMG)", "تخطيط كهربية العضل", 340, "Neurologie"),
+  cnopsEntry("KE-006", "KE", 15, "Électroencéphalogramme (EEG)", "تخطيط كهربية الدماغ", 255, "Neurologie"),
+  cnopsEntry("KE-007", "KE", 30, "Holter ECG 24h", "هولتر تخطيط القلب 24 ساعة", 510, "Cardiologie"),
+
+  // ── Radiologie / Imagerie (Z) ──
+  cnopsEntry("Z-001", "Z", 10, "Radiographie standard (1 incidence)", "أشعة سينية عادية", 140, "Radiologie"),
+  cnopsEntry("Z-002", "Z", 15, "Radiographie avec 2 incidences", "أشعة سينية مع وضعيتين", 210, "Radiologie"),
+  cnopsEntry("Z-003", "Z", 50, "Échographie abdominale", "تصوير بالصدى للبطن", 300, "Radiologie"),
+  cnopsEntry("Z-004", "Z", 50, "Échographie obstétricale", "تصوير بالصدى للحمل", 300, "Gynécologie"),
+  cnopsEntry("Z-005", "Z", 40, "Échographie pelvienne", "تصوير بالصدى للحوض", 240, "Gynécologie"),
+  cnopsEntry("Z-006", "Z", 60, "Échographie mammaire", "تصوير بالصدى للثدي", 350, "Gynécologie"),
+  cnopsEntry("Z-007", "Z", 150, "Scanner (TDM) sans injection", "أشعة مقطعية بدون حقن", 1000, "Radiologie", true),
+  cnopsEntry("Z-008", "Z", 200, "Scanner (TDM) avec injection", "أشعة مقطعية مع حقن", 1400, "Radiologie", true),
+  cnopsEntry("Z-009", "Z", 250, "IRM sans injection", "رنين مغناطيسي بدون حقن", 1800, "Radiologie", true),
+  cnopsEntry("Z-010", "Z", 300, "IRM avec injection", "رنين مغناطيسي مع حقن", 2100, "Radiologie", true),
+  cnopsEntry("Z-011", "Z", 40, "Mammographie bilatérale", "تصوير الثدي بالأشعة", 560, "Radiologie"),
+  cnopsEntry("Z-012", "Z", 30, "Panoramique dentaire", "أشعة بانورامية للأسنان", 420, "Dentaire"),
+
+  // ── Biologie / Laboratoire (B) ──
+  cnopsEntry("B-001", "B", 40, "Numération formule sanguine (NFS)", "تحليل الدم الشامل", 72, "Laboratoire"),
+  cnopsEntry("B-002", "B", 15, "Glycémie à jeun", "قياس السكر صائم", 27, "Laboratoire"),
+  cnopsEntry("B-003", "B", 30, "Hémoglobine glyquée (HbA1c)", "الهيموغلوبين السكري", 54, "Laboratoire"),
+  cnopsEntry("B-004", "B", 15, "Créatinine", "الكرياتينين", 27, "Laboratoire"),
+  cnopsEntry("B-005", "B", 15, "Urée sanguine", "اليوريا في الدم", 27, "Laboratoire"),
+  cnopsEntry("B-006", "B", 30, "Bilan lipidique complet", "تحليل الدهون الكامل", 54, "Laboratoire"),
+  cnopsEntry("B-007", "B", 20, "Transaminases (ASAT/ALAT)", "إنزيمات الكبد", 36, "Laboratoire"),
+  cnopsEntry("B-008", "B", 50, "Bilan thyroïdien (TSH + T4)", "تحليل الغدة الدرقية", 90, "Laboratoire"),
+  cnopsEntry("B-009", "B", 25, "Vitesse de sédimentation (VS)", "سرعة الترسيب", 45, "Laboratoire"),
+  cnopsEntry("B-010", "B", 30, "CRP (protéine C réactive)", "بروتين سي التفاعلي", 54, "Laboratoire"),
+  cnopsEntry("B-011", "B", 20, "Examen cytobactériologique des urines (ECBU)", "تحليل البول الجرثومي", 36, "Laboratoire"),
+  cnopsEntry("B-012", "B", 60, "PSA (Antigène prostatique)", "مستضد البروستات", 108, "Laboratoire"),
+  cnopsEntry("B-013", "B", 40, "Sérologie hépatite B (AgHBs)", "فحص التهاب الكبد ب", 72, "Laboratoire"),
+  cnopsEntry("B-014", "B", 40, "Sérologie hépatite C", "فحص التهاب الكبد ج", 72, "Laboratoire"),
+  cnopsEntry("B-015", "B", 80, "Bilan prénatal complet", "التحاليل ما قبل الولادة", 144, "Laboratoire"),
+
+  // ── Actes dentaires (D) ──
+  cnopsEntry("D-001", "D", 8, "Consultation dentaire", "استشارة طبيب الأسنان", 96, "Dentaire"),
+  cnopsEntry("D-002", "D", 15, "Extraction dentaire simple", "خلع سن بسيط", 180, "Dentaire"),
+  cnopsEntry("D-003", "D", 30, "Extraction dentaire chirurgicale", "خلع سن جراحي", 360, "Dentaire"),
+  cnopsEntry("D-004", "D", 25, "Dévitalisation monoradiculée", "علاج عصب سن أحادي الجذر", 300, "Dentaire"),
+  cnopsEntry("D-005", "D", 40, "Dévitalisation multiradiculée", "علاج عصب سن متعدد الجذور", 480, "Dentaire"),
+  cnopsEntry("D-006", "D", 12, "Obturation (amalgame/composite) 1 face", "حشوة سطح واحد", 144, "Dentaire"),
+  cnopsEntry("D-007", "D", 18, "Obturation (amalgame/composite) 2 faces", "حشوة سطحين", 216, "Dentaire"),
+  cnopsEntry("D-008", "D", 10, "Détartrage", "تنظيف الأسنان من الجير", 120, "Dentaire"),
+  cnopsEntry("D-009", "D", 60, "Couronne céramo-métallique", "تاج خزفي معدني", 720, "Dentaire", true, 0.60),
+  cnopsEntry("D-010", "D", 80, "Couronne céramo-céramique", "تاج خزفي بالكامل", 960, "Dentaire", true, 0.60),
+  cnopsEntry("D-011", "D", 50, "Bridge (par élément)", "جسر أسنان (لكل عنصر)", 600, "Dentaire", true, 0.60),
+  cnopsEntry("D-012", "D", 120, "Prothèse adjointe complète (par arcade)", "طقم أسنان كامل (لكل قوس)", 1440, "Dentaire", true, 0.60),
+  cnopsEntry("D-013", "D", 25, "Traitement de parodontite (par quadrant)", "علاج اللثة (لكل ربع)", 300, "Dentaire"),
+  cnopsEntry("D-014", "D", 150, "Implant dentaire", "زرع الأسنان", 1800, "Dentaire", true, 0.60),
+  cnopsEntry("D-015", "D", 5, "Radiographie rétro-alvéolaire", "أشعة سنية خلفية سنخية", 60, "Dentaire"),
+
+  // ── Actes obstétriques ──
+  cnopsEntry("KC-020", "KC", 60, "Accouchement par voie basse (normal)", "ولادة طبيعية", 1020, "Gynécologie"),
+  cnopsEntry("KC-021", "KC", 80, "Accouchement dystocique", "ولادة متعسرة", 1360, "Gynécologie"),
+  cnopsEntry("KC-022", "KC", 20, "Épisiotomie", "شق العجان", 340, "Gynécologie"),
+  cnopsEntry("KC-023", "KC", 15, "Frottis cervico-vaginal", "مسحة عنق الرحم", 255, "Gynécologie"),
+
+  // ── Kinésithérapie ──
+  cnopsEntry("K-050", "K", 8, "Séance de kinésithérapie", "جلسة علاج طبيعي", 136, "Kinésithérapie"),
+  cnopsEntry("K-051", "K", 12, "Séance de rééducation fonctionnelle", "جلسة إعادة تأهيل وظيفي", 204, "Kinésithérapie"),
+  cnopsEntry("K-052", "K", 10, "Séance de kinésithérapie respiratoire", "جلسة علاج طبيعي تنفسي", 170, "Kinésithérapie"),
+
+  // ── Hospitalisation ──
+  cnopsEntry("H-001", "K", 1, "Hospitalisation (par jour, chambre commune)", "إقامة في المستشفى (يوم, غرفة مشتركة)", 800, "Hospitalisation", false, 0.90),
+  cnopsEntry("H-002", "K", 1, "Hospitalisation (par jour, chambre individuelle)", "إقامة في المستشفى (يوم, غرفة فردية)", 1200, "Hospitalisation", false, 0.80),
+  cnopsEntry("H-003", "K", 1, "Réanimation (par jour)", "إنعاش (يوم)", 3500, "Hospitalisation", true, 0.90),
+
+  // ── Optique (lunettes) ──
+  cnopsEntry("P-001", "P", 1, "Monture de lunettes", "إطار نظارات", 200, "Optique", false, 0.60),
+  cnopsEntry("P-002", "P", 1, "Verre correcteur simple", "عدسة تصحيحية بسيطة", 150, "Optique", false, 0.60),
+  cnopsEntry("P-003", "P", 1, "Verre correcteur progressif", "عدسة تصحيحية متعددة البؤر", 350, "Optique", false, 0.60),
+  cnopsEntry("P-004", "P", 1, "Lentilles de contact (paire)", "عدسات لاصقة (زوج)", 300, "Optique", true, 0.60),
+];
+
+// ---- Lookup Helpers ----
+
+/** Find a CNOPS tariff by act code */
+export function getCNOPSTariffByCode(code: string): CNOPSTariffEntry | undefined {
+  return CNOPS_TARIFFS.find((t) => t.code === code);
+}
+
+/** Find all CNOPS tariffs for a category */
+export function getCNOPSTariffsByCategory(category: string): CNOPSTariffEntry[] {
+  return CNOPS_TARIFFS.filter((t) => t.category === category);
+}
+
+/** Find all CNOPS tariffs for a specialty */
+export function getCNOPSTariffsBySpecialty(specialty: string): CNOPSTariffEntry[] {
+  return CNOPS_TARIFFS.filter((t) => t.specialty === specialty);
+}
+
+/** Search CNOPS tariffs by description (French) */
+export function searchCNOPSTariffs(query: string): CNOPSTariffEntry[] {
+  const q = query.toLowerCase();
+  return CNOPS_TARIFFS.filter(
+    (t) =>
+      t.descriptionFr.toLowerCase().includes(q) ||
+      t.code.toLowerCase().includes(q) ||
+      t.specialty.toLowerCase().includes(q),
+  );
+}
+
+/** Get all unique specialties in the CNOPS tariff table */
+export function getCNOPSSpecialties(): string[] {
+  return [...new Set(CNOPS_TARIFFS.map((t) => t.specialty))];
+}
+
+/** Get all unique categories in the CNOPS tariff table */
+export function getCNOPSCategories(): string[] {
+  return [...new Set(CNOPS_TARIFFS.map((t) => t.category))];
+}

--- a/src/lib/cnss-tariffs.ts
+++ b/src/lib/cnss-tariffs.ts
@@ -1,0 +1,240 @@
+/**
+ * CNSS (Caisse Nationale de Sécurité Sociale) Tariff Table
+ *
+ * Official conventional tariffs for medical acts covered by CNSS.
+ * Based on the Moroccan "Nomenclature Générale des Actes Professionnels" (NGAP)
+ * and the CNSS reimbursement schedule.
+ *
+ * CNSS covers private-sector employees and reimburses at 70% of the
+ * tarif national de référence (TNR) for most medical acts.
+ *
+ * Categories:
+ * - C  = Consultations
+ * - CS = Consultations spécialisées
+ * - K  = Actes de chirurgie et spécialités
+ * - KC = Actes de chirurgie
+ * - KE = Actes d'explorations fonctionnelles
+ * - Z  = Actes de radiologie / imagerie
+ * - B  = Actes de biologie / laboratoire
+ * - D  = Actes dentaires
+ * - P  = Actes de pharmacie / prothèses
+ */
+
+// ---- Types ----
+
+export interface CNSSTariffEntry {
+  /** Unique act code (NGAP-based) */
+  code: string;
+  /** Category letter (C, CS, K, Z, B, D, etc.) */
+  category: string;
+  /** Coefficient / multiplier */
+  coefficient: number;
+  /** Description in French */
+  descriptionFr: string;
+  /** Description in Arabic */
+  descriptionAr: string;
+  /** Tarif National de Référence (TNR) in MAD — the official base price */
+  tarifReference: number;
+  /** CNSS reimbursement rate (0-1) — typically 0.70 */
+  reimbursementRate: number;
+  /** Amount reimbursed by CNSS in MAD */
+  reimbursementAmount: number;
+  /** Patient out-of-pocket (reste à charge) in MAD */
+  patientShare: number;
+  /** Whether this act requires prior approval (entente préalable) */
+  requiresPriorApproval: boolean;
+  /** Medical specialty this act belongs to */
+  specialty: string;
+}
+
+// ---- CNSS Base Rates ----
+
+/** CNSS standard reimbursement rate */
+export const CNSS_REIMBURSEMENT_RATE = 0.70;
+
+/** CNSS letter-key base values in MAD */
+export const CNSS_LETTER_VALUES: Record<string, number> = {
+  C: 80,    // Consultation généraliste
+  CS: 150,  // Consultation spécialisée
+  K: 15,    // Chirurgie coefficient base
+  KC: 15,   // Chirurgie coefficient base
+  KE: 15,   // Explorations fonctionnelles base
+  Z: 12,    // Radiologie coefficient base
+  B: 1.5,   // Biologie coefficient base
+  D: 10,    // Dentaire coefficient base
+  P: 1,     // Prothèses (unit price)
+};
+
+// Helper to compute tariff fields
+function cnssEntry(
+  code: string,
+  category: string,
+  coefficient: number,
+  descriptionFr: string,
+  descriptionAr: string,
+  tarifReference: number,
+  specialty: string,
+  requiresPriorApproval = false,
+  reimbursementRate = CNSS_REIMBURSEMENT_RATE,
+): CNSSTariffEntry {
+  const reimbursementAmount = Math.round(tarifReference * reimbursementRate * 100) / 100;
+  const patientShare = Math.round((tarifReference - reimbursementAmount) * 100) / 100;
+  return {
+    code,
+    category,
+    coefficient,
+    descriptionFr,
+    descriptionAr,
+    tarifReference,
+    reimbursementRate,
+    reimbursementAmount,
+    patientShare,
+    requiresPriorApproval,
+    specialty,
+  };
+}
+
+// ---- Tariff Table ----
+
+export const CNSS_TARIFFS: CNSSTariffEntry[] = [
+  // ── Consultations (C / CS) ──
+  cnssEntry("C-001", "C", 1, "Consultation médecin généraliste", "استشارة طبيب عام", 80, "Médecine générale"),
+  cnssEntry("CS-001", "CS", 1, "Consultation médecin spécialiste", "استشارة طبيب مختص", 150, "Spécialiste"),
+  cnssEntry("CS-002", "CS", 1.5, "Consultation cardiologue", "استشارة طبيب القلب", 200, "Cardiologie"),
+  cnssEntry("CS-003", "CS", 1, "Consultation pédiatre", "استشارة طبيب الأطفال", 150, "Pédiatrie"),
+  cnssEntry("CS-004", "CS", 1.5, "Consultation gynécologue-obstétricien", "استشارة طبيب النساء والتوليد", 200, "Gynécologie"),
+  cnssEntry("CS-005", "CS", 1, "Consultation ORL", "استشارة طبيب الأنف والأذن والحنجرة", 150, "ORL"),
+  cnssEntry("CS-006", "CS", 1, "Consultation ophtalmologue", "استشارة طبيب العيون", 150, "Ophtalmologie"),
+  cnssEntry("CS-007", "CS", 1, "Consultation dermatologue", "استشارة طبيب الجلد", 150, "Dermatologie"),
+  cnssEntry("CS-008", "CS", 1, "Consultation pneumologue", "استشارة طبيب الرئة", 150, "Pneumologie"),
+  cnssEntry("CS-009", "CS", 1, "Consultation rhumatologue", "استشارة طبيب الروماتيزم", 150, "Rhumatologie"),
+  cnssEntry("CS-010", "CS", 1.5, "Consultation neurologie", "استشارة طبيب الأعصاب", 200, "Neurologie"),
+  cnssEntry("CS-011", "CS", 1, "Consultation endocrinologue", "استشارة طبيب الغدد الصماء", 150, "Endocrinologie"),
+  cnssEntry("CS-012", "CS", 1, "Consultation gastro-entérologue", "استشارة طبيب الجهاز الهضمي", 150, "Gastro-entérologie"),
+  cnssEntry("CS-013", "CS", 1, "Consultation urologue", "استشارة طبيب المسالك البولية", 150, "Urologie"),
+  cnssEntry("CS-014", "CS", 1, "Consultation néphrologue", "استشارة طبيب الكلى", 150, "Néphrologie"),
+  cnssEntry("CS-015", "CS", 1, "Consultation psychiatre", "استشارة طبيب نفسي", 150, "Psychiatrie"),
+
+  // ── Actes de chirurgie (KC) ──
+  cnssEntry("KC-001", "KC", 15, "Petite chirurgie / suture simple", "جراحة صغيرة / خياطة بسيطة", 225, "Chirurgie"),
+  cnssEntry("KC-002", "KC", 30, "Chirurgie ambulatoire courante", "جراحة يومية عادية", 450, "Chirurgie"),
+  cnssEntry("KC-003", "KC", 50, "Appendicectomie", "استئصال الزائدة الدودية", 750, "Chirurgie", true),
+  cnssEntry("KC-004", "KC", 80, "Cholécystectomie", "استئصال المرارة", 1200, "Chirurgie", true),
+  cnssEntry("KC-005", "KC", 60, "Hernie inguinale (cure)", "إصلاح الفتق الإربي", 900, "Chirurgie", true),
+  cnssEntry("KC-006", "KC", 120, "Césarienne", "عملية قيصرية", 1800, "Gynécologie", true),
+  cnssEntry("KC-007", "KC", 100, "Hystérectomie", "استئصال الرحم", 1500, "Gynécologie", true),
+  cnssEntry("KC-008", "KC", 40, "Circoncision", "ختان", 600, "Chirurgie"),
+  cnssEntry("KC-009", "KC", 90, "Chirurgie du genou (méniscectomie)", "جراحة الركبة", 1350, "Orthopédie", true),
+  cnssEntry("KC-010", "KC", 150, "Prothèse totale de hanche", "بدلة كاملة للورك", 2250, "Orthopédie", true),
+
+  // ── Explorations fonctionnelles (KE) ──
+  cnssEntry("KE-001", "KE", 10, "Électrocardiogramme (ECG)", "تخطيط القلب", 150, "Cardiologie"),
+  cnssEntry("KE-002", "KE", 25, "Échocardiographie", "تصوير القلب بالصدى", 375, "Cardiologie"),
+  cnssEntry("KE-003", "KE", 20, "Épreuve d'effort", "اختبار الجهد", 300, "Cardiologie", true),
+  cnssEntry("KE-004", "KE", 15, "Spirométrie", "قياس التنفس", 225, "Pneumologie"),
+  cnssEntry("KE-005", "KE", 20, "Électromyogramme (EMG)", "تخطيط كهربية العضل", 300, "Neurologie"),
+  cnssEntry("KE-006", "KE", 15, "Électroencéphalogramme (EEG)", "تخطيط كهربية الدماغ", 225, "Neurologie"),
+  cnssEntry("KE-007", "KE", 30, "Holter ECG 24h", "هولتر تخطيط القلب 24 ساعة", 450, "Cardiologie"),
+
+  // ── Radiologie / Imagerie (Z) ──
+  cnssEntry("Z-001", "Z", 10, "Radiographie standard (1 incidence)", "أشعة سينية عادية", 120, "Radiologie"),
+  cnssEntry("Z-002", "Z", 15, "Radiographie avec 2 incidences", "أشعة سينية مع وضعيتين", 180, "Radiologie"),
+  cnssEntry("Z-003", "Z", 50, "Échographie abdominale", "تصوير بالصدى للبطن", 250, "Radiologie"),
+  cnssEntry("Z-004", "Z", 50, "Échographie obstétricale", "تصوير بالصدى للحمل", 250, "Gynécologie"),
+  cnssEntry("Z-005", "Z", 40, "Échographie pelvienne", "تصوير بالصدى للحوض", 200, "Gynécologie"),
+  cnssEntry("Z-006", "Z", 60, "Échographie mammaire", "تصوير بالصدى للثدي", 300, "Gynécologie"),
+  cnssEntry("Z-007", "Z", 150, "Scanner (TDM) sans injection", "أشعة مقطعية بدون حقن", 900, "Radiologie", true),
+  cnssEntry("Z-008", "Z", 200, "Scanner (TDM) avec injection", "أشعة مقطعية مع حقن", 1200, "Radiologie", true),
+  cnssEntry("Z-009", "Z", 250, "IRM sans injection", "رنين مغناطيسي بدون حقن", 1500, "Radiologie", true),
+  cnssEntry("Z-010", "Z", 300, "IRM avec injection", "رنين مغناطيسي مع حقن", 1800, "Radiologie", true),
+  cnssEntry("Z-011", "Z", 40, "Mammographie bilatérale", "تصوير الثدي بالأشعة", 480, "Radiologie"),
+  cnssEntry("Z-012", "Z", 30, "Panoramique dentaire", "أشعة بانورامية للأسنان", 360, "Dentaire"),
+
+  // ── Biologie / Laboratoire (B) ──
+  cnssEntry("B-001", "B", 40, "Numération formule sanguine (NFS)", "تحليل الدم الشامل", 60, "Laboratoire"),
+  cnssEntry("B-002", "B", 15, "Glycémie à jeun", "قياس السكر صائم", 22.5, "Laboratoire"),
+  cnssEntry("B-003", "B", 30, "Hémoglobine glyquée (HbA1c)", "الهيموغلوبين السكري", 45, "Laboratoire"),
+  cnssEntry("B-004", "B", 15, "Créatinine", "الكرياتينين", 22.5, "Laboratoire"),
+  cnssEntry("B-005", "B", 15, "Urée sanguine", "اليوريا في الدم", 22.5, "Laboratoire"),
+  cnssEntry("B-006", "B", 30, "Bilan lipidique complet", "تحليل الدهون الكامل", 45, "Laboratoire"),
+  cnssEntry("B-007", "B", 20, "Transaminases (ASAT/ALAT)", "إنزيمات الكبد", 30, "Laboratoire"),
+  cnssEntry("B-008", "B", 50, "Bilan thyroïdien (TSH + T4)", "تحليل الغدة الدرقية", 75, "Laboratoire"),
+  cnssEntry("B-009", "B", 25, "Vitesse de sédimentation (VS)", "سرعة الترسيب", 37.5, "Laboratoire"),
+  cnssEntry("B-010", "B", 30, "CRP (protéine C réactive)", "بروتين سي التفاعلي", 45, "Laboratoire"),
+  cnssEntry("B-011", "B", 20, "Examen cytobactériologique des urines (ECBU)", "تحليل البول الجرثومي", 30, "Laboratoire"),
+  cnssEntry("B-012", "B", 60, "PSA (Antigène prostatique)", "مستضد البروستات", 90, "Laboratoire"),
+  cnssEntry("B-013", "B", 40, "Sérologie hépatite B (AgHBs)", "فحص التهاب الكبد ب", 60, "Laboratoire"),
+  cnssEntry("B-014", "B", 40, "Sérologie hépatite C", "فحص التهاب الكبد ج", 60, "Laboratoire"),
+  cnssEntry("B-015", "B", 80, "Bilan prénatal complet", "التحاليل ما قبل الولادة", 120, "Laboratoire"),
+
+  // ── Actes dentaires (D) ──
+  cnssEntry("D-001", "D", 8, "Consultation dentaire", "استشارة طبيب الأسنان", 80, "Dentaire"),
+  cnssEntry("D-002", "D", 15, "Extraction dentaire simple", "خلع سن بسيط", 150, "Dentaire"),
+  cnssEntry("D-003", "D", 30, "Extraction dentaire chirurgicale", "خلع سن جراحي", 300, "Dentaire"),
+  cnssEntry("D-004", "D", 25, "Dévitalisation monoradiculée", "علاج عصب سن أحادي الجذر", 250, "Dentaire"),
+  cnssEntry("D-005", "D", 40, "Dévitalisation multiradiculée", "علاج عصب سن متعدد الجذور", 400, "Dentaire"),
+  cnssEntry("D-006", "D", 12, "Obturation (amalgame/composite) 1 face", "حشوة سطح واحد", 120, "Dentaire"),
+  cnssEntry("D-007", "D", 18, "Obturation (amalgame/composite) 2 faces", "حشوة سطحين", 180, "Dentaire"),
+  cnssEntry("D-008", "D", 10, "Détartrage", "تنظيف الأسنان من الجير", 100, "Dentaire"),
+  cnssEntry("D-009", "D", 60, "Couronne céramo-métallique", "تاج خزفي معدني", 600, "Dentaire", true, 0.50),
+  cnssEntry("D-010", "D", 80, "Couronne céramo-céramique", "تاج خزفي بالكامل", 800, "Dentaire", true, 0.50),
+  cnssEntry("D-011", "D", 50, "Bridge (par élément)", "جسر أسنان (لكل عنصر)", 500, "Dentaire", true, 0.50),
+  cnssEntry("D-012", "D", 120, "Prothèse adjointe complète (par arcade)", "طقم أسنان كامل (لكل قوس)", 1200, "Dentaire", true, 0.50),
+  cnssEntry("D-013", "D", 25, "Traitement de parodontite (par quadrant)", "علاج اللثة (لكل ربع)", 250, "Dentaire"),
+  cnssEntry("D-014", "D", 150, "Implant dentaire", "زرع الأسنان", 1500, "Dentaire", true, 0.50),
+  cnssEntry("D-015", "D", 5, "Radiographie rétro-alvéolaire", "أشعة سنية خلفية سنخية", 50, "Dentaire"),
+
+  // ── Actes obstétriques ──
+  cnssEntry("KC-020", "KC", 60, "Accouchement par voie basse (normal)", "ولادة طبيعية", 900, "Gynécologie"),
+  cnssEntry("KC-021", "KC", 80, "Accouchement dystocique", "ولادة متعسرة", 1200, "Gynécologie"),
+  cnssEntry("KC-022", "KC", 20, "Épisiotomie", "شق العجان", 300, "Gynécologie"),
+  cnssEntry("KC-023", "KC", 15, "Frottis cervico-vaginal", "مسحة عنق الرحم", 225, "Gynécologie"),
+
+  // ── Kinésithérapie ──
+  cnssEntry("K-050", "K", 8, "Séance de kinésithérapie", "جلسة علاج طبيعي", 120, "Kinésithérapie"),
+  cnssEntry("K-051", "K", 12, "Séance de rééducation fonctionnelle", "جلسة إعادة تأهيل وظيفي", 180, "Kinésithérapie"),
+  cnssEntry("K-052", "K", 10, "Séance de kinésithérapie respiratoire", "جلسة علاج طبيعي تنفسي", 150, "Kinésithérapie"),
+
+  // ── Hospitalisation ──
+  cnssEntry("H-001", "K", 1, "Hospitalisation (par jour, chambre commune)", "إقامة في المستشفى (يوم, غرفة مشتركة)", 800, "Hospitalisation", false, 0.90),
+  cnssEntry("H-002", "K", 1, "Hospitalisation (par jour, chambre individuelle)", "إقامة في المستشفى (يوم, غرفة فردية)", 1200, "Hospitalisation", false, 0.70),
+  cnssEntry("H-003", "K", 1, "Réanimation (par jour)", "إنعاش (يوم)", 3000, "Hospitalisation", true, 0.90),
+];
+
+// ---- Lookup Helpers ----
+
+/** Find a CNSS tariff by act code */
+export function getCNSSTariffByCode(code: string): CNSSTariffEntry | undefined {
+  return CNSS_TARIFFS.find((t) => t.code === code);
+}
+
+/** Find all CNSS tariffs for a category */
+export function getCNSSTariffsByCategory(category: string): CNSSTariffEntry[] {
+  return CNSS_TARIFFS.filter((t) => t.category === category);
+}
+
+/** Find all CNSS tariffs for a specialty */
+export function getCNSSTariffsBySpecialty(specialty: string): CNSSTariffEntry[] {
+  return CNSS_TARIFFS.filter((t) => t.specialty === specialty);
+}
+
+/** Search CNSS tariffs by description (French) */
+export function searchCNSSTariffs(query: string): CNSSTariffEntry[] {
+  const q = query.toLowerCase();
+  return CNSS_TARIFFS.filter(
+    (t) =>
+      t.descriptionFr.toLowerCase().includes(q) ||
+      t.code.toLowerCase().includes(q) ||
+      t.specialty.toLowerCase().includes(q),
+  );
+}
+
+/** Get all unique specialties in the CNSS tariff table */
+export function getCNSSSpecialties(): string[] {
+  return [...new Set(CNSS_TARIFFS.map((t) => t.specialty))];
+}
+
+/** Get all unique categories in the CNSS tariff table */
+export function getCNSSCategories(): string[] {
+  return [...new Set(CNSS_TARIFFS.map((t) => t.category))];
+}

--- a/src/lib/insurance-billing.ts
+++ b/src/lib/insurance-billing.ts
@@ -1,0 +1,369 @@
+/**
+ * Insurance Billing — Unified Tariff Lookup
+ *
+ * Provides a single entry point to look up tariffs by act code + insurance type,
+ * calculate coverage for a list of medical acts, and produce insurance-ready
+ * invoice line items with automatic coverage breakdown.
+ */
+
+import {
+  CNSS_TARIFFS,
+  getCNSSTariffByCode,
+  searchCNSSTariffs,
+} from "./cnss-tariffs";
+import {
+  CNOPS_TARIFFS,
+  getCNOPSTariffByCode,
+  searchCNOPSTariffs,
+} from "./cnops-tariffs";
+import type { MoroccanInsuranceType, PatientInsurance } from "./morocco";
+
+// ---- Types ----
+
+/** Supported insurance types for tariff lookup */
+export type InsuranceTariffType = "cnss" | "cnops";
+
+/** Unified tariff entry (works for both CNSS and CNOPS) */
+export interface TariffEntry {
+  code: string;
+  category: string;
+  coefficient: number;
+  descriptionFr: string;
+  descriptionAr: string;
+  tarifReference: number;
+  reimbursementRate: number;
+  reimbursementAmount: number;
+  patientShare: number;
+  requiresPriorApproval: boolean;
+  specialty: string;
+  /** Which insurance table this came from */
+  source: InsuranceTariffType;
+}
+
+/** A billable medical act on an invoice */
+export interface BillableAct {
+  /** Tariff act code */
+  code: string;
+  /** Quantity (default: 1) */
+  quantity: number;
+  /** Override price (if doctor charges more than TNR) */
+  overridePrice?: number;
+  /** Description override */
+  description?: string;
+}
+
+/** Result of calculating coverage for a single act */
+export interface ActCoverageResult {
+  code: string;
+  description: string;
+  quantity: number;
+  /** Price the doctor actually charges */
+  chargedPrice: number;
+  /** Official tarif de référence */
+  tarifReference: number;
+  /** Insurance reimbursement rate */
+  reimbursementRate: number;
+  /** Amount reimbursed (based on TNR, not charged price) */
+  reimbursementAmount: number;
+  /** Amount patient pays */
+  patientShare: number;
+  /** Dépassement d'honoraires (amount above TNR) */
+  depassement: number;
+  /** Whether prior approval is needed */
+  requiresPriorApproval: boolean;
+  /** Total for this line (chargedPrice * quantity) */
+  lineTotal: number;
+  /** Total reimbursed for this line */
+  lineReimbursement: number;
+  /** Total patient pays for this line */
+  linePatientShare: number;
+}
+
+/** Full coverage calculation result */
+export interface CoverageCalculation {
+  /** Insurance type used */
+  insuranceType: InsuranceTariffType;
+  /** Individual act breakdowns */
+  acts: ActCoverageResult[];
+  /** Sum of all line totals (what doctor charges) */
+  totalCharged: number;
+  /** Sum of all tarif de référence amounts */
+  totalTarifReference: number;
+  /** Total reimbursed by insurance */
+  totalReimbursement: number;
+  /** Total patient pays (including dépassements) */
+  totalPatientShare: number;
+  /** Total dépassements d'honoraires */
+  totalDepassement: number;
+  /** Acts requiring prior approval */
+  actsRequiringApproval: string[];
+  /** Mutuelle coverage (if applicable) */
+  mutuelleCoverage: number;
+  /** Final reste à charge after mutuelle */
+  finalResteACharge: number;
+}
+
+// ---- Tariff Lookup ----
+
+/**
+ * Look up a tariff by act code and insurance type.
+ * Returns the unified TariffEntry or undefined if not found.
+ */
+export function getTariffByCode(
+  code: string,
+  insuranceType: InsuranceTariffType,
+): TariffEntry | undefined {
+  if (insuranceType === "cnss") {
+    const entry = getCNSSTariffByCode(code);
+    if (!entry) return undefined;
+    return { ...entry, source: "cnss" };
+  }
+  const entry = getCNOPSTariffByCode(code);
+  if (!entry) return undefined;
+  return { ...entry, source: "cnops" };
+}
+
+/**
+ * Search tariffs across both CNSS and CNOPS tables.
+ * Returns results from the specified insurance type, or both if not specified.
+ */
+export function searchTariffs(
+  query: string,
+  insuranceType?: InsuranceTariffType,
+): TariffEntry[] {
+  const results: TariffEntry[] = [];
+
+  if (!insuranceType || insuranceType === "cnss") {
+    for (const entry of searchCNSSTariffs(query)) {
+      results.push({ ...entry, source: "cnss" });
+    }
+  }
+
+  if (!insuranceType || insuranceType === "cnops") {
+    for (const entry of searchCNOPSTariffs(query)) {
+      results.push({ ...entry, source: "cnops" });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Get all tariffs for a given insurance type.
+ */
+export function getAllTariffs(insuranceType: InsuranceTariffType): TariffEntry[] {
+  const source = insuranceType === "cnss" ? CNSS_TARIFFS : CNOPS_TARIFFS;
+  return source.map((entry) => ({ ...entry, source: insuranceType }));
+}
+
+/**
+ * Get tariffs by category for a given insurance type.
+ */
+export function getTariffsByCategory(
+  category: string,
+  insuranceType: InsuranceTariffType,
+): TariffEntry[] {
+  const source = insuranceType === "cnss" ? CNSS_TARIFFS : CNOPS_TARIFFS;
+  return source
+    .filter((t) => t.category === category)
+    .map((entry) => ({ ...entry, source: insuranceType }));
+}
+
+/**
+ * Get tariffs by specialty for a given insurance type.
+ */
+export function getTariffsBySpecialty(
+  specialty: string,
+  insuranceType: InsuranceTariffType,
+): TariffEntry[] {
+  const source = insuranceType === "cnss" ? CNSS_TARIFFS : CNOPS_TARIFFS;
+  return source
+    .filter((t) => t.specialty === specialty)
+    .map((entry) => ({ ...entry, source: insuranceType }));
+}
+
+// ---- Coverage Calculation ----
+
+/**
+ * Calculate insurance coverage for a list of billable acts.
+ *
+ * Handles:
+ * - Tariff lookup per act code
+ * - Reimbursement based on TNR (not the doctor's charged price)
+ * - Dépassement d'honoraires (when doctor charges above TNR)
+ * - Mutuelle complementary coverage
+ * - Final reste à charge calculation
+ *
+ * @param acts - List of billable medical acts
+ * @param insuranceType - CNSS or CNOPS
+ * @param patientInsurance - Optional patient insurance info (for mutuelle)
+ */
+export function calculateCoverage(
+  acts: BillableAct[],
+  insuranceType: InsuranceTariffType,
+  patientInsurance?: PatientInsurance,
+): CoverageCalculation {
+  const actResults: ActCoverageResult[] = [];
+  let totalCharged = 0;
+  let totalTarifReference = 0;
+  let totalReimbursement = 0;
+  let totalPatientShare = 0;
+  let totalDepassement = 0;
+  const actsRequiringApproval: string[] = [];
+
+  for (const act of acts) {
+    const tariff = getTariffByCode(act.code, insuranceType);
+    if (!tariff) {
+      // Act not found in tariff table — no coverage
+      const chargedPrice = act.overridePrice ?? 0;
+      const lineTotal = chargedPrice * act.quantity;
+      actResults.push({
+        code: act.code,
+        description: act.description ?? `Acte ${act.code} (non conventionné)`,
+        quantity: act.quantity,
+        chargedPrice,
+        tarifReference: 0,
+        reimbursementRate: 0,
+        reimbursementAmount: 0,
+        patientShare: chargedPrice,
+        depassement: chargedPrice,
+        requiresPriorApproval: false,
+        lineTotal,
+        lineReimbursement: 0,
+        linePatientShare: lineTotal,
+      });
+      totalCharged += lineTotal;
+      totalPatientShare += lineTotal;
+      totalDepassement += lineTotal;
+      continue;
+    }
+
+    const chargedPrice = act.overridePrice ?? tariff.tarifReference;
+    const depassement = Math.max(0, chargedPrice - tariff.tarifReference);
+
+    // Insurance reimburses based on TNR, not the charged price
+    const reimbursementAmount = tariff.reimbursementAmount;
+    const patientShare = chargedPrice - reimbursementAmount;
+
+    const lineTotal = chargedPrice * act.quantity;
+    const lineReimbursement = reimbursementAmount * act.quantity;
+    const linePatientShare = patientShare * act.quantity;
+
+    if (tariff.requiresPriorApproval) {
+      actsRequiringApproval.push(
+        `${tariff.code} — ${tariff.descriptionFr}`,
+      );
+    }
+
+    actResults.push({
+      code: act.code,
+      description: act.description ?? tariff.descriptionFr,
+      quantity: act.quantity,
+      chargedPrice,
+      tarifReference: tariff.tarifReference,
+      reimbursementRate: tariff.reimbursementRate,
+      reimbursementAmount,
+      patientShare,
+      depassement,
+      requiresPriorApproval: tariff.requiresPriorApproval,
+      lineTotal,
+      lineReimbursement,
+      linePatientShare,
+    });
+
+    totalCharged += lineTotal;
+    totalTarifReference += tariff.tarifReference * act.quantity;
+    totalReimbursement += lineReimbursement;
+    totalPatientShare += linePatientShare;
+    totalDepassement += depassement * act.quantity;
+  }
+
+  // Mutuelle complementary coverage
+  let mutuelleCoverage = 0;
+  let finalResteACharge = totalPatientShare;
+
+  if (patientInsurance?.mutuelle) {
+    const mutuelleRate = patientInsurance.mutuelle.coverageRate / 100;
+    // Mutuelle covers a portion of the patient's share (excluding dépassements)
+    const shareWithoutDepassement = totalPatientShare - totalDepassement;
+    mutuelleCoverage =
+      Math.round(Math.max(0, shareWithoutDepassement) * mutuelleRate * 100) / 100;
+    finalResteACharge =
+      Math.round((totalPatientShare - mutuelleCoverage) * 100) / 100;
+  }
+
+  return {
+    insuranceType,
+    acts: actResults,
+    totalCharged: Math.round(totalCharged * 100) / 100,
+    totalTarifReference: Math.round(totalTarifReference * 100) / 100,
+    totalReimbursement: Math.round(totalReimbursement * 100) / 100,
+    totalPatientShare: Math.round(totalPatientShare * 100) / 100,
+    totalDepassement: Math.round(totalDepassement * 100) / 100,
+    actsRequiringApproval,
+    mutuelleCoverage,
+    finalResteACharge,
+  };
+}
+
+// ---- Helpers ----
+
+/**
+ * Determine the tariff insurance type from a MoroccanInsuranceType.
+ * Returns undefined for insurance types that don't have tariff tables.
+ */
+export function toTariffInsuranceType(
+  insuranceType: MoroccanInsuranceType,
+): InsuranceTariffType | undefined {
+  switch (insuranceType) {
+    case "cnss":
+      return "cnss";
+    case "cnops":
+      return "cnops";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Get a summary label for an insurance type.
+ */
+export function getInsuranceLabel(insuranceType: InsuranceTariffType): string {
+  switch (insuranceType) {
+    case "cnss":
+      return "CNSS (70%)";
+    case "cnops":
+      return "CNOPS (80%)";
+  }
+}
+
+/**
+ * Get all unique categories across both tariff tables.
+ */
+export function getAllCategories(): { code: string; label: string }[] {
+  return [
+    { code: "C", label: "Consultations généralistes" },
+    { code: "CS", label: "Consultations spécialisées" },
+    { code: "KC", label: "Chirurgie" },
+    { code: "KE", label: "Explorations fonctionnelles" },
+    { code: "K", label: "Actes techniques" },
+    { code: "Z", label: "Radiologie / Imagerie" },
+    { code: "B", label: "Biologie / Laboratoire" },
+    { code: "D", label: "Actes dentaires" },
+    { code: "P", label: "Prothèses / Optique" },
+  ];
+}
+
+/**
+ * Compare CNSS vs CNOPS coverage for a list of acts.
+ * Useful for showing patients the difference.
+ */
+export function compareCoverage(
+  acts: BillableAct[],
+  patientInsurance?: PatientInsurance,
+): { cnss: CoverageCalculation; cnops: CoverageCalculation } {
+  return {
+    cnss: calculateCoverage(acts, "cnss", patientInsurance),
+    cnops: calculateCoverage(acts, "cnops", patientInsurance),
+  };
+}

--- a/src/lib/invoice-generator.ts
+++ b/src/lib/invoice-generator.ts
@@ -28,6 +28,12 @@ export interface InvoiceLineItem {
   unitPrice: number;
   tvaRate: TVARate;
   discount?: number; // percentage
+  /** Optional tariff act code (CNSS/CNOPS NGAP code) */
+  actCode?: string;
+  /** Tarif national de référence (if different from unitPrice) */
+  tarifReference?: number;
+  /** Insurance reimbursement amount per unit (auto-calculated from tariff) */
+  insuranceReimbursement?: number;
 }
 
 export interface ClinicLegalInfo {
@@ -77,6 +83,15 @@ export interface InvoiceData {
   isProforma?: boolean;
   /** Additional notes */
   notes?: string;
+  /** Tariff-based coverage calculation (from insurance-billing module) */
+  coverageCalculation?: {
+    totalReimbursement: number;
+    totalPatientShare: number;
+    totalDepassement: number;
+    mutuelleCoverage: number;
+    finalResteACharge: number;
+    actsRequiringApproval: string[];
+  };
 }
 
 export interface InvoiceTotals {
@@ -130,12 +145,18 @@ export function calculateInvoiceTotals(invoice: InvoiceData): InvoiceTotals {
     tvaAmount: Math.round(values.tvaAmount * 100) / 100,
   }));
 
-  // Insurance calculation
+  // Insurance calculation — prefer tariff-based if available
   let insuranceCovered = 0;
   let mutuelleCovered = 0;
   let resteACharge = totalTTC;
 
-  if (invoice.patient.insurance) {
+  if (invoice.coverageCalculation) {
+    // Use pre-calculated tariff-based coverage
+    insuranceCovered = invoice.coverageCalculation.totalReimbursement;
+    mutuelleCovered = invoice.coverageCalculation.mutuelleCoverage;
+    resteACharge = invoice.coverageCalculation.finalResteACharge;
+  } else if (invoice.patient.insurance) {
+    // Fallback to percentage-based calculation
     const coverage = calculateResteACharge(totalTTC, invoice.patient.insurance);
     insuranceCovered = coverage.insuranceCovered;
     mutuelleCovered = coverage.mutuelleCovered;
@@ -337,6 +358,8 @@ export function generateInvoiceHTML(invoice: InvoiceData): string {
       <h4>Informations Assurance</h4>
       <p>N° Affiliation: ${escapeHtml(invoice.patient.insurance.affiliationNumber)}</p>
       ${invoice.patient.insurance.mutuelle ? `<p>Mutuelle: ${escapeHtml(invoice.patient.insurance.mutuelle.name)} (N° ${escapeHtml(invoice.patient.insurance.mutuelle.registrationNumber)})</p>` : ""}
+      ${invoice.coverageCalculation && invoice.coverageCalculation.totalDepassement > 0 ? `<p style="color: #b45309; margin-top: 4px;">Dépassement d'honoraires: ${formatMADFormal(invoice.coverageCalculation.totalDepassement)}</p>` : ""}
+      ${invoice.coverageCalculation && invoice.coverageCalculation.actsRequiringApproval.length > 0 ? `<p style="color: #dc2626; margin-top: 4px;">⚠ Entente préalable requise pour: ${invoice.coverageCalculation.actsRequiringApproval.join(", ")}</p>` : ""}
     </div>` : ""}
 
     ${invoice.paymentMethod ? `<div class="payment-info">


### PR DESCRIPTION
## CNSS/CNOPS Insurance Billing Tables & Tariff System

Implements all 8 sub-tasks for Task 8: CNSS/CNOPS Insurance Billing.

### Changes

#### 8.1 — CNSS Tariff Table (`src/lib/cnss-tariffs.ts`)
- 70+ medical acts covering consultations, surgery, radiology, lab, dental, obstetrics, physio, hospitalization
- CNSS reimbursement rate: 70%
- Tarif de référence values from 22.5 MAD (lab tests) to 3000 MAD (ICU)
- Prior approval flags for major procedures
- French and Arabic descriptions
- Lookup helpers: by code, category, specialty, search

#### 8.2 — CNOPS Tariff Table (`src/lib/cnops-tariffs.ts`)
- 80+ medical acts with higher tarif de référence values
- CNOPS reimbursement rate: 80%
- Better dental prosthetic coverage (60% vs 50%)
- Additional optique entries (glasses, contacts)
- Same lookup helpers as CNSS

#### 8.3 — Tariff Lookup System (`src/lib/insurance-billing.ts`)
- Unified `getTariffByCode(code, insuranceType)` function
- `calculateCoverage()` — full coverage calculation with dépassement d'honoraires and mutuelle
- `compareCoverage()` — CNSS vs CNOPS side-by-side comparison
- `searchTariffs()` — cross-table search

#### 8.4 — Enhanced Invoice Generator (`src/lib/invoice-generator.ts`)
- Tariff-based coverage breakdown (prefers tariff over percentage-based)
- Dépassement d'honoraires display
- Entente préalable warnings for acts requiring prior approval
- New fields: `actCode`, `tarifReference`, `insuranceReimbursement`, `coverageCalculation`

#### 8.5 — Enhanced Patient Form (`src/components/receptionist/patient-registration-dialog.tsx`)
- French insurance labels with coverage rates (CNSS 70%, CNOPS 80%, AMO 70%, RAMED 100%)
- Added AMO insurance option
- Mutuelle complémentaire fields (name, registration number, coverage rate)
- Conditionally shown when insurance is selected

#### 8.6 — Bordereau de Soins Generator (`src/lib/bordereau-generator.ts`)
- Batch insurance claim form for CNSS/CNOPS submissions
- Groups claims by patient with act-level detail
- Summary bar with claim count, act count, totals
- Print-ready HTML with legal notices and signature areas
- Reference number format: BRD-{CNSS|CNOPS}-YYYY-MM-NNNN

#### 8.7 — Insurance Billing Report (`src/components/insurance-billing-report.tsx`)
- CNSS and CNOPS stats cards (total billed, pending, received, rejected)
- Claim list with search, status filter, and insurance type tabs
- Batch selection for bordereau generation
- Monthly summary with recovery rate calculation
- Status tracking: pending → submitted → approved → paid / rejected

#### 8.8 — Tests Updated
- Updated patient registration tests to match new French labels
- All 8 tests passing

### Real Tariff Examples
| Act | CNSS TNR | CNSS Reimb. | CNOPS TNR | CNOPS Reimb. |
|---|---|---|---|---|
| Consultation généraliste | 80 MAD | 56 MAD (70%) | 80 MAD | 64 MAD (80%) |
| Extraction dentaire | 150 MAD | 105 MAD | 180 MAD | 144 MAD |
| Échographie abdominale | 250 MAD | 175 MAD | 250 MAD | 200 MAD |
| Appendicectomie | 750 MAD | 525 MAD | 850 MAD | 680 MAD |