### PR TITLE
fix(auth): remove fallback HMAC literal and split profile-header key from CRON_SECRET (R-01, R-02)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,16 @@ BOOKING_TOKEN_SECRET=
 # Generate with: openssl rand -hex 32
 CRON_SECRET=
 
+# ---- Profile-header HMAC [Required in production] ----
+# Signs the x-auth-profile-* headers passed from middleware to withAuth so
+# downstream API routes can trust them without a second DB lookup.
+# MUST be distinct from CRON_SECRET — a leak of one must not compromise
+# the other (audit R-02). Generate with: openssl rand -hex 32
+# If unset, the middleware skips signing and withAuth performs the
+# authoritative DB lookup on every request (no security impact, just an
+# extra query).
+PROFILE_HEADER_HMAC_KEY=
+
 # ---- Cloudflare R2 Storage [Optional — file uploads] ----
 # If not set, file upload endpoints return 503
 # How to obtain: Cloudflare Dashboard → R2 → Overview → Manage R2 API Tokens

--- a/.env.production.example
+++ b/.env.production.example
@@ -26,6 +26,13 @@ ROOT_DOMAIN=oltigo.com
 # Set via: wrangler secret put CRON_SECRET
 # CRON_SECRET=
 
+# Profile-header HMAC — signs x-auth-profile-* headers from middleware to withAuth.
+# MUST be a distinct value from CRON_SECRET (audit R-02): a leak of one
+# must not allow forging cron auth or session headers via the other.
+# Generate with: openssl rand -hex 32
+# Set via: wrangler secret put PROFILE_HEADER_HMAC_KEY
+# PROFILE_HEADER_HMAC_KEY=
+
 # Booking Token Secret — HMAC-SHA256 key for signing OTP verification tokens
 # Generate with: openssl rand -hex 32
 # Set via: wrangler secret put BOOKING_TOKEN_SECRET

--- a/secrets-template.env
+++ b/secrets-template.env
@@ -69,6 +69,12 @@ SENTRY_AUTH_TOKEN=
 # Generate with: openssl rand -hex 32
 CRON_SECRET=
 
+# === PROFILE HEADER HMAC ===
+# Signs x-auth-profile-* headers between middleware and withAuth.
+# MUST be distinct from CRON_SECRET (audit R-02).
+# Generate with: openssl rand -hex 32
+PROFILE_HEADER_HMAC_KEY=
+
 # === BOOKING TOKEN SECRET ===
 # Generate with: openssl rand -hex 32
 BOOKING_TOKEN_SECRET=

