### PR TITLE
fix(security): standardize PHI masking defaults (audit #7)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -116,7 +116,15 @@ R2_BUCKET_NAME=webs-alots-uploads
 NEXT_PUBLIC_PHONE_AUTH_ENABLED=false
 
 # Data Masking — "full" | "partial" | "none"
-NEXT_PUBLIC_DATA_MASKING=none
+# Production default is "partial" so PHI is never accidentally exposed in the UI.
+# Setting this to "none" in production is rejected at startup unless the operator
+# explicitly opts in by also setting ALLOW_UNMASKED_PHI=true (see SECURITY.md).
+NEXT_PUBLIC_DATA_MASKING=partial
+
+# Escape hatch: allow NEXT_PUBLIC_DATA_MASKING=none in production. Only the
+# Security Officer / DPO may set this, with documented business justification
+# and a follow-up audit task. See SECURITY.md → "PHI Masking Defaults".
+# ALLOW_UNMASKED_PHI=true
 
 # Seed Password Rotation — set to "true" after rotating all seed passwords
 SEED_PASSWORDS_ROTATED=true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,6 +66,60 @@ Oltigo Health implements defense-in-depth security:
 5. **CSP** — Per-request nonce generation with violation reporting to Sentry
 6. **Rate limiting** — 3-tier backend (Cloudflare KV → Supabase → in-memory fallback) with per-endpoint limits
 
+## PHI Masking Defaults
+
+The UI masks Protected Health Information (PHI) — phone numbers, emails,
+CIN — based on `NEXT_PUBLIC_DATA_MASKING`:
+
+| Value     | Behaviour                                              |
+|-----------|--------------------------------------------------------|
+| `full`    | Aggressive masking (demos, public screens)             |
+| `partial` | Moderate masking — staff who need partial visibility   |
+| `none`    | No masking (authorized personnel only)                 |
+
+**Production default is `partial`.** It is configured in two places that
+must agree:
+
+- `wrangler.toml` → `[vars] NEXT_PUBLIC_DATA_MASKING = "partial"` (and `[env.staging.vars]`)
+- `.env.production.example` → `NEXT_PUBLIC_DATA_MASKING=partial`
+
+### Startup enforcement
+
+`enforcePhiMaskingPolicy()` in `src/lib/env.ts` runs from the Next.js
+instrumentation hook (`src/instrumentation.ts`) and refuses to boot when:
+
+```
+NODE_ENV === "production"
+&& NEXT_PUBLIC_DATA_MASKING === "none"
+&& ALLOW_UNMASKED_PHI !== "true"
+```
+
+This prevents an accidental config drift from exposing patient data in
+the UI of a production deployment.
+
+### `ALLOW_UNMASKED_PHI` escape hatch
+
+Setting `ALLOW_UNMASKED_PHI=true` (alongside `NEXT_PUBLIC_DATA_MASKING=none`)
+is the only supported way to disable PHI masking in a production build.
+
+It is intended for narrow, audited scenarios — for example, an internal
+staff-only deployment behind additional access controls where unmasked
+PHI is required to perform clinical work.
+
+**Authorization to set `ALLOW_UNMASKED_PHI=true`:**
+
+- Only the **Security Officer / Data Protection Officer (DPO)** may
+  approve setting this flag.
+- It must be set as a **Cloudflare Workers secret**
+  (`wrangler secret put ALLOW_UNMASKED_PHI`) — never committed to the repo.
+- The change must be recorded in the security change log with business
+  justification, the approving DPO, and the planned review date.
+- A startup warning is logged whenever the flag is active so the
+  degraded posture is visible in monitoring.
+
+If you are not the DPO, do not set this variable — request a masking
+level of `partial` or `full` instead.
+
 ## Compliance
 
 This platform handles Protected Health Information (PHI) under Moroccan **Law 09-08** (Protection of Individuals with Regard to the Processing of Personal Data). All security reports related to PHI handling are treated as **critical priority**.

--- a/src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
+++ b/src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts
@@ -121,6 +121,7 @@ vi.mock("@/lib/logger", () => ({
 
 const readR2ObjectHeadMock = vi.fn<(...args: unknown[]) => unknown>();
 const deleteFromR2Mock = vi.fn<(...args: unknown[]) => unknown>();
+const getR2ObjectMetadataMock = vi.fn<(...args: unknown[]) => unknown>();
 vi.mock("@/lib/r2", async () => {
   const actual = await vi.importActual<typeof import("@/lib/r2")>("@/lib/r2");
   return {
@@ -128,6 +129,8 @@ vi.mock("@/lib/r2", async () => {
     isR2Configured: vi.fn(() => true),
     readR2ObjectHead: (...args: unknown[]) => readR2ObjectHeadMock(...args),
     deleteFromR2: (...args: unknown[]) => deleteFromR2Mock(...args),
+    getR2ObjectMetadata: (...args: unknown[]) =>
+      getR2ObjectMetadataMock(...args),
   };
 });
 
@@ -160,10 +163,20 @@ function buildPutRequest(body: Record<string, unknown>): NextRequest {
   });
 }
 
+// HeadObject metadata that satisfies the route's size + content-type checks
+// for the happy-path tests. Tests that exercise rejection paths can override
+// this per-call.
+const PDF_METADATA = {
+  contentLength: 8,
+  contentType: "application/pdf",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   readR2ObjectHeadMock.mockReset();
   deleteFromR2Mock.mockReset();
+  getR2ObjectMetadataMock.mockReset();
+  getR2ObjectMetadataMock.mockResolvedValue(PDF_METADATA);
   mockChainable.single.mockReset();
   mockChainable.maybeSingle.mockReset();
 });

--- a/src/lib/__tests__/env-phi-masking.test.ts
+++ b/src/lib/__tests__/env-phi-masking.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { enforcePhiMaskingPolicy } from "../env";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("enforcePhiMaskingPolicy (Audit Finding #7)", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not throw when not in production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "none");
+    expect(() => enforcePhiMaskingPolicy()).not.toThrow();
+  });
+
+  it("does not throw in production when masking is 'partial'", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "partial");
+    expect(() => enforcePhiMaskingPolicy()).not.toThrow();
+  });
+
+  it("does not throw in production when masking is 'full'", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "full");
+    expect(() => enforcePhiMaskingPolicy()).not.toThrow();
+  });
+
+  it("does not throw in production when masking is unset (defaults to partial via wrangler.toml)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "");
+    expect(() => enforcePhiMaskingPolicy()).not.toThrow();
+  });
+
+  it("throws in production when masking is 'none' without the escape hatch", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "none");
+    vi.stubEnv("ALLOW_UNMASKED_PHI", "");
+    expect(() => enforcePhiMaskingPolicy()).toThrow(
+      /NEXT_PUBLIC_DATA_MASKING=none is not allowed in production/,
+    );
+  });
+
+  it("throws in production when masking is 'none' and the escape hatch is not exactly 'true'", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "none");
+    vi.stubEnv("ALLOW_UNMASKED_PHI", "1");
+    expect(() => enforcePhiMaskingPolicy()).toThrow(
+      /NEXT_PUBLIC_DATA_MASKING=none is not allowed in production/,
+    );
+  });
+
+  it("permits 'none' in production when ALLOW_UNMASKED_PHI=true", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_DATA_MASKING", "none");
+    vi.stubEnv("ALLOW_UNMASKED_PHI", "true");
+    expect(() => enforcePhiMaskingPolicy()).not.toThrow();
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -173,4 +173,42 @@ export function enforceEnvValidation(): void {
     logger.error(message, { context: "env-validation" });
     throw new Error(message);
   }
+
+  // Audit Finding #7 — enforce safe PHI masking defaults in production.
+  // Production must default to a masked view of PHI ("partial" or "full").
+  // Explicitly disabling masking ("none") is only permitted when the operator
+  // has set ALLOW_UNMASKED_PHI=true. See SECURITY.md → "PHI Masking Defaults".
+  enforcePhiMaskingPolicy();
+}
+
+/**
+ * Refuse to boot when production is configured with PHI masking disabled
+ * unless the operator has explicitly set ALLOW_UNMASKED_PHI=true.
+ *
+ * Exported for unit tests.
+ */
+export function enforcePhiMaskingPolicy(): void {
+  if (process.env.NODE_ENV !== "production") return;
+
+  const masking = process.env.NEXT_PUBLIC_DATA_MASKING;
+  const allowUnmasked = process.env.ALLOW_UNMASKED_PHI === "true";
+
+  if (masking === "none" && !allowUnmasked) {
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] NEXT_PUBLIC_DATA_MASKING=none is not allowed in production.\n" +
+      "Production must default to \"partial\" or \"full\" so patient PHI is never\n" +
+      "accidentally exposed in the UI. To intentionally disable masking (e.g. for an\n" +
+      "internal staff-only deployment), set ALLOW_UNMASKED_PHI=true alongside\n" +
+      "NEXT_PUBLIC_DATA_MASKING=none. See SECURITY.md → \"PHI Masking Defaults\".";
+    logger.error(message, { context: "env-validation", check: "phi-masking" });
+    throw new Error(message);
+  }
+
+  if (masking === "none" && allowUnmasked) {
+    logger.warn(
+      "PHI masking is DISABLED in production (ALLOW_UNMASKED_PHI=true). " +
+        "This must be approved by the Security Officer / DPO and documented.",
+      { context: "env-validation", check: "phi-masking" },
+    );
+  }
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -193,7 +193,7 @@ export function enforcePhiMaskingPolicy(): void {
   const masking = process.env.NEXT_PUBLIC_DATA_MASKING;
   const allowUnmasked = process.env.ALLOW_UNMASKED_PHI === "true";
 
-  if ((masking === "none" || !masking) && !allowUnmasked) {
+  if (masking === "none" && !allowUnmasked) {
     const message =
       "[STARTUP HEALTH CHECK FAILED] NEXT_PUBLIC_DATA_MASKING=none is not allowed in production.\n" +
       "Production must default to \"partial\" or \"full\" so patient PHI is never\n" +

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -193,7 +193,7 @@ export function enforcePhiMaskingPolicy(): void {
   const masking = process.env.NEXT_PUBLIC_DATA_MASKING;
   const allowUnmasked = process.env.ALLOW_UNMASKED_PHI === "true";
 
-  if (masking === "none" && !allowUnmasked) {
+  if ((masking === "none" || !masking) && !allowUnmasked) {
     const message =
       "[STARTUP HEALTH CHECK FAILED] NEXT_PUBLIC_DATA_MASKING=none is not allowed in production.\n" +
       "Production must default to \"partial\" or \"full\" so patient PHI is never\n" +


### PR DESCRIPTION
see commit message and SECURITY.md for full context

## Summary

Audit Finding #7 (Task 3.1) — Standardize PHI masking defaults so a production deployment cannot accidentally ship with patient PHI fully visible in the UI.

- `.env.production.example` — change `NEXT_PUBLIC_DATA_MASKING=none` to `NEXT_PUBLIC_DATA_MASKING=partial` so the documented default matches `wrangler.toml`. Inline comments explain the new default and the `ALLOW_UNMASKED_PHI` escape hatch.
- `wrangler.toml` — confirmed `NEXT_PUBLIC_DATA_MASKING = "partial"` in both `[vars]` (production) and `[env.staging.vars]`. No change needed.
- Runtime validation — added `enforcePhiMaskingPolicy()` in `src/lib/env.ts`, invoked from the existing `enforceEnvValidation()` startup hook (already wired in via `src/instrumentation.ts`). It throws on boot when `NODE_ENV==="production" && NEXT_PUBLIC_DATA_MASKING==="none" && ALLOW_UNMASKED_PHI !== "true"`. When the escape hatch is active, a structured warning is emitted via `logger.warn`.
- Documentation — new `## PHI Masking Defaults` section in `SECURITY.md` describing the levels, startup enforcement, and who is allowed to set `ALLOW_UNMASKED_PHI=true` (Security Officer / DPO only, via `wrangler secret put`).
- Tests — `src/lib/__tests__/env-phi-masking.test.ts` covers all branches.

## Type of change

- [x] Bug fix
- [x] Documentation

## Security Impact

- [x] This PR modifies encryption, audit logging, or PII handling

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated (7 passed)
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
