### PR TITLE
fix: Audit Layer 1 — remove static clinicConfig leaks, consolidate error boundaries & dashboard stats

### DIFF
--- a/src/app/(admin)/error.tsx
+++ b/src/app/(admin)/error.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
-import { t } from "@/lib/i18n";
-import { useLocale } from "@/components/locale-switcher";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function AdminError({
   error,
@@ -15,34 +9,5 @@ export default function AdminError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [locale] = useLocale();
-
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "admin-error", error });
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ClinicErrorBoundary error={error} reset={reset} context="admin" variant="page" />;
 }

--- a/src/app/(doctor)/error.tsx
+++ b/src/app/(doctor)/error.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
-import { t } from "@/lib/i18n";
-import { useLocale } from "@/components/locale-switcher";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function DoctorError({
   error,
@@ -15,34 +9,5 @@ export default function DoctorError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [locale] = useLocale();
-
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "doctor-error", error });
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ClinicErrorBoundary error={error} reset={reset} context="doctor" variant="page" />;
 }

--- a/src/app/(doctor)/layout.tsx
+++ b/src/app/(doctor)/layout.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SignOutButton } from "@/components/sign-out-button";
 import { useClinicFeatures, SPECIALTY_FEATURES } from "@/lib/hooks/use-clinic-features";
-import { clinicConfig } from "@/config/clinic.config";
+import { useTenant } from "@/components/tenant-provider";
 import { useLocale } from "@/components/locale-switcher";
 import { t } from "@/lib/i18n";
 import type { TranslationKey } from "@/lib/i18n";
@@ -348,8 +348,10 @@ export default function DoctorLayout({
   const pathname = usePathname();
   const [locale] = useLocale();
   const { hasFeature } = useClinicFeatures();
-  // Auto-detect specialty from clinic config type (Issue 15).
-  // Maps clinic types to the specialty filter keys used by SPECIALTY_FEATURES.
+  const tenant = useTenant();
+  // Auto-detect specialty from runtime tenant context (Issue 15).
+  // Previously used static clinicConfig.type which leaked a single-tenant
+  // assumption (audit MT-02). Now reads clinicType from tenant headers.
   const CLINIC_TYPE_TO_SPECIALTY: Record<string, string> = {
     doctor: "gp",
     dentist: "dentist",
@@ -364,7 +366,7 @@ export default function DoctorLayout({
     physiotherapist: "physiotherapist",
     nutritionist: "nutritionist",
   };
-  const detectedSpecialty = CLINIC_TYPE_TO_SPECIALTY[clinicConfig.type] ?? null;
+  const detectedSpecialty = CLINIC_TYPE_TO_SPECIALTY[tenant?.clinicType ?? ""] ?? null;
   const [selectedSpecialty, setSelectedSpecialty] = useState<string | null>(detectedSpecialty);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 

--- a/src/app/(patient)/error.tsx
+++ b/src/app/(patient)/error.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
-import { t } from "@/lib/i18n";
-import { useLocale } from "@/components/locale-switcher";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function PatientError({
   error,
@@ -15,34 +9,5 @@ export default function PatientError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [locale] = useLocale();
-
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "patient-error", error });
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ClinicErrorBoundary error={error} reset={reset} context="patient" variant="page" />;
 }

--- a/src/app/(public)/error.tsx
+++ b/src/app/(public)/error.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw, Home } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
+import Link from "next/link";
+import { Home } from "lucide-react";
 import { t } from "@/lib/i18n";
 import { useLocale } from "@/components/locale-switcher";
-import Link from "next/link";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function PublicError({
   error,
@@ -18,41 +15,15 @@ export default function PublicError({
 }) {
   const [locale] = useLocale();
 
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "public-error", error });
-  }, [error]);
-
   return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <div className="flex items-center justify-center gap-3">
-            <Button onClick={reset} size="lg">
-              <RefreshCw className="mr-2 h-4 w-4" />
-              {t(locale, "error.retry")}
-            </Button>
-            <Link
-              href="/"
-              className="inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors"
-            >
-              <Home className="mr-2 h-4 w-4" />
-              {t(locale, "notFound.backHome")}
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <ClinicErrorBoundary error={error} reset={reset} context="public" variant="page">
+      <Link
+        href="/"
+        className="mt-3 inline-flex items-center justify-center rounded-lg border border-border bg-background px-4 py-2 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <Home className="mr-2 h-4 w-4" />
+        {t(locale, "notFound.backHome")}
+      </Link>
+    </ClinicErrorBoundary>
   );
 }

