### PR TITLE
feat: Task 4.3 Preset Grid + Task 5 Product Store Click Behaviors

### DIFF
--- a/src/app/(admin)/admin/branding/page.tsx
+++ b/src/app/(admin)/admin/branding/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRef, useState } from "react";
 import {
   AlertCircle,
   Palette,
@@ -12,7 +11,12 @@ import {
   Phone,
   MapPin,
   Clock,
+  Wand2,
+  Check,
+  Loader2,
 } from "lucide-react";
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -20,13 +24,13 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PageLoader } from "@/components/ui/page-loader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { PageLoader } from "@/components/ui/page-loader";
 import { useAsyncData } from "@/lib/hooks/use-async-data";
+import { presetList, type TemplatePreset } from "@/lib/template-presets";
 
 interface BrandingState {
   name: string;
@@ -106,6 +110,9 @@ export default function BrandingPage() {
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [applyingPreset, setApplyingPreset] = useState<string | null>(null);
+  const [appliedPreset, setAppliedPreset] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("presets");
 
   const logoRef = useRef<HTMLInputElement>(null);
   const faviconRef = useRef<HTMLInputElement>(null);
@@ -228,8 +235,12 @@ export default function BrandingPage() {
         </Button>
       </div>
 
-      <Tabs defaultValue="info">
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
         <TabsList className="mb-6 flex-wrap">
+          <TabsTrigger value="presets">
+            <Wand2 className="h-4 w-4 mr-2" />
+            Presets
+          </TabsTrigger>
           <TabsTrigger value="info">
             <Building2 className="h-4 w-4 mr-2" />
             Clinic Info
@@ -247,6 +258,43 @@ export default function BrandingPage() {
             Fonts
           </TabsTrigger>
         </TabsList>
+
+        {/* ── Presets Tab ── */}
+        <TabsContent value="presets">
+          <PresetsGrid
+            applyingPreset={applyingPreset}
+            appliedPreset={appliedPreset}
+            onApply={async (preset) => {
+              setApplyingPreset(preset.id);
+              try {
+                const res = await fetch("/api/branding/apply-preset", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ presetId: preset.id }),
+                });
+                if (res.ok) {
+                  setAppliedPreset(preset.id);
+                  setBranding((prev) => ({
+                    ...prev,
+                    primary_color: preset.theme.primaryColor,
+                    secondary_color: preset.theme.secondaryColor,
+                  }));
+                  setTimeout(() => setAppliedPreset(null), 3000);
+                }
+              } finally {
+                setApplyingPreset(null);
+              }
+            }}
+            onCustomize={(preset) => {
+              setBranding((prev) => ({
+                ...prev,
+                primary_color: preset.theme.primaryColor,
+                secondary_color: preset.theme.secondaryColor,
+              }));
+              setActiveTab("colors");
+            }}
+          />
+        </TabsContent>
 
         {/* ── Clinic Info Tab ── */}
         <TabsContent value="info">
@@ -693,6 +741,167 @@ export default function BrandingPage() {
           </Card>
         </TabsContent>
       </Tabs>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Presets Grid Sub-component
+// ---------------------------------------------------------------------------
+
+function PresetsGrid({
+  applyingPreset,
+  appliedPreset,
+  onApply,
+  onCustomize,
+}: {
+  applyingPreset: string | null;
+  appliedPreset: string | null;
+  onApply: (preset: TemplatePreset) => void;
+  onCustomize: (preset: TemplatePreset) => void;
+}) {
+  const [filterVertical, setFilterVertical] = useState<string>("all");
+
+  const verticals = [
+    { value: "all", label: "All Verticals" },
+    { value: "healthcare", label: "Healthcare" },
+    { value: "beauty", label: "Beauty" },
+    { value: "restaurant", label: "Restaurant" },
+    { value: "fitness", label: "Fitness" },
+    { value: "veterinary", label: "Veterinary" },
+  ];
+
+  const filtered =
+    filterVertical === "all"
+      ? presetList
+      : presetList.filter((p) => p.vertical === filterVertical);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Wand2 className="h-4 w-4" />
+            Template Presets
+          </CardTitle>
+          <CardDescription>
+            Pick a preset to instantly change your entire site&apos;s look and feel.
+            You can fine-tune colors and fonts afterwards.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {/* Vertical filter */}
+          <div className="flex gap-2 flex-wrap mb-6">
+            {verticals.map((v) => (
+              <button
+                key={v.value}
+                onClick={() => setFilterVertical(v.value)}
+                className={`inline-flex items-center rounded-lg px-3 py-1.5 text-sm transition-colors ${
+                  filterVertical === v.value
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
+                }`}
+              >
+                {v.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Preset grid */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered.map((preset) => {
+              const isApplying = applyingPreset === preset.id;
+              const isApplied = appliedPreset === preset.id;
+
+              return (
+                <div
+                  key={preset.id}
+                  className={`rounded-xl border-2 p-4 transition-all ${
+                    isApplied
+                      ? "border-green-500 bg-green-50 dark:bg-green-900/20"
+                      : "border-border hover:border-primary/50 hover:shadow-md"
+                  }`}
+                >
+                  {/* Color swatches */}
+                  <div className="flex gap-2 mb-3">
+                    <div
+                      className="h-8 w-8 rounded-full border shadow-sm"
+                      style={{ backgroundColor: preset.theme.primaryColor }}
+                      title="Primary"
+                    />
+                    <div
+                      className="h-8 w-8 rounded-full border shadow-sm"
+                      style={{ backgroundColor: preset.theme.secondaryColor }}
+                      title="Secondary"
+                    />
+                    <div
+                      className="h-8 w-8 rounded-full border shadow-sm"
+                      style={{ backgroundColor: preset.theme.accentColor }}
+                      title="Accent"
+                    />
+                  </div>
+
+                  {/* Name & description */}
+                  <h3 className="font-semibold text-sm mb-0.5">{preset.name}</h3>
+                  <p className="text-xs text-muted-foreground mb-1" dir="rtl">
+                    {preset.nameAr}
+                  </p>
+                  <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
+                    {preset.description}
+                  </p>
+
+                  {/* Template & vertical badges */}
+                  <div className="flex gap-1.5 mb-3">
+                    <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs capitalize">
+                      {preset.templateId}
+                    </span>
+                    <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs capitalize">
+                      {preset.vertical}
+                    </span>
+                  </div>
+
+                  {/* Action buttons */}
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      className="flex-1"
+                      disabled={isApplying || applyingPreset !== null}
+                      onClick={() => onApply(preset)}
+                    >
+                      {isApplying ? (
+                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                      ) : isApplied ? (
+                        <Check className="h-3.5 w-3.5 mr-1" />
+                      ) : (
+                        <Wand2 className="h-3.5 w-3.5 mr-1" />
+                      )}
+                      {isApplied ? "Applied!" : isApplying ? "Applying..." : "Apply"}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onCustomize(preset)}
+                    >
+                      <Palette className="h-3.5 w-3.5 mr-1" />
+                      Customize
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {filtered.length === 0 && (
+            <div className="text-center py-12">
+              <Wand2 className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+              <p className="font-medium">No presets for this vertical</p>
+              <p className="text-sm text-muted-foreground">
+                Try selecting a different vertical filter
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/(clinic-public)/pharmacy/catalog/[id]/page.tsx
+++ b/src/app/(clinic-public)/pharmacy/catalog/[id]/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { MessageCircle, Phone, Package, ArrowLeft, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useState, useEffect } from "react";
+import { useTenant } from "@/components/tenant-provider";
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
+import {
+  Card,
+  CardContent,
+} from "@/components/ui/card";
+import { createClient } from "@/lib/supabase-client";
+
+const DEFAULT_CURRENCY = "MAD";
+
+interface ProductDetail {
+  id: string;
+  name: string;
+  genericName?: string;
+  category: string;
+  description: string;
+  price: number;
+  currency: string;
+  requiresPrescription: boolean;
+  stockQuantity: number;
+  minimumStock: number;
+  manufacturer?: string;
+  dosageForm?: string;
+  strength?: string;
+  active: boolean;
+}
+
+function getStockLabel(qty: number, min: number): { label: string; variant: "outline" | "secondary" | "destructive"; color: string } {
+  if (qty === 0) return { label: "Out of Stock", variant: "destructive", color: "" };
+  if (qty <= min) return { label: "Low Stock", variant: "secondary", color: "text-yellow-600" };
+  return { label: "In Stock", variant: "outline", color: "text-emerald-600 border-emerald-600" };
+}
+
+function buildWhatsAppUrl(phone: string, product: ProductDetail): string {
+  const text = encodeURIComponent(
+    `Bonjour, je souhaite commander : ${product.name} (${product.price} ${product.currency}). Merci !`
+  );
+  const cleanPhone = phone.replace(/\s+/g, "");
+  return `https://wa.me/${cleanPhone}?text=${text}`;
+}
+
+async function fetchProduct(clinicId: string, productId: string): Promise<ProductDetail | null> {
+  const supabase = createClient();
+
+  const [{ data: product }, { data: stockRow }] = await Promise.all([
+    supabase
+      .from("products")
+      .select("id, name, generic_name, category, description, price, requires_prescription, is_active, manufacturer, barcode, dosage_form, strength")
+      .eq("clinic_id", clinicId)
+      .eq("id", productId)
+      .maybeSingle(),
+    supabase
+      .from("stock")
+      .select("quantity, min_threshold, expiry_date")
+      .eq("clinic_id", clinicId)
+      .eq("product_id", productId)
+      .maybeSingle(),
+  ]);
+
+  if (!product) return null;
+
+  const p = product as Record<string, unknown>;
+  return {
+    id: p.id as string,
+    name: p.name as string,
+    genericName: (p.generic_name as string) ?? undefined,
+    category: (p.category as string) ?? "medication",
+    description: (p.description as string) ?? "",
+    price: (p.price as number) ?? 0,
+    currency: DEFAULT_CURRENCY,
+    requiresPrescription: (p.requires_prescription as boolean) ?? false,
+    stockQuantity: (stockRow as Record<string, unknown> | null)?.quantity as number ?? 0,
+    minimumStock: (stockRow as Record<string, unknown> | null)?.min_threshold as number ?? 0,
+    manufacturer: (p.manufacturer as string) ?? undefined,
+    dosageForm: (p.dosage_form as string) ?? undefined,
+    strength: (p.strength as string) ?? undefined,
+    active: (p.is_active as boolean) ?? true,
+  };
+}
+
+export default function ProductLandingPage() {
+  const params = useParams();
+  const productId = params.id as string;
+  const tenant = useTenant();
+  const clinicPhone = "+212000000000";
+
+  const [product, setProduct] = useState<ProductDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (!tenant?.clinicId || !productId) {
+      return;
+    }
+
+    fetchProduct(tenant.clinicId, productId)
+      .then((p) => {
+        if (!controller.signal.aborted) setProduct(p);
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : "Failed to load product");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => { controller.abort(); };
+  }, [tenant?.clinicId, productId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-32">
+        <Loader2 className="h-8 w-8 animate-spin text-emerald-600" />
+      </div>
+    );
+  }
+
+  if (error || !product) {
+    return (
+      <div className="container mx-auto px-4 py-16 text-center">
+        <Package className="h-16 w-16 text-muted-foreground mx-auto mb-4" />
+        <h2 className="text-2xl font-bold mb-2">Product Not Found</h2>
+        <p className="text-muted-foreground mb-6">
+          {error ?? "The product you are looking for does not exist or has been removed."}
+        </p>
+        <Link
+          href="/pharmacy/catalog"
+          className="inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Catalog
+        </Link>
+      </div>
+    );
+  }
+
+  const stock = getStockLabel(product.stockQuantity, product.minimumStock);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* Breadcrumb */}
+      <Breadcrumb
+        className="mb-6"
+        items={[
+          { label: "Catalog", href: "/pharmacy/catalog" },
+          { label: product.name },
+        ]}
+      />
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        {/* Left column: Product info */}
+        <div className="space-y-6">
+          {/* Title & badges */}
+          <div>
+            <h1 className="text-3xl font-bold mb-3">{product.name}</h1>
+            {product.genericName && (
+              <p className="text-lg text-muted-foreground italic mb-3">
+                {product.genericName}
+              </p>
+            )}
+            <div className="flex flex-wrap gap-2">
+              <Badge
+                variant={product.requiresPrescription ? "destructive" : "secondary"}
+              >
+                {product.requiresPrescription ? "Rx Required" : "OTC"}
+              </Badge>
+              <Badge variant="outline" className="capitalize">
+                {product.category.replace("-", " ")}
+              </Badge>
+              <Badge variant={stock.variant} className={stock.color}>
+                {stock.label}
+              </Badge>
+            </div>
+          </div>
+
+          {/* Description */}
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Description</h2>
+            <p className="text-muted-foreground leading-relaxed">
+              {product.description}
+            </p>
+          </div>
+
+          {/* Product details card */}
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="font-semibold mb-3">Product Details</h3>
+              <div className="space-y-2 text-sm">
+                {product.dosageForm && (
+                  <div className="flex justify-between py-1.5 border-b">
+                    <span className="text-muted-foreground">Dosage Form</span>
+                    <span className="font-medium">{product.dosageForm}</span>
+                  </div>
+                )}
+                {product.strength && (
+                  <div className="flex justify-between py-1.5 border-b">
+                    <span className="text-muted-foreground">Strength</span>
+                    <span className="font-medium">{product.strength}</span>
+                  </div>
+                )}
+                {product.manufacturer && (
+                  <div className="flex justify-between py-1.5 border-b">
+                    <span className="text-muted-foreground">Manufacturer</span>
+                    <span className="font-medium">{product.manufacturer}</span>
+                  </div>
+                )}
+                <div className="flex justify-between py-1.5">
+                  <span className="text-muted-foreground">Availability</span>
+                  <span className="font-medium">{product.stockQuantity} units in stock</span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right column: Price & actions */}
+        <div>
+          <Card className="sticky top-24">
+            <CardContent className="pt-6 space-y-6">
+              {/* Price */}
+              <div className="text-center">
+                <p className="text-sm text-muted-foreground mb-1">Price</p>
+                <p className="text-4xl font-bold text-emerald-600">
+                  {product.price} {product.currency}
+                </p>
+              </div>
+
+              {/* Actions */}
+              <div className="space-y-3">
+                <a
+                  href={buildWhatsAppUrl(clinicPhone, product)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-medium text-white bg-green-600 hover:bg-green-700 transition-colors"
+                >
+                  <MessageCircle className="h-5 w-5 mr-2" />
+                  Order via WhatsApp
+                </a>
+                <a
+                  href={`tel:${clinicPhone.replace(/\s+/g, "")}`}
+                  className="w-full inline-flex items-center justify-center rounded-md border px-6 py-3 text-sm font-medium hover:bg-muted transition-colors"
+                >
+                  <Phone className="h-5 w-5 mr-2" />
+                  Call to Order
+                </a>
+              </div>
+
+              {/* Prescription notice */}
+              {product.requiresPrescription && (
+                <div className="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 p-3 text-sm text-amber-800 dark:text-amber-200">
+                  This product requires a valid prescription. Please have your
+                  prescription ready when ordering.
+                </div>
+              )}
+
+              {/* Back link */}
+              <Link
+                href="/pharmacy/catalog"
+                className="w-full inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+              >
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back to Catalog
+              </Link>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(clinic-public)/pharmacy/catalog/page.tsx
+++ b/src/app/(clinic-public)/pharmacy/catalog/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Search, Filter, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useMemo, useEffect } from "react";
+import { ProductDetailModal, type ProductInfo } from "@/components/public/product-detail-modal";
+import { ProductSidePanel } from "@/components/public/product-side-panel";
 import { useTenant } from "@/components/tenant-provider";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { createClient } from "@/lib/supabase-client";
+import { getTemplate, type ProductClickBehavior } from "@/lib/templates";
 
 /** Default currency when tenant config is not yet loaded. */
 const DEFAULT_CURRENCY = "MAD";
@@ -100,13 +104,79 @@ const categories = [
   { value: "supplements", label: "Supplements" },
 ];
 
+function toProductInfo(p: PublicPharmacyProduct): ProductInfo {
+  return {
+    id: p.id,
+    name: p.name,
+    genericName: p.genericName,
+    category: p.category,
+    description: p.description,
+    price: p.price,
+    currency: p.currency,
+    requiresPrescription: p.requiresPrescription,
+    stockQuantity: p.stockQuantity,
+    minimumStock: p.minimumStock,
+    manufacturer: p.manufacturer,
+    dosageForm: p.dosageForm,
+    strength: p.strength,
+    active: p.active,
+  };
+}
+
 export default function CatalogPage() {
   const tenant = useTenant();
+  const router = useRouter();
   const [query, setQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("all");
   const [allProducts, setAllProducts] = useState<PublicPharmacyProduct[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
+  // Product click behavior state
+  const [selectedProduct, setSelectedProduct] = useState<ProductInfo | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  // Determine click behavior from template (default: modal)
+  const [clickBehavior, setClickBehavior] = useState<ProductClickBehavior>("modal");
+
+  useEffect(() => {
+    async function loadTemplate() {
+      if (!tenant?.clinicId) return;
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("clinics")
+        .select("template_id")
+        .eq("id", tenant.clinicId)
+        .maybeSingle();
+      if (data) {
+        const row = data as Record<string, unknown>;
+        const tmpl = getTemplate((row.template_id as string) ?? "modern");
+        setClickBehavior(tmpl.productClickBehavior);
+      }
+    }
+    loadTemplate();
+  }, [tenant?.clinicId]);
+
+  function handleProductClick(product: PublicPharmacyProduct) {
+    const info = toProductInfo(product);
+    switch (clickBehavior) {
+      case "modal":
+        setSelectedProduct(info);
+        setModalOpen(true);
+        break;
+      case "side-panel":
+        setSelectedProduct(info);
+        setPanelOpen(true);
+        break;
+      case "landing-page":
+        router.push(`/pharmacy/catalog/${product.id}`);
+        break;
+      case "new-tab":
+        window.open(`/pharmacy/catalog/${product.id}`, "_blank");
+        break;
+    }
+  }
 
   useEffect(() => {
     const controller = new AbortController();
@@ -195,7 +265,11 @@ export default function CatalogPage() {
         {filtered.map((product) => {
           const stock = getStockStatus(product);
           return (
-            <Card key={product.id} className="hover:shadow-md transition-shadow">
+            <Card
+              key={product.id}
+              className="hover:shadow-md transition-shadow cursor-pointer"
+              onClick={() => handleProductClick(product)}
+            >
               <CardContent className="pt-6">
                 <div className="flex items-start justify-between mb-3">
                   <Badge
@@ -251,6 +325,26 @@ export default function CatalogPage() {
       )}
         </>
       )}
+
+      {/* Product detail modal */}
+      <ProductDetailModal
+        product={selectedProduct}
+        open={modalOpen}
+        onClose={() => {
+          setModalOpen(false);
+          setSelectedProduct(null);
+        }}
+      />
+
+      {/* Product side panel */}
+      <ProductSidePanel
+        product={selectedProduct}
+        open={panelOpen}
+        onClose={() => {
+          setPanelOpen(false);
+          setSelectedProduct(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/components/public/product-detail-modal.tsx
+++ b/src/components/public/product-detail-modal.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { MessageCircle, Phone, Package, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export interface ProductInfo {
+  id: string;
+  name: string;
+  genericName?: string;
+  category: string;
+  description: string;
+  price: number;
+  currency: string;
+  requiresPrescription: boolean;
+  stockQuantity: number;
+  minimumStock: number;
+  manufacturer?: string;
+  dosageForm?: string;
+  strength?: string;
+  active: boolean;
+}
+
+function getStockLabel(qty: number, min: number): { label: string; variant: "outline" | "secondary" | "destructive"; color: string } {
+  if (qty === 0) return { label: "Out of Stock", variant: "destructive", color: "" };
+  if (qty <= min) return { label: "Low Stock", variant: "secondary", color: "text-yellow-600" };
+  return { label: "In Stock", variant: "outline", color: "text-emerald-600 border-emerald-600" };
+}
+
+function buildWhatsAppUrl(phone: string, product: ProductInfo): string {
+  const text = encodeURIComponent(
+    `Bonjour, je souhaite commander : ${product.name} (${product.price} ${product.currency}). Merci !`
+  );
+  const cleanPhone = phone.replace(/\s+/g, "");
+  return `https://wa.me/${cleanPhone}?text=${text}`;
+}
+
+interface ProductDetailModalProps {
+  product: ProductInfo | null;
+  open: boolean;
+  onClose: () => void;
+  clinicPhone?: string;
+}
+
+export function ProductDetailModal({
+  product,
+  open,
+  onClose,
+  clinicPhone = "+212000000000",
+}: ProductDetailModalProps) {
+  if (!product) return null;
+
+  const stock = getStockLabel(product.stockQuantity, product.minimumStock);
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        onClose={onClose}
+        className="sm:max-w-lg max-h-[90vh] overflow-y-auto"
+      >
+        <DialogHeader>
+          <DialogTitle className="text-xl">{product.name}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 mt-2">
+          {/* Badges row */}
+          <div className="flex flex-wrap gap-2">
+            <Badge
+              variant={product.requiresPrescription ? "destructive" : "secondary"}
+            >
+              {product.requiresPrescription ? "Rx Required" : "OTC"}
+            </Badge>
+            <Badge variant="outline" className="capitalize">
+              {product.category.replace("-", " ")}
+            </Badge>
+            <Badge variant={stock.variant} className={stock.color}>
+              {stock.label}
+            </Badge>
+          </div>
+
+          {/* Generic name */}
+          {product.genericName && (
+            <p className="text-sm text-muted-foreground italic">
+              {product.genericName}
+            </p>
+          )}
+
+          {/* Description */}
+          <p className="text-sm leading-relaxed">{product.description}</p>
+
+          {/* Details grid */}
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            {product.dosageForm && (
+              <div>
+                <span className="text-muted-foreground">Form:</span>{" "}
+                <span className="font-medium">{product.dosageForm}</span>
+              </div>
+            )}
+            {product.strength && (
+              <div>
+                <span className="text-muted-foreground">Strength:</span>{" "}
+                <span className="font-medium">{product.strength}</span>
+              </div>
+            )}
+            {product.manufacturer && (
+              <div>
+                <span className="text-muted-foreground">Manufacturer:</span>{" "}
+                <span className="font-medium">{product.manufacturer}</span>
+              </div>
+            )}
+            <div>
+              <span className="text-muted-foreground">Stock:</span>{" "}
+              <span className="font-medium">{product.stockQuantity} units</span>
+            </div>
+          </div>
+
+          {/* Price */}
+          <div className="flex items-center justify-between border-t pt-4">
+            <div className="flex items-center gap-2">
+              <Package className="h-5 w-5 text-muted-foreground" />
+              <span className="text-2xl font-bold text-emerald-600">
+                {product.price} {product.currency}
+              </span>
+            </div>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex flex-col sm:flex-row gap-3">
+            <a
+              href={buildWhatsAppUrl(clinicPhone, product)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-1 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 transition-colors"
+            >
+              <MessageCircle className="h-4 w-4 mr-2" />
+              Order via WhatsApp
+            </a>
+            <a
+              href={`tel:${clinicPhone.replace(/\s+/g, "")}`}
+              className="flex-1 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+            >
+              <Phone className="h-4 w-4 mr-2" />
+              Call
+            </a>
+          </div>
+
+          {/* Close button for mobile */}
+          <Button
+            variant="ghost"
+            className="w-full sm:hidden"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4 mr-2" />
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/public/product-side-panel.tsx
+++ b/src/components/public/product-side-panel.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { MessageCircle, Phone, Package } from "lucide-react";
+import type { ProductInfo } from "@/components/public/product-detail-modal";
+import { Badge } from "@/components/ui/badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+
+function getStockLabel(qty: number, min: number): { label: string; variant: "outline" | "secondary" | "destructive"; color: string } {
+  if (qty === 0) return { label: "Out of Stock", variant: "destructive", color: "" };
+  if (qty <= min) return { label: "Low Stock", variant: "secondary", color: "text-yellow-600" };
+  return { label: "In Stock", variant: "outline", color: "text-emerald-600 border-emerald-600" };
+}
+
+function buildWhatsAppUrl(phone: string, product: ProductInfo): string {
+  const text = encodeURIComponent(
+    `Bonjour, je souhaite commander : ${product.name} (${product.price} ${product.currency}). Merci !`
+  );
+  const cleanPhone = phone.replace(/\s+/g, "");
+  return `https://wa.me/${cleanPhone}?text=${text}`;
+}
+
+interface ProductSidePanelProps {
+  product: ProductInfo | null;
+  open: boolean;
+  onClose: () => void;
+  clinicPhone?: string;
+}
+
+export function ProductSidePanel({
+  product,
+  open,
+  onClose,
+  clinicPhone = "+212000000000",
+}: ProductSidePanelProps) {
+  if (!product) return null;
+
+  const stock = getStockLabel(product.stockQuantity, product.minimumStock);
+
+  return (
+    <Sheet open={open}>
+      <SheetContent side="right" onClose={onClose} className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="text-xl">{product.name}</SheetTitle>
+          {product.genericName && (
+            <SheetDescription className="italic">
+              {product.genericName}
+            </SheetDescription>
+          )}
+        </SheetHeader>
+
+        <div className="space-y-4 mt-6">
+          {/* Badges row */}
+          <div className="flex flex-wrap gap-2">
+            <Badge
+              variant={product.requiresPrescription ? "destructive" : "secondary"}
+            >
+              {product.requiresPrescription ? "Rx Required" : "OTC"}
+            </Badge>
+            <Badge variant="outline" className="capitalize">
+              {product.category.replace("-", " ")}
+            </Badge>
+            <Badge variant={stock.variant} className={stock.color}>
+              {stock.label}
+            </Badge>
+          </div>
+
+          {/* Description */}
+          <p className="text-sm leading-relaxed">{product.description}</p>
+
+          {/* Details */}
+          <div className="space-y-2 text-sm">
+            {product.dosageForm && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Form</span>
+                <span className="font-medium">
+                  {product.dosageForm}
+                  {product.strength ? ` - ${product.strength}` : ""}
+                </span>
+              </div>
+            )}
+            {product.manufacturer && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Manufacturer</span>
+                <span className="font-medium">{product.manufacturer}</span>
+              </div>
+            )}
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Stock</span>
+              <span className="font-medium">{product.stockQuantity} units</span>
+            </div>
+          </div>
+
+          {/* Price */}
+          <div className="flex items-center gap-2 border-t pt-4">
+            <Package className="h-5 w-5 text-muted-foreground" />
+            <span className="text-2xl font-bold text-emerald-600">
+              {product.price} {product.currency}
+            </span>
+          </div>
+
+          {/* Action buttons */}
+          <div className="space-y-2">
+            <a
+              href={buildWhatsAppUrl(clinicPhone, product)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-full inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 transition-colors"
+            >
+              <MessageCircle className="h-4 w-4 mr-2" />
+              Order via WhatsApp
+            </a>
+            <a
+              href={`tel:${clinicPhone.replace(/\s+/g, "")}`}
+              className="w-full inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+            >
+              <Phone className="h-4 w-4 mr-2" />
+              Call
+            </a>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -83,7 +83,9 @@ export type ClinicFeatureKey =
   | "pregnancy_tracking"
   | "ultrasound_records"
   | "vision_tests"
-  | "iop_tracking";
+  | "iop_tracking"
+  // Store
+  | "public_catalog";
 
 /** A features_config object as stored in the DB. */
 export type FeaturesConfig = Partial<Record<ClinicFeatureKey, boolean>>;


### PR DESCRIPTION
## Summary

Implements Task 4.3 (Preset Grid UI in Admin Branding) and Task 5 (Product Store Click Behaviors).

### Task 4.3: Admin Branding Preset Grid
- Added new **Presets** tab to admin branding page
- Grid of preset thumbnails with color swatches, filterable by vertical
- **Apply** button calls `POST /api/branding/apply-preset` for one-click site change
- **Customize** button pre-fills colors and switches to Colors tab

### Task 5.1: Product Detail Modal
- New `product-detail-modal.tsx` component
- Shows product info, badges (Rx/OTC, category, stock status), price
- WhatsApp order + Call action buttons
- Responsive with close button

### Task 5.2: Product Landing Page
- New `pharmacy/catalog/[id]/page.tsx`
- Full product page with breadcrumb navigation
- Details card, prescription notice, WhatsApp/Call CTAs
- SEO-friendly standalone page

### Task 5.3: Product Side Panel
- New `product-side-panel.tsx` using Sheet component
- Slides in from right, keeps catalog visible
- Same content as modal in panel format

### Task 5.4: Click Behavior Wiring
- Catalog page reads `template.productClickBehavior` from clinic config
- Supports: modal, side-panel, landing-page, new-tab modes
- Each template defines its default click behavior

### Task 5.5: Feature Flag
- Added `public_catalog` to `ClinicFeatureKey` in `features.ts`

### Files Changed
- `src/app/(admin)/admin/branding/page.tsx` — Added Presets tab + PresetsGrid component
- `src/app/(clinic-public)/pharmacy/catalog/page.tsx` — Wired up click behavior
- `src/app/(clinic-public)/pharmacy/catalog/[id]/page.tsx` — New product landing page
- `src/components/public/product-detail-modal.tsx` — New modal component
- `src/components/public/product-side-panel.tsx` — New side panel component
- `src/lib/features.ts` — Added public_catalog feature flag