### PR TITLE
feat: Starter plan price drop to 199 MAD + competitor comparison table

### DIFF
--- a/src/app/(public)/compare/page.tsx
+++ b/src/app/(public)/compare/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { LandingLocaleProvider } from "@/components/landing/landing-locale-provider";
+import { LandingHeader } from "@/components/landing/landing-header";
+import { LandingFooter } from "@/components/landing/landing-footer";
+import { FullComparisonTable } from "@/components/marketing/comparison-table";
+
+export const metadata: Metadata = {
+  title: "Comparatif — Oltigo vs IYADA, SmartDoc, CABIDOC, Pratisoft",
+  description:
+    "Comparez Oltigo avec les autres solutions de gestion de cabinet médical au Maroc : IYADA, SmartDoc, CABIDOC et Pratisoft. IA, WhatsApp, QR, multi-tenant et plus.",
+  openGraph: {
+    title: "Comparatif — Oltigo vs concurrents | Oltigo",
+    description:
+      "Tableau comparatif complet des fonctionnalités : tarifs, IA, WhatsApp, facturation assurance, ordonnances QR et plus.",
+  },
+};
+
+export default function ComparePage() {
+  return (
+    <LandingLocaleProvider>
+      <div className="flex min-h-screen flex-col bg-white">
+        <LandingHeader />
+        <main className="flex-1">
+          {/* Header */}
+          <div className="mx-auto max-w-6xl px-4 pb-12 pt-20 text-center sm:px-6">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-blue-600">
+              Comparatif complet
+            </p>
+            <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+              Oltigo vs la concurrence
+            </h1>
+            <p className="mx-auto mt-4 max-w-2xl text-lg text-gray-600">
+              Découvrez pourquoi Oltigo est la solution la plus complète pour
+              les professionnels de santé au Maroc.
+            </p>
+          </div>
+
+          {/* Full comparison table */}
+          <div className="pb-20">
+            <FullComparisonTable />
+          </div>
+        </main>
+        <LandingFooter />
+      </div>
+    </LandingLocaleProvider>
+  );
+}

