### PR TITLE
audit: fix remaining Layers 5-8 items (SEO, performance)

### DIFF
--- a/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
@@ -14,6 +14,7 @@ import {
   TOP_CITY_SPECIALTY_COMBOS,
 } from "@/lib/directory-constants";
 import { getDirectoryDoctorsByCityAndSpecialty } from "@/lib/data/directory";
+import { HreflangTags } from "@/components/hreflang-tags";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
 const ROOT_DOMAIN = process.env.ROOT_DOMAIN ?? "oltigo.com";
@@ -60,11 +61,20 @@ export default async function CitySpecialtyPage({ params }: CitySpecialtyPagePro
 
   const doctors = await getDirectoryDoctorsByCityAndSpecialty(citySlug, specialtySlug);
 
+  // Audit 7.7 — Use CollectionPage instead of MedicalBusiness for the
+  // directory listing page. MedicalBusiness describes a single clinic;
+  // CollectionPage correctly describes a directory/index of items.
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "MedicalBusiness",
+    "@type": "CollectionPage",
     name: `${specialty.nameFr} à ${city.name}`,
     url: `${BASE_URL}/annuaire/${city.slug}/${specialty.slug}`,
+    description: `${specialty.nameFr} à ${city.name}, Maroc — annuaire médical Oltigo`,
+    isPartOf: {
+      "@type": "WebSite",
+      name: "Oltigo",
+      url: BASE_URL,
+    },
     medicalSpecialty: specialty.name,
     areaServed: {
       "@type": "City",
@@ -103,6 +113,8 @@ export default async function CitySpecialtyPage({ params }: CitySpecialtyPagePro
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
       />
+      {/* Audit 7.6 — hreflang tags for multilingual SEO */}
+      <HreflangTags path={`/annuaire/${city.slug}/${specialty.slug}`} />
 
       {/* Breadcrumb */}
       <nav className="text-sm text-muted-foreground mb-6">

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect } from "react";
 /**
- * Audit 5.2 — recharts is imported dynamically via next/dynamic on the
- * AnalyticsDashboard export (see bottom of file). This keeps the ~200 KB
- * recharts bundle out of the initial page load.
+ * Audit 5.2 — recharts is code-split because the pages that consume this
+ * component (admin/reports/page.tsx and doctor/analytics/page.tsx) load it
+ * via next/dynamic. This keeps the ~200 KB recharts + D3 bundle out of
+ * the initial page load — it is only fetched when the user navigates to
+ * the analytics/reports route.
  */
 import {
   BarChart, Bar, LineChart, Line, PieChart, Pie, Cell,


### PR DESCRIPTION
## Audit Checklist — Remaining Layers 5-8 Fixes

This PR addresses the remaining open items from the Layers 5-8 audit that were not covered in PR #366.

### Changes

**[7-LOW] HreflangTags on annuaire directory pages**
- Added `<HreflangTags>` component to `/annuaire/[city]/[specialty]` pages with fr and ar alternates for multilingual SEO

**[7-LOW] JSON-LD CollectionPage type**
- Changed `@type` from `MedicalBusiness` to `CollectionPage` in annuaire city+specialty pages
- `MedicalBusiness` describes a single clinic; `CollectionPage` correctly describes a directory/index of items
- Added `description` and `isPartOf` properties for richer structured data

**[5-HIGH] Recharts dynamic import comment**
- Fixed misleading comment in `analytics-dashboard.tsx` that said "see bottom of file" for dynamic import
- The actual code-splitting happens in the page files (`admin/reports/page.tsx` and `doctor/analytics/page.tsx`) via `next/dynamic`

**[5-LOW] VirtualList audit**
- Audited dashboard list views (patient appointment list, admin activity log, receptionist views)
- Current lists either use variable-height Card components (incompatible with fixed-height VirtualList) or have server-limited data
- No immediate VirtualList adoption needed; component is ready for future use when lists grow

### Already Fixed in PR #366 (20 items)
All HIGH/CRITICAL items and most MEDIUM items were already resolved in PR #366, including: KV namespace separation, r2-sync credential handling, staging subdomain reservation, email verification sending, sitemap admin client, canonical URL standardization, lang attribute i18n, CSP hardening, CSRF documentation, account lockout documentation, wrangler rollback, backup encryption, cron interval, health check CI, and more.