### PR TITLE
audit: fix bugs, improve architecture, and clean up codebase

### DIFF
--- a/src/components/receptionist/end-of-day-report-button.tsx
+++ b/src/components/receptionist/end-of-day-report-button.tsx
@@ -23,9 +23,8 @@ import {
   getCurrentUser,
   fetchTodayAppointments,
   fetchInvoices,
-  type AppointmentView,
-  type InvoiceView,
 } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface EndOfDayReportButtonProps {
   trigger?: React.ReactNode;
@@ -56,7 +55,7 @@ export function EndOfDayReportButton({ trigger }: EndOfDayReportButtonProps) {
         return;
       }
 
-      const today = new Date().toISOString().split("T")[0];
+      const today = getLocalDateStr();
       const [appts, invoices] = await Promise.all([
         fetchTodayAppointments(user.clinic_id),
         fetchInvoices(user.clinic_id),

--- a/src/components/receptionist/realtime-waiting-room.tsx
+++ b/src/components/receptionist/realtime-waiting-room.tsx
@@ -114,24 +114,28 @@ export function RealtimeWaitingRoom({ clinicId, onCallIn }: RealtimeWaitingRoomP
                     Call In
                   </Button>
                   <div className="flex gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      onClick={() => handleCallPatient(apt.patientName)}
-                      title="Call"
-                    >
-                      <Phone className="h-3 w-3 text-blue-600" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      onClick={() => handleWhatsApp(apt.patientName)}
-                      title="WhatsApp"
-                    >
-                      <MessageCircle className="h-3 w-3 text-green-600" />
-                    </Button>
+                    {apt.patientPhone && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        onClick={() => handleCallPatient(apt.patientPhone!)}
+                        title="Call"
+                      >
+                        <Phone className="h-3 w-3 text-blue-600" />
+                      </Button>
+                    )}
+                    {apt.patientPhone && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        onClick={() => handleWhatsApp(apt.patientPhone!)}
+                        title="WhatsApp"
+                      >
+                        <MessageCircle className="h-3 w-3 text-green-600" />
+                      </Button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/lib/data/client/appointments.ts
+++ b/src/lib/data/client/appointments.ts
@@ -11,6 +11,7 @@ export interface AppointmentView {
   id: string;
   patientId: string;
   patientName: string;
+  patientPhone?: string;
   doctorId: string;
   doctorName: string;
   serviceId: string;
@@ -65,6 +66,7 @@ function mapAppointment(raw: AppointmentRaw): AppointmentView {
     id: raw.id,
     patientId: raw.patient_id,
     patientName: patient?.name ?? "Unknown",
+    patientPhone: patient?.phone || undefined,
     doctorId: raw.doctor_id,
     doctorName: doctor?.name ?? "Unknown",
     serviceId: raw.service_id ?? "",

--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -33,24 +33,22 @@ export async function applyRateLimit(
   const rule = rateLimitRules.find((r) => pathname.startsWith(r.prefix));
 
   if (rule) {
-    // Get the window and max from the limiter options
-    // For now, we'll use default values based on the rule
-    const windowMs = 60_000; // Default 60 seconds
-    const max = 30; // Default max
-
     const allowed = await rule.limiter.check(rateLimitKey);
     if (!allowed) {
-      const reset = Math.ceil(Date.now() / 1000) + Math.ceil(windowMs / 1000);
-      return {
-        response: withSecurityHeaders(
-          NextResponse.json(
-            { error: "Too many requests. Please try again later.", code: "RATE_LIMIT_EXCEEDED" },
-            { status: 429 },
-          ),
-          cspHeaderValue,
+      const retryAfterSec = Math.ceil(rule.windowMs / 1000);
+      const reset = Math.ceil(Date.now() / 1000) + retryAfterSec;
+      const response = withSecurityHeaders(
+        NextResponse.json(
+          { error: "Too many requests. Please try again later.", code: "RATE_LIMIT_EXCEEDED" },
+          { status: 429 },
         ),
+        cspHeaderValue,
+      );
+      response.headers.set("Retry-After", String(retryAfterSec));
+      return {
+        response,
         rateLimitInfo: {
-          limit: max,
+          limit: rule.max,
           remaining: 0,
           reset,
         },

--- a/src/lib/middleware/security-headers.ts
+++ b/src/lib/middleware/security-headers.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
 
+/** OWASP-recommended HSTS max-age: 2 years (63 072 000 seconds). */
+const HSTS_VALUE = "max-age=63072000; includeSubDomains; preload";
+
 /**
  * Build the Content-Security-Policy header value with a per-request nonce.
  */
@@ -28,7 +31,7 @@ export function withSecurityHeaders(
   cspHeaderValue: string,
 ): NextResponse {
   response.headers.set("Content-Security-Policy", cspHeaderValue);
-  response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
   return response;
@@ -39,7 +42,7 @@ export function withSecurityHeaders(
  */
 export function secureRedirect(url: string | URL, init?: number | ResponseInit): NextResponse {
   const response = NextResponse.redirect(url, init);
-  response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
   return response;
@@ -55,7 +58,7 @@ export function applyAllSecurityHeaders(
 ): void {
   response.headers.set("Content-Security-Policy", cspHeaderValue);
   response.headers.set("x-nonce", nonce);
-  response.headers.set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+  response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
   response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -575,24 +575,28 @@ export interface RateLimitRule {
   prefix: string;
   /** The limiter instance to use */
   limiter: RateLimiter;
+  /** Time window in milliseconds (mirrors the limiter's config for header reporting) */
+  windowMs: number;
+  /** Maximum requests allowed per window (mirrors the limiter's config for header reporting) */
+  max: number;
 }
 
 /**
  * Ordered list of rate-limit rules. First matching prefix wins.
  */
 export const rateLimitRules: RateLimitRule[] = [
-  { prefix: "/api/booking/waiting-list", limiter: waitingListLimiter },
-  { prefix: "/api/book", limiter: bookingLimiter },
-  { prefix: "/api/verify-email", limiter: emailVerificationLimiter },
-  { prefix: "/api/upload", limiter: uploadLimiter },
-  { prefix: "/api/onboarding", limiter: onboardingLimiter },
-  { prefix: "/api/v1/ai/patient-summary", limiter: aiPatientSummaryLimiter },
-  { prefix: "/api/v1/ai/drug-check", limiter: aiDrugCheckLimiter },
-  { prefix: "/api/v1/ai/prescription", limiter: aiPrescriptionLimiter },
-  { prefix: "/api/chat", limiter: chatLimiter },
-  { prefix: "/api/webhooks", limiter: webhookLimiter },
-  { prefix: "/api/branding", limiter: brandingLimiter },
-  { prefix: "/api/notifications", limiter: apiMutationLimiter },
+  { prefix: "/api/booking/waiting-list", limiter: waitingListLimiter, windowMs: 60 * 60_000, max: 3 },
+  { prefix: "/api/book", limiter: bookingLimiter, windowMs: 60_000, max: 10 },
+  { prefix: "/api/verify-email", limiter: emailVerificationLimiter, windowMs: 60_000, max: 5 },
+  { prefix: "/api/upload", limiter: uploadLimiter, windowMs: 60_000, max: 10 },
+  { prefix: "/api/onboarding", limiter: onboardingLimiter, windowMs: 60_000, max: 5 },
+  { prefix: "/api/v1/ai/patient-summary", limiter: aiPatientSummaryLimiter, windowMs: 24 * 60 * 60_000, max: 30 },
+  { prefix: "/api/v1/ai/drug-check", limiter: aiDrugCheckLimiter, windowMs: 24 * 60 * 60_000, max: 100 },
+  { prefix: "/api/v1/ai/prescription", limiter: aiPrescriptionLimiter, windowMs: 24 * 60 * 60_000, max: 50 },
+  { prefix: "/api/chat", limiter: chatLimiter, windowMs: 60_000, max: 15 },
+  { prefix: "/api/webhooks", limiter: webhookLimiter, windowMs: 60_000, max: 100 },
+  { prefix: "/api/branding", limiter: brandingLimiter, windowMs: 60_000, max: 20 },
+  { prefix: "/api/notifications", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
   // Catch-all for other API mutations (applied in middleware only to POST/PUT/PATCH/DELETE)
-  { prefix: "/api/", limiter: apiMutationLimiter },
+  { prefix: "/api/", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
 ];


### PR DESCRIPTION
## Comprehensive Audit & Improvement

This PR addresses issues found during a thorough codebase audit across 5 areas:

### Bug Fixes
- **Waiting room phone/WhatsApp buttons** (`realtime-waiting-room.tsx`): Fixed buttons that were passing `patientName` (a string name) to `handleCallPatient()` and `handleWhatsApp()` instead of a phone number. Buttons now use `patientPhone` and are hidden when no phone is on file.
- **Rate-limit headers returning wrong values** (`middleware/rate-limiting.ts`): `X-RateLimit-Limit` and `X-RateLimit-Reset` were hardcoded to `30`/`60s` regardless of which limiter matched. Now uses actual values from the matched rule.
- **HSTS max-age inconsistency** (`middleware/security-headers.ts`): `withSecurityHeaders` used 1-year max-age while `applyAllSecurityHeaders` used 2-year. Unified to OWASP-recommended 2 years (63072000s) via shared constant.
- **End-of-day report UTC date bug** (`end-of-day-report-button.tsx`): Used `toISOString().split("T")[0]` which returns UTC date — wrong near midnight in Morocco. Replaced with timezone-safe `getLocalDateStr()`.

### Architecture
- **Exposed `windowMs`/`max` in `RateLimitRule`** (`rate-limit.ts`): Extended the interface so middleware can read actual limiter config for accurate response headers.
- **Added `Retry-After` header** to 429 responses per RFC 6585.
- **Extracted HSTS constant** to prevent future drift between helper functions.

### Feature Enhancement
- **Added `patientPhone` to `AppointmentView`** (`appointments.ts`): New optional field populated from the user lookup map, enabling phone/WhatsApp functionality in the waiting room.

### Cleanup
- **Removed unused imports** (`end-of-day-report-button.tsx`): Removed `AppointmentView` and `InvoiceView` type imports that were flagged by lint.

### Verification
- Typecheck: Clean ✓
- Lint: 0 errors (2 pre-existing warnings, reduced from 4) ✓
- Tests: 457/457 passing ✓
- Pre-commit hooks: All passed ✓

---
[Devin Session](https://app.devin.ai/sessions/a378deac946b4f52a2e73ac45e691ea9)