--- a/src/app/api/__tests__/billing.test.ts
+++ b/src/app/api/__tests__/billing.test.ts
@@ -36,7 +36,7 @@ describe("Billing API — plan configuration", () => {
   });
 
   it("starter plan has correct monthly price", () => {
-    expect(getPlanPrice("starter", "monthly")).toBe(299);
+    expect(getPlanPrice("starter", "monthly")).toBe(199);
   });
 
   it("professional plan has correct yearly price", () => {

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -7,6 +7,7 @@ import { TrustSection } from "./trust-section";
 import { FeaturesSection } from "./features-section";
 import { HowItWorksSection } from "./how-it-works-section";
 import { DemoSection } from "./demo-section";
+import { ComparisonSection } from "@/components/marketing/comparison-table";
 import { CtaSection } from "./cta-section";
 import { LandingFooter } from "./landing-footer";
 import { CookieConsent } from "@/components/cookie-consent";
@@ -34,6 +35,7 @@ export function LandingPage() {
           <FeaturesSection />
           <HowItWorksSection />
           <DemoSection />
+          <ComparisonSection />
           <CtaSection />
         </main>
         <LandingFooter />

--- a/src/components/marketing/comparison-table.tsx
+++ b/src/components/marketing/comparison-table.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, Check, X, Minus } from "lucide-react";
+import {
+  COMPETITORS,
+  COMPARISON_FEATURES,
+  CATEGORY_LABELS,
+  getFeaturesByCategory,
+  type FeatureSupport,
+  type ComparisonCategory,
+} from "@/lib/competitor-comparison";
+
+function SupportIcon({ value }: { value: FeatureSupport }) {
+  switch (value) {
+    case "full":
+      return (
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+          <Check className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Inclus</span>
+        </span>
+      );
+    case "partial":
+      return (
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-amber-100 text-amber-600">
+          <Minus className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Partiel</span>
+        </span>
+      );
+    case "none":
+      return (
+        <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+          <span className="sr-only">Non inclus</span>
+        </span>
+      );
+  }
+}
+
+/**
+ * Compact comparison section for the landing page.
+ * Shows a subset of features with a link to the full comparison.
+ */
+export function ComparisonSection() {
+  const grouped = getFeaturesByCategory();
+  const highlightCategories: ComparisonCategory[] = [
+    "pricing",
+    "ai",
+    "whatsapp",
+    "prescriptions",
+  ];
+
+  const previewFeatures = highlightCategories.flatMap(
+    (cat) => grouped[cat]?.slice(0, 2) ?? [],
+  );
+
+  return (
+    <section
+      id="comparatif"
+      className="bg-gray-50 py-20 sm:py-28"
+    >
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mx-auto max-w-2xl text-center">
+          <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-blue-600">
+            Comparatif
+          </p>
+          <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+            Pourquoi choisir Oltigo ?
+          </h2>
+          <p className="mt-4 text-lg text-gray-600">
+            Comparez les fonctionnalités d&apos;Oltigo avec les autres solutions du marché marocain.
+          </p>
+        </div>
+
+        {/* Desktop table */}
+        <div className="mt-12 hidden overflow-x-auto md:block">
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="py-4 pr-4 text-left font-medium text-gray-500">
+                  Fonctionnalité
+                </th>
+                {COMPETITORS.map((c) => (
+                  <th
+                    key={c.id}
+                    className={`px-4 py-4 text-center font-semibold ${
+                      c.highlight
+                        ? "text-blue-600"
+                        : "text-gray-700"
+                    }`}
+                  >
+                    {c.name}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {previewFeatures.map((feature, idx) => (
+                <tr
+                  key={feature.label}
+                  className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}
+                >
+                  <td className="py-3 pr-4 text-gray-700">
+                    {feature.label}
+                  </td>
+                  {COMPETITORS.map((c) => (
+                    <td key={c.id} className="px-4 py-3 text-center">
+                      <SupportIcon value={feature.values[c.id]} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Mobile cards */}
+        <div className="mt-12 space-y-4 md:hidden">
+          {previewFeatures.map((feature) => (
+            <div
+              key={feature.label}
+              className="rounded-xl border border-gray-200 bg-white p-4"
+            >
+              <p className="mb-3 font-medium text-gray-900">
+                {feature.label}
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                {COMPETITORS.map((c) => (
+                  <div
+                    key={c.id}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <SupportIcon value={feature.values[c.id]} />
+                    <span
+                      className={
+                        c.highlight
+                          ? "font-semibold text-blue-600"
+                          : "text-gray-600"
+                      }
+                    >
+                      {c.name}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Legend */}
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-500">
+          <div className="flex items-center gap-2">
+            <SupportIcon value="full" />
+            <span>Inclus</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <SupportIcon value="partial" />
+            <span>Partiel</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <SupportIcon value="none" />
+            <span>Non disponible</span>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div className="mt-10 text-center">
+          <Link
+            href="/compare"
+            className="group inline-flex items-center gap-2 rounded-xl bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-600/20 transition-all hover:bg-blue-700"
+          >
+            Voir le comparatif complet
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Full comparison table for the dedicated /compare page.
+ * Shows all features grouped by category.
+ */
+export function FullComparisonTable() {
+  const grouped = getFeaturesByCategory();
+  const categories = Object.keys(grouped) as ComparisonCategory[];
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 sm:px-6">
+      {/* Legend */}
+      <div className="mb-8 flex flex-wrap items-center justify-center gap-6 text-sm text-gray-500">
+        <div className="flex items-center gap-2">
+          <SupportIcon value="full" />
+          <span>Inclus</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <SupportIcon value="partial" />
+          <span>Partiel</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <SupportIcon value="none" />
+          <span>Non disponible</span>
+        </div>
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden overflow-x-auto md:block">
+        <table className="w-full border-collapse text-sm">
+          <thead className="sticky top-0 z-10 bg-white">
+            <tr className="border-b-2 border-gray-200">
+              <th className="py-4 pr-4 text-left font-medium text-gray-500">
+                Fonctionnalité
+              </th>
+              {COMPETITORS.map((c) => (
+                <th
+                  key={c.id}
+                  className={`px-4 py-4 text-center font-semibold ${
+                    c.highlight
+                      ? "text-blue-600"
+                      : "text-gray-700"
+                  }`}
+                >
+                  {c.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((category) => (
+              <>
+                <tr key={`cat-${category}`}>
+                  <td
+                    colSpan={COMPETITORS.length + 1}
+                    className="pb-2 pt-6 text-xs font-bold uppercase tracking-widest text-blue-600"
+                  >
+                    {CATEGORY_LABELS[category]}
+                  </td>
+                </tr>
+                {grouped[category].map((feature, idx) => (
+                  <tr
+                    key={feature.label}
+                    className={
+                      idx % 2 === 0 ? "bg-white" : "bg-gray-50"
+                    }
+                  >
+                    <td className="py-3 pr-4 text-gray-700">
+                      {feature.label}
+                    </td>
+                    {COMPETITORS.map((c) => (
+                      <td
+                        key={c.id}
+                        className="px-4 py-3 text-center"
+                      >
+                        <SupportIcon value={feature.values[c.id]} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile: grouped cards */}
+      <div className="space-y-8 md:hidden">
+        {categories.map((category) => (
+          <div key={category}>
+            <h3 className="mb-4 text-xs font-bold uppercase tracking-widest text-blue-600">
+              {CATEGORY_LABELS[category]}
+            </h3>
+            <div className="space-y-3">
+              {grouped[category].map((feature) => (
+                <div
+                  key={feature.label}
+                  className="rounded-xl border border-gray-200 bg-white p-4"
+                >
+                  <p className="mb-3 font-medium text-gray-900">
+                    {feature.label}
+                  </p>
+                  <div className="grid grid-cols-2 gap-2">
+                    {COMPETITORS.map((c) => (
+                      <div
+                        key={c.id}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <SupportIcon value={feature.values[c.id]} />
+                        <span
+                          className={
+                            c.highlight
+                              ? "font-semibold text-blue-600"
+                              : "text-gray-600"
+                          }
+                        >
+                          {c.name}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Score summary */}
+      <div className="mt-12 rounded-2xl border border-blue-100 bg-blue-50 p-8 text-center">
+        <p className="text-lg font-semibold text-gray-900">
+          Oltigo couvre{" "}
+          <span className="text-blue-600">
+            {COMPARISON_FEATURES.filter(
+              (f) => f.values.oltigo === "full",
+            ).length}
+          </span>{" "}
+          fonctionnalités sur{" "}
+          <span className="text-blue-600">
+            {COMPARISON_FEATURES.length}
+          </span>{" "}
+          — plus que tout autre concurrent.
+        </p>
+        <Link
+          href="/register-clinic"
+          className="mt-6 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-600/20 transition-all hover:bg-blue-700"
+        >
+          Commencer gratuitement
+          <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/subscription-billing.test.ts
+++ b/src/lib/__tests__/subscription-billing.test.ts
@@ -67,11 +67,11 @@ describe("getPlanConfig", () => {
 
 describe("getPlanPrice", () => {
   it("returns monthly price for monthly interval", () => {
-    expect(getPlanPrice("starter", "monthly")).toBe(299);
+    expect(getPlanPrice("starter", "monthly")).toBe(199);
   });
 
   it("returns yearly price for yearly interval", () => {
-    expect(getPlanPrice("starter", "yearly")).toBe(2990);
+    expect(getPlanPrice("starter", "yearly")).toBe(1990);
   });
 
   it("returns 0 for free plan monthly", () => {
@@ -93,8 +93,8 @@ describe("getPlanPrice", () => {
 
 describe("getYearlySavings", () => {
   it("calculates savings for starter plan", () => {
-    // 299 * 12 - 2990 = 3588 - 2990 = 598
-    expect(getYearlySavings("starter")).toBe(598);
+    // 199 * 12 - 1990 = 2388 - 1990 = 398
+    expect(getYearlySavings("starter")).toBe(398);
   });
 
   it("calculates savings for professional plan", () => {

--- a/src/lib/competitor-comparison.ts
+++ b/src/lib/competitor-comparison.ts
@@ -1,0 +1,221 @@
+/**
+ * Competitor Comparison Data
+ *
+ * Feature comparison between Oltigo and competing platforms
+ * in the Moroccan healthcare SaaS market.
+ */
+
+export type CompetitorId = "oltigo" | "iyada" | "smartdoc" | "cabidoc" | "pratisoft";
+
+export interface CompetitorInfo {
+  id: CompetitorId;
+  name: string;
+  highlight?: boolean;
+}
+
+export type FeatureSupport = "full" | "partial" | "none";
+
+export interface ComparisonFeature {
+  label: string;
+  category: ComparisonCategory;
+  values: Record<CompetitorId, FeatureSupport>;
+}
+
+export type ComparisonCategory =
+  | "pricing"
+  | "ai"
+  | "mobile"
+  | "whatsapp"
+  | "insurance"
+  | "prescriptions"
+  | "multi-tenant"
+  | "offline";
+
+export const CATEGORY_LABELS: Record<ComparisonCategory, string> = {
+  pricing: "Tarification",
+  ai: "Fonctionnalités IA",
+  mobile: "Mobile / PWA",
+  whatsapp: "WhatsApp",
+  insurance: "Facturation Assurance",
+  prescriptions: "Ordonnances QR",
+  "multi-tenant": "Multi-tenant",
+  offline: "Mode Hors-ligne",
+};
+
+export const COMPETITORS: CompetitorInfo[] = [
+  { id: "oltigo", name: "Oltigo", highlight: true },
+  { id: "iyada", name: "IYADA" },
+  { id: "smartdoc", name: "SmartDoc" },
+  { id: "cabidoc", name: "CABIDOC" },
+  { id: "pratisoft", name: "Pratisoft" },
+];
+
+export const COMPARISON_FEATURES: ComparisonFeature[] = [
+  // Pricing
+  {
+    label: "Plan gratuit disponible",
+    category: "pricing",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Tarifs transparents en ligne",
+    category: "pricing",
+    values: { oltigo: "full", iyada: "partial", smartdoc: "none", cabidoc: "none", pratisoft: "partial" },
+  },
+  {
+    label: "Pas d'engagement annuel obligatoire",
+    category: "pricing",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+
+  // AI Features
+  {
+    label: "Rédaction d'ordonnances par IA",
+    category: "ai",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Suggestions diagnostiques IA",
+    category: "ai",
+    values: { oltigo: "full", iyada: "none", smartdoc: "partial", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Résumé automatique des consultations",
+    category: "ai",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+
+  // Mobile / PWA
+  {
+    label: "Application mobile (PWA)",
+    category: "mobile",
+    values: { oltigo: "full", iyada: "partial", smartdoc: "none", cabidoc: "none", pratisoft: "partial" },
+  },
+  {
+    label: "Interface responsive complète",
+    category: "mobile",
+    values: { oltigo: "full", iyada: "partial", smartdoc: "partial", cabidoc: "partial", pratisoft: "partial" },
+  },
+  {
+    label: "Portail patient mobile",
+    category: "mobile",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+
+  // WhatsApp
+  {
+    label: "Rappels WhatsApp automatiques",
+    category: "whatsapp",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Envoi d'ordonnances par WhatsApp",
+    category: "whatsapp",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Notifications en Darija",
+    category: "whatsapp",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+
+  // Insurance Billing
+  {
+    label: "Facturation CNSS / CNOPS",
+    category: "insurance",
+    values: { oltigo: "full", iyada: "partial", smartdoc: "partial", cabidoc: "full", pratisoft: "full" },
+  },
+  {
+    label: "Calcul automatique du reste à charge",
+    category: "insurance",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "partial", pratisoft: "partial" },
+  },
+  {
+    label: "Export comptable DGI",
+    category: "insurance",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "partial", pratisoft: "full" },
+  },
+
+  // QR Prescriptions
+  {
+    label: "Ordonnances électroniques avec QR",
+    category: "prescriptions",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Vérification en pharmacie par QR",
+    category: "prescriptions",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Base DCI marocaine intégrée",
+    category: "prescriptions",
+    values: { oltigo: "full", iyada: "partial", smartdoc: "partial", cabidoc: "partial", pratisoft: "full" },
+  },
+
+  // Multi-tenant
+  {
+    label: "Multi-cabinet (SaaS)",
+    category: "multi-tenant",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "partial" },
+  },
+  {
+    label: "Sous-domaine personnalisé",
+    category: "multi-tenant",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Isolation des données par cabinet",
+    category: "multi-tenant",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+
+  // Offline
+  {
+    label: "Mode hors-ligne (PWA)",
+    category: "offline",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Synchronisation automatique",
+    category: "offline",
+    values: { oltigo: "full", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+  {
+    label: "Consultation sans internet",
+    category: "offline",
+    values: { oltigo: "partial", iyada: "none", smartdoc: "none", cabidoc: "none", pratisoft: "none" },
+  },
+];
+
+/**
+ * Get features grouped by category.
+ */
+export function getFeaturesByCategory(): Record<ComparisonCategory, ComparisonFeature[]> {
+  const grouped = {} as Record<ComparisonCategory, ComparisonFeature[]>;
+  for (const feature of COMPARISON_FEATURES) {
+    if (!grouped[feature.category]) {
+      grouped[feature.category] = [];
+    }
+    grouped[feature.category].push(feature);
+  }
+  return grouped;
+}
+
+/**
+ * Count how many "full" or "partial" features each competitor supports.
+ */
+export function getCompetitorScores(): Record<CompetitorId, { full: number; partial: number; total: number }> {
+  const scores = {} as Record<CompetitorId, { full: number; partial: number; total: number }>;
+  for (const competitor of COMPETITORS) {
+    scores[competitor.id] = { full: 0, partial: 0, total: COMPARISON_FEATURES.length };
+  }
+  for (const feature of COMPARISON_FEATURES) {
+    for (const competitor of COMPETITORS) {
+      const val = feature.values[competitor.id];
+      if (val === "full") scores[competitor.id].full++;
+      if (val === "partial") scores[competitor.id].partial++;
+    }
+  }
+  return scores;
+}

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -85,8 +85,8 @@ export const SUBSCRIPTION_PLANS: PlanConfig[] = [
   {
     id: "starter",
     name: "Starter",
-    priceMonthly: 299,
-    priceYearly: 2990,
+    priceMonthly: 199,
+    priceYearly: 1990,
     currency: "MAD",
     features: ["Up to 5 doctors", "500 patients", "500 appointments/month", "SMS & WhatsApp (100/mo)", "CSV Export"],
     maxDoctors: 5,


### PR DESCRIPTION
## Summary

### Task 9: Starter Plan Price Drop to 199 MAD
- Updated `priceMonthly` from 299 to **199** MAD
- Updated `priceYearly` from 2990 to **1990** MAD
- Updated all related test assertions in both test files

### Task 10: Competitor Comparison Table
- **New data structure** (`src/lib/competitor-comparison.ts`): Features × competitors matrix covering 8 categories
- **New comparison table component** (`src/components/marketing/comparison-table.tsx`): Responsive desktop table + mobile cards with checkmarks/partial/X icons
- **Landing page section**: Added after the demo section, showing a preview of key differentiators with a CTA to the full comparison
- **Dedicated /compare page** (`src/app/(public)/compare/page.tsx`): Full feature breakdown by category

#### Comparison Categories
- Pricing
- AI Features
- Mobile / PWA
- WhatsApp
- Insurance Billing (CNSS/CNOPS)
- QR Prescriptions
- Multi-tenant
- Offline

#### Competitors Compared
Oltigo vs IYADA, SmartDoc, CABIDOC, Pratisoft

## Files Changed
- `src/lib/subscription-billing.ts` — Starter plan pricing update
- `src/lib/__tests__/subscription-billing.test.ts` — Test assertions updated
- `src/app/api/__tests__/billing.test.ts` — Test assertions updated
- `src/lib/competitor-comparison.ts` — **New**: Comparison data structure
- `src/components/marketing/comparison-table.tsx` — **New**: Comparison table component
- `src/components/landing/landing-page.tsx` — Added ComparisonSection
- `src/app/(public)/compare/page.tsx` — **New**: Dedicated compare page

Link to Devin session: https://app.devin.ai/sessions/e7d98ae721344fe6b7f0e4ac0f7115a6