### PR TITLE
fix(TS-01, TS-02, ENV-01, PKG-01, RLS-05): replace unsafe casts, document env vars, strip x-clinic-id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,11 @@ SMTP_PORT=587
 SMTP_USER=
 SMTP_PASS=
 EMAIL_FROM=noreply@yourdomain.com
+# Alternative relay transport (used when SMTP_* is not set)
+EMAIL_RELAY_HOST=
+EMAIL_RELAY_PORT=587
+EMAIL_RELAY_USER=
+EMAIL_RELAY_PASS=
 
 # ---- Google Calendar Sync [Optional] ----
 GOOGLE_CALENDAR_CLIENT_ID=
@@ -127,6 +132,8 @@ SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
 
 # ---- Platform Analytics [Optional] ----
+# Google Analytics Measurement ID (e.g., G-XXXXXXXXXX)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
 # Plausible domain for root-domain (SaaS landing) analytics.
 # Leave empty to disable. Example: oltigo.com
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=
@@ -138,9 +145,39 @@ NEXT_PUBLIC_PLAUSIBLE_DOMAIN=
 # Leave empty to deny all cross-origin requests.
 ALLOWED_API_ORIGINS=
 
+# ---- Data Masking [Optional] ----
+# Controls masking of sensitive patient data (phone, email, CIN) in the UI.
+# "full" — aggressive masking for demos / public screens
+# "partial" — moderate masking for staff who need partial visibility
+# "none" — no masking (authorized personnel, default)
+NEXT_PUBLIC_DATA_MASKING=none
+
+# ---- Performance Monitoring [Optional] ----
+NEXT_PUBLIC_ENABLE_PERF_MONITORING=false
+
+# ---- Push Notifications [Optional] ----
+# VAPID public key for Web Push (generate with: npx web-push generate-vapid-keys)
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+
+# ---- Sentry CSP Reporting [Optional] ----
+# Endpoint for Content-Security-Policy violation reports
+SENTRY_CSP_REPORT_URI=
+
+# ---- Seed User Cleanup [Optional] ----
+# Set to "true" after all seed users have been deleted in production.
+SEED_USERS_DELETED=false
+
+# ---- Staff Default Password [Optional] ----
+# Default password assigned to newly created staff accounts.
+# Change in production. Generate with: openssl rand -base64 16
+STAFF_DEFAULT_PASSWORD=
+
 # ---- Rate Limiting [Optional] ----
 # Backend: "supabase" (distributed, default when credentials present) or "memory" (local)
 RATE_LIMIT_BACKEND=
 
-# ---- Database Backup [Optional] ----
+# ---- Database [Optional] ----
+# Direct database connection URL (used by backup scripts)
 SUPABASE_DB_URL=postgresql://postgres:password@db.xxx.supabase.co:5432/postgres
+# Alternative direct DATABASE_URL (used by some scripts)
+DATABASE_URL=

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,6 +1,6 @@
 import { PublicHeader } from "@/components/public/header";
 import { PublicFooter } from "@/components/public/footer";
-import { getPublicBranding } from "@/lib/data/public";
+import { getPublicBranding, type ClinicBranding } from "@/lib/data/public";
 import { getTenant } from "@/lib/tenant";
 import { AnalyticsScript } from "@/components/analytics-script";
 import { CookieConsent } from "@/components/cookie-consent";
