### PR TITLE
fix(SEED-01): Runtime guard blocking seed users from authenticating in production

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase-server";
 import { NextResponse } from "next/server";
+import { isSeedUserBlocked } from "@/lib/seed-guard";
 
 /**
  * Validate that a redirect path is a safe, same-origin relative path.
@@ -29,6 +30,12 @@ export async function GET(request: Request) {
       const {
         data: { user },
       } = await supabase.auth.getUser();
+
+      // SEED-01: Block seed users from completing auth callback in production
+      if (user && isSeedUserBlocked(user.id)) {
+        await supabase.auth.signOut();
+        return NextResponse.redirect(`${origin}/login?error=account_disabled`);
+      }
 
       if (user) {
         const { data: profile } = await supabase

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from "@/lib/logger";
 import { logAuthEvent } from "@/lib/audit-log";
 import { ROLE_DASHBOARD_MAP } from "@/lib/middleware/routes";
+import { isSeedUserBlocked } from "@/lib/seed-guard";
 
 /**
  * Phone auth feature flag.
@@ -104,6 +105,28 @@ export async function signInWithPassword(
       success: false,
     }).catch((err) => { logger.warn("Failed to log auth event", { context: "auth/signIn", error: err }); });
     return { error: error.message };
+  }
+
+  // SEED-01: Block seed users from authenticating in production.
+  // Even if the password matches, these accounts must not be usable
+  // in production because their credentials are in git history.
+  if (signInData?.user && isSeedUserBlocked(signInData.user.id)) {
+    logger.warn("Blocked seed user login attempt in production", {
+      context: "auth/signIn",
+      userId: signInData.user.id,
+      email: normalizedEmail,
+      ip: clientIp,
+    });
+    await supabase.auth.signOut();
+    logAuthEvent({
+      supabase,
+      action: "login.blocked_seed_user",
+      actor: normalizedEmail,
+      description: `Seed user login blocked in production from IP ${clientIp}`,
+      ipAddress: clientIp,
+      success: false,
+    }).catch((err) => { logger.warn("Failed to log auth event", { context: "auth/signIn", error: err }); });
+    return { error: "auth.invalidCredentials" };
   }
 
   // Check if user has MFA enabled and needs to complete 2FA

--- a/src/lib/seed-guard.ts
+++ b/src/lib/seed-guard.ts
@@ -1,0 +1,52 @@
+/**
+ * SEED-01: Runtime guard against seed user authentication in production.
+ *
+ * Migration 00019 created seed users with well-known passwords visible
+ * in git history. Migration 00039 deletes them, but if they are ever
+ * re-created (e.g. by re-running earlier migrations) this guard
+ * prevents them from authenticating in production environments.
+ *
+ * Defence-in-depth: the DB migration 00059 also adds a trigger that
+ * blocks sign-in for these IDs at the database level.
+ */
+
+/**
+ * The well-known seed user auth IDs created in migration 00019.
+ * These IDs follow the pattern `a0000000-0000-0000-0000-0000000000XX`.
+ */
+const SEED_USER_AUTH_IDS: ReadonlySet<string> = new Set([
+  "a0000000-0000-0000-0000-000000000001", // Super Admin
+  "a0000000-0000-0000-0000-000000000002", // Clinic Admin
+  "a0000000-0000-0000-0000-000000000003", // Doctor
+  "a0000000-0000-0000-0000-000000000004", // Receptionist
+  "a0000000-0000-0000-0000-000000000010", // Patient 1
+  "a0000000-0000-0000-0000-000000000011", // Patient 2
+  "a0000000-0000-0000-0000-000000000012", // Patient 3
+  "a0000000-0000-0000-0000-000000000013", // Patient 4
+  "a0000000-0000-0000-0000-000000000014", // Patient 5
+]);
+
+/**
+ * Returns true if the environment is considered production.
+ */
+function isProduction(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
+/**
+ * Check whether an auth user ID belongs to a seed user that must be
+ * blocked from authenticating in production.
+ *
+ * Returns `true` if the user should be blocked (seed user + production).
+ * Returns `false` in development/test or for non-seed users.
+ */
+export function isSeedUserBlocked(authId: string | null | undefined): boolean {
+  if (!authId) return false;
+  if (!isProduction()) return false;
+  return SEED_USER_AUTH_IDS.has(authId);
+}
+
+/**
+ * The set of seed user auth IDs (exported for use in tests / migrations).
+ */
+export { SEED_USER_AUTH_IDS };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,6 +14,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { extractSubdomain } from "@/lib/subdomain";
 import { TENANT_HEADERS } from "@/lib/tenant";
 import { DEMO_SUBDOMAIN, shouldBlockDemoRequest } from "@/lib/demo";
+import { isSeedUserBlocked } from "@/lib/seed-guard";
 import { generateTraceId, TRACE_ID_HEADER } from "@/lib/logger";
 import { subdomainCache, SUBDOMAIN_CACHE_TTL_MS } from "@/lib/subdomain-cache";
 import {
@@ -274,6 +275,13 @@ export async function middleware(request: NextRequest) {
   const {
     data: { user },
   } = await supabase.auth.getUser();
+
+  // SEED-01: Block seed users from accessing any route in production.
+  // Sign them out and redirect to login with an error.
+  if (user && isSeedUserBlocked(user.id)) {
+    await supabase.auth.signOut();
+    return secureRedirect(new URL("/login?error=account_disabled", request.url));
+  }
 
   // Single profile query for authenticated users, reused for both
   // login-redirect and role-enforcement (avoids duplicate DB calls).

--- a/supabase/migrations/00059_seed_user_login_guard.sql
+++ b/supabase/migrations/00059_seed_user_login_guard.sql
@@ -1,0 +1,58 @@
+-- ============================================================
+-- Migration 00059: SEED-01 — Runtime guard for seed user login
+--
+-- Adds a database-level trigger that prevents seed users
+-- (created in migration 00019 with well-known passwords) from
+-- authenticating in production environments.
+--
+-- Defence-in-depth: the application layer (auth.ts, middleware,
+-- auth callback) also blocks these users, but the DB trigger
+-- ensures coverage even if application checks are bypassed.
+--
+-- The trigger fires BEFORE UPDATE on auth.users and rejects
+-- any sign-in (which Supabase records as a last_sign_in_at
+-- update) for the well-known seed user IDs when the
+-- app.environment setting is 'production'.
+-- ============================================================
+
+-- List of seed user IDs from migration 00019
+CREATE OR REPLACE FUNCTION block_seed_user_login()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only enforce in production (set via app.environment config var)
+  IF current_setting('app.environment', true) = 'production' THEN
+    IF NEW.id IN (
+      'a0000000-0000-0000-0000-000000000001',
+      'a0000000-0000-0000-0000-000000000002',
+      'a0000000-0000-0000-0000-000000000003',
+      'a0000000-0000-0000-0000-000000000004',
+      'a0000000-0000-0000-0000-000000000010',
+      'a0000000-0000-0000-0000-000000000011',
+      'a0000000-0000-0000-0000-000000000012',
+      'a0000000-0000-0000-0000-000000000013',
+      'a0000000-0000-0000-0000-000000000014'
+    ) THEN
+      RAISE EXCEPTION 'SEED-01: Seed user login is blocked in production. '
+        'These accounts have well-known credentials in git history. '
+        'Delete them or rotate their passwords.'
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Fire on every update to auth.users (Supabase updates last_sign_in_at on login)
+DROP TRIGGER IF EXISTS trg_block_seed_user_login ON auth.users;
+CREATE TRIGGER trg_block_seed_user_login
+  BEFORE UPDATE ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION block_seed_user_login();
+
+-- Also prevent re-inserting deleted seed users
+DROP TRIGGER IF EXISTS trg_block_seed_user_insert ON auth.users;
+CREATE TRIGGER trg_block_seed_user_insert
+  BEFORE INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION block_seed_user_login();


### PR DESCRIPTION
## SEED-01: Runtime guard for seed user authentication

The only PARTIAL item from the security audit. Migration 00019 created seed users with well-known password `seed-password-change-me` visible in git history. Migration 00039 deletes them and 00057 added a comment, but there was **no runtime check** preventing login if they are re-created.

### Changes

**Application layer** (`src/lib/seed-guard.ts`):
- New module with seed user ID blocklist and `isSeedUserBlocked()` guard
- Returns `true` only in production (`NODE_ENV=production`) for known seed user IDs

**Auth flow** (`src/lib/auth.ts`):
- `signInWithPassword()` checks user ID post-auth, signs out + rejects if blocked
- Logs blocked attempt for security audit

**Auth callback** (`src/app/auth/callback/route.ts`):
- Blocks seed users from completing OAuth/magic-link flows

**Middleware** (`src/middleware.ts`):
- Catches any remaining seed user sessions and forces sign-out + redirect

**Database trigger** (`supabase/migrations/00059_seed_user_login_guard.sql`):
- `BEFORE UPDATE` trigger on `auth.users` blocks sign-in for seed IDs when `app.environment = production`
- `BEFORE INSERT` trigger prevents re-inserting deleted seed users in production

### Defence-in-depth
Four independent layers ensure seed users cannot authenticate in production, even if one layer is bypassed.