### PR TITLE
feat: Task 4 — Template Presets + One-Click Apply

### DIFF
--- a/src/app/(admin)/admin/templates/page.tsx
+++ b/src/app/(admin)/admin/templates/page.tsx
@@ -1,7 +1,21 @@
 "use client";
 
+import {
+  AlertCircle,
+  Check,
+  Eye,
+  Layout,
+  Loader2,
+  Palette,
+  Save,
+  Sparkles,
+  Wand2,
+  X,
+} from "lucide-react";
 import { useState } from "react";
-import { AlertCircle, Check, Layout, Loader2, Save } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -9,11 +23,27 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { templateList, type TemplateId } from "@/lib/templates";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import type { VerticalId } from "@/lib/config/verticals";
 import { useAsyncData } from "@/lib/hooks/use-async-data";
-import { Breadcrumb } from "@/components/ui/breadcrumb";
+import {
+  presetList,
+  type TemplatePreset,
+} from "@/lib/template-presets";
+import { templateList, type TemplateId } from "@/lib/templates";
+
+const VERTICAL_LABELS: Record<VerticalId, string> = {
+  healthcare: "Healthcare",
+  beauty: "Beauty & Wellness",
+  restaurant: "Restaurant",
+  fitness: "Fitness",
+  veterinary: "Veterinary",
+};
+
+const VERTICAL_FILTERS: { value: string; label: string }[] = [
+  { value: "all", label: "All Presets" },
+  ...Object.entries(VERTICAL_LABELS).map(([value, label]) => ({ value, label })),
+];
 
 export default function TemplatesPage() {
   const { data: initialTemplate, loading, error } = useAsyncData(
@@ -30,6 +60,12 @@ export default function TemplatesPage() {
   const [saved, setSaved] = useState<TemplateId>("modern");
   const [initialized, setInitialized] = useState(false);
   const [saving, setSaving] = useState(false);
+
+  // Preset state
+  const [verticalFilter, setVerticalFilter] = useState("all");
+  const [applyingPreset, setApplyingPreset] = useState<string | null>(null);
+  const [appliedPreset, setAppliedPreset] = useState<string | null>(null);
+  const [previewPreset, setPreviewPreset] = useState<TemplatePreset | null>(null);
 
   // Sync initial data once loaded
   if (!initialized && !loading && !error) {
@@ -52,7 +88,36 @@ export default function TemplatesPage() {
     }
   };
 
+  const handleApplyPreset = async (preset: TemplatePreset) => {
+    setApplyingPreset(preset.id);
+    try {
+      const res = await fetch("/api/branding/apply-preset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ presetId: preset.id }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        alert(err?.error ?? "Failed to apply preset");
+        return;
+      }
+
+      setAppliedPreset(preset.id);
+      setSelected(preset.templateId);
+      setSaved(preset.templateId);
+      setTimeout(() => setAppliedPreset(null), 3000);
+    } finally {
+      setApplyingPreset(null);
+    }
+  };
+
   const hasChanges = selected !== saved;
+
+  const filteredPresets =
+    verticalFilter === "all"
+      ? presetList
+      : presetList.filter((p) => p.vertical === verticalFilter);
 
   if (loading) {
     return (
@@ -85,106 +150,377 @@ export default function TemplatesPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
+          <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Templates" }]} />
           <h1 className="text-2xl font-bold">Layout Templates</h1>
           <p className="text-sm text-muted-foreground">
-            Choose a homepage layout for your clinic website. The template
-            controls the visual style — your content stays the same.
+            Choose a preset for instant setup, or pick a base template and
+            customize in the branding editor.
           </p>
         </div>
-        <Button onClick={handleSave} disabled={saving || !hasChanges}>
-          <Save className="h-4 w-4 mr-2" />
-          {saving ? "Saving..." : hasChanges ? "Save Template" : "Saved"}
-        </Button>
       </div>
 
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {templateList.map((tmpl) => {
-          const isSelected = selected === tmpl.id;
-          return (
-            <Card
-              key={tmpl.id}
-              className={`cursor-pointer transition-all hover:shadow-md ${
-                isSelected
-                  ? "ring-2 ring-primary shadow-md"
-                  : "hover:ring-1 hover:ring-border"
-              }`}
-              onClick={() => setSelected(tmpl.id)}
-            >
-              <CardHeader className="pb-3">
-                <div className="flex items-center justify-between">
-                  <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Templates" }]} />
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <Layout className="h-4 w-4" />
-                    {tmpl.name}
-                  </CardTitle>
-                  {isSelected && (
-                    <Badge variant="default" className="gap-1">
-                      <Check className="h-3 w-3" />
-                      Selected
-                    </Badge>
-                  )}
-                </div>
-                <CardDescription>{tmpl.description}</CardDescription>
-              </CardHeader>
-              <CardContent>
-                {/* Template preview card */}
-                <div
-                  className={`rounded-lg border p-4 text-xs space-y-2 ${tmpl.wrapperClass}`}
-                >
-                  {/* Mini hero preview */}
-                  <div
-                    className={`h-12 rounded flex items-center justify-center text-[10px] font-medium ${
-                      tmpl.bgMode === "dark"
-                        ? "bg-white/10 text-white/80"
-                        : "bg-primary/10 text-primary"
-                    }`}
+      <Tabs defaultValue="presets">
+        <TabsList className="mb-6">
+          <TabsTrigger value="presets">
+            <Sparkles className="h-4 w-4 mr-2" />
+            Presets
+          </TabsTrigger>
+          <TabsTrigger value="templates">
+            <Layout className="h-4 w-4 mr-2" />
+            Base Templates
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Presets Tab */}
+        <TabsContent value="presets">
+          {/* Vertical filter */}
+          <div className="flex flex-wrap gap-2 mb-6">
+            {VERTICAL_FILTERS.map((f) => (
+              <Button
+                key={f.value}
+                variant={verticalFilter === f.value ? "default" : "outline"}
+                size="sm"
+                onClick={() => setVerticalFilter(f.value)}
+              >
+                {f.label}
+              </Button>
+            ))}
+          </div>
+
+          {filteredPresets.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No presets available for this vertical.
+            </p>
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {filteredPresets.map((preset) => {
+                const isApplying = applyingPreset === preset.id;
+                const justApplied = appliedPreset === preset.id;
+                return (
+                  <Card
+                    key={preset.id}
+                    className="relative transition-all hover:shadow-md"
                   >
-                    Hero — {tmpl.heroStyle}
-                  </div>
-                  {/* Mini cards preview */}
-                  <div className="grid grid-cols-3 gap-1">
-                    {[1, 2, 3].map((i) => (
+                    <CardHeader className="pb-3">
+                      <div className="flex items-center justify-between">
+                        <CardTitle className="text-base flex items-center gap-2">
+                          <Wand2 className="h-4 w-4" />
+                          {preset.name}
+                        </CardTitle>
+                        <Badge variant="secondary" className="text-xs">
+                          {VERTICAL_LABELS[preset.vertical]}
+                        </Badge>
+                      </div>
+                      <CardDescription>{preset.description}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      {/* Color preview */}
+                      <div className="rounded-lg border p-3 mb-3 space-y-2">
+                        <div className="flex gap-2 items-center">
+                          <div
+                            className="h-6 w-6 rounded-full border"
+                            style={{ backgroundColor: preset.theme.primaryColor }}
+                          />
+                          <div
+                            className="h-6 w-6 rounded-full border"
+                            style={{ backgroundColor: preset.theme.secondaryColor }}
+                          />
+                          <div
+                            className="h-6 w-6 rounded-full border"
+                            style={{ backgroundColor: preset.theme.accentColor }}
+                          />
+                          <span className="text-xs text-muted-foreground ml-auto">
+                            {preset.templateId}
+                          </span>
+                        </div>
+                      </div>
+
+                      <p className="text-xs text-muted-foreground mb-3">
+                        {preset.preview}
+                      </p>
+
+                      {/* Action buttons */}
+                      <div className="flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="flex-1"
+                          onClick={() => setPreviewPreset(preset)}
+                        >
+                          <Eye className="h-3.5 w-3.5 mr-1" />
+                          Preview
+                        </Button>
+                        <Button
+                          size="sm"
+                          className="flex-1"
+                          disabled={isApplying}
+                          onClick={() => handleApplyPreset(preset)}
+                        >
+                          {justApplied ? (
+                            <>
+                              <Check className="h-3.5 w-3.5 mr-1" />
+                              Applied!
+                            </>
+                          ) : isApplying ? (
+                            <>
+                              <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                              Applying...
+                            </>
+                          ) : (
+                            <>
+                              <Wand2 className="h-3.5 w-3.5 mr-1" />
+                              Apply
+                            </>
+                          )}
+                        </Button>
+                      </div>
+
+                      {justApplied && (
+                        <p className="text-xs text-center text-green-600 mt-2">
+                          Preset applied! Your site is updated.
+                        </p>
+                      )}
+                    </CardContent>
+                  </Card>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Customize CTA */}
+          <div className="mt-6 rounded-lg border-2 border-dashed p-4 text-center">
+            <p className="text-sm text-muted-foreground mb-2">
+              Want more control? Fine-tune colors, fonts, and images in the
+              branding editor.
+            </p>
+            <a href="/admin/branding">
+              <Button variant="outline">
+                <Palette className="h-4 w-4 mr-2" />
+                Open Branding Editor
+              </Button>
+            </a>
+          </div>
+        </TabsContent>
+
+        {/* Base Templates Tab */}
+        <TabsContent value="templates">
+          <div className="flex justify-end mb-4">
+            <Button onClick={handleSave} disabled={saving || !hasChanges}>
+              <Save className="h-4 w-4 mr-2" />
+              {saving ? "Saving..." : hasChanges ? "Save Template" : "Saved"}
+            </Button>
+          </div>
+
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {templateList.map((tmpl) => {
+              const isSelected = selected === tmpl.id;
+              return (
+                <Card
+                  key={tmpl.id}
+                  className={`cursor-pointer transition-all hover:shadow-md ${
+                    isSelected
+                      ? "ring-2 ring-primary shadow-md"
+                      : "hover:ring-1 hover:ring-border"
+                  }`}
+                  onClick={() => setSelected(tmpl.id)}
+                >
+                  <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <CardTitle className="text-base flex items-center gap-2">
+                        <Layout className="h-4 w-4" />
+                        {tmpl.name}
+                      </CardTitle>
+                      {isSelected && (
+                        <Badge variant="default" className="gap-1">
+                          <Check className="h-3 w-3" />
+                          Selected
+                        </Badge>
+                      )}
+                    </div>
+                    <CardDescription>{tmpl.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    {/* Template preview card */}
+                    <div
+                      className={`rounded-lg border p-4 text-xs space-y-2 ${tmpl.wrapperClass}`}
+                    >
+                      {/* Mini hero preview */}
                       <div
-                        key={i}
-                        className={`h-8 rounded flex items-center justify-center text-[9px] ${
-                          tmpl.cardStyle === "shadow"
-                            ? "shadow-sm bg-white dark:bg-gray-800"
-                            : tmpl.cardStyle === "bordered"
-                              ? "border bg-transparent"
-                              : tmpl.cardStyle === "elevated"
-                                ? "shadow-md bg-white dark:bg-gray-800"
-                                : tmpl.bgMode === "dark"
-                                  ? "bg-white/5"
-                                  : "bg-gray-100"
+                        className={`h-12 rounded flex items-center justify-center text-[10px] font-medium ${
+                          tmpl.bgMode === "dark"
+                            ? "bg-white/10 text-white/80"
+                            : "bg-primary/10 text-primary"
                         }`}
                       >
-                        Card {i}
+                        Hero — {tmpl.heroStyle}
                       </div>
-                    ))}
+                      {/* Mini cards preview */}
+                      <div className="grid grid-cols-3 gap-1">
+                        {[1, 2, 3].map((i) => (
+                          <div
+                            key={i}
+                            className={`h-8 rounded flex items-center justify-center text-[9px] ${
+                              tmpl.cardStyle === "shadow"
+                                ? "shadow-sm bg-white dark:bg-gray-800"
+                                : tmpl.cardStyle === "bordered"
+                                  ? "border bg-transparent"
+                                  : tmpl.cardStyle === "elevated"
+                                    ? "shadow-md bg-white dark:bg-gray-800"
+                                    : tmpl.bgMode === "dark"
+                                      ? "bg-white/5"
+                                      : "bg-gray-100"
+                            }`}
+                          >
+                            Card {i}
+                          </div>
+                        ))}
+                      </div>
+                      {/* Properties */}
+                      <div className="flex flex-wrap gap-1 pt-1">
+                        <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
+                          {tmpl.borderRadius} radius
+                        </span>
+                        <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
+                          {tmpl.bgMode} bg
+                        </span>
+                        {tmpl.rtl && (
+                          <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
+                            RTL
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-3">
+                      {tmpl.preview}
+                    </p>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      {/* Preview Modal */}
+      {previewPreset && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-background rounded-xl shadow-2xl max-w-lg w-full max-h-[80vh] overflow-y-auto">
+            <div className="flex items-center justify-between p-4 border-b">
+              <h2 className="font-semibold text-lg">
+                {previewPreset.name}
+              </h2>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setPreviewPreset(null)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="p-4 space-y-4">
+              {/* Hero preview */}
+              <div
+                className="rounded-lg p-6 text-center text-white"
+                style={{
+                  background: `linear-gradient(135deg, ${previewPreset.theme.primaryColor}, ${previewPreset.theme.secondaryColor})`,
+                }}
+              >
+                <h3 className="text-xl font-bold mb-2">
+                  {previewPreset.hero.title}
+                </h3>
+                <p className="text-sm opacity-90">
+                  {previewPreset.hero.subtitle}
+                </p>
+              </div>
+
+              {/* Arabic preview */}
+              <div
+                className="rounded-lg p-6 text-center text-white"
+                dir="rtl"
+                style={{
+                  background: `linear-gradient(135deg, ${previewPreset.theme.secondaryColor}, ${previewPreset.theme.primaryColor})`,
+                }}
+              >
+                <h3 className="text-xl font-bold mb-2">
+                  {previewPreset.hero.titleAr}
+                </h3>
+                <p className="text-sm opacity-90">
+                  {previewPreset.hero.subtitleAr}
+                </p>
+              </div>
+
+              {/* Details */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-medium w-24">Colors:</span>
+                  <div className="flex gap-2">
+                    <div
+                      className="h-6 w-6 rounded-full border"
+                      style={{ backgroundColor: previewPreset.theme.primaryColor }}
+                      title={previewPreset.theme.primaryColor}
+                    />
+                    <div
+                      className="h-6 w-6 rounded-full border"
+                      style={{ backgroundColor: previewPreset.theme.secondaryColor }}
+                      title={previewPreset.theme.secondaryColor}
+                    />
+                    <div
+                      className="h-6 w-6 rounded-full border"
+                      style={{ backgroundColor: previewPreset.theme.accentColor }}
+                      title={previewPreset.theme.accentColor}
+                    />
                   </div>
-                  {/* Properties */}
-                  <div className="flex flex-wrap gap-1 pt-1">
-                    <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
-                      {tmpl.borderRadius} radius
-                    </span>
-                    <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
-                      {tmpl.bgMode} bg
-                    </span>
-                    {tmpl.rtl && (
-                      <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
-                        RTL
-                      </span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-medium w-24">Template:</span>
+                  <Badge variant="secondary">{previewPreset.templateId}</Badge>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-medium w-24">Vertical:</span>
+                  <Badge variant="outline">
+                    {VERTICAL_LABELS[previewPreset.vertical]}
+                  </Badge>
+                </div>
+                <div>
+                  <span className="text-sm font-medium">Sections:</span>
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {Object.entries(previewPreset.sections).map(
+                      ([key, enabled]) => (
+                        <Badge
+                          key={key}
+                          variant={enabled ? "default" : "outline"}
+                          className="text-xs"
+                        >
+                          {key}
+                        </Badge>
+                      ),
                     )}
                   </div>
                 </div>
-                <p className="text-xs text-muted-foreground mt-3">
-                  {tmpl.preview}
-                </p>
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+              </div>
+            </div>
+            <div className="flex gap-2 p-4 border-t">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => setPreviewPreset(null)}
+              >
+                Close
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={() => {
+                  handleApplyPreset(previewPreset);
+                  setPreviewPreset(null);
+                }}
+              >
+                <Wand2 className="h-4 w-4 mr-2" />
+                Apply Preset
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
   ArrowRight,
@@ -19,6 +17,10 @@ import {
   User,
   Briefcase,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useCallback } from "react";
+import { ClinicTypeIcon } from "@/components/clinic-type-icon";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -28,9 +30,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import { ClinicTypeIcon } from "@/components/clinic-type-icon";
 import {
   CLINIC_CATEGORIES,
   getTypesByCategory,
@@ -41,6 +41,11 @@ import {
   getDefaultServices,
   type DefaultService,
 } from "@/lib/config/default-services";
+import type { VerticalId } from "@/lib/config/verticals";
+import {
+  getPresetsByVertical,
+  type TemplatePreset,
+} from "@/lib/template-presets";
 import { templateList, type TemplateDefinition } from "@/lib/templates";
 import type { ClinicTypeCategory } from "@/lib/types/database";
 
@@ -279,6 +284,7 @@ export default function OnboardingPage() {
     secondaryColor: "#0F6E56",
     templateId: "modern",
   });
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
 
   // --- Derived ---
   const currentCategory = profile.selectedCategory
@@ -1004,6 +1010,31 @@ export default function OnboardingPage() {
   // ---------------------------------------------------------------------------
   // Step 4: Branding
   // ---------------------------------------------------------------------------
+  // Derive the vertical from the selected category to filter presets
+  const CATEGORY_TO_VERTICAL: Record<string, VerticalId> = {
+    medical: "healthcare",
+    dental: "healthcare",
+    beauty: "beauty",
+    restaurant: "restaurant",
+    fitness: "fitness",
+    veterinary: "veterinary",
+  };
+  const detectedVertical: VerticalId | null = profile.selectedCategory
+    ? CATEGORY_TO_VERTICAL[profile.selectedCategory] ?? null
+    : null;
+  const availablePresets = detectedVertical
+    ? getPresetsByVertical(detectedVertical)
+    : [];
+
+  function handlePickPreset(preset: TemplatePreset) {
+    setSelectedPreset(preset.id);
+    setBranding({
+      primaryColor: preset.theme.primaryColor,
+      secondaryColor: preset.theme.secondaryColor,
+      templateId: preset.templateId,
+    });
+  }
+
   const step4Content = (
     <Card>
       <CardHeader>
@@ -1017,6 +1048,50 @@ export default function OnboardingPage() {
       </CardHeader>
       <CardContent>
         <div className="space-y-6">
+          {/* Quick-start presets */}
+          {availablePresets.length > 0 && (
+            <div className="space-y-2">
+              <Label>D\u00e9marrage rapide \u2014 choisissez un preset</Label>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {availablePresets.slice(0, 4).map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    className={`text-left rounded-lg border-2 p-3 transition-all hover:shadow-md ${
+                      selectedPreset === preset.id
+                        ? "border-primary bg-primary/5"
+                        : "border-border hover:border-primary/50"
+                    }`}
+                    onClick={() => handlePickPreset(preset)}
+                  >
+                    <div className="flex items-center gap-2 mb-1">
+                      <div className="flex gap-1">
+                        <div
+                          className="h-5 w-5 rounded-full border"
+                          style={{ backgroundColor: preset.theme.primaryColor }}
+                        />
+                        <div
+                          className="h-5 w-5 rounded-full border"
+                          style={{ backgroundColor: preset.theme.secondaryColor }}
+                        />
+                      </div>
+                      <span className="font-medium text-sm">{preset.name}</span>
+                      {selectedPreset === preset.id && (
+                        <Check className="h-4 w-4 text-primary ml-auto" />
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {preset.description}
+                    </p>
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground text-center">
+                Ou personnalisez manuellement ci-dessous
+              </p>
+            </div>
+          )}
+
           {/* Primary Color */}
           <div className="space-y-2">
             <Label>Couleur principale</Label>

--- a/src/app/api/branding/apply-preset/route.ts
+++ b/src/app/api/branding/apply-preset/route.ts
@@ -1,0 +1,75 @@
+/**
+ * POST /api/branding/apply-preset
+ *
+ * One-click apply a template preset to the current clinic.
+ *
+ * Body: { presetId: "beauty-elegant" }
+ *
+ * What it does:
+ * 1. Looks up preset from TEMPLATE_PRESETS
+ * 2. Updates clinic's branding record: template_id, primary_color, secondary_color
+ * 3. Updates clinic's section_visibility: which sections are ON/OFF
+ * 4. Returns success + the applied preset details
+ *
+ * Auth: Requires clinic_admin or super_admin role
+ * Tenant: Scoped to current clinic_id
+ */
+
+import { revalidatePath } from "next/cache";
+import { apiError, apiInternalError, apiSuccess } from "@/lib/api-response";
+import { withAuthValidation } from "@/lib/api-validate";
+import { logger } from "@/lib/logger";
+import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
+import { getPreset } from "@/lib/template-presets";
+import { requireTenant } from "@/lib/tenant";
+import type { UserRole } from "@/lib/types/database";
+import { applyPresetSchema } from "@/lib/validations";
+
+const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
+
+export const POST = withAuthValidation(applyPresetSchema, async (body, _request, { supabase }) => {
+  const tenant = await requireTenant();
+  const clinicId = tenant.clinicId;
+
+  const preset = getPreset(body.presetId);
+  if (!preset) {
+    return apiError("Preset not found", 404, "PRESET_NOT_FOUND");
+  }
+
+  // Build the update payload for the clinics table
+  const updates: Record<string, unknown> = {
+    template_id: preset.templateId,
+    primary_color: preset.theme.primaryColor,
+    secondary_color: preset.theme.secondaryColor,
+    section_visibility: preset.sections,
+  };
+
+  const { error } = await supabase
+    .from("clinics")
+    .update(updates)
+    .eq("id", clinicId);
+
+  if (error) {
+    logger.warn("Failed to apply preset", {
+      context: "branding/apply-preset",
+      presetId: body.presetId,
+      clinicId,
+      error,
+    });
+    return apiInternalError("Failed to apply preset");
+  }
+
+  // Invalidate caches so the public site picks up the change immediately
+  revalidatePath("/", "layout");
+  invalidateAllSubdomainCaches();
+
+  return apiSuccess({
+    applied: true,
+    preset: {
+      id: preset.id,
+      name: preset.name,
+      templateId: preset.templateId,
+      theme: preset.theme,
+    },
+  });
+}, ADMIN_ROLES);

--- a/src/lib/template-presets.ts
+++ b/src/lib/template-presets.ts
@@ -1,0 +1,594 @@
+/**
+ * Template Presets — Pre-configured theme + content combinations.
+ *
+ * Each preset ties together a base template, color theme, hero text,
+ * section visibility, and default services key so that a clinic admin
+ * can pick "beauty-elegant" and get an entire site configured instantly.
+ *
+ * Used by:
+ * - POST /api/branding/apply-preset  (one-click apply)
+ * - Admin templates page             (preset grid)
+ * - Onboarding wizard step 4         (quick-start presets)
+ */
+
+import type { VerticalId } from "@/lib/config/verticals";
+import type { SectionVisibility } from "@/lib/section-visibility";
+import type { TemplateId } from "@/lib/templates";
+
+export interface TemplatePreset {
+  id: string;
+  vertical: VerticalId;
+  templateId: TemplateId;
+  name: string;
+  nameAr: string;
+  description: string;
+  theme: {
+    primaryColor: string;
+    secondaryColor: string;
+    accentColor: string;
+  };
+  hero: {
+    title: string;
+    titleAr: string;
+    subtitle: string;
+    subtitleAr: string;
+  };
+  sections: Partial<SectionVisibility>;
+  defaultServices: string;
+  preview: string;
+}
+
+export const TEMPLATE_PRESETS: Record<string, TemplatePreset> = {
+  // ── Healthcare Presets ──────────────────────────────────────────────
+
+  "doctor-modern": {
+    id: "doctor-modern",
+    vertical: "healthcare",
+    templateId: "modern",
+    name: "Doctor Modern",
+    nameAr: "طبيب عصري",
+    description: "Clean, professional look with card-based layout for medical practices",
+    theme: {
+      primaryColor: "#1E4DA1",
+      secondaryColor: "#0F6E56",
+      accentColor: "#3B82F6",
+    },
+    hero: {
+      title: "Votre Sant\u00e9, Notre Priorit\u00e9",
+      titleAr: "\u0635\u062d\u062a\u0643 \u0623\u0648\u0644\u0648\u064a\u062a\u0646\u0627",
+      subtitle: "Des soins de sant\u00e9 professionnels avec une touche personnelle. Prenez rendez-vous en ligne facilement.",
+      subtitleAr: "\u0631\u0639\u0627\u064a\u0629 \u0635\u062d\u064a\u0629 \u0645\u0647\u0646\u064a\u0629 \u0628\u0644\u0645\u0633\u0629 \u0634\u062e\u0635\u064a\u0629. \u0627\u062d\u062c\u0632 \u0645\u0648\u0639\u062f\u0643 \u0639\u0628\u0631 \u0627\u0644\u0625\u0646\u062a\u0631\u0646\u062a \u0628\u0633\u0647\u0648\u0644\u0629.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: true,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: true,
+      faq: true,
+    },
+    defaultServices: "general_medicine",
+    preview: "Professional medical design with blue tones, card layout, and online booking",
+  },
+
+  "doctor-elegant": {
+    id: "doctor-elegant",
+    vertical: "healthcare",
+    templateId: "elegant",
+    name: "Doctor Elegant",
+    nameAr: "\u0637\u0628\u064a\u0628 \u0623\u0646\u064a\u0642",
+    description: "Refined, luxury aesthetic for premium medical practices and specialists",
+    theme: {
+      primaryColor: "#1E3A5F",
+      secondaryColor: "#2E7D6F",
+      accentColor: "#4A90D9",
+    },
+    hero: {
+      title: "L'Excellence M\u00e9dicale \u00e0 Votre Service",
+      titleAr: "\u0627\u0644\u062a\u0645\u064a\u0632 \u0627\u0644\u0637\u0628\u064a \u0641\u064a \u062e\u062f\u0645\u062a\u0643",
+      subtitle: "Une approche personnalis\u00e9e et des soins de qualit\u00e9 sup\u00e9rieure dans un cadre \u00e9l\u00e9gant.",
+      subtitleAr: "\u0646\u0647\u062c \u0634\u062e\u0635\u064a \u0648\u0631\u0639\u0627\u064a\u0629 \u0639\u0627\u0644\u064a\u0629 \u0627\u0644\u062c\u0648\u062f\u0629 \u0641\u064a \u0625\u0637\u0627\u0631 \u0623\u0646\u064a\u0642.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: true,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: true,
+      faq: true,
+    },
+    defaultServices: "general_medicine",
+    preview: "Sophisticated medical design with navy tones, parallax hero, and refined typography",
+  },
+
+  "doctor-bold": {
+    id: "doctor-bold",
+    vertical: "healthcare",
+    templateId: "bold",
+    name: "Doctor Bold",
+    nameAr: "\u0637\u0628\u064a\u0628 \u062c\u0631\u064a\u0621",
+    description: "Dark, impactful design for modern clinics that want to stand out",
+    theme: {
+      primaryColor: "#3B82F6",
+      secondaryColor: "#10B981",
+      accentColor: "#60A5FA",
+    },
+    hero: {
+      title: "M\u00e9decine Moderne, R\u00e9sultats Exceptionnels",
+      titleAr: "\u0637\u0628 \u062d\u062f\u064a\u062b\u060c \u0646\u062a\u0627\u0626\u062c \u0627\u0633\u062a\u062b\u0646\u0627\u0626\u064a\u0629",
+      subtitle: "Technologies de pointe et expertise m\u00e9dicale pour des soins sans compromis.",
+      subtitleAr: "\u062a\u0642\u0646\u064a\u0627\u062a \u0645\u062a\u0637\u0648\u0631\u0629 \u0648\u062e\u0628\u0631\u0629 \u0637\u0628\u064a\u0629 \u0644\u0631\u0639\u0627\u064a\u0629 \u0628\u0644\u0627 \u062a\u0646\u0627\u0632\u0644.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: true,
+      faq: false,
+    },
+    defaultServices: "general_medicine",
+    preview: "Dark-themed medical design with bold typography and vibrant blue accents",
+  },
+
+  "dentist-modern": {
+    id: "dentist-modern",
+    vertical: "healthcare",
+    templateId: "modern",
+    name: "Dentist Modern",
+    nameAr: "\u0637\u0628\u064a\u0628 \u0623\u0633\u0646\u0627\u0646 \u0639\u0635\u0631\u064a",
+    description: "Bright, welcoming design tailored for dental clinics",
+    theme: {
+      primaryColor: "#0891B2",
+      secondaryColor: "#0D9488",
+      accentColor: "#22D3EE",
+    },
+    hero: {
+      title: "Un Sourire \u00c9clatant Commence Ici",
+      titleAr: "\u0627\u0628\u062a\u0633\u0627\u0645\u0629 \u0645\u0634\u0631\u0642\u0629 \u062a\u0628\u062f\u0623 \u0645\u0646 \u0647\u0646\u0627",
+      subtitle: "Des soins dentaires modernes dans un environnement chaleureux. Votre sourire m\u00e9rite le meilleur.",
+      subtitleAr: "\u0631\u0639\u0627\u064a\u0629 \u0623\u0633\u0646\u0627\u0646 \u062d\u062f\u064a\u062b\u0629 \u0641\u064a \u0628\u064a\u0626\u0629 \u062f\u0627\u0641\u0626\u0629. \u0627\u0628\u062a\u0633\u0627\u0645\u062a\u0643 \u062a\u0633\u062a\u062d\u0642 \u0627\u0644\u0623\u0641\u0636\u0644.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: true,
+      faq: true,
+    },
+    defaultServices: "dental_clinic",
+    preview: "Teal-themed dental design with warm imagery and before/after gallery",
+  },
+
+  "dentist-bold": {
+    id: "dentist-bold",
+    vertical: "healthcare",
+    templateId: "bold",
+    name: "Dentist Bold",
+    nameAr: "\u0637\u0628\u064a\u0628 \u0623\u0633\u0646\u0627\u0646 \u062c\u0631\u064a\u0621",
+    description: "High-impact dark design for modern dental practices",
+    theme: {
+      primaryColor: "#06B6D4",
+      secondaryColor: "#14B8A6",
+      accentColor: "#67E8F9",
+    },
+    hero: {
+      title: "Dentisterie d'Avant-Garde",
+      titleAr: "\u0637\u0628 \u0623\u0633\u0646\u0627\u0646 \u0645\u062a\u0642\u062f\u0645",
+      subtitle: "Technologies dentaires de derni\u00e8re g\u00e9n\u00e9ration pour un sourire parfait.",
+      subtitleAr: "\u062a\u0642\u0646\u064a\u0627\u062a \u0637\u0628 \u0627\u0644\u0623\u0633\u0646\u0627\u0646 \u0627\u0644\u0623\u062d\u062f\u062b \u0644\u0627\u0628\u062a\u0633\u0627\u0645\u0629 \u0645\u062b\u0627\u0644\u064a\u0629.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: true,
+      faq: false,
+    },
+    defaultServices: "dental_clinic",
+    preview: "Dark-themed dental design with cyan accents and bold visual impact",
+  },
+
+  // ── Beauty Presets ──────────────────────────────────────────────────
+
+  "beauty-elegant": {
+    id: "beauty-elegant",
+    vertical: "beauty",
+    templateId: "elegant",
+    name: "Beauty Elegant",
+    nameAr: "\u062c\u0645\u0627\u0644 \u0623\u0646\u064a\u0642",
+    description: "Luxurious, refined design for spas and aesthetic clinics",
+    theme: {
+      primaryColor: "#BE185D",
+      secondaryColor: "#9D174D",
+      accentColor: "#F472B6",
+    },
+    hero: {
+      title: "R\u00e9v\u00e9lez Votre Beaut\u00e9 Naturelle",
+      titleAr: "\u0623\u0638\u0647\u0631\u064a \u062c\u0645\u0627\u0644\u0643 \u0627\u0644\u0637\u0628\u064a\u0639\u064a",
+      subtitle: "Des soins esth\u00e9tiques haut de gamme dans un cadre luxueux. Offrez-vous le meilleur.",
+      subtitleAr: "\u0639\u0646\u0627\u064a\u0629 \u062a\u062c\u0645\u064a\u0644\u064a\u0629 \u0631\u0627\u0642\u064a\u0629 \u0641\u064a \u0625\u0637\u0627\u0631 \u0641\u0627\u062e\u0631. \u0627\u0645\u0646\u062d\u064a \u0646\u0641\u0633\u0643 \u0627\u0644\u0623\u0641\u0636\u0644.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: true,
+    },
+    defaultServices: "aesthetic_clinic",
+    preview: "Rose-gold beauty design with parallax hero and before/after gallery",
+  },
+
+  "beauty-modern": {
+    id: "beauty-modern",
+    vertical: "beauty",
+    templateId: "modern",
+    name: "Beauty Modern",
+    nameAr: "\u062c\u0645\u0627\u0644 \u0639\u0635\u0631\u064a",
+    description: "Fresh, contemporary design for beauty salons and wellness centers",
+    theme: {
+      primaryColor: "#D946EF",
+      secondaryColor: "#A855F7",
+      accentColor: "#E879F9",
+    },
+    hero: {
+      title: "Votre Espace Bien-\u00catre",
+      titleAr: "\u0645\u0633\u0627\u062d\u062a\u0643 \u0644\u0644\u0639\u0646\u0627\u064a\u0629",
+      subtitle: "Soins personnalis\u00e9s et produits de qualit\u00e9 pour sublimer votre beaut\u00e9 au quotidien.",
+      subtitleAr: "\u0639\u0646\u0627\u064a\u0629 \u0634\u062e\u0635\u064a\u0629 \u0648\u0645\u0646\u062a\u062c\u0627\u062a \u0639\u0627\u0644\u064a\u0629 \u0627\u0644\u062c\u0648\u062f\u0629 \u0644\u062a\u0639\u0632\u064a\u0632 \u062c\u0645\u0627\u0644\u0643 \u064a\u0648\u0645\u064a\u0627\u064b.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: false,
+    },
+    defaultServices: "aesthetic_clinic",
+    preview: "Purple-pink modern design with card layout for beauty salons",
+  },
+
+  "beauty-bold": {
+    id: "beauty-bold",
+    vertical: "beauty",
+    templateId: "bold",
+    name: "Beauty Bold",
+    nameAr: "\u062c\u0645\u0627\u0644 \u062c\u0631\u064a\u0621",
+    description: "Dramatic dark design for high-end beauty and cosmetic brands",
+    theme: {
+      primaryColor: "#EC4899",
+      secondaryColor: "#DB2777",
+      accentColor: "#F9A8D4",
+    },
+    hero: {
+      title: "Beaut\u00e9 Sans Limites",
+      titleAr: "\u062c\u0645\u0627\u0644 \u0628\u0644\u0627 \u062d\u062f\u0648\u062f",
+      subtitle: "Transformez-vous avec nos traitements esth\u00e9tiques exclusifs et personnalis\u00e9s.",
+      subtitleAr: "\u063a\u064a\u0631\u064a \u0625\u0637\u0644\u0627\u0644\u062a\u0643 \u0645\u0639 \u0639\u0644\u0627\u062c\u0627\u062a\u0646\u0627 \u0627\u0644\u062a\u062c\u0645\u064a\u0644\u064a\u0629 \u0627\u0644\u062d\u0635\u0631\u064a\u0629.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: false,
+    },
+    defaultServices: "aesthetic_clinic",
+    preview: "Dark-themed beauty design with hot-pink accents and dramatic typography",
+  },
+
+  // ── Restaurant Presets ──────────────────────────────────────────────
+
+  "restaurant-bold": {
+    id: "restaurant-bold",
+    vertical: "restaurant",
+    templateId: "bold",
+    name: "Restaurant Bold",
+    nameAr: "\u0645\u0637\u0639\u0645 \u062c\u0631\u064a\u0621",
+    description: "Dark, appetizing design for upscale restaurants and fine dining",
+    theme: {
+      primaryColor: "#DC2626",
+      secondaryColor: "#B91C1C",
+      accentColor: "#F87171",
+    },
+    hero: {
+      title: "Une Exp\u00e9rience Culinaire Unique",
+      titleAr: "\u062a\u062c\u0631\u0628\u0629 \u0637\u0647\u064a \u0641\u0631\u064a\u062f\u0629",
+      subtitle: "D\u00e9couvrez des saveurs authentiques dans un cadre exceptionnel. R\u00e9servez votre table.",
+      subtitleAr: "\u0627\u0643\u062a\u0634\u0641 \u0646\u0643\u0647\u0627\u062a \u0623\u0635\u064a\u0644\u0629 \u0641\u064a \u0625\u0637\u0627\u0631 \u0627\u0633\u062a\u062b\u0646\u0627\u0626\u064a. \u0627\u062d\u062c\u0632 \u0637\u0627\u0648\u0644\u062a\u0643.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: false,
+      reviews: true,
+      blog: false,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: false,
+    },
+    defaultServices: "restaurant",
+    preview: "Dark restaurant design with red accents, fullscreen hero, and reservation CTA",
+  },
+
+  "restaurant-elegant": {
+    id: "restaurant-elegant",
+    vertical: "restaurant",
+    templateId: "elegant",
+    name: "Restaurant Elegant",
+    nameAr: "\u0645\u0637\u0639\u0645 \u0623\u0646\u064a\u0642",
+    description: "Sophisticated design for fine dining and gourmet restaurants",
+    theme: {
+      primaryColor: "#92400E",
+      secondaryColor: "#78350F",
+      accentColor: "#D97706",
+    },
+    hero: {
+      title: "L'Art de la Gastronomie",
+      titleAr: "\u0641\u0646 \u0627\u0644\u0637\u0647\u064a",
+      subtitle: "Cuisine raffin\u00e9e pr\u00e9par\u00e9e avec passion. Une invitation au voyage des sens.",
+      subtitleAr: "\u0645\u0637\u0628\u062e \u0631\u0627\u0642\u064d \u0645\u064f\u0639\u062f\u064c \u0628\u0634\u063a\u0641. \u062f\u0639\u0648\u0629 \u0644\u0631\u062d\u0644\u0629 \u062d\u0633\u064a\u0629.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: false,
+      reviews: true,
+      blog: false,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: false,
+    },
+    defaultServices: "restaurant",
+    preview: "Warm amber-toned elegant design for fine dining with parallax imagery",
+  },
+
+  "restaurant-modern": {
+    id: "restaurant-modern",
+    vertical: "restaurant",
+    templateId: "modern",
+    name: "Restaurant Modern",
+    nameAr: "\u0645\u0637\u0639\u0645 \u0639\u0635\u0631\u064a",
+    description: "Clean, contemporary design for casual dining and cafes",
+    theme: {
+      primaryColor: "#EA580C",
+      secondaryColor: "#C2410C",
+      accentColor: "#FB923C",
+    },
+    hero: {
+      title: "Saveurs Fraiches, Ambiance Moderne",
+      titleAr: "\u0646\u0643\u0647\u0627\u062a \u0637\u0627\u0632\u062c\u0629\u060c \u0623\u062c\u0648\u0627\u0621 \u0639\u0635\u0631\u064a\u0629",
+      subtitle: "Des plats pr\u00e9par\u00e9s avec des ingr\u00e9dients frais dans une ambiance conviviale.",
+      subtitleAr: "\u0623\u0637\u0628\u0627\u0642 \u0645\u062d\u0636\u0631\u0629 \u0628\u0645\u0643\u0648\u0646\u0627\u062a \u0637\u0627\u0632\u062c\u0629 \u0641\u064a \u0623\u062c\u0648\u0627\u0621 \u0648\u062f\u064a\u0629.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: false,
+      reviews: true,
+      blog: true,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: true,
+    },
+    defaultServices: "restaurant",
+    preview: "Orange-toned modern design for casual restaurants with card-based menu",
+  },
+
+  // ── Fitness Presets ─────────────────────────────────────────────────
+
+  "fitness-bold": {
+    id: "fitness-bold",
+    vertical: "fitness",
+    templateId: "bold",
+    name: "Fitness Bold",
+    nameAr: "\u0644\u064a\u0627\u0642\u0629 \u062c\u0631\u064a\u0626\u0629",
+    description: "High-energy dark design for gyms and training centers",
+    theme: {
+      primaryColor: "#EAB308",
+      secondaryColor: "#CA8A04",
+      accentColor: "#FDE047",
+    },
+    hero: {
+      title: "D\u00e9passez Vos Limites",
+      titleAr: "\u062a\u062c\u0627\u0648\u0632 \u062d\u062f\u0648\u062f\u0643",
+      subtitle: "Entra\u00eenements personnalis\u00e9s et coaching professionnel pour atteindre vos objectifs.",
+      subtitleAr: "\u062a\u062f\u0631\u064a\u0628\u0627\u062a \u0634\u062e\u0635\u064a\u0629 \u0648\u062a\u062f\u0631\u064a\u0628 \u0645\u0647\u0646\u064a \u0644\u062a\u062d\u0642\u064a\u0642 \u0623\u0647\u062f\u0627\u0641\u0643.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: false,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: false,
+    },
+    defaultServices: "physiotherapy",
+    preview: "Dark gym design with yellow accents, video hero, and bold motivation",
+  },
+
+  "fitness-modern": {
+    id: "fitness-modern",
+    vertical: "fitness",
+    templateId: "modern",
+    name: "Fitness Modern",
+    nameAr: "\u0644\u064a\u0627\u0642\u0629 \u0639\u0635\u0631\u064a\u0629",
+    description: "Clean, energetic design for yoga studios and wellness fitness",
+    theme: {
+      primaryColor: "#059669",
+      secondaryColor: "#047857",
+      accentColor: "#34D399",
+    },
+    hero: {
+      title: "Votre Parcours Bien-\u00catre",
+      titleAr: "\u0631\u062d\u0644\u0629 \u0639\u0627\u0641\u064a\u062a\u0643",
+      subtitle: "Programmes adapt\u00e9s \u00e0 tous les niveaux. Rejoignez notre communaut\u00e9 fitness.",
+      subtitleAr: "\u0628\u0631\u0627\u0645\u062c \u0645\u0646\u0627\u0633\u0628\u0629 \u0644\u062c\u0645\u064a\u0639 \u0627\u0644\u0645\u0633\u062a\u0648\u064a\u0627\u062a. \u0627\u0646\u0636\u0645 \u0625\u0644\u0649 \u0645\u062c\u062a\u0645\u0639\u0646\u0627.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: true,
+      beforeAfter: true,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: true,
+    },
+    defaultServices: "physiotherapy",
+    preview: "Green-toned modern fitness design with clean layout and progress tracking",
+  },
+
+  // ── Veterinary Presets ──────────────────────────────────────────────
+
+  "vet-modern": {
+    id: "vet-modern",
+    vertical: "veterinary",
+    templateId: "modern",
+    name: "Vet Modern",
+    nameAr: "\u0628\u064a\u0637\u0631\u064a \u0639\u0635\u0631\u064a",
+    description: "Friendly, professional design for veterinary clinics",
+    theme: {
+      primaryColor: "#4F46E5",
+      secondaryColor: "#4338CA",
+      accentColor: "#818CF8",
+    },
+    hero: {
+      title: "Des Soins Attentionn\u00e9s pour Vos Compagnons",
+      titleAr: "\u0631\u0639\u0627\u064a\u0629 \u062d\u0646\u0648\u0646\u0629 \u0644\u0631\u0641\u0627\u0642\u0643",
+      subtitle: "M\u00e9decine v\u00e9t\u00e9rinaire moderne et bienveillante. Votre animal m\u00e9rite le meilleur.",
+      subtitleAr: "\u0637\u0628 \u0628\u064a\u0637\u0631\u064a \u062d\u062f\u064a\u062b \u0648\u0631\u062d\u064a\u0645. \u062d\u064a\u0648\u0627\u0646\u0643 \u064a\u0633\u062a\u062d\u0642 \u0627\u0644\u0623\u0641\u0636\u0644.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: true,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: true,
+    },
+    defaultServices: "general_medicine",
+    preview: "Indigo-toned vet design with friendly imagery and online pet appointments",
+  },
+
+  "vet-classic": {
+    id: "vet-classic",
+    vertical: "veterinary",
+    templateId: "classic",
+    name: "Vet Classic",
+    nameAr: "\u0628\u064a\u0637\u0631\u064a \u0643\u0644\u0627\u0633\u064a\u0643\u064a",
+    description: "Traditional, trustworthy design for established veterinary practices",
+    theme: {
+      primaryColor: "#15803D",
+      secondaryColor: "#166534",
+      accentColor: "#4ADE80",
+    },
+    hero: {
+      title: "La Sant\u00e9 de Vos Animaux, Notre Mission",
+      titleAr: "\u0635\u062d\u0629 \u062d\u064a\u0648\u0627\u0646\u0627\u062a\u0643\u060c \u0645\u0647\u0645\u062a\u0646\u0627",
+      subtitle: "Une \u00e9quipe d\u00e9vou\u00e9e au bien-\u00eatre animal depuis des ann\u00e9es. Consultations et urgences.",
+      subtitleAr: "\u0641\u0631\u064a\u0642 \u0645\u062a\u0641\u0627\u0646\u064d \u0644\u0631\u0639\u0627\u064a\u0629 \u0627\u0644\u062d\u064a\u0648\u0627\u0646\u0627\u062a \u0645\u0646\u0630 \u0633\u0646\u0648\u0627\u062a. \u0627\u0633\u062a\u0634\u0627\u0631\u0627\u062a \u0648\u0637\u0648\u0627\u0631\u0626.",
+    },
+    sections: {
+      hero: true,
+      services: true,
+      doctors: true,
+      reviews: true,
+      blog: true,
+      beforeAfter: false,
+      location: true,
+      booking: true,
+      contactForm: true,
+      insurance: false,
+      faq: true,
+    },
+    defaultServices: "general_medicine",
+    preview: "Green-toned classic vet design with structured layout and trust indicators",
+  },
+};
+
+/** Get all presets as an array */
+export const presetList: TemplatePreset[] = Object.values(TEMPLATE_PRESETS);
+
+/** Get a single preset by ID */
+export function getPreset(id: string): TemplatePreset | undefined {
+  return TEMPLATE_PRESETS[id];
+}
+
+/** Get all presets for a given vertical */
+export function getPresetsByVertical(vertical: VerticalId): TemplatePreset[] {
+  return presetList.filter((p) => p.vertical === vertical);
+}
+
+/** Get preset IDs for a given vertical (matches vertical.templatePresets arrays) */
+export function getPresetIdsForVertical(vertical: VerticalId): string[] {
+  return getPresetsByVertical(vertical).map((p) => p.id);
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -400,6 +400,10 @@ export const brandingUpdateSchema = z.object({
   section_visibility: z.record(z.string(), z.boolean()).optional(),
 });
 
+export const applyPresetSchema = z.object({
+  presetId: z.string().min(1).max(100),
+});
+
 // ── Upload ──────────────────────────────────────────────────────────────
 
 export const uploadPresignedSchema = z.object({


### PR DESCRIPTION
## Task 4: Template Presets + One-Click Apply

### Changes

**New files:**
- `src/lib/template-presets.ts` — 15 presets across all verticals (healthcare, beauty, restaurant, fitness, veterinary)
- `src/app/api/branding/apply-preset/route.ts` — POST endpoint with auth + Zod validation

**Modified files:**
- `src/app/(admin)/admin/templates/page.tsx` — Added Presets tab with grid, preview modal, and one-click apply
- `src/app/(auth)/onboarding/page.tsx` — Added preset quick-start picker in step 4 (Branding)
- `src/lib/validations.ts` — Added `applyPresetSchema`

### Features
- **15 template presets** covering healthcare (5), beauty (3), restaurant (3), fitness (2), veterinary (2)
- **One-click apply API** — `POST /api/branding/apply-preset` updates template, colors, and section visibility instantly
- **Admin preset grid** — Filter by vertical, preview with modal, apply with one click
- **Onboarding integration** — Step 4 shows 3-4 preset options filtered by clinic vertical
- Proper tenant isolation via `requireTenant()`
- Cache invalidation after preset apply

### Testing
- ✅ TypeScript typecheck passes
- ✅ ESLint passes (0 errors)
- ✅ All 519 unit tests pass
- ✅ Pre-commit hooks pass