@@ -24,9 +24,9 @@ export default async function PublicLayout({
   const branding = await getPublicBranding();
 
   // Analytics IDs from branding config (stored in clinic's JSONB config)
-  const brandingRecord = branding as unknown as Record<string, unknown>;
-  const gaId = (brandingRecord.gaId as string | undefined) ?? null;
-  const gtmId = (brandingRecord.gtmId as string | undefined) ?? null;
+  const brandingConfig = branding as ClinicBranding & { gaId?: string; gtmId?: string };
+  const gaId = brandingConfig.gaId ?? null;
+  const gtmId = brandingConfig.gtmId ?? null;
 
   const isDemo = tenant.subdomain === "demo";
 

--- a/src/components/doctor/prescription-writer.tsx
+++ b/src/components/doctor/prescription-writer.tsx
@@ -11,6 +11,7 @@ import {
   getCurrentUser,
   fetchPatients,
   type PatientView,
+  type ClinicUser,
 } from "@/lib/data/client";
 import { downloadPrescriptionPDF } from "@/lib/prescription-pdf";
 import { PageLoader } from "@/components/ui/page-loader";
@@ -82,13 +83,12 @@ export function PrescriptionWriter() {
 
       // Extract doctor info from the current user
       setDoctorName(user.name ?? "");
-      const userRecord = user as unknown as Record<string, unknown>;
-      setDoctorNameAr((userRecord.name_ar as string) ?? "");
-      const meta = userRecord.metadata as Record<string, unknown> | undefined;
-      if (meta?.inpe_number) {
-        setDoctorINPE(meta.inpe_number as string);
+      const userRecord = user as ClinicUser & { name_ar?: string; metadata?: { inpe_number?: string }; clinic_name?: string };
+      setDoctorNameAr(userRecord.name_ar ?? "");
+      if (userRecord.metadata?.inpe_number) {
+        setDoctorINPE(userRecord.metadata.inpe_number);
       }
-      setClinicName((userRecord.clinic_name as string) ?? "");
+      setClinicName(userRecord.clinic_name ?? "");
 
       const pts = await fetchPatients(user.clinic_id);
       if (controller.signal.aborted) return;

--- a/src/lib/chatbot-data.ts
+++ b/src/lib/chatbot-data.ts
@@ -6,6 +6,14 @@
 
 import { createClient } from "@/lib/supabase-server";
 
+/** Shape of the `clinics.config` JSONB column (subset used by chatbot). */
+interface ClinicConfigJson {
+  address?: string;
+  city?: string;
+  phone?: string;
+  email?: string;
+}
+
 export interface ChatbotClinicContext {
   clinic: {
     id: string;
@@ -85,11 +93,11 @@ export async function fetchChatbotContext(clinicId: string): Promise<ChatbotClin
           name: clinicData.name as string,
           type: clinicData.type as string,
           tier: clinicData.tier as string,
-          address: (clinicData.config as Record<string, unknown> | null)?.address as string | undefined,
-          city: clinicData.city as string | undefined,
-          phone: clinicData.owner_phone as string | undefined,
-          email: clinicData.owner_email as string | undefined,
-          domain: clinicData.domain as string | undefined,
+          address: (clinicData.config as ClinicConfigJson | null)?.address ?? undefined,
+          city: clinicData.city ?? undefined,
+          phone: clinicData.owner_phone ?? undefined,
+          email: clinicData.owner_email ?? undefined,
+          domain: clinicData.domain ?? undefined,
           config: (clinicData.config as Record<string, unknown>) ?? {},
         }
       : null,

--- a/src/lib/hooks/use-patient-search.ts
+++ b/src/lib/hooks/use-patient-search.ts
@@ -56,7 +56,8 @@ export function usePatientSearch(
         }
 
         const results: CommandPaletteItem[] = (data ?? []).map((p) => {
-          const cin = (p.metadata as Record<string, unknown>)?.cin as string | undefined;
+          const meta = (p.metadata ?? {}) as { cin?: string };
+          const cin = meta.cin;
           return {
             id: p.id,
             label: p.name,

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -630,17 +630,17 @@ export async function fetchAnnouncements(): Promise<Announcement[]> {
 
   if (error || !data) return [];
 
-  return (data as Record<string, unknown>[]).map((row) => ({
-    id: row.id as string,
-    title: (row.title as string) ?? "",
-    message: (row.message as string) ?? "",
-    type: ((row.type as string) ?? "info") as Announcement["type"],
-    target: (row.target as string) ?? "all",
-    targetLabel: (row.target_label as string) ?? "All Clinics",
-    publishedAt: ((row.published_at ?? row.created_at) as string)?.split("T")[0] ?? "",
-    expiresAt: row.expires_at ? (row.expires_at as string).split("T")[0] : undefined,
-    active: (row.active as boolean) ?? true,
-    createdBy: (row.created_by as string) ?? "System",
+  return data.map((row) => ({
+    id: row.id,
+    title: row.title ?? "",
+    message: row.message ?? "",
+    type: (row.type ?? "info") as Announcement["type"],
+    target: row.target ?? "all",
+    targetLabel: row.target_label ?? "All Clinics",
+    publishedAt: (row.published_at ?? row.created_at ?? "").split("T")[0] ?? "",
+    expiresAt: row.expires_at ? row.expires_at.split("T")[0] : undefined,
+    active: row.is_active ?? true,
+    createdBy: row.created_by ?? "System",
   }));
 }
 
@@ -667,15 +667,15 @@ export async function fetchActivityLogs(): Promise<ActivityLog[]> {
 
   if (error || !data) return [];
 
-  return (data as Record<string, unknown>[]).map((row) => ({
-    id: row.id as string,
-    action: (row.action as string) ?? "",
-    description: (row.description as string) ?? "",
-    clinicId: row.clinic_id as string | undefined,
-    clinicName: row.clinic_name as string | undefined,
-    timestamp: (row.created_at as string) ?? "",
-    actor: (row.actor as string) ?? "System",
-    type: ((row.type as string) ?? "clinic") as ActivityLog["type"],
+  return data.map((row) => ({
+    id: row.id,
+    action: row.action ?? "",
+    description: row.description ?? "",
+    clinicId: row.clinic_id ?? undefined,
+    clinicName: row.clinic_name ?? undefined,
+    timestamp: row.created_at ?? "",
+    actor: row.actor ?? "System",
+    type: (row.type ?? "clinic") as ActivityLog["type"],
   }));
 }
 
@@ -700,14 +700,14 @@ export async function fetchFeatureDefinitions(): Promise<FeatureDefinition[]> {
 
   if (error || !data) return [];
 
-  return (data as Record<string, unknown>[]).map((row) => ({
-    id: row.id as string,
-    name: (row.name as string) ?? "",
-    description: (row.description as string) ?? "",
-    key: (row.key as string) ?? "",
-    category: ((row.category as string) ?? "core") as FeatureDefinition["category"],
-    availableTiers: (row.available_tiers as string[]) ?? [],
-    globalEnabled: (row.global_enabled as boolean) ?? true,
+  return data.map((row) => ({
+    id: row.id,
+    name: row.name ?? "",
+    description: row.description ?? "",
+    key: row.key ?? "",
+    category: (row.category ?? "core") as FeatureDefinition["category"],
+    availableTiers: row.available_tiers ?? [],
+    globalEnabled: row.global_enabled ?? true,
   }));
 }
 
@@ -741,12 +741,12 @@ export async function fetchPricingTiers(): Promise<PricingTierRow[]> {
 
   if (error || !data) return [];
 
-  return (data as Record<string, unknown>[]).map((row) => ({
-    id: row.id as string,
-    slug: (row.slug as string) ?? "",
-    name: (row.name as string) ?? "",
-    description: (row.description as string) ?? "",
-    popular: (row.popular as boolean) ?? false,
+  return data.map((row) => ({
+    id: row.id,
+    slug: row.slug ?? "",
+    name: row.name ?? "",
+    description: row.description ?? "",
+    popular: row.is_popular ?? false,
     pricing: (row.pricing as Record<string, { monthly: number; yearly: number }>) ?? {},
     features: (row.features as { key: string; label: string; included: boolean; limit?: string }[]) ?? [],
     limits: (row.limits as PricingTierRow["limits"]) ?? {
@@ -778,15 +778,15 @@ export async function fetchFeatureToggles(): Promise<FeatureToggleRow[]> {
 
   if (error || !data) return [];
 
-  return (data as Record<string, unknown>[]).map((row) => ({
-    id: row.id as string,
-    key: (row.key as string) ?? "",
-    label: (row.label as string) ?? "",
-    description: (row.description as string) ?? "",
-    category: ((row.category as string) ?? "core") as FeatureToggleRow["category"],
-    systemTypes: (row.system_types as string[]) ?? [],
-    tiers: (row.tiers as string[]) ?? [],
-    enabled: (row.enabled as boolean) ?? true,
+  return data.map((row) => ({
+    id: row.id,
+    key: row.key ?? "",
+    label: row.label ?? "",
+    description: row.description ?? "",
+    category: (row.category ?? "core") as FeatureToggleRow["category"],
+    systemTypes: row.system_types ?? [],
+    tiers: row.tiers ?? [],
+    enabled: row.enabled ?? true,
   }));
 }
 

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -112,23 +112,37 @@ export async function getClinicConfig(clinicId: string): Promise<TenantClinicCon
     .eq("id", clinicId)
     .single();
 
-  const dbConfig = (data?.config ?? {}) as Record<string, unknown>;
+  /** Shape of the `clinics.config` JSONB column for tenant settings. */
+  interface ClinicDbConfig {
+    timezone?: string;
+    currency?: string;
+    workingHours?: TenantClinicConfig["workingHours"];
+    slotDuration?: number;
+    bufferTime?: number;
+    maxAdvanceDays?: number;
+    maxPerSlot?: number;
+    cancellationHours?: number;
+    depositAmount?: number;
+    depositPercentage?: number;
+    maxRecurringWeeks?: number;
+  }
+
+  const dbConfig = (data?.config ?? {}) as ClinicDbConfig;
 
   // Merge DB config with static defaults (DB takes precedence)
   return {
-    timezone: (dbConfig.timezone as string) ?? clinicConfig.timezone ?? DEFAULT_TIMEZONE,
-    currency: (dbConfig.currency as string) ?? clinicConfig.currency ?? "MAD",
-    workingHours: (dbConfig.workingHours as TenantClinicConfig["workingHours"])
-      ?? clinicConfig.workingHours,
+    timezone: dbConfig.timezone ?? clinicConfig.timezone ?? DEFAULT_TIMEZONE,
+    currency: dbConfig.currency ?? clinicConfig.currency ?? "MAD",
+    workingHours: dbConfig.workingHours ?? clinicConfig.workingHours,
     booking: {
-      slotDuration: (dbConfig.slotDuration as number) ?? clinicConfig.booking.slotDuration,
-      bufferTime: (dbConfig.bufferTime as number) ?? clinicConfig.booking.bufferTime,
-      maxAdvanceDays: (dbConfig.maxAdvanceDays as number) ?? clinicConfig.booking.maxAdvanceDays,
-      maxPerSlot: (dbConfig.maxPerSlot as number) ?? clinicConfig.booking.maxPerSlot,
-      cancellationHours: (dbConfig.cancellationHours as number) ?? clinicConfig.booking.cancellationHours,
-      depositAmount: (dbConfig.depositAmount as number) ?? clinicConfig.booking.depositAmount,
-      depositPercentage: (dbConfig.depositPercentage as number) ?? clinicConfig.booking.depositPercentage,
-      maxRecurringWeeks: (dbConfig.maxRecurringWeeks as number) ?? clinicConfig.booking.maxRecurringWeeks,
+      slotDuration: dbConfig.slotDuration ?? clinicConfig.booking.slotDuration,
+      bufferTime: dbConfig.bufferTime ?? clinicConfig.booking.bufferTime,
+      maxAdvanceDays: dbConfig.maxAdvanceDays ?? clinicConfig.booking.maxAdvanceDays,
+      maxPerSlot: dbConfig.maxPerSlot ?? clinicConfig.booking.maxPerSlot,
+      cancellationHours: dbConfig.cancellationHours ?? clinicConfig.booking.cancellationHours,
+      depositAmount: dbConfig.depositAmount ?? clinicConfig.booking.depositAmount,
+      depositPercentage: dbConfig.depositPercentage ?? clinicConfig.booking.depositPercentage,
+      maxRecurringWeeks: dbConfig.maxRecurringWeeks ?? clinicConfig.booking.maxRecurringWeeks,
     },
   };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -112,6 +112,10 @@ export async function middleware(request: NextRequest) {
   for (const key of Object.values(TENANT_HEADERS)) {
     requestHeaders.delete(key);
   }
+  // RLS-05: Also strip the legacy x-clinic-id header used by tenant-scoped
+  // Supabase clients (createTenantClient). An attacker could inject this
+  // header to bypass RLS policies that read `request.headers->>'x-clinic-id'`.
+  requestHeaders.delete("x-clinic-id");
 
   // --- Subdomain resolution ---
   const subdomain = extractSubdomain(hostname, rootDomain);


### PR DESCRIPTION
## Summary

Fixes 5 security/code quality findings:

### TS-01 / TS-02: Remove unsafe `as Record<string, unknown>` casts
- **super-admin-actions.ts**: Let Supabase infer types from `.select()` calls for announcements, activity logs, feature definitions, pricing tiers, and feature toggles (5 functions fixed)
- **chatbot-data.ts**: Add `ClinicConfigJson` interface for JSONB config field
- **use-patient-search.ts**: Narrow metadata to `{ cin?: string }` instead of `Record<string, unknown>`
- **prescription-writer.tsx**: Use intersection type with `ClinicUser` instead of double-cast through `unknown`
- **layout.tsx**: Use intersection type with `ClinicBranding` for analytics IDs
- **tenant.ts**: Define `ClinicDbConfig` interface for all config JSONB fields

### ENV-01: Document all env vars
- Added 9 missing env vars to `.env.example`: `EMAIL_RELAY_*`, `NEXT_PUBLIC_DATA_MASKING`, `NEXT_PUBLIC_GA_MEASUREMENT_ID`, `NEXT_PUBLIC_ENABLE_PERF_MONITORING`, `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `SENTRY_CSP_REPORT_URI`, `SEED_USERS_DELETED`, `STAFF_DEFAULT_PASSWORD`, `DATABASE_URL`

### PKG-01: npm audit
- `npm audit` — **0 vulnerabilities** found

### RLS-05: Strip x-clinic-id header in middleware
- Added explicit `requestHeaders.delete("x-clinic-id")` after `TENANT_HEADERS` stripping to prevent attackers from injecting the legacy header used by `createTenantClient` to bypass RLS policies

## Validation
- ✅ `npm run typecheck` passes
- ✅ `npm run lint` passes (0 errors)
- ✅ `npm run test` — 43/43 tests pass
- ✅ Pre-commit hooks (lint-staged + vitest) pass

[Devin session](https://app.devin.ai/sessions/f1e2a2b98c5f44b29edbb7884c36b0fa)