### PR TITLE
fix(upload): use clinics/{id}/ prefix for tenant isolation check

### DIFF
--- a/src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
+++ b/src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression tests for the upload confirmation route's tenant-prefix check.
+ *
+ * Pre-fix bug: keys produced by `buildUploadKey()` are
+ *   clinics/{clinicId}/{category}/{filename}
+ * but the PUT confirmation handler compared against `${clinicId}/`, which
+ * never matches. Legitimate clinic uploads were rejected as forbidden,
+ * leaving orphaned objects in R2.
+ */
+import { describe, it, expect } from "vitest";
+import { buildUploadKey } from "@/lib/r2";
+import { expectedKeyPrefixForProfile } from "../upload/route";
+
+describe("expectedKeyPrefixForProfile", () => {
+  it("returns the clinic-scoped prefix for staff with a clinic_id", () => {
+    expect(expectedKeyPrefixForProfile("clinic_admin", "abc123")).toBe(
+      "clinics/abc123/",
+    );
+    expect(expectedKeyPrefixForProfile("doctor", "abc123")).toBe(
+      "clinics/abc123/",
+    );
+    expect(expectedKeyPrefixForProfile("receptionist", "abc123")).toBe(
+      "clinics/abc123/",
+    );
+  });
+
+  it("returns the shared `clinics/` prefix for super_admin", () => {
+    expect(expectedKeyPrefixForProfile("super_admin", null)).toBe("clinics/");
+    expect(expectedKeyPrefixForProfile("super_admin", "abc123")).toBe(
+      "clinics/",
+    );
+  });
+
+  it("returns null for non-super-admin staff with no clinic_id", () => {
+    expect(expectedKeyPrefixForProfile("doctor", null)).toBeNull();
+    expect(expectedKeyPrefixForProfile("doctor", undefined)).toBeNull();
+  });
+
+  it("matches keys produced by buildUploadKey() for the same clinic", () => {
+    const clinicId = "clinic-uuid-1234";
+    const key = buildUploadKey(clinicId, "documents", "file.pdf");
+    const prefix = expectedKeyPrefixForProfile("doctor", clinicId);
+
+    expect(prefix).not.toBeNull();
+    expect(key.startsWith(prefix as string)).toBe(true);
+  });
+
+  it("rejects a key that belongs to a different clinic", () => {
+    const ownerClinic = "clinic-A";
+    const otherClinic = "clinic-B";
+    const otherClinicKey = buildUploadKey(otherClinic, "documents", "file.pdf");
+    const prefix = expectedKeyPrefixForProfile("doctor", ownerClinic);
+
+    expect(prefix).not.toBeNull();
+    expect(otherClinicKey.startsWith(prefix as string)).toBe(false);
+  });
+
+  it("super_admin can confirm uploads from any clinic", () => {
+    const key = buildUploadKey("clinic-X", "logos", "logo.png");
+    const prefix = expectedKeyPrefixForProfile("super_admin", null);
+
+    expect(prefix).not.toBeNull();
+    expect(key.startsWith(prefix as string)).toBe(true);
+  });
+});

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -66,6 +66,27 @@ function validateFileContent(buffer: Buffer, declaredType: string): boolean {
   );
 }
 
+/**
+ * Compute the R2 key prefix that the authenticated profile is allowed to
+ * confirm. Keys produced by `buildUploadKey()` are of the form
+ *   clinics/{clinicId}/{category}/{filename}
+ * so non-super-admin users must own a key starting with their clinic prefix.
+ * Super-admins may confirm any key under the shared `clinics/` namespace.
+ *
+ * Returns `null` when the profile cannot legitimately confirm any upload
+ * (e.g. a non-super-admin staff user with no `clinic_id`).
+ *
+ * Exported for testability.
+ */
+export function expectedKeyPrefixForProfile(
+  role: string,
+  clinicId: string | null | undefined,
+): string | null {
+  if (role === "super_admin") return "clinics/";
+  if (clinicId) return `clinics/${clinicId}/`;
+  return null;
+}
+
 export const POST = withAuth(async (request, { profile }) => {
   if (!isR2Configured()) {
     logger.warn("Upload attempted but R2 storage is not configured", { context: "upload" });
@@ -139,10 +160,13 @@ export const PUT = withAuthValidation(uploadConfirmSchema, async (body, request,
   const { key, contentType } = body;
 
   // Tenant isolation: verify the R2 key belongs to this user's clinic.
-  // Keys follow the pattern: {clinicId}/{category}/{filename}
-  const clinicId = profile.clinic_id ?? (profile.role === "super_admin" ? null : null);
-  if (clinicId && !key.startsWith(`${clinicId}/`)) {
-    return apiForbidden("Access denied: file does not belong to your clinic");
+  // Keys are produced by `buildUploadKey()` and follow the pattern:
+  //   clinics/{clinicId}/{category}/{filename}
+  // Super-admins are allowed to confirm any key under `clinics/`.
+  const expectedPrefix = expectedKeyPrefixForProfile(profile.role, profile.clinic_id);
+
+  if (!expectedPrefix || !key.startsWith(expectedPrefix)) {
+    return apiForbidden("Upload key does not belong to your clinic");
   }
 
   if (!ALLOWED_TYPES.has(contentType)) {


### PR DESCRIPTION
Keys produced by buildUploadKey() are
  clinics/{clinicId}/{category}/{filename}
but the PUT /api/upload confirmation handler compared the key against ${clinicId}/, which never matched. Legitimate clinic uploads were rejected as forbidden after the file had already been uploaded to R2, producing broken UX and orphaned objects.

Extract the prefix computation into expectedKeyPrefixForProfile() and compare against clinics/{clinicId}/. Super-admins remain allowed to confirm any key under the shared clinics/ namespace; non-super-admin staff with no clinic_id are rejected (previously they bypassed the check entirely because of an && short-circuit).

Add a focused regression test that pairs buildUploadKey() output with the prefix helper to lock the contract.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
