### PR TITLE
feat: Task 4 — Complete Template Presets + One-Click Apply (website_config, service seeding, onboarding)

### DIFF
--- a/src/app/(admin)/admin/templates/page.tsx
+++ b/src/app/(admin)/admin/templates/page.tsx
@@ -274,6 +274,19 @@ export default function TemplatesPage() {
                           )}
                         </Button>
                       </div>
+                      <a
+                        href={`/admin/branding?preset=${preset.id}`}
+                        className="mt-2 block"
+                      >
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="w-full text-xs"
+                        >
+                          <Palette className="h-3.5 w-3.5 mr-1" />
+                          Customize
+                        </Button>
+                      </a>
 
                       {justApplied && (
                         <p className="text-xs text-center text-green-600 mt-2">

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,18 +1,9 @@
+import { Star, ArrowRight } from "lucide-react";
 import type { Metadata } from "next";
-import { getTenant } from "@/lib/tenant";
+import Link from "next/link";
+import { notFound } from "next/navigation";
 import { LandingPage } from "@/components/landing/landing-page";
 import { HeroSection } from "@/components/public/hero-section";
-import { ServicesPreview } from "@/components/public/services-preview";
-import {
-  getPublicReviews,
-  getPublicAverageRating,
-  getPublicBranding,
-} from "@/lib/data/public";
-import { mergeSectionVisibility } from "@/lib/section-visibility";
-import { getTemplate } from "@/lib/templates";
-import { Star, ArrowRight } from "lucide-react";
-import Link from "next/link";
-import { Card, CardContent } from "@/components/ui/card";
 import {
   DoctorsSection,
   BookingSection,
@@ -22,9 +13,18 @@ import {
   BlogSection,
   LocationSection,
 } from "@/components/public/sections";
+import { ServicesPreview } from "@/components/public/services-preview";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  getPublicReviews,
+  getPublicAverageRating,
+  getPublicBranding,
+} from "@/lib/data/public";
 import { safeJsonLdStringify } from "@/lib/json-ld";
 import { logger } from "@/lib/logger";
-import { notFound } from "next/navigation";
+import { mergeSectionVisibility } from "@/lib/section-visibility";
+import { getTemplate } from "@/lib/templates";
+import { getTenant } from "@/lib/tenant";
 
 /** Default timeout (ms) for Supabase data-fetching on public pages. */
 const DATA_FETCH_TIMEOUT_MS = 10_000;
@@ -193,7 +193,18 @@ export default async function HomePage() {
         dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(clinicSchema) }}
       />
       {/* Hero — always visible */}
-      {sections.hero && <HeroSection />}
+      {sections.hero && (
+        <HeroSection
+          overrides={
+            branding.websiteConfig
+              ? {
+                  title: (branding.websiteConfig as { hero?: { title?: string } }).hero?.title,
+                  subtitle: (branding.websiteConfig as { hero?: { subtitle?: string } }).hero?.subtitle,
+                }
+              : undefined
+          }
+        />
+      )}
 
       {/* Services */}
       {sections.services && <ServicesPreview />}

--- a/src/app/api/branding/apply-preset/route.ts
+++ b/src/app/api/branding/apply-preset/route.ts
@@ -8,8 +8,10 @@
  * What it does:
  * 1. Looks up preset from TEMPLATE_PRESETS
  * 2. Updates clinic's branding record: template_id, primary_color, secondary_color
- * 3. Updates clinic's section_visibility: which sections are ON/OFF
- * 4. Returns success + the applied preset details
+ * 3. Updates clinic's website_config: hero title, subtitle
+ * 4. Updates clinic's section_visibility: which sections are ON/OFF
+ * 5. If defaultServices provided, seeds default services for the clinic
+ * 6. Returns success + the applied preset details
  *
  * Auth: Requires clinic_admin or super_admin role
  * Tenant: Scoped to current clinic_id
@@ -18,6 +20,7 @@
 import { revalidatePath } from "next/cache";
 import { apiError, apiInternalError, apiSuccess } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
+import { getDefaultServices } from "@/lib/config/default-services";
 import { logger } from "@/lib/logger";
 import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 import { getPreset } from "@/lib/template-presets";
@@ -42,6 +45,14 @@ export const POST = withAuthValidation(applyPresetSchema, async (body, _request,
     primary_color: preset.theme.primaryColor,
     secondary_color: preset.theme.secondaryColor,
     section_visibility: preset.sections,
+    website_config: {
+      hero: {
+        title: preset.hero.title,
+        titleAr: preset.hero.titleAr,
+        subtitle: preset.hero.subtitle,
+        subtitleAr: preset.hero.subtitleAr,
+      },
+    },
   };
 
   const { error } = await supabase
@@ -59,6 +70,45 @@ export const POST = withAuthValidation(applyPresetSchema, async (body, _request,
     return apiInternalError("Failed to apply preset");
   }
 
+  // Seed default services if the preset specifies a service key
+  let seededServices = 0;
+  if (preset.defaultServices) {
+    const defaults = getDefaultServices(preset.defaultServices);
+    if (defaults.length > 0) {
+      // Only seed if the clinic has no services yet to avoid duplicates
+      const { data: existing } = await supabase
+        .from("services")
+        .select("id")
+        .eq("clinic_id", clinicId)
+        .limit(1);
+
+      if (!existing || existing.length === 0) {
+        const rows = defaults.map((svc) => ({
+          clinic_id: clinicId,
+          name: svc.name,
+          duration_minutes: svc.duration_minutes,
+          price: svc.price,
+        }));
+
+        const { error: svcError } = await supabase
+          .from("services")
+          .insert(rows);
+
+        if (svcError) {
+          logger.warn("Failed to seed default services", {
+            context: "branding/apply-preset",
+            presetId: body.presetId,
+            clinicId,
+            error: svcError,
+          });
+          // Non-fatal: preset is still applied even if service seeding fails
+        } else {
+          seededServices = rows.length;
+        }
+      }
+    }
+  }
+
   // Invalidate caches so the public site picks up the change immediately
   revalidatePath("/", "layout");
   invalidateAllSubdomainCaches();
@@ -71,5 +121,6 @@ export const POST = withAuthValidation(applyPresetSchema, async (body, _request,
       templateId: preset.templateId,
       theme: preset.theme,
     },
+    seededServices,
   });
 }, ADMIN_ROLES);

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -76,7 +76,7 @@ export async function GET() {
     const { data, error } = await supabase
       .from("clinics")
       .select(
-        "name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, phone, address",
+        "name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, website_config, phone, address",
       )
       .eq("id", clinicId)
       .single();
@@ -95,6 +95,7 @@ export async function GET() {
         cover_photo_url: null,
         template_id: "modern",
         section_visibility: {},
+        website_config: null,
         phone: null,
         address: null,
       });