--- a/src/app/(receptionist)/error.tsx
+++ b/src/app/(receptionist)/error.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
-import { t } from "@/lib/i18n";
-import { useLocale } from "@/components/locale-switcher";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function ReceptionistError({
   error,
@@ -15,34 +9,5 @@ export default function ReceptionistError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [locale] = useLocale();
-
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "receptionist-error", error });
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ClinicErrorBoundary error={error} reset={reset} context="receptionist" variant="page" />;
 }

--- a/src/app/(super-admin)/error.tsx
+++ b/src/app/(super-admin)/error.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
-import { t } from "@/lib/i18n";
-import { useLocale } from "@/components/locale-switcher";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function SuperAdminError({
   error,
@@ -15,34 +9,5 @@ export default function SuperAdminError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [locale] = useLocale();
-
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "super-admin-error", error });
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ClinicErrorBoundary error={error} reset={reset} context="super-admin" variant="page" />;
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { logger } from "@/lib/logger";
-import { t } from "@/lib/i18n";
-import { useLocale } from "@/components/locale-switcher";
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
 
 export default function Error({
   error,
@@ -15,34 +9,5 @@ export default function Error({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
-  const [locale] = useLocale();
-
-  useEffect(() => {
-    logger.warn("Operation failed", { context: "error", error });
-  }, [error]);
-
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-4">
-      <Card className="w-full max-w-md text-center">
-        <CardContent className="p-8">
-          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-destructive/10">
-            <AlertTriangle className="h-7 w-7 text-destructive" />
-          </div>
-          <h2 className="mb-2 text-lg font-semibold">{t(locale, "error.title")}</h2>
-          <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.description")}
-          </p>
-          {error.digest && (
-            <p className="mb-4 text-xs text-muted-foreground">
-              Error ID: {error.digest}
-            </p>
-          )}
-          <Button onClick={reset} size="lg">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            {t(locale, "error.retry")}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <ClinicErrorBoundary error={error} reset={reset} context="error" variant="page" />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Noto_Sans_Arabic } from "next/font/google";
 import "./globals.css";
 import { getTenant } from "@/lib/tenant";
-import { clinicConfig } from "@/config/clinic.config";
 import { TenantProvider } from "@/components/tenant-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ToastProvider } from "@/components/ui/toast";
@@ -97,7 +96,13 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const tenant = await getTenant();
-  const locale: Locale = (clinicConfig.locale as Locale) ?? "fr";
+  // Default locale for server-side rendering. Previously used the static
+  // clinicConfig.locale which created a single-tenant bottleneck in the
+  // shared root layout (audit MT-01). Client-side locale switching is
+  // handled by useLocale() in locale-switcher.tsx via localStorage.
+  // TODO: Extend tenant headers to carry per-clinic locale from the DB
+  // config JSONB column so each tenant gets their preferred initial locale.
+  const locale: Locale = "fr";
   const dir = getDirection(locale);
 
   return (

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,9 +1,11 @@
 import Link from "next/link";
 import { t, type Locale } from "@/lib/i18n";
-import { clinicConfig } from "@/config/clinic.config";
 
 export default function NotFound() {
-  const locale: Locale = (clinicConfig.locale as Locale) ?? "fr";
+  // Default locale for server-rendered 404 page. Removed static clinicConfig
+  // import which leaked a single-tenant assumption (audit MT-02).
+  // Client-side locale is handled by useLocale() via localStorage.
+  const locale: Locale = "fr";
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center px-4">

--- a/src/components/error-boundaries/clinic-error-boundary.tsx
+++ b/src/components/error-boundaries/clinic-error-boundary.tsx
@@ -9,21 +9,34 @@ import { t } from "@/lib/i18n";
 import { useLocale } from "@/components/locale-switcher";
 
 /**
- * Shared error boundary for clinic-type route groups.
+ * Shared error boundary for all route groups.
  *
- * Used by (clinic-public), (specialist), and other clinic-type route
- * groups to provide consistent error handling with i18n.
+ * Consolidates the duplicated error boundary pattern across
+ * (admin), (doctor), (patient), (receptionist), (super-admin),
+ * (clinic-public), and the root error.tsx (audit DRY-01).
+ *
+ * @param context  - Logging context label (e.g. "admin", "doctor")
+ * @param variant  - "page" uses error.title / error.description (root-level);
+ *                   "section" uses error.sectionTitle / error.sectionDescription
+ * @param children - Optional extra actions rendered after the retry button
  */
 export default function ClinicErrorBoundary({
   error,
   reset,
   context = "clinic",
+  variant = "section",
+  children,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
   context?: string;
+  variant?: "page" | "section";
+  children?: React.ReactNode;
 }) {
   const [locale] = useLocale();
+
+  const titleKey = variant === "page" ? "error.title" : "error.sectionTitle";
+  const descKey = variant === "page" ? "error.description" : "error.sectionDescription";
 
   useEffect(() => {
     logger.warn("Operation failed", { context: `${context}-error`, error });
@@ -37,10 +50,10 @@ export default function ClinicErrorBoundary({
             <AlertTriangle className="h-7 w-7 text-destructive" />
           </div>
           <h2 className="mb-2 text-lg font-semibold">
-            {t(locale, "error.sectionTitle")}
+            {t(locale, titleKey)}
           </h2>
           <p className="mb-6 text-sm text-muted-foreground">
-            {t(locale, "error.sectionDescription")}
+            {t(locale, descKey)}
           </p>
           {error.digest && (
             <p className="mb-4 text-xs text-muted-foreground">
@@ -51,6 +64,7 @@ export default function ClinicErrorBoundary({
             <RefreshCw className="mr-2 h-4 w-4" />
             {t(locale, "error.retry")}
           </Button>
+          {children}
         </CardContent>
       </Card>
     </div>

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -920,18 +920,22 @@ export async function getLoyaltyPoints(clinicId: string): Promise<LoyaltyPointsR
 // Dashboard Stats (aggregated)
 // ────────────────────────────────────────────
 
-export interface ClinicDashboardStats {
+/**
+ * Shared base stats fetched by all dashboard variants.
+ * Extracted to eliminate duplication between getClinicDashboardStats
+ * (removed) and getDashboardStats (audit DRY-02).
+ */
+interface BaseDashboardStats {
   totalPatients: number;
   totalAppointments: number;
-  totalRevenue: number;
   completedAppointments: number;
   noShowCount: number;
+  totalRevenue: number;
   averageRating: number;
   doctorCount: number;
-  activeServices: number;
 }
 
-export async function getClinicDashboardStats(clinicId: string): Promise<ClinicDashboardStats> {
+async function fetchBaseDashboardStats(clinicId: string): Promise<BaseDashboardStats> {
   const supabase = await createClient();
 
   const [
@@ -942,7 +946,6 @@ export async function getClinicDashboardStats(clinicId: string): Promise<ClinicD
     paymentsRes,
     reviewsRes,
     doctorCountRes,
-    serviceCountRes,
   ] = await Promise.all([
     supabase.from("users").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId).eq("role", "patient"),
     supabase.from("appointments").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId),
@@ -951,7 +954,6 @@ export async function getClinicDashboardStats(clinicId: string): Promise<ClinicD
     supabase.from("payments").select("amount").eq("clinic_id", clinicId).eq("status", "completed"),
     supabase.from("reviews").select("stars").eq("clinic_id", clinicId),
     supabase.from("users").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId).eq("role", "doctor"),
-    supabase.from("services").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId),
   ]);
 
   const payments = (paymentsRes.data ?? []) as { amount: number }[];
@@ -965,12 +967,11 @@ export async function getClinicDashboardStats(clinicId: string): Promise<ClinicD
   return {
     totalPatients: patientCountRes.count ?? 0,
     totalAppointments: appointmentCountRes.count ?? 0,
-    totalRevenue,
     completedAppointments: completedCountRes.count ?? 0,
     noShowCount: noShowCountRes.count ?? 0,
+    totalRevenue,
     averageRating: avgRating,
     doctorCount: doctorCountRes.count ?? 0,
-    activeServices: serviceCountRes.count ?? 0,
   };
 }
 
@@ -1296,45 +1297,23 @@ export interface DashboardStats {
 }
 
 export async function getDashboardStats(clinicId: string): Promise<DashboardStats> {
-  const supabase = await createClient();
-  const [
-    patientCountRes,
-    appointmentCountRes,
-    completedCountRes,
-    noShowCountRes,
-    paymentsRes,
-    reviewsRes,
-    doctorCountRes,
-    insurancePatientsRes,
-  ] = await Promise.all([
-    supabase.from("users").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId).eq("role", "patient"),
-    supabase.from("appointments").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId),
-    supabase.from("appointments").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId).eq("status", "completed"),
-    supabase.from("appointments").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId).eq("status", "no_show"),
-    supabase.from("payments").select("amount").eq("clinic_id", clinicId).eq("status", "completed"),
-    supabase.from("reviews").select("stars").eq("clinic_id", clinicId),
-    supabase.from("users").select("id", { count: "exact", head: true }).eq("clinic_id", clinicId).eq("role", "doctor"),
-    supabase.from("users").select("id, metadata").eq("clinic_id", clinicId).eq("role", "patient"),
+  // Reuse shared base queries (audit DRY-02)
+  const [base, supabase] = await Promise.all([
+    fetchBaseDashboardStats(clinicId),
+    createClient(),
   ]);
-  const payments = (paymentsRes.data ?? []) as { amount: number }[];
-  const reviews = (reviewsRes.data ?? []) as { stars: number }[];
-  const insurancePatients = (insurancePatientsRes.data ?? []) as { id: string; metadata: Record<string, unknown> | null }[];
 
-  const totalRevenue = payments.reduce((s, p) => s + (p.amount ?? 0), 0);
-  const avgRating = reviews.length > 0 ? reviews.reduce((s, r) => s + r.stars, 0) / reviews.length : 0;
+  // Fetch dashboard-specific data in parallel
+  const [insurancePatientsRes, recentActivity] = await Promise.all([
+    supabase.from("users").select("id, metadata").eq("clinic_id", clinicId).eq("role", "patient"),
+    getRecentActivity(supabase, clinicId),
+  ]);
+
+  const insurancePatients = (insurancePatientsRes.data ?? []) as { id: string; metadata: Record<string, unknown> | null }[];
   const insuranceCount = insurancePatients.filter((p) => p.metadata && (p.metadata as Record<string, unknown>).insurance).length;
 
-  // Fetch recent activity from the audit trail
-  const recentActivity = await getRecentActivity(supabase, clinicId);
-
   return {
-    totalPatients: patientCountRes.count ?? 0,
-    totalAppointments: appointmentCountRes.count ?? 0,
-    completedAppointments: completedCountRes.count ?? 0,
-    noShowCount: noShowCountRes.count ?? 0,
-    totalRevenue,
-    averageRating: avgRating,
-    doctorCount: doctorCountRes.count ?? 0,
+    ...base,
     insurancePatients: insuranceCount,
     recentActivity,
   };


### PR DESCRIPTION
## Audit Layer 1 Fixes

Addresses findings from the Fractional CTO Audit Report (Part 1 of 3, Layers 1-4).

### CRITICAL
- **MT-01**: Removed static `clinicConfig.locale` import from root layout (`src/app/layout.tsx`). The locale was being read from a build-time static config, meaning all tenants would share the same locale. Now defaults to `"fr"` with a TODO to extend tenant headers to carry per-clinic locale from the DB config JSONB column.

### HIGH
- **MT-02**: Replaced `clinicConfig` imports in two additional files:
  - `src/app/not-found.tsx` — removed `clinicConfig.locale` usage, defaults to `"fr"`
  - `src/app/(doctor)/layout.tsx` — replaced `clinicConfig.type` with `useTenant()` hook for runtime clinic type detection

### LOW
- **DRY-01**: Consolidated 7 nearly-identical error boundary files to delegate to the shared `ClinicErrorBoundary` component. Added `variant` prop ("page" vs "section") and optional `children` slot for custom actions. `(public)/error.tsx` retains its Home link via children.
- **DRY-02**: Extracted `fetchBaseDashboardStats()` helper from duplicated query logic in `src/lib/data/server.ts`. `getDashboardStats()` now reuses it. Removed unused `getClinicDashboardStats()` (had zero callers).

### Also verified
- **PKG-01**: `npm audit` returns **0 vulnerabilities**
- **TS checks**: `tsc --noEmit` passes cleanly
- **Lint**: ESLint passes on all changed files
- Pre-commit hooks (lint-staged + tsc + vitest) all pass

### Files changed (12)
- `src/app/layout.tsx`
- `src/app/not-found.tsx`
- `src/app/(doctor)/layout.tsx`
- `src/app/error.tsx`
- `src/app/(admin)/error.tsx`
- `src/app/(doctor)/error.tsx`
- `src/app/(patient)/error.tsx`
- `src/app/(public)/error.tsx`
- `src/app/(receptionist)/error.tsx`
- `src/app/(super-admin)/error.tsx`
- `src/components/error-boundaries/clinic-error-boundary.tsx`
- `src/lib/data/server.ts`