### PR TITLE
feat: fail-fast production env validation for SUPABASE_SERVICE_ROLE_KEY

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -51,7 +51,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Dynamic clinic subdomain pages
-  if (process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  const isProduction = process.env.NODE_ENV === "production";
+  const hasServiceRoleKey = !!(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  if (isProduction && !hasServiceRoleKey) {
+    throw new Error(
+      "[sitemap] SUPABASE_SERVICE_ROLE_KEY is required in production for dynamic sitemap generation. " +
+      "Set this environment variable or feature-gate this route if service-role access is intentionally unavailable.",
+    );
+  }
+
+  if (hasServiceRoleKey) {
     try {
       // Use admin client (service role) so the sitemap query works without
       // authentication cookies. Googlebot won't have session cookies, so the
@@ -91,6 +101,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         }
       }
     } catch (err) {
+      if (isProduction) throw err;
       logger.warn("Failed to fetch clinic subdomains for sitemap", { context: "sitemap", error: err });
     }
   } else {
@@ -128,7 +139,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Individual doctor profile pages
-  if (process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  if (hasServiceRoleKey) {
     try {
       const doctors = await getDirectoryDoctors();
       for (const doctor of doctors) {
@@ -140,6 +151,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         });
       }
     } catch (err) {
+      if (isProduction) throw err;
       logger.warn("Failed to fetch directory doctors for sitemap", { context: "sitemap", error: err });
     }
   }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -51,10 +51,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // Dynamic clinic subdomain pages
-  const isProduction = process.env.NODE_ENV === "production";
+  //
+  // At production *runtime*, SUPABASE_SERVICE_ROLE_KEY is guaranteed to exist
+  // because enforceEnvValidation() (called from instrumentation.ts) refuses to
+  // boot without it. During `next build` prerendering NODE_ENV is "production"
+  // but the key may legitimately be absent (CI builds), so we detect that via
+  // NEXT_PHASE and skip gracefully.
+  const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+  const isProductionRuntime = process.env.NODE_ENV === "production" && !isBuildPhase;
   const hasServiceRoleKey = !!(process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY);
 
-  if (isProduction && !hasServiceRoleKey) {
+  if (isProductionRuntime && !hasServiceRoleKey) {
     throw new Error(
       "[sitemap] SUPABASE_SERVICE_ROLE_KEY is required in production for dynamic sitemap generation. " +
       "Set this environment variable or feature-gate this route if service-role access is intentionally unavailable.",
@@ -101,7 +108,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         }
       }
     } catch (err) {
-      if (isProduction) throw err;
+      if (isProductionRuntime) throw err;
       logger.warn("Failed to fetch clinic subdomains for sitemap", { context: "sitemap", error: err });
     }
   } else {
@@ -151,7 +158,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         });
       }
     } catch (err) {
-      if (isProduction) throw err;
+      if (isProductionRuntime) throw err;
       logger.warn("Failed to fetch directory doctors for sitemap", { context: "sitemap", error: err });
     }
   }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -48,7 +48,7 @@ const ENV_RULES: EnvRule[] = [
   { name: "NEXT_PUBLIC_SITE_URL", required: process.env.NODE_ENV === "production", description: "Public site URL for CSRF and links (required in production)", group: "tenant" },
 
   // ── Supabase Service Role (needed for rate limiter, cron, admin ops) ─
-  { name: "SUPABASE_SERVICE_ROLE_KEY", required: false, description: "Supabase service-role key for server-side admin operations", group: "core" },
+  { name: "SUPABASE_SERVICE_ROLE_KEY", required: process.env.NODE_ENV === "production", description: "Required server-only key for admin Supabase operations (required in production)", group: "core" },
 
   // ── Cloudflare R2 Storage ──────────────────────────────────────────
   { name: "R2_ACCOUNT_ID", required: false, description: "Cloudflare R2 account ID", group: "storage" },


### PR DESCRIPTION
- Mark SUPABASE_SERVICE_ROLE_KEY as required when NODE_ENV=production in env.ts so enforceEnvValidation() refuses to boot without it.
- Feature-gate sitemap.ts: throw immediately in production if the key is missing instead of silently returning empty results. In dev, the existing graceful skip behavior is preserved.
- Re-throw query errors in production sitemap so failures surface loudly instead of degrading to a partial sitemap.
- All other createAdminClient() callers already fail loudly via requireEnv() — no changes needed.

Addresses audit finding #4 (HIGH): silent degradation of server secrets.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