--- a/src/components/onboarding/setup-wizard.tsx
+++ b/src/components/onboarding/setup-wizard.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   User, Palette, Stethoscope, Clock, UserPlus,
-  ChevronRight, ChevronLeft, Check, Loader2,
+  ChevronRight, ChevronLeft, Check, Loader2, Wand2,
 } from "lucide-react";
+import { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { presetList, type TemplatePreset } from "@/lib/template-presets";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -125,6 +126,32 @@ export function SetupWizard({ clinicId, onComplete }: WizardProps) {
     secondary_color: "#0F6E56",
     description: "",
   });
+  const [selectedPreset, setSelectedPreset] = useState<string | null>(null);
+  const [applyingPreset, setApplyingPreset] = useState(false);
+
+  // Show a small selection of presets (first 4) for quick setup
+  const onboardingPresets = presetList.slice(0, 4);
+
+  async function handlePresetSelect(preset: TemplatePreset) {
+    setSelectedPreset(preset.id);
+    setApplyingPreset(true);
+    try {
+      const res = await fetch("/api/branding/apply-preset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ presetId: preset.id }),
+      });
+      if (res.ok) {
+        setBranding((b) => ({
+          ...b,
+          primary_color: preset.theme.primaryColor,
+          secondary_color: preset.theme.secondaryColor,
+        }));
+      }
+    } finally {
+      setApplyingPreset(false);
+    }
+  }
 
   // Step 3: Services
   const [services, setServices] = useState<ServiceEntry[]>(
@@ -442,6 +469,64 @@ export function SetupWizard({ clinicId, onComplete }: WizardProps) {
           {/* Step 2: Clinic Branding */}
           {currentStep === 1 && (
             <div className="space-y-4">
+              {/* Quick preset picker */}
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">Quick Start: Pick a preset</Label>
+                <p className="text-xs text-muted-foreground">
+                  Choose a preset to instantly set up your site&apos;s look, or customize manually below.
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  {onboardingPresets.map((preset) => (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      disabled={applyingPreset}
+                      onClick={() => handlePresetSelect(preset)}
+                      className={`rounded-lg border p-3 text-left transition-all hover:shadow-sm ${
+                        selectedPreset === preset.id
+                          ? "ring-2 ring-primary border-primary"
+                          : "hover:border-primary/50"
+                      }`}
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <Wand2 className="h-3.5 w-3.5 text-muted-foreground" />
+                        <span className="text-sm font-medium truncate">{preset.name}</span>
+                      </div>
+                      <div className="flex gap-1.5">
+                        <div
+                          className="h-4 w-4 rounded-full border"
+                          style={{ backgroundColor: preset.theme.primaryColor }}
+                        />
+                        <div
+                          className="h-4 w-4 rounded-full border"
+                          style={{ backgroundColor: preset.theme.secondaryColor }}
+                        />
+                        <div
+                          className="h-4 w-4 rounded-full border"
+                          style={{ backgroundColor: preset.theme.accentColor }}
+                        />
+                      </div>
+                      {selectedPreset === preset.id && (
+                        <p className="text-xs text-green-600 mt-1 flex items-center gap-1">
+                          <Check className="h-3 w-3" /> Applied
+                        </p>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-background px-2 text-muted-foreground">
+                    Or customize manually
+                  </span>
+                </div>
+              </div>
+
               <div className="space-y-1.5">
                 <Label htmlFor="brand-logo">URL du logo</Label>
                 <Input

--- a/src/components/public/hero-section.tsx
+++ b/src/components/public/hero-section.tsx
@@ -1,10 +1,22 @@
-import Link from "next/link";
 import Image from "next/image";
+import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { defaultWebsiteConfig } from "@/lib/website-config";
 
-export function HeroSection() {
-  const cfg = defaultWebsiteConfig.hero;
+interface HeroOverrides {
+  title?: string;
+  subtitle?: string;
+}
+
+interface HeroSectionProps {
+  overrides?: HeroOverrides;
+}
+
+export function HeroSection({ overrides }: HeroSectionProps) {
+  const cfg = {
+    ...defaultWebsiteConfig.hero,
+    ...overrides,
+  };
 
   return (
     <section className="relative bg-gradient-to-br from-primary/5 to-primary/10 py-24">

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -7,13 +7,13 @@
  * can swap from demo-data imports with minimal changes.
  */
 
-import { createClient, createTenantClient } from "@/lib/supabase-server";
-import { APPOINTMENT_STATUS } from "@/lib/types/database";
-import { getTenant, getClinicConfig } from "@/lib/tenant";
-import { getLocalDateStr } from "@/lib/utils";
 import { cacheLife } from "next/cache";
 import { cacheTag } from "next/cache";
 import { logger } from "@/lib/logger";
+import { createClient, createTenantClient } from "@/lib/supabase-server";
+import { getTenant, getClinicConfig } from "@/lib/tenant";
+import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import { getLocalDateStr } from "@/lib/utils";
 
 // ── JSONB field types (TS-01 / TS-02: replace Record<string, unknown> casts) ──
 
@@ -100,6 +100,7 @@ export interface ClinicBranding {
   phone: string | null;
   address: string | null;
   email: string | null;
+  websiteConfig: Record<string, unknown> | null;
 }
 
 // ── Helpers ──
@@ -184,6 +185,7 @@ const DEFAULT_BRANDING: ClinicBranding = {
   phone: null,
   address: null,
   email: null,
+  websiteConfig: null,
 };
 
 /**
@@ -196,7 +198,7 @@ async function fetchBrandingFromDb(clinicId: string, fallbackName: string): Prom
 
   const { data, error } = await supabase
     .from("clinics")
-    .select("name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, phone, address, owner_email, config")
+    .select("name, logo_url, favicon_url, primary_color, secondary_color, heading_font, body_font, hero_image_url, tagline, cover_photo_url, template_id, section_visibility, website_config, phone, address, owner_email, config")
     .eq("id", clinicId)
     .single();
 
@@ -223,6 +225,7 @@ async function fetchBrandingFromDb(clinicId: string, fallbackName: string): Prom
     phone: data.phone ?? cfg.phone ?? null,
     address: data.address ?? cfg.address ?? null,
     email: data.owner_email ?? cfg.email ?? null,
+    websiteConfig: (data.website_config as Record<string, unknown> | null) ?? null,
   };
 }
 

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -1147,6 +1147,7 @@ export type Database = {
           tier: string
           type: string
           updated_at: string | null
+          website_config: Json | null
         }
         Insert: {
           address?: string | null
@@ -1180,6 +1181,7 @@ export type Database = {
           tier?: string
           type: string
           updated_at?: string | null
+          website_config?: Json | null
         }
         Update: {
           address?: string | null
@@ -1213,6 +1215,7 @@ export type Database = {
           tier?: string
           type?: string
           updated_at?: string | null
+          website_config?: Json | null
         }
         Relationships: [
           {
@@ -8635,6 +8638,7 @@ export type Clinic = {
   cover_photo_url: string | null;
   template_id: string | null;
   section_visibility: Record<string, boolean> | null;
+  website_config: Record<string, unknown> | null;
   phone: string | null;
   address: string | null;
   created_at: string;

--- a/supabase/migrations/00060_website_config.sql
+++ b/supabase/migrations/00060_website_config.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- 00060: Add website_config JSONB column to clinics table
+--
+-- Stores per-clinic website content (hero title, subtitle, etc.)
+-- that can be set via template presets or manual editing.
+-- Falls back to defaultWebsiteConfig in the app when NULL.
+-- ============================================================
+
+ALTER TABLE clinics
+  ADD COLUMN IF NOT EXISTS website_config JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN clinics.website_config IS
+  'Per-clinic website content overrides (hero title/subtitle, etc). NULL = use defaults.';


### PR DESCRIPTION
## Task 4: Template Presets + One-Click Apply — Completion

Completes the remaining gaps in Task 4 implementation (building on PR #375).

### Changes

**Step 4.2 — Apply-Preset API (enhanced):**
- Update `website_config` JSONB with hero title/subtitle from preset
- Seed default services for new clinics using `getDefaultServices()`
- Only seeds when clinic has no existing services (avoids duplicates)

**Step 4.3 — Admin Templates Page (enhanced):**
- Add per-preset **Customize** button linking to branding editor with preset pre-selected

**Step 4.4 — Onboarding Flow (NEW):**
- Add preset selection quick-start picker in the setup wizard branding step
- Shows 4 preset options with color swatches for instant one-click apply
- Auto-applies preset via API and updates branding colors in the wizard

**Infrastructure:**
- Add `website_config` JSONB column migration (`00060_website_config.sql`)
- Update database types (Row, Insert, Update, Clinic) for `website_config`
- Update branding GET API to include `website_config` in response
- Update `ClinicBranding` interface and `fetchBrandingFromDb` to expose `websiteConfig`
- Update `HeroSection` to accept overrides from DB `website_config`
- Pass `websiteConfig` hero overrides through public page to HeroSection

### Files Changed
- `supabase/migrations/00060_website_config.sql` (new)
- `src/app/api/branding/apply-preset/route.ts`
- `src/app/api/branding/route.ts`
- `src/lib/data/public.ts`
- `src/lib/types/database.ts`
- `src/components/public/hero-section.tsx`
- `src/app/(public)/page.tsx`
- `src/app/(admin)/admin/templates/page.tsx`
- `src/components/onboarding/setup-wizard.tsx`

### Testing
- TypeScript: `tsc --noEmit` passes
- Lint: `eslint` passes (no new warnings)
- Unit tests: 519/519 pass
- Pre-commit hooks: all pass