--- a/src/lib/__tests__/profile-header-hmac.test.ts
+++ b/src/lib/__tests__/profile-header-hmac.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Regression tests for the profile-header HMAC helper.
+ *
+ * Audit fixes covered:
+ *   R-01: When no HMAC key is configured, sign returns null and verify
+ *         rejects every header — including a request that "looks valid"
+ *         and would previously have been accepted via the literal
+ *         "fallback_secret_key".
+ *   R-02: PROFILE_HEADER_HMAC_KEY is read first; CRON_SECRET only acts
+ *         as a transitional fallback. Headers signed with one key MUST
+ *         NOT verify under the other.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  signProfileHeader,
+  verifyProfileHeader,
+  PROFILE_HEADER_NAMES,
+} from "@/lib/profile-header-hmac";
+
+const ORIGINAL_PROFILE_KEY = process.env.PROFILE_HEADER_HMAC_KEY;
+const ORIGINAL_CRON = process.env.CRON_SECRET;
+
+function clearKeys() {
+  delete process.env.PROFILE_HEADER_HMAC_KEY;
+  delete process.env.CRON_SECRET;
+}
+
+function restoreKeys() {
+  if (ORIGINAL_PROFILE_KEY === undefined) delete process.env.PROFILE_HEADER_HMAC_KEY;
+  else process.env.PROFILE_HEADER_HMAC_KEY = ORIGINAL_PROFILE_KEY;
+  if (ORIGINAL_CRON === undefined) delete process.env.CRON_SECRET;
+  else process.env.CRON_SECRET = ORIGINAL_CRON;
+}
+
+describe("profile-header-hmac", () => {
+  beforeEach(() => {
+    clearKeys();
+  });
+
+  afterEach(() => {
+    restoreKeys();
+    vi.restoreAllMocks();
+  });
+
+  it("exposes the canonical header names", () => {
+    expect(PROFILE_HEADER_NAMES).toEqual({
+      id: "x-auth-profile-id",
+      role: "x-auth-profile-role",
+      clinic: "x-auth-profile-clinic",
+      sig: "x-auth-profile-sig",
+    });
+  });
+
+  describe("R-01: no fallback key", () => {
+    it("signProfileHeader returns null when no key is configured", async () => {
+      const sig = await signProfileHeader({
+        id: "profile-1",
+        role: "super_admin",
+        clinic_id: null,
+      });
+      expect(sig).toBeNull();
+    });
+
+    it("verifyProfileHeader rejects forged headers when no key is configured", async () => {
+      // An attacker submits headers that *look* valid. With no configured
+      // HMAC key there is nothing to verify against, so verification MUST
+      // fail (the previous fallback literal would have accepted this).
+      const result = await verifyProfileHeader({
+        id: "attacker-profile-id",
+        role: "super_admin",
+        clinic_id: "victim-clinic",
+        signature: "a".repeat(64),
+      });
+      expect(result).toBeNull();
+    });
+
+    it("verifyProfileHeader rejects headers signed with the literal 'fallback_secret_key'", async () => {
+      // Demonstrates the previous vulnerability: a signature produced
+      // with the public fallback key MUST NOT verify under the new code,
+      // regardless of whether any key is configured.
+      const profile = { id: "p", role: "super_admin", clinic_id: "c" };
+      const fallbackSig = await signWithRawKey("fallback_secret_key", profile);
+
+      // Case A: no key configured — must reject.
+      let result = await verifyProfileHeader({ ...profile, signature: fallbackSig });
+      expect(result).toBeNull();
+
+      // Case B: a real key is configured — must reject (key mismatch).
+      process.env.PROFILE_HEADER_HMAC_KEY = "real-production-key";
+      result = await verifyProfileHeader({ ...profile, signature: fallbackSig });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("R-02: dedicated key separate from CRON_SECRET", () => {
+    it("uses PROFILE_HEADER_HMAC_KEY when both keys are set", async () => {
+      process.env.PROFILE_HEADER_HMAC_KEY = "profile-key";
+      process.env.CRON_SECRET = "cron-key";
+
+      const profile = { id: "p", role: "doctor", clinic_id: "c" };
+      const sig = await signProfileHeader(profile);
+      expect(sig).not.toBeNull();
+
+      const verified = await verifyProfileHeader({ ...profile, signature: sig });
+      expect(verified).toEqual(profile);
+    });
+
+    it("a signature made with CRON_SECRET does NOT verify when PROFILE_HEADER_HMAC_KEY is set", async () => {
+      // Simulates a deployment that has rotated to a dedicated profile
+      // key. Old signatures (or signatures forged using a leaked
+      // CRON_SECRET) must be rejected.
+      const profile = { id: "p", role: "clinic_admin", clinic_id: "c" };
+      const cronSig = await signWithRawKey("cron-key", profile);
+
+      process.env.PROFILE_HEADER_HMAC_KEY = "profile-key";
+      process.env.CRON_SECRET = "cron-key";
+
+      const verified = await verifyProfileHeader({ ...profile, signature: cronSig });
+      expect(verified).toBeNull();
+    });
+
+    it("falls back to CRON_SECRET only when PROFILE_HEADER_HMAC_KEY is unset (transitional)", async () => {
+      process.env.CRON_SECRET = "legacy-key";
+
+      const profile = { id: "p", role: "receptionist", clinic_id: null };
+      const sig = await signProfileHeader(profile);
+      expect(sig).not.toBeNull();
+
+      const verified = await verifyProfileHeader({ ...profile, signature: sig });
+      expect(verified).toEqual(profile);
+    });
+  });
+
+  describe("verification correctness", () => {
+    beforeEach(() => {
+      process.env.PROFILE_HEADER_HMAC_KEY = "test-key";
+    });
+
+    it("rejects when the role is tampered with", async () => {
+      const sig = await signProfileHeader({
+        id: "p",
+        role: "patient",
+        clinic_id: "c",
+      });
+      const verified = await verifyProfileHeader({
+        id: "p",
+        role: "super_admin", // attacker bumps role
+        clinic_id: "c",
+        signature: sig,
+      });
+      expect(verified).toBeNull();
+    });
+
+    it("rejects when the clinic_id is tampered with", async () => {
+      const sig = await signProfileHeader({
+        id: "p",
+        role: "doctor",
+        clinic_id: "clinic-a",
+      });
+      const verified = await verifyProfileHeader({
+        id: "p",
+        role: "doctor",
+        clinic_id: "clinic-b", // cross-tenant attempt
+        signature: sig,
+      });
+      expect(verified).toBeNull();
+    });
+
+    it("rejects when any required header is missing", async () => {
+      const sig = await signProfileHeader({
+        id: "p",
+        role: "doctor",
+        clinic_id: null,
+      });
+
+      expect(
+        await verifyProfileHeader({ id: null, role: "doctor", clinic_id: null, signature: sig }),
+      ).toBeNull();
+      expect(
+        await verifyProfileHeader({ id: "p", role: null, clinic_id: null, signature: sig }),
+      ).toBeNull();
+      expect(
+        await verifyProfileHeader({ id: "p", role: "doctor", clinic_id: null, signature: null }),
+      ).toBeNull();
+    });
+  });
+});
+
+/**
+ * Sign a profile payload with an arbitrary raw key — used by the tests
+ * to simulate forged headers without going through the helper's env
+ * lookup logic.
+ */
+async function signWithRawKey(
+  rawKey: string,
+  profile: { id: string; role: string; clinic_id: string | null },
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(rawKey),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const payload = `${profile.id}:${profile.role}:${profile.clinic_id ?? ""}`;
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/lib/__tests__/with-auth.test.ts
+++ b/src/lib/__tests__/with-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createClient } from "@/lib/supabase-server";
 import { withAuth, type AuthContext } from "../with-auth";
 
@@ -6,9 +6,27 @@ vi.mock("@/lib/supabase-server", () => ({
   createClient: vi.fn(),
 }));
 
-function createMockRequest(): { headers: Map<string, string>; method: string; nextUrl: { pathname: string } } {
+function createMockRequest(initialHeaders?: Record<string, string>): {
+  headers: Map<string, string>;
+  method: string;
+  nextUrl: { pathname: string };
+} {
+  const headers = new Map<string, string>();
+  if (initialHeaders) {
+    for (const [k, v] of Object.entries(initialHeaders)) {
+      headers.set(k, v);
+    }
+  }
+  // Map.get returns undefined for missing keys, but Headers.get returns null.
+  // withAuth expects null, so wrap in a small adapter that mimics Headers.get.
+  const headersAdapter = {
+    get(key: string): string | null {
+      const value = headers.get(key);
+      return value === undefined ? null : value;
+    },
+  };
   return {
-    headers: new Map(),
+    headers: headersAdapter as unknown as Map<string, string>,
     method: "GET",
     nextUrl: { pathname: "/api/test" },
   };
@@ -151,5 +169,84 @@ describe("withAuth", () => {
 
     const authArg = handler.mock.calls[0][1] as AuthContext;
     expect(authArg.profile.clinic_id).toBeNull();
+  });
+
+  describe("R-01: forged x-auth-profile-* headers without configured HMAC key", () => {
+    const ORIGINAL_PROFILE_KEY = process.env.PROFILE_HEADER_HMAC_KEY;
+    const ORIGINAL_CRON = process.env.CRON_SECRET;
+
+    beforeEach(() => {
+      delete process.env.PROFILE_HEADER_HMAC_KEY;
+      delete process.env.CRON_SECRET;
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_PROFILE_KEY === undefined) {
+        delete process.env.PROFILE_HEADER_HMAC_KEY;
+      } else {
+        process.env.PROFILE_HEADER_HMAC_KEY = ORIGINAL_PROFILE_KEY;
+      }
+      if (ORIGINAL_CRON === undefined) {
+        delete process.env.CRON_SECRET;
+      } else {
+        process.env.CRON_SECRET = ORIGINAL_CRON;
+      }
+    });
+
+    it("falls back to the DB lookup and ignores forged profile headers", async () => {
+      // Real user authenticates as a low-privilege patient.
+      const realUser = { id: "auth-user-1" };
+      const realProfile = { id: "real-profile", role: "patient", clinic_id: "clinic-real" };
+      const mockSupabase = createMockSupabase(realUser, realProfile);
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+      // Attacker injects forged super_admin profile headers. With no
+      // HMAC key configured, withAuth must NOT trust them and must fetch
+      // the real profile from the database instead.
+      const request = createMockRequest({
+        "x-auth-profile-id": "attacker-profile-id",
+        "x-auth-profile-role": "super_admin",
+        "x-auth-profile-clinic": "victim-clinic",
+        "x-auth-profile-sig": "deadbeef".repeat(8),
+      });
+
+      const handler = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
+      const wrappedHandler = withAuth(handler, ["patient"]);
+
+      await wrappedHandler(request as never);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const authArg = handler.mock.calls[0][1] as AuthContext;
+      // The attacker-supplied super_admin claims are discarded; the
+      // real DB-backed patient profile wins.
+      expect(authArg.profile.id).toBe("real-profile");
+      expect(authArg.profile.role).toBe("patient");
+      expect(authArg.profile.clinic_id).toBe("clinic-real");
+    });
+
+    it("rejects the forged super_admin role at the role-check gate", async () => {
+      // Same forged headers, but the route only allows super_admin.
+      // The DB-backed profile is `patient`, so withAuth must respond 403.
+      const realUser = { id: "auth-user-1" };
+      const realProfile = { id: "real-profile", role: "patient", clinic_id: "clinic-real" };
+      const mockSupabase = createMockSupabase(realUser, realProfile);
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+      const request = createMockRequest({
+        "x-auth-profile-id": "attacker-profile-id",
+        "x-auth-profile-role": "super_admin",
+        "x-auth-profile-clinic": "victim-clinic",
+        "x-auth-profile-sig": "deadbeef".repeat(8),
+      });
+
+      const handler = vi.fn();
+      const wrappedHandler = withAuth(handler, ["super_admin"]);
+
+      const response = await wrappedHandler(request as never);
+      expect(response.status).toBe(403);
+      expect(handler).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -77,6 +77,12 @@ const ENV_RULES: EnvRule[] = [
   // ── Cron ───────────────────────────────────────────────────────────
   { name: "CRON_SECRET", required: process.env.NODE_ENV === "production", description: "Bearer token for cron endpoints (required in production)", group: "cron" },
 
+  // ── Profile-header HMAC (R-02) ────────────────────────────────────
+  // Distinct key from CRON_SECRET so leaking one does not compromise
+  // both cron invocation and session-header forgery. Falls back to
+  // CRON_SECRET only as a transitional measure (see profile-header-hmac.ts).
+  { name: "PROFILE_HEADER_HMAC_KEY", required: process.env.NODE_ENV === "production", description: "HMAC key used to sign x-auth-profile-* headers between middleware and withAuth (required in production)", group: "auth" },
+
   // ── Custom Domains ─────────────────────────────────────────────────
   { name: "CLOUDFLARE_API_TOKEN", required: false, description: "Cloudflare API token for DNS management", group: "domains" },
   { name: "CLOUDFLARE_ZONE_ID", required: false, description: "Cloudflare zone ID for DNS management", group: "domains" },

--- a/src/lib/profile-header-hmac.ts
+++ b/src/lib/profile-header-hmac.ts
@@ -1,0 +1,134 @@
+/**
+ * Profile-header HMAC sign/verify helper.
+ *
+ * The middleware signs `(profile.id, role, clinic_id)` and forwards them
+ * via `x-auth-profile-*` request headers so that `withAuth` can avoid a
+ * second DB query. Those headers MUST NOT be trusted unless a valid HMAC
+ * accompanies them — otherwise any caller could impersonate any user.
+ *
+ * Audit fixes:
+ *   R-01: No hard-coded fallback. If the HMAC key is unset we refuse to
+ *         sign and refuse to verify, forcing the authoritative DB lookup
+ *         in `withAuth`. A forged header without a configured key is
+ *         therefore inert.
+ *   R-02: Uses a dedicated `PROFILE_HEADER_HMAC_KEY` distinct from
+ *         `CRON_SECRET`, so a leak of one does not compromise the other.
+ *         Falls back to `CRON_SECRET` only for backwards compatibility
+ *         until operators have provisioned the new key.
+ */
+
+const HEADER_ID = "x-auth-profile-id";
+const HEADER_ROLE = "x-auth-profile-role";
+const HEADER_CLINIC = "x-auth-profile-clinic";
+const HEADER_SIG = "x-auth-profile-sig";
+
+export const PROFILE_HEADER_NAMES = {
+  id: HEADER_ID,
+  role: HEADER_ROLE,
+  clinic: HEADER_CLINIC,
+  sig: HEADER_SIG,
+} as const;
+
+export interface SignedProfile {
+  id: string;
+  role: string;
+  clinic_id: string | null;
+}
+
+/**
+ * Returns the configured HMAC key for profile headers, or `null` when
+ * none is set. Callers MUST treat `null` as "do not sign / do not trust
+ * inbound headers" — never substitute a literal.
+ *
+ * Prefers `PROFILE_HEADER_HMAC_KEY` (R-02) but accepts `CRON_SECRET` as
+ * a transitional fallback so existing deployments keep working until the
+ * dedicated key is provisioned. Once `PROFILE_HEADER_HMAC_KEY` is set in
+ * an environment, `CRON_SECRET` is no longer consulted for header HMAC.
+ */
+function getProfileHeaderSecret(): string | null {
+  const dedicated = process.env.PROFILE_HEADER_HMAC_KEY;
+  if (dedicated && dedicated.length > 0) return dedicated;
+  const legacy = process.env.CRON_SECRET;
+  if (legacy && legacy.length > 0) return legacy;
+  return null;
+}
+
+function buildPayload(profile: SignedProfile): string {
+  return `${profile.id}:${profile.role}:${profile.clinic_id ?? ""}`;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+/**
+ * Constant-time hex string comparison. Avoids early-exit timing leaks
+ * that `===` would introduce on attacker-controlled input.
+ */
+function timingSafeHexEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+async function importHmacKey(secret: string, usage: "sign" | "verify"): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    [usage],
+  );
+}
+
+/**
+ * Sign a profile and return the hex-encoded signature, or `null` when
+ * no HMAC key is configured. The caller must skip setting the
+ * `x-auth-profile-*` headers when this returns `null`.
+ */
+export async function signProfileHeader(profile: SignedProfile): Promise<string | null> {
+  const secret = getProfileHeaderSecret();
+  if (!secret) return null;
+  const key = await importHmacKey(secret, "sign");
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(buildPayload(profile)));
+  return bytesToHex(new Uint8Array(sig));
+}
+
+export interface VerifyHeaderInput {
+  id: string | null;
+  role: string | null;
+  clinic_id: string | null;
+  signature: string | null;
+}
+
+/**
+ * Verify the inbound `x-auth-profile-*` headers. Returns the parsed
+ * profile on success, or `null` on any failure (missing fields, no
+ * configured key, or signature mismatch). The caller MUST then perform
+ * the authoritative DB lookup — `null` here means "do not trust the
+ * headers", never "the user is anonymous".
+ */
+export async function verifyProfileHeader(input: VerifyHeaderInput): Promise<SignedProfile | null> {
+  if (!input.id || !input.role || !input.signature) return null;
+  const secret = getProfileHeaderSecret();
+  if (!secret) return null;
+
+  const key = await importHmacKey(secret, "sign");
+  const expected = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(buildPayload({ id: input.id, role: input.role, clinic_id: input.clinic_id })),
+  );
+  const expectedHex = bytesToHex(new Uint8Array(expected));
+
+  if (!timingSafeHexEqual(expectedHex, input.signature)) return null;
+
+  return { id: input.id, role: input.role, clinic_id: input.clinic_id };
+}

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -18,6 +18,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { User } from "@supabase/supabase-js";
 import { NextResponse, type NextRequest } from "next/server";
 import { logger } from "@/lib/logger";
+import { verifyProfileHeader, PROFILE_HEADER_NAMES } from "@/lib/profile-header-hmac";
 import { createClient } from "@/lib/supabase-server";
 import { getTenant } from "@/lib/tenant";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
@@ -61,36 +62,26 @@ export function withAuth(
         );
       }
 
-      // Check for signed profile headers from middleware to avoid double-querying (Audit P1 #8)
-      const headerProfileId = request.headers.get("x-auth-profile-id");
-      const headerProfileRole = request.headers.get("x-auth-profile-role");
-      const headerProfileClinic = request.headers.get("x-auth-profile-clinic") || null;
-      const headerProfileSig = request.headers.get("x-auth-profile-sig");
+      // Check for signed profile headers from middleware to avoid double-querying (Audit P1 #8).
+      // R-01: If the header HMAC key is unset, `verifyProfileHeader` returns null so we
+      //       fall through to the authoritative DB lookup below. We never trust these
+      //       headers without a valid signature.
+      const verified = await verifyProfileHeader({
+        id: request.headers.get(PROFILE_HEADER_NAMES.id),
+        role: request.headers.get(PROFILE_HEADER_NAMES.role),
+        clinic_id: request.headers.get(PROFILE_HEADER_NAMES.clinic),
+        signature: request.headers.get(PROFILE_HEADER_NAMES.sig),
+      });
 
-      let profile: { id: string; role: UserRole; clinic_id: string | null } | null = null;
+      let profile: { id: string; role: UserRole; clinic_id: string | null } | null = verified
+        ? { id: verified.id, role: verified.role as UserRole, clinic_id: verified.clinic_id }
+        : null;
 
-      if (headerProfileId && headerProfileRole && headerProfileSig) {
-        // Verify HMAC signature
-        const hmacData = `${headerProfileId}:${headerProfileRole}:${headerProfileClinic ?? ""}`;
-        const hmacKey = await crypto.subtle.importKey(
-          "raw",
-          new TextEncoder().encode(process.env.CRON_SECRET || "fallback_secret_key"),
-          { name: "HMAC", hash: "SHA-256" },
-          false,
-          ["verify"]
-        );
-        const expectedSig = await crypto.subtle.sign("HMAC", hmacKey, new TextEncoder().encode(hmacData));
-        const expectedSigHex = Array.from(new Uint8Array(expectedSig)).map(b => b.toString(16).padStart(2, '0')).join('');
-        
-        if (expectedSigHex === headerProfileSig) {
-          profile = {
-            id: headerProfileId,
-            role: headerProfileRole as UserRole,
-            clinic_id: headerProfileClinic
-          };
-        } else {
-          logger.warn("Invalid profile signature in headers, falling back to DB", { context: "with-auth", userId: user.id });
-        }
+      if (!profile && request.headers.get(PROFILE_HEADER_NAMES.sig)) {
+        logger.warn("Profile headers present but signature could not be verified — falling back to DB", {
+          context: "with-auth",
+          userId: user.id,
+        });
       }
 
       if (!profile) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -28,6 +28,7 @@ import {
   secureRedirect,
   applyAllSecurityHeaders,
 } from "@/lib/middleware/security-headers";
+import { signProfileHeader, PROFILE_HEADER_NAMES } from "@/lib/profile-header-hmac";
 import { isSeedUserBlocked } from "@/lib/seed-guard";
 import { extractSubdomain } from "@/lib/subdomain";
 import { subdomainCache, SUBDOMAIN_CACHE_TTL_MS, setSubdomainCache, negativeSubdomainCache, NEGATIVE_CACHE_TTL_MS, setNegativeSubdomainCache } from "@/lib/subdomain-cache";
@@ -127,13 +128,12 @@ export async function middleware(request: NextRequest) {
   // Strip incoming x-auth-profile-* headers. These are set later in this
   // middleware (after the user/profile lookup) with an HMAC signature so
   // downstream API routes (`withAuth`) can trust them without re-querying
-  // the DB. Allowing a client to forge them would let an authenticated
-  // attacker who knows the HMAC key (e.g. the dev fallback) escalate
-  // privilege. Always overwrite with server-derived values below.
-  requestHeaders.delete("x-auth-profile-id");
-  requestHeaders.delete("x-auth-profile-role");
-  requestHeaders.delete("x-auth-profile-clinic");
-  requestHeaders.delete("x-auth-profile-sig");
+  // the DB. Allowing a client to forge them would let an attacker
+  // impersonate any user, so we always overwrite with server-derived
+  // values (or omit them entirely if no HMAC key is configured).
+  for (const name of Object.values(PROFILE_HEADER_NAMES)) {
+    requestHeaders.delete(name);
+  }
 
   // --- Subdomain resolution ---
   const subdomain = extractSubdomain(hostname, rootDomain);
@@ -328,59 +328,59 @@ export async function middleware(request: NextRequest) {
         .maybeSingle();
       profile = data;
 
-      // Pass the profile data downstream via signed headers to avoid double-querying in `withAuth`
+      // Pass the profile data downstream via signed headers to avoid double-querying in `withAuth`.
+      // R-01: When PROFILE_HEADER_HMAC_KEY (or CRON_SECRET as a transitional fallback) is
+      //       unset, `signProfileHeader` returns null and we skip emitting the headers
+      //       entirely. Downstream `withAuth` then performs the authoritative DB lookup —
+      //       there is no literal fallback key that could be used to forge a signature.
       if (profile) {
-        // Use a lightweight HMAC to prevent header spoofing by the client
-        const hmacData = `${profile.id}:${profile.role}:${profile.clinic_id ?? ""}`;
-        const hmacKey = await crypto.subtle.importKey(
-          "raw",
-          new TextEncoder().encode(process.env.CRON_SECRET || "fallback_secret_key"),
-          { name: "HMAC", hash: "SHA-256" },
-          false,
-          ["sign"],
-        );
-        const signature = await crypto.subtle.sign("HMAC", hmacKey, new TextEncoder().encode(hmacData));
-        const sigHex = Array.from(new Uint8Array(signature)).map((b) => b.toString(16).padStart(2, "0")).join("");
-
-        // Set on the forwarded request headers so API routes (and `withAuth`)
-        // can read them. These are stripped from the inbound request above so
-        // a client cannot forge them.
-        requestHeaders.set("x-auth-profile-id", profile.id);
-        requestHeaders.set("x-auth-profile-role", profile.role);
-        if (profile.clinic_id) {
-          requestHeaders.set("x-auth-profile-clinic", profile.clinic_id);
-        } else {
-          requestHeaders.delete("x-auth-profile-clinic");
-        }
-        requestHeaders.set("x-auth-profile-sig", sigHex);
-
-        // Re-create the response so the new request headers are forwarded
-        // downstream, but preserve any Set-Cookie headers (e.g. refreshed
-        // Supabase auth tokens written by the `setAll` callback during
-        // getUser()) and any tenant/security headers already on the
-        // existing response. Recreating without copying these would silently
-        // drop the refreshed session cookies and effectively log the user out.
-        const previousResponse = supabaseResponse;
-        supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
-        previousResponse.headers.forEach((value, key) => {
-          if (key.toLowerCase() === "set-cookie") {
-            supabaseResponse.headers.append(key, value);
-          } else {
-            supabaseResponse.headers.set(key, value);
-          }
+        const sigHex = await signProfileHeader({
+          id: profile.id,
+          role: profile.role,
+          clinic_id: profile.clinic_id,
         });
 
-        // Set the auth-profile response headers (informational; the request
-        // headers above are what `withAuth` reads). Re-apply security and
-        // tenant headers since the response was just recreated.
-        supabaseResponse.headers.set("x-auth-profile-id", profile.id);
-        supabaseResponse.headers.set("x-auth-profile-role", profile.role);
-        if (profile.clinic_id) {
-          supabaseResponse.headers.set("x-auth-profile-clinic", profile.clinic_id);
+        if (sigHex) {
+          // Set on the forwarded request headers so API routes (and `withAuth`)
+          // can read them. These are stripped from the inbound request above so
+          // a client cannot forge them.
+          requestHeaders.set(PROFILE_HEADER_NAMES.id, profile.id);
+          requestHeaders.set(PROFILE_HEADER_NAMES.role, profile.role);
+          if (profile.clinic_id) {
+            requestHeaders.set(PROFILE_HEADER_NAMES.clinic, profile.clinic_id);
+          } else {
+            requestHeaders.delete(PROFILE_HEADER_NAMES.clinic);
+          }
+          requestHeaders.set(PROFILE_HEADER_NAMES.sig, sigHex);
+
+          // Re-create the response so the new request headers are forwarded
+          // downstream, but preserve any Set-Cookie headers (e.g. refreshed
+          // Supabase auth tokens written by the `setAll` callback during
+          // getUser()) and any tenant/security headers already on the
+          // existing response. Recreating without copying these would silently
+          // drop the refreshed session cookies and effectively log the user out.
+          const previousResponse = supabaseResponse;
+          supabaseResponse = NextResponse.next({ request: { headers: requestHeaders } });
+          previousResponse.headers.forEach((value, key) => {
+            if (key.toLowerCase() === "set-cookie") {
+              supabaseResponse.headers.append(key, value);
+            } else {
+              supabaseResponse.headers.set(key, value);
+            }
+          });
+
+          // Set the auth-profile response headers (informational; the request
+          // headers above are what `withAuth` reads). Re-apply security and
+          // tenant headers since the response was just recreated.
+          supabaseResponse.headers.set(PROFILE_HEADER_NAMES.id, profile.id);
+          supabaseResponse.headers.set(PROFILE_HEADER_NAMES.role, profile.role);
+          if (profile.clinic_id) {
+            supabaseResponse.headers.set(PROFILE_HEADER_NAMES.clinic, profile.clinic_id);
+          }
+          supabaseResponse.headers.set(PROFILE_HEADER_NAMES.sig, sigHex);
+          applyAllSecurityHeaders(supabaseResponse, cspHeaderValue, nonce);
+          if (resolvedClinic) setTenantHeaders(supabaseResponse, resolvedClinic);
         }
-        supabaseResponse.headers.set("x-auth-profile-sig", sigHex);
-        applyAllSecurityHeaders(supabaseResponse, cspHeaderValue, nonce);
-        if (resolvedClinic) setTenantHeaders(supabaseResponse, resolvedClinic);
       }
     }
   }


### PR DESCRIPTION
## Summary

Addresses the two P0 findings from the audit (commit `2a39109f`):

- **R-01 — Remove hard-coded HMAC fallback `"fallback_secret_key"`.** `src/middleware.ts:337` and `src/lib/with-auth.ts:77` previously fell back to the literal `"fallback_secret_key"` when `CRON_SECRET` was unset. The literal is in a public repo, so any environment with a missing `CRON_SECRET` (preview deploys, forks, misconfigured staging, missing CI secret) allowed an attacker to forge `x-auth-profile-id|role|clinic|sig` headers and impersonate any user with any role/clinic.
- **R-02 — Split `CRON_SECRET` into two distinct keys.** A single leak of `CRON_SECRET` previously compromised both cron invocation **and** full session forgery via the profile-header HMAC.

### What changed

A new helper `src/lib/profile-header-hmac.ts` centralises sign/verify for `x-auth-profile-*`:

- Reads `PROFILE_HEADER_HMAC_KEY` first (R-02). Falls back to `CRON_SECRET` only as a transitional measure so existing deployments don't break before the new key is provisioned. Once `PROFILE_HEADER_HMAC_KEY` is set, `CRON_SECRET` is no longer consulted for header HMAC, so a leak of one cannot be replayed against the other.
- Returns `null` when **no** key is configured (R-01). The middleware then skips emitting the headers entirely; `withAuth` falls through to the authoritative DB lookup. There is no literal fallback key — a request with valid-looking forged `x-auth-profile-*` headers and no key set is now inert.
- Uses constant-time hex comparison instead of `===` to avoid early-exit timing leaks on attacker-controlled signatures.

`src/middleware.ts` and `src/lib/with-auth.ts` now delegate to the helper. The header-name strings are also centralised so the strip-on-inbound list and the set-on-outbound list cannot drift apart.

### Operator action required

Provision a new secret distinct from `CRON_SECRET`:

```
wrangler secret put PROFILE_HEADER_HMAC_KEY  # value: openssl rand -hex 32
```

`src/lib/env.ts` now marks `PROFILE_HEADER_HMAC_KEY` as required in production, matching the existing pattern for `CRON_SECRET`. `.env.example`, `.env.production.example`, and `secrets-template.env` are updated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

Tenant isolation behaviour is unchanged — when no HMAC key is configured, `withAuth` performs the same DB lookup it has always performed when headers are missing, so existing role and tenant checks still apply.

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

New tests:

- `src/lib/__tests__/profile-header-hmac.test.ts` — covers sign/verify behaviour, the no-key case, the forged-fallback-literal case (signing with `"fallback_secret_key"` no longer verifies), and cross-key rejection (signed with `CRON_SECRET`, verified with `PROFILE_HEADER_HMAC_KEY` set).
- `src/lib/__tests__/with-auth.test.ts` — adds two regression tests for R-01: when no HMAC key is set, forged `super_admin` headers are ignored in favour of the real DB-backed `patient` profile, and the role check correctly rejects with 403.

Local results:

- `npm run test` — 539 passing, 24 skipped, 0 failed.
- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (pre-existing warnings only).

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
