### PR TITLE
test(e2e): gate upgrade-insecure-requests CSP assertion on prod target

### DIFF
--- a/e2e/csp-headers.spec.ts
+++ b/e2e/csp-headers.spec.ts
@@ -12,6 +12,18 @@ const CRITICAL_PAGES = [
   { name: "login", path: "/login" },
 ];
 
+/**
+ * `buildCsp` (src/lib/middleware/security-headers.ts) intentionally omits
+ * `upgrade-insecure-requests`, `report-uri`, and `report-to` when
+ * `NODE_ENV === "development"`. The Playwright config runs `next dev`
+ * (development mode) for local runs and `next start` (production mode) only
+ * in CI or when `E2E_BASE_URL` points at an external server.
+ *
+ * Mirror that gate here so production-only directives are asserted only when
+ * the test target is actually a production build.
+ */
+const IS_PRODUCTION_TARGET = !!process.env.CI || !!process.env.E2E_BASE_URL;
+
 test.describe("CSP header enforcement", () => {
   for (const { name, path } of CRITICAL_PAGES) {
     test(`${name} (${path}) serves enforced strict CSP`, async ({ page }) => {
@@ -27,7 +39,9 @@ test.describe("CSP header enforcement", () => {
       expect(csp).toContain("'nonce-");
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("frame-ancestors 'none'");
-      expect(csp).toContain("upgrade-insecure-requests");
+      if (IS_PRODUCTION_TARGET) {
+        expect(csp).toContain("upgrade-insecure-requests");
+      }
 
       // Legacy wildcards must NOT appear in the strict policy
       expect(csp).not.toContain("*.supabase.co");


### PR DESCRIPTION
## Summary

`e2e/csp-headers.spec.ts:30` unconditionally asserted that the CSP header contains `upgrade-insecure-requests`, but `buildCsp` (`src/lib/middleware/security-headers.ts:97`) only emits that directive when `NODE_ENV !== "development"`. `playwright.config.ts:51-55` runs `npm run dev` (i.e., `next dev` → `NODE_ENV=development`) for local runs and `next start` (production) only when `process.env.CI` is set, so the test always failed locally.

This PR mirrors the same gate inside the test: a new `IS_PRODUCTION_TARGET` constant guards the `upgrade-insecure-requests` assertion, evaluating true when either `process.env.CI` or `process.env.E2E_BASE_URL` is set (the same conditions under which the Playwright config points at a production build). All other strict-CSP assertions remain unconditional, so policy correctness is still enforced everywhere.

Why option 1 over the alternatives:
- **Option 2 (always run `next build && next start`)** would slow every local `npm run test:e2e` invocation by tens of seconds and force a full rebuild on every code change.
- **Option 3 (drop the assertion)** loses real coverage in CI/production where `upgrade-insecure-requests` is the policy that matters.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

CSP policy generation is unchanged. Only the test assertion is adjusted to match the documented dev-vs-prod behavior of `buildCsp`. The directive is still asserted in CI (where `process.env.CI=true`) and against any externally-targeted server (where `E2E_BASE_URL` is set).

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] E2E tests pass locally (assertion now correctly skipped in dev)

- `npx tsc --noEmit` clean
- `npx eslint e2e/csp-headers.spec.ts` clean
- CI runs Playwright with `process.env.CI=true`, so the production-only directive is still asserted there.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
