### PR TITLE
fix(RL-01, BACKUP-01): add explicit rate limiting for auth endpoints, add backup verify subcommand

### DIFF
--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -49,6 +49,62 @@ export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
 export AWS_DEFAULT_REGION="auto"
 
+# ---- Verify subcommand ----
+if [[ "${BACKUP_TYPE}" == "verify" ]]; then
+  log_info "Verifying latest backup..."
+
+  # Find the most recent daily backup; fall back to weekly
+  LATEST=$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/backups/daily/" \
+    --endpoint-url "${R2_ENDPOINT}" 2>/dev/null \
+    | sort -r | head -1 | awk '{print $4}')
+  PREFIX="daily"
+
+  if [[ -z "${LATEST}" ]]; then
+    log_warn "No daily backup found, checking weekly..."
+    LATEST=$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/backups/weekly/" \
+      --endpoint-url "${R2_ENDPOINT}" 2>/dev/null \
+      | sort -r | head -1 | awk '{print $4}')
+    PREFIX="weekly"
+  fi
+
+  if [[ -z "${LATEST}" ]]; then
+    log_error "No backups found in R2 bucket."
+    exit 1
+  fi
+
+  VERIFY_FILE="/tmp/verify_backup_${TIMESTAMP}.sql.gz"
+  log_info "Downloading: backups/${PREFIX}/${LATEST}"
+  aws s3 cp "s3://${R2_BACKUP_BUCKET}/backups/${PREFIX}/${LATEST}" \
+    "${VERIFY_FILE}" --endpoint-url "${R2_ENDPOINT}"
+
+  # Basic integrity checks
+  FILESIZE=$(stat -c%s "${VERIFY_FILE}" 2>/dev/null || stat -f%z "${VERIFY_FILE}" 2>/dev/null)
+  if [[ "${FILESIZE}" -lt 1024 ]]; then
+    log_error "Backup file is suspiciously small (${FILESIZE} bytes). Possibly corrupt."
+    rm -f "${VERIFY_FILE}"
+    exit 1
+  fi
+
+  # Verify gzip integrity
+  if ! gunzip -t "${VERIFY_FILE}" 2>/dev/null; then
+    log_error "Backup file failed gzip integrity check."
+    rm -f "${VERIFY_FILE}"
+    exit 1
+  fi
+
+  # Verify SQL content contains expected table references
+  TABLE_COUNT=$(gunzip -c "${VERIFY_FILE}" | grep -c "CREATE TABLE" || true)
+  if [[ "${TABLE_COUNT}" -lt 5 ]]; then
+    log_error "Backup contains only ${TABLE_COUNT} CREATE TABLE statements. Possibly incomplete."
+    rm -f "${VERIFY_FILE}"
+    exit 1
+  fi
+
+  rm -f "${VERIFY_FILE}"
+  log_info "Backup verification PASSED — ${LATEST} (${PREFIX}, ${TABLE_COUNT} tables, ${FILESIZE} bytes)"
+  exit 0
+fi
+
 # ---- Create backup ----
 log_info "Creating ${BACKUP_TYPE} backup: ${FILENAME}"
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -585,6 +585,16 @@ export interface RateLimitRule {
  * Ordered list of rate-limit rules. First matching prefix wins.
  */
 export const rateLimitRules: RateLimitRule[] = [
+  // RL-01: Auth endpoints — strict limits to prevent brute-force / credential stuffing.
+  // Auth is primarily handled by Supabase, but demo-login and any future
+  // auth routes under /api/auth/ get the loginLimiter (5 req / 60s).
+  { prefix: "/api/auth/", limiter: loginLimiter, windowMs: 60_000, max: 5 },
+  // RL-01: Public registration — same limits as onboarding to prevent abuse
+  { prefix: "/api/v1/register-clinic", limiter: onboardingLimiter, windowMs: 60_000, max: 5 },
+  // RL-01: Public check-in kiosk endpoints
+  { prefix: "/api/checkin", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
+  // RL-01: Password reset — strict limit to prevent email spam
+  { prefix: "/api/patient/delete-account", limiter: passwordResetLimiter, windowMs: 60_000, max: 3 },
   { prefix: "/api/booking/waiting-list", limiter: waitingListLimiter, windowMs: 60 * 60_000, max: 3 },
   { prefix: "/api/book", limiter: bookingLimiter, windowMs: 60_000, max: 10 },
   { prefix: "/api/verify-email", limiter: emailVerificationLimiter, windowMs: 60_000, max: 5 },


### PR DESCRIPTION
## Security Audit Fixes

### RL-01: Rate Limiting on Auth Endpoints
Added explicit rate limiting rules to `rateLimitRules` array for:
- `/api/auth/` — loginLimiter (5 req/60s) for brute-force protection
- `/api/v1/register-clinic` — onboardingLimiter (5 req/60s) for public registration abuse prevention
- `/api/checkin` — apiMutationLimiter (30 req/60s) for public kiosk endpoints
- `/api/patient/delete-account` — passwordResetLimiter (3 req/60s) for sensitive operations

### BACKUP-01: Backup Verify Subcommand
Implemented the `verify` subcommand in `scripts/backup-database.sh` that:
- Downloads latest backup from R2 (daily, fallback to weekly)
- Validates file size (>1KB)
- Verifies gzip integrity
- Checks SQL content contains >=5 CREATE TABLE statements

### VAL-01: Zod Validation Audit (Verified)
Audited all POST/PUT/PATCH endpoints — all use `withValidation`, `withAuthValidation`, or manual Zod `safeParse`.

### MT-02: clinicConfig (Already Fixed in PR #358)
Only 1 legitimate import remains in `src/lib/tenant.ts`.