### PR TITLE
test(upload): add PUT /api/upload route handler tests for tenant-prefix enforcement (Task 1.3)

### DIFF
--- a/src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
+++ b/src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
@@ -6,10 +6,21 @@
  * but the PUT confirmation handler compared against `${clinicId}/`, which
  * never matches. Legitimate clinic uploads were rejected as forbidden,
  * leaving orphaned objects in R2.
+ *
+ * The fix lives in two layers and we test both:
+ *
+ *   1. `expectedKeyPrefixForProfile()` — pure helper exposed for unit tests.
+ *   2. `PUT /api/upload` — full route handler exercised end-to-end with a
+ *      mocked Supabase client and R2 layer, per the AGENTS.md test
+ *      conventions ("schema tests are supplementary — always pair with
+ *      route handler tests").
  */
-import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { buildUploadKey } from "@/lib/r2";
 import { expectedKeyPrefixForProfile } from "../upload/route";
+
+// ── Helper-level tests ───────────────────────────────────────────────
 
 describe("expectedKeyPrefixForProfile", () => {
   it("returns the clinic-scoped prefix for staff with a clinic_id", () => {
@@ -61,5 +72,216 @@ describe("expectedKeyPrefixForProfile", () => {
 
     expect(prefix).not.toBeNull();
     expect(key.startsWith(prefix as string)).toBe(true);
+  });
+});
+
+// ── Route-handler-level tests for PUT /api/upload ────────────────────
+//
+// These tests exercise the full request → auth → validation → handler
+// chain so the tenant-prefix contract is enforced end-to-end (not just
+// at the helper layer). Per AGENTS.md, schema-only tests are
+// insufficient for security-critical multi-tenant boundaries.
+
+const mockChainable = {
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  single: vi.fn(),
+  maybeSingle: vi.fn(),
+};
+
+const mockSupabase = {
+  from: vi.fn(() => mockChainable),
+  auth: {
+    getUser: vi.fn(),
+  },
+  rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+};
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: vi.fn(async () => mockSupabase),
+  createTenantClient: vi.fn(async () => mockSupabase),
+  createAdminClient: vi.fn(() => mockSupabase),
+}));
+
+vi.mock("@/lib/tenant", () => ({
+  // Profile-derived clinic_id carries the auth in this suite; no subdomain.
+  getTenant: vi.fn(async () => null),
+}));
+
+vi.mock("@/lib/tenant-context", () => ({
+  setTenantContext: vi.fn(),
+  logTenantContext: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const readR2ObjectHeadMock = vi.fn<(...args: unknown[]) => unknown>();
+const deleteFromR2Mock = vi.fn<(...args: unknown[]) => unknown>();
+vi.mock("@/lib/r2", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/r2")>("@/lib/r2");
+  return {
+    ...actual,
+    isR2Configured: vi.fn(() => true),
+    readR2ObjectHead: (...args: unknown[]) => readR2ObjectHeadMock(...args),
+    deleteFromR2: (...args: unknown[]) => deleteFromR2Mock(...args),
+  };
+});
+
+const OWNER_CLINIC_ID = "abc123";
+const OTHER_CLINIC_ID = "other-clinic-999";
+
+// PDF magic bytes (`%PDF`) — must match the route's MAGIC_BYTES table.
+const PDF_HEAD = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]);
+
+function authedAs(
+  role: "doctor" | "clinic_admin" | "receptionist" | "super_admin",
+  clinicId: string | null,
+) {
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: "auth-user-1", email: "user@test.com" } },
+    error: null,
+  });
+  // The first .single() call inside withAuth fetches the user's profile.
+  mockChainable.single.mockResolvedValue({
+    data: { id: "user-1", role, clinic_id: clinicId },
+    error: null,
+  });
+}
+
+function buildPutRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://t.test/api/upload", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readR2ObjectHeadMock.mockReset();
+  deleteFromR2Mock.mockReset();
+  mockChainable.single.mockReset();
+  mockChainable.maybeSingle.mockReset();
+});
+
+describe("PUT /api/upload — tenant prefix enforcement", () => {
+  it("confirms an upload when a clinic user owns the key (clinics/{clinicId}/...)", async () => {
+    authedAs("clinic_admin", OWNER_CLINIC_ID);
+    readR2ObjectHeadMock.mockResolvedValueOnce(PDF_HEAD);
+
+    const { PUT } = await import("../upload/route");
+    const response = await PUT(
+      buildPutRequest({
+        key: `clinics/${OWNER_CLINIC_ID}/documents/file.pdf`,
+        contentType: "application/pdf",
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, data: { valid: true } });
+
+    // The R2 object must have been head-read (for magic-byte validation)
+    // and never deleted on the happy path.
+    expect(readR2ObjectHeadMock).toHaveBeenCalledTimes(1);
+    expect(deleteFromR2Mock).not.toHaveBeenCalled();
+  });
+
+  it("confirms an upload whose key was produced by buildUploadKey() for the caller's clinic", async () => {
+    authedAs("doctor", OWNER_CLINIC_ID);
+    readR2ObjectHeadMock.mockResolvedValueOnce(PDF_HEAD);
+
+    // Use the production key builder so the test fails if the prefix
+    // contract drifts on either side.
+    const realKey = buildUploadKey(OWNER_CLINIC_ID, "documents", "file.pdf");
+
+    const { PUT } = await import("../upload/route");
+    const response = await PUT(
+      buildPutRequest({ key: realKey, contentType: "application/pdf" }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, data: { valid: true } });
+    expect(deleteFromR2Mock).not.toHaveBeenCalled();
+  });
+
+  it("rejects with 403 when a clinic user tries to confirm another clinic's key", async () => {
+    authedAs("clinic_admin", OWNER_CLINIC_ID);
+
+    const { PUT } = await import("../upload/route");
+    const response = await PUT(
+      buildPutRequest({
+        key: `clinics/${OTHER_CLINIC_ID}/documents/file.pdf`,
+        contentType: "application/pdf",
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/does not belong to your clinic/i);
+
+    // Forbidden requests must short-circuit before touching R2 — no
+    // head-read, no deletion side effects.
+    expect(readR2ObjectHeadMock).not.toHaveBeenCalled();
+    expect(deleteFromR2Mock).not.toHaveBeenCalled();
+  });
+
+  it("rejects with 403 when the key uses a non-clinics/ prefix", async () => {
+    authedAs("clinic_admin", OWNER_CLINIC_ID);
+
+    const { PUT } = await import("../upload/route");
+    const response = await PUT(
+      buildPutRequest({
+        // Pre-fix bug shape: bare `${clinicId}/...` without the `clinics/` root.
+        key: `${OWNER_CLINIC_ID}/documents/file.pdf`,
+        contentType: "application/pdf",
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.ok).toBe(false);
+    expect(readR2ObjectHeadMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-super-admin staff with no clinic_id (no expected prefix)", async () => {
+    authedAs("doctor", null);
+
+    const { PUT } = await import("../upload/route");
+    const response = await PUT(
+      buildPutRequest({
+        key: `clinics/${OWNER_CLINIC_ID}/documents/file.pdf`,
+        contentType: "application/pdf",
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(json.ok).toBe(false);
+    expect(readR2ObjectHeadMock).not.toHaveBeenCalled();
+  });
+
+  it("allows super_admin to confirm a key from any clinic under clinics/", async () => {
+    authedAs("super_admin", null);
+    readR2ObjectHeadMock.mockResolvedValueOnce(PDF_HEAD);
+
+    const { PUT } = await import("../upload/route");
+    const response = await PUT(
+      buildPutRequest({
+        key: `clinics/${OTHER_CLINIC_ID}/documents/file.pdf`,
+        contentType: "application/pdf",
+      }),
+    );
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json).toMatchObject({ ok: true, data: { valid: true } });
+    expect(deleteFromR2Mock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Task 1.3 follow-up — strengthen the regression coverage for the upload-confirmation tenant-prefix bug fixed in #445.

The original fix (PR #445) introduced `expectedKeyPrefixForProfile()` and a helper-level test that compares prefixes against `buildUploadKey()` output. Per `AGENTS.md`:

> Schema tests are supplementary — Always pair with route handler tests that exercise the full request → auth → validation → mutation → response chain.

This PR keeps the existing helper tests and adds full route-handler tests for `PUT /api/upload`, mocking Supabase auth and the R2 layer (`isR2Configured`, `readR2ObjectHead`, `deleteFromR2`) while keeping the real `buildUploadKey()` so the prefix contract is validated end-to-end on both sides.

### Test cases added

| Scenario | Expected | Side effects |
| --- | --- | --- |
| `clinic_admin` confirms `clinics/abc123/documents/file.pdf` | 200 + `{ valid: true }` | head-read once, no delete |
| `doctor` confirms a key produced by `buildUploadKey(ownerClinic, …)` | 200 + `{ valid: true }` | no delete |
| `clinic_admin` tries to confirm another clinic's key | 403 "does not belong to your clinic" | no R2 read, no delete |
| Bare `${clinicId}/...` legacy-shape key (pre-fix bug shape) | 403 | no R2 read |
| Non-super-admin staff with `clinic_id = null` | 403 | no R2 read |
| `super_admin` confirms any key under `clinics/` | 200 + `{ valid: true }` | no delete |

The 403 paths assert that the handler short-circuits before touching R2 (no head-read, no deletion side effects), so a forbidden caller cannot induce R2 calls.

## Type of change

- [x] Bug fix _(test coverage for #445)_
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [x] This PR changes tenant isolation or multi-tenant scoping _(adds end-to-end tests for the existing tenant-isolation check on `PUT /api/upload`)_
- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated — `src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts`: 12 tests, all passing locally (6 new route-handler tests + 6 existing helper tests).
- [ ] Manual testing performed
- [ ] E2E tests pass locally

```
$ npx vitest run src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes (file-scoped)
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
