### PR TITLE
Fix lab report storage to use encrypted PHI path

### DIFF
--- a/src/app/api/__tests__/lab-report-encrypted-storage.test.ts
+++ b/src/app/api/__tests__/lab-report-encrypted-storage.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Regression tests for finding #3 (CRITICAL): lab report storage must use
+ * the encrypted PHI path and must only be served via an authenticated
+ * download route — never via a public R2 URL.
+ *
+ * These tests exercise the actual route handlers (POST /api/lab/report-html
+ * and GET /api/files/download) with mocked Supabase / R2 / encryption
+ * dependencies, asserting:
+ *
+ *   1. report-html invokes encryptAndUpload (not the plain uploadToR2)
+ *   2. The R2 key it writes to is tenant-scoped under
+ *      `clinics/{clinicId}/lab-reports/`.
+ *   3. The route response and the persisted pdf_url reference the
+ *      authenticated download route, not a public/presigned URL.
+ *   4. /api/files/download requires authentication.
+ *   5. /api/files/download enforces the caller's clinic prefix
+ *      (cross-tenant download attempts are rejected with 403).
+ */
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks (must come before importing the route handlers) ────────────
+
+const mockChainable = {
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  single: vi.fn(),
+  maybeSingle: vi.fn(),
+};
+
+const mockSupabase = {
+  from: vi.fn(() => mockChainable),
+  auth: {
+    getUser: vi.fn(),
+  },
+  rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+};
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: vi.fn(async () => mockSupabase),
+  createTenantClient: vi.fn(async () => mockSupabase),
+  createAdminClient: vi.fn(() => mockSupabase),
+}));
+
+vi.mock("@/lib/tenant", () => ({
+  // No subdomain-derived tenant — let the profile.clinic_id carry the auth.
+  getTenant: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/tenant-context", () => ({
+  setTenantContext: vi.fn(),
+  logTenantContext: vi.fn(),
+}));
+
+vi.mock("@/lib/audit-log", () => ({
+  logAuditEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const encryptAndUploadMock = vi.fn<(...args: unknown[]) => unknown>();
+const downloadAndDecryptMock = vi.fn<(...args: unknown[]) => unknown>();
+vi.mock("@/lib/r2-encrypted", () => ({
+  encryptAndUpload: (...args: unknown[]) => encryptAndUploadMock(...args),
+  downloadAndDecrypt: (...args: unknown[]) => downloadAndDecryptMock(...args),
+}));
+
+const uploadToR2Mock = vi.fn<(...args: unknown[]) => unknown>();
+vi.mock("@/lib/r2", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/r2")>("@/lib/r2");
+  return {
+    ...actual,
+    uploadToR2: (...args: unknown[]) => uploadToR2Mock(...args),
+    isR2Configured: vi.fn(() => true),
+  };
+});
+
+const updateLabOrderPdfUrlMock = vi.fn<(...args: unknown[]) => Promise<boolean>>();
+vi.mock("@/lib/data/server", () => ({
+  updateLabOrderPdfUrl: (...args: unknown[]) => updateLabOrderPdfUrlMock(...args),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const CLINIC_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_CLINIC_ID = "22222222-2222-2222-2222-222222222222";
+
+function authedAs(role: "doctor" | "clinic_admin" | "patient" | "super_admin", clinicId: string | null) {
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "auth-user-1", email: "user@test.com" } },
+    error: null,
+  });
+  // The first .single() call inside withAuth fetches the user profile.
+  mockChainable.single.mockResolvedValue({
+    data: { id: "user-1", role, clinic_id: clinicId },
+    error: null,
+  });
+}
+
+function buildJsonRequest(url: string, body: Record<string, unknown>): NextRequest {
+  return new NextRequest(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function buildGetRequest(url: string): NextRequest {
+  return new NextRequest(url, { method: "GET" });
+}
+
+const validReportBody = {
+  orderId: "order-1",
+  patientName: "Jane Doe",
+  orderNumber: "LAB-001",
+  results: [
+    {
+      testName: "Glucose",
+      value: "95",
+      unit: "mg/dL",
+      referenceMin: 70,
+      referenceMax: 100,
+      flag: "normal",
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  encryptAndUploadMock.mockReset();
+  downloadAndDecryptMock.mockReset();
+  uploadToR2Mock.mockReset();
+  updateLabOrderPdfUrlMock.mockReset();
+  updateLabOrderPdfUrlMock.mockResolvedValue(true);
+  mockChainable.single.mockReset();
+  mockChainable.maybeSingle.mockReset();
+});
+
+// ── POST /api/lab/report-html ────────────────────────────────────────
+
+describe("POST /api/lab/report-html — encrypted PHI storage", () => {
+  it("writes through encryptAndUpload (not uploadToR2) under a clinic-scoped key", async () => {
+    authedAs("doctor", CLINIC_ID);
+    // Order lookup (.maybeSingle) returns the matching tenant-scoped order.
+    mockChainable.maybeSingle.mockResolvedValueOnce({
+      data: { id: "order-1", clinic_id: CLINIC_ID, patient_id: "patient-1" },
+      error: null,
+    });
+    encryptAndUploadMock.mockResolvedValueOnce("https://r2.example/clinics/x/lab-reports/abc.html.enc");
+
+    const { POST } = await import("@/app/api/lab/report-html/route");
+    const response = await POST(buildJsonRequest("http://t.test/api/lab/report-html", validReportBody));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+
+    // The dangerous helper must NOT be called.
+    expect(uploadToR2Mock).not.toHaveBeenCalled();
+
+    // Encrypted upload must be invoked exactly once with a tenant-scoped key.
+    expect(encryptAndUploadMock).toHaveBeenCalledTimes(1);
+    const [key, buffer, contentType, metadata] = encryptAndUploadMock.mock.calls[0];
+
+    expect(typeof key).toBe("string");
+    expect(key as string).toMatch(new RegExp(`^clinics/${CLINIC_ID}/lab-reports/`));
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(contentType).toBe("text/html");
+    expect(metadata).toMatchObject({
+      clinicId: CLINIC_ID,
+      category: "lab-reports",
+      patientId: "patient-1",
+    });
+  });
+
+  it("returns only an authenticated download URL (never the public R2 URL)", async () => {
+    authedAs("doctor", CLINIC_ID);
+    mockChainable.maybeSingle.mockResolvedValueOnce({
+      data: { id: "order-1", clinic_id: CLINIC_ID, patient_id: "patient-1" },
+      error: null,
+    });
+    const publicR2Url = "https://r2.public.example/clinics/x/lab-reports/abc.html.enc";
+    encryptAndUploadMock.mockResolvedValueOnce(publicR2Url);
+
+    const { POST } = await import("@/app/api/lab/report-html/route");
+    const response = await POST(buildJsonRequest("http://t.test/api/lab/report-html", validReportBody));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.ok).toBe(true);
+
+    // The R2 URL must not appear in the response.
+    expect(JSON.stringify(json.data)).not.toContain(publicR2Url);
+    expect(JSON.stringify(json.data)).not.toContain("r2.public.example");
+
+    // The download URL must be an authenticated route, not a presigned URL.
+    expect(json.data.downloadUrl).toMatch(/^\/api\/files\/download\?key=/);
+    expect(json.data.pdfUrl).toBe(json.data.downloadUrl);
+
+    // The persisted pdf_url must be the auth route too.
+    expect(updateLabOrderPdfUrlMock).toHaveBeenCalledTimes(1);
+    const [, persistedUrl] = updateLabOrderPdfUrlMock.mock.calls[0];
+    expect(persistedUrl).toMatch(/^\/api\/files\/download\?key=/);
+    expect(persistedUrl).not.toContain("https://");
+  });
+
+  it("rejects when the lab order does not belong to the caller's clinic", async () => {
+    authedAs("doctor", CLINIC_ID);
+    // Order lookup is filtered by clinic_id, so a cross-tenant order returns null.
+    mockChainable.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+    const { POST } = await import("@/app/api/lab/report-html/route");
+    const response = await POST(buildJsonRequest("http://t.test/api/lab/report-html", validReportBody));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.ok).toBe(false);
+    expect(encryptAndUploadMock).not.toHaveBeenCalled();
+    expect(uploadToR2Mock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (no data: URL fallback) when encrypted storage is unavailable", async () => {
+    authedAs("doctor", CLINIC_ID);
+    mockChainable.maybeSingle.mockResolvedValueOnce({
+      data: { id: "order-1", clinic_id: CLINIC_ID, patient_id: "patient-1" },
+      error: null,
+    });
+    encryptAndUploadMock.mockResolvedValueOnce(null);
+
+    const { POST } = await import("@/app/api/lab/report-html/route");
+    const response = await POST(buildJsonRequest("http://t.test/api/lab/report-html", validReportBody));
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.ok).toBe(false);
+    // Critically, no `data:` URL is leaked.
+    expect(JSON.stringify(json)).not.toContain("data:text/html");
+    expect(updateLabOrderPdfUrlMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET /api/files/download ──────────────────────────────────────────
+
+describe("GET /api/files/download — auth and tenant scoping", () => {
+  it("requires authentication", async () => {
+    mockSupabase.auth.getUser.mockResolvedValueOnce({
+      data: { user: null },
+      error: null,
+    });
+
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=clinics/${CLINIC_ID}/lab-reports/x.html`),
+    );
+
+    expect(response.status).toBe(401);
+    expect(downloadAndDecryptMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects keys belonging to a different clinic with 403", async () => {
+    authedAs("doctor", CLINIC_ID);
+
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=clinics/${OTHER_CLINIC_ID}/lab-reports/x.html`),
+    );
+
+    expect(response.status).toBe(403);
+    expect(downloadAndDecryptMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects path-traversal keys with 400", async () => {
+    authedAs("doctor", CLINIC_ID);
+
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=${encodeURIComponent("clinics/" + CLINIC_ID + "/../" + OTHER_CLINIC_ID + "/x.html")}`),
+    );
+
+    expect(response.status).toBe(400);
+    expect(downloadAndDecryptMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the decrypted file with HTML content-type and inline disposition for HTML keys", async () => {
+    authedAs("doctor", CLINIC_ID);
+    downloadAndDecryptMock.mockResolvedValueOnce(Buffer.from("<html>secret</html>", "utf-8"));
+
+    const key = `clinics/${CLINIC_ID}/lab-reports/123-abc-def.html`;
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=${encodeURIComponent(key)}`),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toMatch(/^text\/html/);
+    expect(response.headers.get("Content-Disposition")).toMatch(/^inline/);
+    expect(response.headers.get("Cache-Control")).toMatch(/no-store/);
+    expect(downloadAndDecryptMock).toHaveBeenCalledWith(key);
+    expect(await response.text()).toBe("<html>secret</html>");
+  });
+
+  it("super_admin can download from any clinic", async () => {
+    authedAs("super_admin", null);
+    downloadAndDecryptMock.mockResolvedValueOnce(Buffer.from("ok", "utf-8"));
+
+    const key = `clinics/${OTHER_CLINIC_ID}/lab-reports/abc.html`;
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=${encodeURIComponent(key)}`),
+    );
+
+    expect(response.status).toBe(200);
+    expect(downloadAndDecryptMock).toHaveBeenCalledWith(key);
+  });
+});
+
+// ── Pure-helper unit tests ───────────────────────────────────────────
+
+describe("download route helpers", () => {
+  it("expectedDownloadPrefixForProfile mirrors upload-side scoping", async () => {
+    const { expectedDownloadPrefixForProfile } = await import("@/app/api/files/download/route");
+
+    expect(expectedDownloadPrefixForProfile("doctor", CLINIC_ID)).toBe(`clinics/${CLINIC_ID}/`);
+    expect(expectedDownloadPrefixForProfile("clinic_admin", CLINIC_ID)).toBe(`clinics/${CLINIC_ID}/`);
+    expect(expectedDownloadPrefixForProfile("patient", CLINIC_ID)).toBe(`clinics/${CLINIC_ID}/`);
+    expect(expectedDownloadPrefixForProfile("super_admin", null)).toBe("clinics/");
+    expect(expectedDownloadPrefixForProfile("super_admin", CLINIC_ID)).toBe("clinics/");
+    expect(expectedDownloadPrefixForProfile("doctor", null)).toBeNull();
+  });
+
+  it("isSafeKey rejects traversal and absolute-path inputs", async () => {
+    const { isSafeKey } = await import("@/app/api/files/download/route");
+    expect(isSafeKey("")).toBe(false);
+    expect(isSafeKey("/etc/passwd")).toBe(false);
+    expect(isSafeKey("clinics/x/../../y")).toBe(false);
+    expect(isSafeKey("clinics/x\0y")).toBe(false);
+    expect(isSafeKey("clinics/abc/lab-reports/file.html")).toBe(true);
+  });
+
+  it("contentTypeForKey derives MIME from the key extension", async () => {
+    const { contentTypeForKey } = await import("@/app/api/files/download/route");
+    expect(contentTypeForKey("clinics/x/lab-reports/file.html")).toMatch(/^text\/html/);
+    expect(contentTypeForKey("clinics/x/lab-reports/file.pdf")).toBe("application/pdf");
+    expect(contentTypeForKey("clinics/x/photos/file.jpg")).toBe("image/jpeg");
+    expect(contentTypeForKey("clinics/x/files/unknown.xyz")).toBe("application/octet-stream");
+  });
+});

--- a/src/app/api/__tests__/lab-report-encrypted-storage.test.ts
+++ b/src/app/api/__tests__/lab-report-encrypted-storage.test.ts
@@ -54,8 +54,9 @@ vi.mock("@/lib/tenant-context", () => ({
   logTenantContext: vi.fn(),
 }));
 
+const logAuditEventMock = vi.fn(async () => undefined);
 vi.mock("@/lib/audit-log", () => ({
-  logAuditEvent: vi.fn(async () => undefined),
+  logAuditEvent: (...args: unknown[]) => logAuditEventMock(...(args as [])),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -67,6 +68,13 @@ const downloadAndDecryptMock = vi.fn<(...args: unknown[]) => unknown>();
 vi.mock("@/lib/r2-encrypted", () => ({
   encryptAndUpload: (...args: unknown[]) => encryptAndUploadMock(...args),
   downloadAndDecrypt: (...args: unknown[]) => downloadAndDecryptMock(...args),
+}));
+
+const isEncryptionConfiguredMock = vi.fn<() => boolean>();
+vi.mock("@/lib/encryption", () => ({
+  isEncryptionConfigured: () => isEncryptionConfiguredMock(),
+  encryptBuffer: vi.fn(),
+  decryptBuffer: vi.fn(),
 }));
 
 const uploadToR2Mock = vi.fn<(...args: unknown[]) => unknown>();
@@ -136,6 +144,12 @@ beforeEach(() => {
   uploadToR2Mock.mockReset();
   updateLabOrderPdfUrlMock.mockReset();
   updateLabOrderPdfUrlMock.mockResolvedValue(true);
+  isEncryptionConfiguredMock.mockReset();
+  // Default to "encryption configured" for the happy paths; individual
+  // tests opt out by overriding the mock.
+  isEncryptionConfiguredMock.mockReturnValue(true);
+  logAuditEventMock.mockReset();
+  logAuditEventMock.mockResolvedValue(undefined);
   mockChainable.single.mockReset();
   mockChainable.maybeSingle.mockReset();
 });
@@ -221,6 +235,29 @@ describe("POST /api/lab/report-html — encrypted PHI storage", () => {
     expect(json.ok).toBe(false);
     expect(encryptAndUploadMock).not.toHaveBeenCalled();
     expect(uploadToR2Mock).not.toHaveBeenCalled();
+  });
+
+  it("refuses up-front when PHI encryption is not configured (no plaintext upload)", async () => {
+    authedAs("doctor", CLINIC_ID);
+    isEncryptionConfiguredMock.mockReturnValue(false);
+    mockChainable.maybeSingle.mockResolvedValueOnce({
+      data: { id: "order-1", clinic_id: CLINIC_ID, patient_id: "patient-1" },
+      error: null,
+    });
+
+    const { POST } = await import("@/app/api/lab/report-html/route");
+    const response = await POST(buildJsonRequest("http://t.test/api/lab/report-html", validReportBody));
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.ok).toBe(false);
+    expect(json.code).toBe("ENCRYPTION_NOT_CONFIGURED");
+    // The dev plaintext fallback inside encryptAndUpload must NEVER be
+    // exercised through this route — it would leave the report unreadable
+    // to the auth-only download endpoint and (in prod) leak unencrypted PHI.
+    expect(encryptAndUploadMock).not.toHaveBeenCalled();
+    expect(uploadToR2Mock).not.toHaveBeenCalled();
+    expect(updateLabOrderPdfUrlMock).not.toHaveBeenCalled();
   });
 
   it("fails closed (no data: URL fallback) when encrypted storage is unavailable", async () => {
@@ -316,6 +353,59 @@ describe("GET /api/files/download — auth and tenant scoping", () => {
     expect(response.status).toBe(200);
     expect(downloadAndDecryptMock).toHaveBeenCalledWith(key);
   });
+
+  it("audit-logs super_admin downloads against the clinic that owns the key", async () => {
+    authedAs("super_admin", null);
+    downloadAndDecryptMock.mockResolvedValueOnce(Buffer.from("ok", "utf-8"));
+
+    const key = `clinics/${OTHER_CLINIC_ID}/lab-reports/audit.html`;
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=${encodeURIComponent(key)}`),
+    );
+
+    expect(response.status).toBe(200);
+    expect(logAuditEventMock).toHaveBeenCalledTimes(1);
+
+    const [params] = logAuditEventMock.mock.calls[0] as unknown as [
+      {
+        action: string;
+        type: string;
+        clinicId: string;
+        actor: string | null | undefined;
+        metadata: { key: string; role: string; crossTenant: boolean; callerClinicId: string | null };
+      },
+    ];
+    expect(params.action).toBe("file_downloaded");
+    expect(params.type).toBe("patient");
+    // Clinic context comes from the key prefix because super_admin has clinic_id: null.
+    expect(params.clinicId).toBe(OTHER_CLINIC_ID);
+    expect(params.metadata.key).toBe(key);
+    expect(params.metadata.role).toBe("super_admin");
+    expect(params.metadata.crossTenant).toBe(true);
+    expect(params.metadata.callerClinicId).toBeNull();
+  });
+
+  it("audit-logs in-clinic downloads with crossTenant=false", async () => {
+    authedAs("doctor", CLINIC_ID);
+    downloadAndDecryptMock.mockResolvedValueOnce(Buffer.from("ok", "utf-8"));
+
+    const key = `clinics/${CLINIC_ID}/lab-reports/in-clinic.html`;
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=${encodeURIComponent(key)}`),
+    );
+
+    expect(response.status).toBe(200);
+    expect(logAuditEventMock).toHaveBeenCalledTimes(1);
+
+    const [params] = logAuditEventMock.mock.calls[0] as unknown as [
+      { clinicId: string; metadata: { crossTenant: boolean; callerClinicId: string | null } },
+    ];
+    expect(params.clinicId).toBe(CLINIC_ID);
+    expect(params.metadata.crossTenant).toBe(false);
+    expect(params.metadata.callerClinicId).toBe(CLINIC_ID);
+  });
 });
 
 // ── Pure-helper unit tests ───────────────────────────────────────────
@@ -330,6 +420,17 @@ describe("download route helpers", () => {
     expect(expectedDownloadPrefixForProfile("super_admin", null)).toBe("clinics/");
     expect(expectedDownloadPrefixForProfile("super_admin", CLINIC_ID)).toBe("clinics/");
     expect(expectedDownloadPrefixForProfile("doctor", null)).toBeNull();
+  });
+
+  it("extractClinicIdFromKey parses the clinic UUID out of a tenant-scoped key", async () => {
+    const { extractClinicIdFromKey } = await import("@/app/api/files/download/route");
+    expect(extractClinicIdFromKey(`clinics/${CLINIC_ID}/lab-reports/x.html`)).toBe(CLINIC_ID);
+    expect(extractClinicIdFromKey(`clinics/${OTHER_CLINIC_ID}/photos/y.jpg`)).toBe(OTHER_CLINIC_ID);
+    // Non-clinic prefixes and malformed UUIDs return null.
+    expect(extractClinicIdFromKey("public/shared/x.html")).toBeNull();
+    expect(extractClinicIdFromKey("clinics//x.html")).toBeNull();
+    expect(extractClinicIdFromKey("clinics/not-a-uuid/x.html")).toBeNull();
+    expect(extractClinicIdFromKey("")).toBeNull();
   });
 
   it("isSafeKey rejects traversal and absolute-path inputs", async () => {

--- a/src/app/api/files/download/route.ts
+++ b/src/app/api/files/download/route.ts
@@ -1,0 +1,177 @@
+/**
+ * GET /api/files/download — Authenticated download of an encrypted PHI file
+ *
+ * Query params:
+ *   - key: R2 object key (without `.enc` suffix), e.g.
+ *          `clinics/{clinicId}/lab-reports/{timestamp}-{rand}-{hash}.html`
+ *
+ * Authorization
+ *   1. Caller must be authenticated (handled by `withAuthAnyRole`).
+ *   2. Caller must belong to the clinic that owns the key (super_admin
+ *      may access any `clinics/...` key).
+ *   3. The role check above is intentionally lenient (any authenticated
+ *      role) so that patients can fetch reports they themselves are
+ *      tied to via tenant scoping. Tenant prefix enforcement is the
+ *      primary access control here, mirroring `expectedKeyPrefixForProfile`
+ *      in the upload-confirm route.
+ *
+ * Decryption: encrypted blobs (with `.enc` suffix) are pulled from R2,
+ * decrypted via `downloadAndDecrypt`, and streamed back with a derived
+ * Content-Type. The R2 URL itself is never exposed to the caller.
+ *
+ * Auditing: every successful download is recorded via `logAuditEvent`.
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { apiError, apiForbidden, apiInternalError, apiNotFound } from "@/lib/api-response";
+import { logAuditEvent } from "@/lib/audit-log";
+import { logger } from "@/lib/logger";
+import { downloadAndDecrypt } from "@/lib/r2-encrypted";
+import type { UserRole } from "@/lib/types/database";
+import { withAuthAnyRole, type AuthContext } from "@/lib/with-auth";
+
+const ALLOWED_DOWNLOAD_ROLES: ReadonlySet<UserRole> = new Set<UserRole>([
+  "super_admin",
+  "clinic_admin",
+  "receptionist",
+  "doctor",
+  "patient",
+]);
+
+/**
+ * Compute the R2 key prefix the authenticated profile is allowed to read.
+ * Mirrors `expectedKeyPrefixForProfile` in the upload-confirm route so that
+ * upload-side and download-side authorization stay in lockstep.
+ *
+ * Returns `null` when the profile has no clinic and isn't a super_admin —
+ * such a user cannot legitimately read any encrypted file.
+ */
+export function expectedDownloadPrefixForProfile(
+  role: UserRole,
+  clinicId: string | null | undefined,
+): string | null {
+  if (role === "super_admin") return "clinics/";
+  if (clinicId) return `clinics/${clinicId}/`;
+  return null;
+}
+
+/**
+ * Pick a Content-Type from the underlying object key extension. The encrypted
+ * blob doesn't preserve MIME type metadata, so we derive it from the key.
+ *
+ * Defaults to `application/octet-stream` for unknown extensions so the
+ * browser falls back to the Content-Disposition filename.
+ */
+export function contentTypeForKey(key: string): string {
+  const lower = key.toLowerCase();
+  if (lower.endsWith(".html") || lower.endsWith(".htm")) return "text/html; charset=utf-8";
+  if (lower.endsWith(".pdf")) return "application/pdf";
+  if (lower.endsWith(".json")) return "application/json; charset=utf-8";
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".txt")) return "text/plain; charset=utf-8";
+  return "application/octet-stream";
+}
+
+/**
+ * Reject keys with traversal segments or absolute paths. The R2 helper
+ * `buildUploadKey` already sanitizes inputs, but this is defense-in-depth
+ * for any caller-supplied key.
+ */
+export function isSafeKey(key: string): boolean {
+  if (!key) return false;
+  if (key.startsWith("/")) return false;
+  if (key.includes("..")) return false;
+  if (key.includes("\0")) return false;
+  return true;
+}
+
+async function handler(request: NextRequest, { supabase, profile }: AuthContext): Promise<NextResponse> {
+  if (!ALLOWED_DOWNLOAD_ROLES.has(profile.role)) {
+    return apiForbidden();
+  }
+
+  const rawKey = request.nextUrl.searchParams.get("key");
+  if (!rawKey) {
+    return apiError("Missing 'key' query parameter", 400, "MISSING_KEY");
+  }
+
+  if (!isSafeKey(rawKey)) {
+    return apiError("Invalid key", 400, "INVALID_KEY");
+  }
+
+  // Strip a `.enc` suffix if a caller passed one — `downloadAndDecrypt`
+  // will append it again. We compare prefixes against the unsuffixed key.
+  const baseKey = rawKey.endsWith(".enc") ? rawKey.slice(0, -4) : rawKey;
+
+  const allowedPrefix = expectedDownloadPrefixForProfile(profile.role, profile.clinic_id);
+  if (!allowedPrefix || !baseKey.startsWith(allowedPrefix)) {
+    logger.warn("Cross-tenant download attempt blocked", {
+      context: "api/files/download",
+      role: profile.role,
+      profileClinicId: profile.clinic_id,
+      keyPrefix: baseKey.split("/").slice(0, 2).join("/"),
+    });
+    return apiForbidden("File belongs to a different clinic");
+  }
+
+  const plaintext = await downloadAndDecrypt(baseKey);
+  if (!plaintext) {
+    return apiNotFound("File not found or could not be decrypted");
+  }
+
+  // Audit the access. We do not include the file body in the audit metadata.
+  if (profile.clinic_id) {
+    await logAuditEvent({
+      supabase,
+      action: "file_downloaded",
+      type: "patient",
+      clinicId: profile.clinic_id,
+      actor: profile.id,
+      description: `Downloaded encrypted file ${baseKey}`,
+      metadata: { key: baseKey, role: profile.role },
+    }).catch((err) => {
+      logger.warn("Failed to log file download audit event", {
+        context: "api/files/download",
+        error: err,
+      });
+    });
+  }
+
+  const filename = baseKey.split("/").pop() ?? "download";
+  const contentType = contentTypeForKey(baseKey);
+
+  // Force `inline` for HTML so existing UI flows (window.open) render the
+  // report; everything else is offered as an attachment so the browser
+  // doesn't try to execute or interpret arbitrary PHI bytes.
+  const disposition = contentType.startsWith("text/html") ? "inline" : "attachment";
+
+  // Cast the Node Buffer through `unknown` so it satisfies the Web BodyInit
+  // type used by NextResponse — Buffers are streamable in Next.js but TS
+  // doesn't model that overlap.
+  const body = plaintext as unknown as BodyInit;
+
+  try {
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        "Content-Length": String(plaintext.byteLength),
+        "Content-Disposition": `${disposition}; filename="${filename.replace(/"/g, "")}"`,
+        // Short-lived private cache: PHI must not be cached by intermediaries.
+        "Cache-Control": "private, no-store, max-age=0",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (err) {
+    logger.error("Failed to build download response", {
+      context: "api/files/download",
+      key: baseKey,
+      error: err,
+    });
+    return apiInternalError("Download failed");
+  }
+}
+
+export const GET = withAuthAnyRole(handler);

--- a/src/app/api/files/download/route.ts
+++ b/src/app/api/files/download/route.ts
@@ -87,6 +87,18 @@ export function isSafeKey(key: string): boolean {
   return true;
 }
 
+/**
+ * Extract the clinic UUID from a tenant-scoped key (`clinics/{clinicId}/...`).
+ * Used for audit logging when the caller's profile has no `clinic_id`
+ * (e.g. super_admin) so that PHI access is still attributed to the
+ * clinic that owns the file. Returns `null` for keys that don't match
+ * the expected shape.
+ */
+export function extractClinicIdFromKey(key: string): string | null {
+  const match = /^clinics\/([0-9a-fA-F-]{36})\//.exec(key);
+  return match ? match[1] : null;
+}
+
 async function handler(request: NextRequest, { supabase, profile }: AuthContext): Promise<NextResponse> {
   if (!ALLOWED_DOWNLOAD_ROLES.has(profile.role)) {
     return apiForbidden();
@@ -122,20 +134,44 @@ async function handler(request: NextRequest, { supabase, profile }: AuthContext)
   }
 
   // Audit the access. We do not include the file body in the audit metadata.
-  if (profile.clinic_id) {
+  // Privileged access (super_admin) MUST also be logged — for those callers
+  // we attribute the event to the clinic that owns the key, which is parsed
+  // from the `clinics/{clinicId}/...` prefix. Compliance with Moroccan Law
+  // 09-08 requires that PHI access be auditable; silently skipping audit
+  // writes when `profile.clinic_id` is null would create a privileged
+  // back-door.
+  const auditClinicId =
+    profile.clinic_id ?? extractClinicIdFromKey(baseKey);
+
+  if (auditClinicId) {
     await logAuditEvent({
       supabase,
       action: "file_downloaded",
       type: "patient",
-      clinicId: profile.clinic_id,
+      clinicId: auditClinicId,
       actor: profile.id,
       description: `Downloaded encrypted file ${baseKey}`,
-      metadata: { key: baseKey, role: profile.role },
+      metadata: {
+        key: baseKey,
+        role: profile.role,
+        // Flag privileged cross-tenant access explicitly in the audit trail.
+        crossTenant: profile.clinic_id !== auditClinicId,
+        callerClinicId: profile.clinic_id ?? null,
+      },
     }).catch((err) => {
       logger.warn("Failed to log file download audit event", {
         context: "api/files/download",
         error: err,
       });
+    });
+  } else {
+    // Should not happen in practice — `allowedPrefix` enforcement above
+    // guarantees the key starts with `clinics/{uuid}/` for any caller we
+    // got this far with. Log a warning so we notice if it ever does.
+    logger.warn("File download served without auditable clinic context", {
+      context: "api/files/download",
+      role: profile.role,
+      keyPrefix: baseKey.split("/").slice(0, 2).join("/"),
     });
   }
 

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -21,6 +21,7 @@ import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { updateLabOrderPdfUrl } from "@/lib/data/server";
+import { isEncryptionConfigured } from "@/lib/encryption";
 import { escapeHtml } from "@/lib/escape-html";
 import { logger } from "@/lib/logger";
 import { buildUploadKey } from "@/lib/r2";
@@ -142,6 +143,27 @@ export const POST = withAuthValidation(labReportSchema, async (body, request, { 
     const clinicId = profile.clinic_id;
     if (!clinicId) {
       return apiError("User must belong to a clinic");
+    }
+
+    // Fail closed if PHI encryption is not configured.
+    //
+    // `encryptAndUpload` has a non-production plaintext fallback (no `.enc`
+    // suffix) for local convenience, but `downloadAndDecrypt` always reads
+    // the `.enc` object — so a plaintext upload here would produce a report
+    // that the download route can never serve. Refusing up-front avoids the
+    // asymmetry and guarantees lab reports only land in encrypted storage,
+    // matching the Moroccan Law 09-08 PHI handling requirement.
+    if (!isEncryptionConfigured()) {
+      logger.error("Lab report generation refused: PHI encryption not configured", {
+        context: "api/lab/report-html",
+        clinicId,
+        orderId,
+      });
+      return apiError(
+        "Encrypted report storage is not configured. Contact the administrator.",
+        503,
+        "ENCRYPTION_NOT_CONFIGURED",
+      );
     }
 
     const generatedAt = formatDisplayDate(new Date(), "en", "datetime");

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -1,19 +1,30 @@
 /**
- * POST /api/lab/report-html — Generate an HTML report for a lab test order
+ * POST /api/lab/report-html — Generate a lab report for a lab test order
  *
  * Body: { orderId, patientName, orderNumber, results }
  * clinic_id is derived from the authenticated user's profile.
  *
- * Generates an HTML report, uploads to R2, and updates the order's pdf_url.
- * Returns: { pdfUrl }
+ * The report is rendered as a protected HTML artifact, encrypted at rest
+ * via `encryptAndUpload`, and served through the authenticated download
+ * route. The route never returns a public R2 URL — only an authenticated
+ * download path that re-validates the caller's clinic and role.
+ *
+ * Returns: { reportKey, downloadUrl, pdfUrl }
+ *   - reportKey:   the underlying R2 key (without `.enc` suffix)
+ *   - downloadUrl: `/api/files/download?key=<reportKey>`
+ *   - pdfUrl:      same as downloadUrl, kept for backward compatibility
+ *                  with existing UI callers that read `data.pdfUrl`.
  */
 
 import { apiError, apiInternalError, apiSuccess } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
+import { logAuditEvent } from "@/lib/audit-log";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { updateLabOrderPdfUrl } from "@/lib/data/server";
 import { escapeHtml } from "@/lib/escape-html";
-import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
+import { logger } from "@/lib/logger";
+import { buildUploadKey } from "@/lib/r2";
+import { encryptAndUpload } from "@/lib/r2-encrypted";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatCurrency, formatNumber, formatDisplayDate } from "@/lib/utils";
 import { labReportSchema } from "@/lib/validations";
@@ -117,7 +128,15 @@ function generateLabReportHtml(data: {
 </html>`;
 }
 
-export const POST = withAuthValidation(labReportSchema, async (body, request, { profile }) => {
+/**
+ * Sanitize the order number for use as a file basename so we don't introduce
+ * path separators or `.enc` collisions through user-influenced data.
+ */
+function sanitizeOrderNumber(orderNumber: string): string {
+  return orderNumber.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80);
+}
+
+export const POST = withAuthValidation(labReportSchema, async (body, request, { supabase, profile }) => {
     const { orderId, patientName, orderNumber, results } = body;
     // Derive clinic_id from the authenticated user's profile — never from the request body
     const clinicId = profile.clinic_id;
@@ -134,22 +153,78 @@ export const POST = withAuthValidation(labReportSchema, async (body, request, { 
       generatedAt,
     });
 
-    const fileName = `lab-report-${orderId.slice(0, 8)}-${Date.now()}.html`;
-    const key = buildUploadKey(clinicId, "lab-reports", fileName);
+    // Look up the order so we can (1) confirm tenant ownership and (2) audit
+    // the patient context. If the order doesn't belong to this clinic we
+    // refuse before writing any PHI to storage.
+    const { data: order, error: orderError } = await supabase
+      .from("lab_test_orders")
+      .select("id, clinic_id, patient_id")
+      .eq("id", orderId)
+      .eq("clinic_id", clinicId)
+      .maybeSingle();
 
-    if (!isR2Configured()) {
-      const dataUrl = `data:text/html;base64,${Buffer.from(html).toString("base64")}`;
-      return apiSuccess({ pdfUrl: dataUrl, fallback: true });
+    if (orderError) {
+      logger.warn("Failed to load lab order for report generation", {
+        context: "api/lab/report-html",
+        orderId,
+        error: orderError,
+      });
+      return apiInternalError("Failed to load order");
     }
+    if (!order) {
+      return apiError("Lab order not found", 404, "NOT_FOUND");
+    }
+
+    // Tenant-scoped key under the encrypted PHI namespace.
+    // buildUploadKey() produces `clinics/{clinicId}/lab-reports/{timestamp}-{rand}-{hashedName}`
+    // and `encryptAndUpload()` appends `.enc` for the stored object.
+    const fileName = `${sanitizeOrderNumber(orderNumber)}.html`;
+    const reportKey = buildUploadKey(clinicId, "lab-reports", fileName);
 
     const buffer = Buffer.from(html, "utf-8");
-    const url = await uploadToR2(key, buffer, "text/html");
+    const stored = await encryptAndUpload(reportKey, buffer, "text/html", {
+      clinicId,
+      category: "lab-reports",
+      patientId: order.patient_id ?? null,
+    });
 
-    if (!url) {
-      return apiInternalError("Failed to upload report");
+    if (!stored) {
+      // Either R2 is not configured or PHI encryption is missing in production.
+      // Fail closed — we never fall back to a data: URL because that would
+      // ship raw PHI HTML inline to the caller.
+      return apiError(
+        "Encrypted report storage is not configured. Contact the administrator.",
+        503,
+        "STORAGE_NOT_CONFIGURED",
+      );
     }
 
-    await updateLabOrderPdfUrl(orderId, url);
+    // Only an authenticated download route is exposed to the caller. The
+    // underlying R2 URL is never surfaced — that path bypasses tenant + role
+    // re-checks and would leak PHI if the URL were ever shared.
+    const downloadUrl = `/api/files/download?key=${encodeURIComponent(reportKey)}`;
 
-    return apiSuccess({ pdfUrl: url });
+    await updateLabOrderPdfUrl(orderId, downloadUrl);
+
+    await logAuditEvent({
+      supabase,
+      action: "lab_report_generated",
+      type: "patient",
+      clinicId,
+      actor: profile.id,
+      description: `Lab report for order ${orderNumber} stored at ${reportKey}`,
+      metadata: {
+        orderId,
+        orderNumber,
+        reportKey,
+        patientId: order.patient_id ?? null,
+      },
+    });
+
+    return apiSuccess({
+      reportKey,
+      downloadUrl,
+      // Backward-compat field for existing UI callers that read `pdfUrl`.
+      pdfUrl: downloadUrl,
+    });
 }, STAFF_ROLES);

--- a/src/lib/r2-encrypted.ts
+++ b/src/lib/r2-encrypted.ts
@@ -14,6 +14,19 @@ import { logger } from "@/lib/logger";
 import { uploadToR2, deleteFromR2 } from "@/lib/r2";
 
 /**
+ * Diagnostic / audit metadata threaded through encrypted upload calls.
+ *
+ * The values are NOT written into the encrypted blob (which would defeat
+ * the purpose of encryption); they are surfaced in structured logs so PHI
+ * upload activity can be traced back to a clinic, category and patient.
+ */
+export interface EncryptedUploadMetadata {
+  clinicId?: string;
+  category?: string;
+  patientId?: string | null;
+}
+
+/**
  * Encrypt a file and upload the ciphertext to R2.
  *
  * The R2 key gets a `.enc` suffix to signal that the stored object
@@ -22,12 +35,15 @@ import { uploadToR2, deleteFromR2 } from "@/lib/r2";
  * @param key         R2 object key (the `.enc` suffix is appended automatically)
  * @param plaintext   File contents as Buffer
  * @param contentType Original MIME type (stored as R2 metadata, not in the encrypted blob)
+ * @param metadata    Optional diagnostic context (clinicId, category, patientId)
+ *                    used for audit logging only — never stored in the encrypted blob.
  * @returns Public URL of the encrypted object, or null on failure
  */
 export async function encryptAndUpload(
   key: string,
   plaintext: Buffer | Uint8Array,
   contentType: string,
+  metadata?: EncryptedUploadMetadata,
 ): Promise<string | null> {
   if (!isEncryptionConfigured()) {
     // In production, PHI MUST be encrypted to comply with Moroccan Law 09-08.
@@ -37,6 +53,7 @@ export async function encryptAndUpload(
       logger.error("PHI encryption not configured in production — aborting upload to prevent unencrypted PHI storage", {
         context: "r2-encrypted",
         key,
+        metadata,
       });
       return null;
     }
@@ -44,6 +61,7 @@ export async function encryptAndUpload(
     logger.warn("PHI encryption not configured — uploading plaintext as fallback (non-production only)", {
       context: "r2-encrypted",
       key,
+      metadata,
     });
     return uploadToR2(key, Buffer.from(plaintext), contentType);
   }
@@ -53,6 +71,7 @@ export async function encryptAndUpload(
     logger.error("Failed to encrypt file — aborting upload", {
       context: "r2-encrypted",
       key,
+      metadata,
     });
     return null;
   }


### PR DESCRIPTION
Finding #3 (CRITICAL): the lab report-html route uploaded raw HTML through the generic uploadToR2 helper and surfaced a public R2 URL, bypassing the PHI-safe encrypted storage path.

- src/lib/r2-encrypted.ts: encryptAndUpload now accepts an optional metadata argument (clinicId, category, patientId) for audit logging.
- src/app/api/lab/report-html/route.ts: route writes the protected HTML artifact through encryptAndUpload under a tenant-scoped key (clinics/{clinicId}/lab-reports/...), persists the auth download URL in pdf_url, audits the generation, and fails closed with 503 when encrypted storage is unavailable (no more data: URL fallback). Also confirms the lab order belongs to the caller's clinic before writing PHI.
- src/app/api/files/download/route.ts: new GET handler that serves decrypted files only after verifying the caller's clinic prefix matches the requested key (super_admin can read any clinics/ key). Path-traversal keys are rejected; downloads are audit-logged.
- Regression test covers the encrypted-path upload contract, the fail-closed behavior, and the auth + tenant scoping on the new download endpoint.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
