### PR TITLE
feat(r2): native lifecycle backstop — abort incomplete multipart + apply script (Task 3.3.4)

### DIFF
--- a/docs/r2-lifecycle.md
+++ b/docs/r2-lifecycle.md
@@ -83,3 +83,132 @@ If a future feature requires longer-lived direct uploads, either:
   policy in `src/lib/r2.ts`) means abandoned uploads are bounded to
   `MAX_FILE_SIZE` (2 MB) — the lifecycle rule is the second line of defense,
   not the first.
+
+---
+
+## Native R2 Lifecycle Backstop (Task 3.3.4)
+
+Separate from the cron-driven cleanup and the `expire-abandoned-uploads`
+rule documented above, we run R2's **native** lifecycle engine as a
+defense-in-depth backstop. This is purely additive — if the cron is wedged,
+if the Worker is down, or if a future feature regresses the cleanup path,
+R2 itself still enforces the minimum retention guarantees declared here.
+
+The rule set lives as a checked-in JSON file and is applied to a bucket via
+a small Node script that calls the Cloudflare REST API directly.
+
+### Files
+
+- [`r2-lifecycle.json`](../r2-lifecycle.json) — JSONC-ish declaration of the
+  lifecycle rules. Shape matches the [Cloudflare R2 lifecycle
+  API](https://developers.cloudflare.com/api/resources/r2/subresources/buckets/subresources/lifecycle/methods/update).
+  `//` line comments and object fields starting with `_` are stripped by
+  the apply script before the body is POSTed.
+- [`scripts/apply-r2-lifecycle.mjs`](../scripts/apply-r2-lifecycle.mjs) —
+  applies the JSON to a bucket. Reads account ID, API token, and bucket
+  name from environment variables. Idempotent: the Cloudflare API replaces
+  the entire rule set on every `PUT`.
+
+### Rules
+
+#### `abort-incomplete-multipart-1d` (enabled)
+
+Aborts any multipart upload that has not been completed within 24 hours and
+releases the associated part storage. Applies to the **entire bucket**
+(empty prefix).
+
+The direct-upload flow uses presigned POSTs capped at 2 MB, so it does not
+start multipart uploads. This rule covers every other producer of multipart
+state:
+
+- the AWS SDK used by backup/recovery scripts (`scripts/backup.sh`,
+  `scripts/recover.sh`, `scripts/r2-sync.sh`),
+- ad-hoc SOP tooling (PHI key rotation, staging swap),
+- any future large-file feature (clinical imaging, exports) that opts into
+  the multipart API.
+
+Abandoned part data is billed against the bucket and is invisible to the
+confirm-upload route's cleanup — R2's own engine is the only thing that
+can reclaim it reliably.
+
+#### `expire-pending-uploads-30d` (commented-out stub)
+
+Commented out inside `r2-lifecycle.json` because it depends on a future
+code change (see below). When enabled, it would delete any object under
+the `clinics/_pending/` prefix after 30 days — a belt-and-braces expiry on
+direct uploads that were accepted by R2 but never promoted to a confirmed
+record.
+
+Do **not** uncomment the stub until the application actually writes
+unconfirmed uploads to `clinics/_pending/`. Today they are written directly
+to `clinics/{id}/...` alongside long-lived assets (logos, templates), so an
+age-based delete on any `clinics/` sub-prefix would destroy confirmed data.
+
+### Running the script
+
+```bash
+# Staging
+export CLOUDFLARE_ACCOUNT_ID=...       # same as Workers deploy
+export CLOUDFLARE_API_TOKEN=...        # token with "R2 Edit" on the bucket
+export R2_BUCKET_NAME=webs-alots-uploads-staging
+node scripts/apply-r2-lifecycle.mjs
+
+# Production
+export R2_BUCKET_NAME=webs-alots-uploads
+node scripts/apply-r2-lifecycle.mjs
+```
+
+The script exits non-zero if any env var is missing or if the Cloudflare
+API returns an error (`success: false` or non-2xx), so it is safe to wire
+into a deploy pipeline.
+
+Useful flags:
+
+- `--dry-run` — prints the exact request body without hitting the API.
+  Use this to inspect what the JSONC stripper produced.
+- `--file=PATH` — apply a non-default config file (e.g. during a migration).
+
+### Verifying
+
+After applying, confirm via `wrangler`:
+
+```bash
+wrangler r2 bucket lifecycle list "$R2_BUCKET_NAME"
+```
+
+The `abort-incomplete-multipart-1d` rule should appear with an
+AbortIncompleteMultipartUpload transition at 1 day. `wrangler` also surfaces
+the `expire-abandoned-uploads` rule from the pre-existing setup — both
+coexist because each targets a different object lifecycle concern.
+
+### Required API token scopes
+
+Create a scoped token at
+<https://dash.cloudflare.com/profile/api-tokens> with:
+
+- **Account** → **Workers R2 Storage** → **Edit** (scoped to the specific
+  account and, if the UI allows, to the individual bucket).
+
+Store it as `CLOUDFLARE_API_TOKEN` in the CI secret store. The token used
+for `wrangler deploy` has the right scope; you can reuse it.
+
+### Future refactor: `clinics/_pending/`
+
+The long-term plan is to stop writing unconfirmed direct uploads straight
+to `clinics/{id}/...` and instead:
+
+1. Presigned POST targets `clinics/_pending/{clinic_id}/{upload_id}`.
+2. The confirm-upload route moves the object to its final
+   `clinics/{id}/...` key after magic-byte validation and DB persistence.
+3. The `expire-pending-uploads-30d` rule then safely cleans up anything
+   that never got promoted, without risk to long-lived assets.
+
+Once that refactor lands:
+
+- Uncomment the `expire-pending-uploads-30d` rule in
+  [`r2-lifecycle.json`](../r2-lifecycle.json).
+- Re-run `node scripts/apply-r2-lifecycle.mjs` against both staging and
+  production.
+- Consider retiring the legacy `expire-abandoned-uploads` rule described
+  at the top of this document — its `clinics/` prefix becomes redundant
+  once unconfirmed uploads live under `clinics/_pending/`.

--- a/r2-lifecycle.json
+++ b/r2-lifecycle.json
@@ -1,0 +1,47 @@
+{
+  "_doc": [
+    "Native R2 lifecycle rules applied via scripts/apply-r2-lifecycle.mjs.",
+    "This file is JSONC-ish: fields whose name starts with '_' and any '// ...'",
+    "line comments are stripped by the apply script before the request body is",
+    "posted to the Cloudflare API. Keep schema in sync with:",
+    "  https://developers.cloudflare.com/api/resources/r2/subresources/buckets/subresources/lifecycle/"
+  ],
+  "rules": [
+    {
+      "id": "abort-incomplete-multipart-1d",
+      "enabled": true,
+      "conditions": { "prefix": "" },
+      "abortMultipartUploadsTransition": {
+        "condition": { "maxAge": 86400, "type": "Age" }
+      },
+      "_comment": [
+        "Aborts multipart uploads that have not been completed within 24h.",
+        "The direct-upload flow uses presigned POSTs capped at 2 MB so it does",
+        "NOT start multipart uploads, but any ad-hoc client (the AWS SDK in",
+        "scripts/, SOP tooling, a future large-file feature) can leave part",
+        "data behind on network/process failure. The part data is billed and",
+        "not visible to the confirm-upload route's cleanup, so we rely on R2's",
+        "own engine as the backstop."
+      ]
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Future-refactor stub — DO NOT ENABLE without a corresponding code
+    // change that moves unconfirmed direct uploads under `clinics/_pending/`
+    // and only re-keys them to `clinics/{id}/...` after confirmation.
+    //
+    // Today the direct-upload flow writes straight to `clinics/{id}/...`, so
+    // an age-based delete rule on that prefix would also nuke long-lived
+    // assets (logos, templates). The `clinics/_pending/` refactor is
+    // tracked in docs/r2-lifecycle.md under "Future refactor".
+    //
+    // ,{
+    //   "id": "expire-pending-uploads-30d",
+    //   "enabled": true,
+    //   "conditions": { "prefix": "clinics/_pending/" },
+    //   "deleteObjectsTransition": {
+    //     "condition": { "maxAge": 2592000, "type": "Age" }
+    //   }
+    // }
+  ]
+}

--- a/scripts/apply-r2-lifecycle.mjs
+++ b/scripts/apply-r2-lifecycle.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Apply the native R2 lifecycle rules declared in `r2-lifecycle.json` to a
+ * bucket via the Cloudflare REST API.
+ *
+ * This is Task 3.3.4 — a defense-in-depth backstop independent of the cron
+ * cleanup. See docs/r2-lifecycle.md for the rationale and operating notes.
+ *
+ * Usage:
+ *   CLOUDFLARE_ACCOUNT_ID=... \
+ *   CLOUDFLARE_API_TOKEN=... \
+ *   R2_BUCKET_NAME=webs-alots-uploads-staging \
+ *     node scripts/apply-r2-lifecycle.mjs
+ *
+ * Flags:
+ *   --dry-run    Print the request body without calling the API.
+ *   --file=PATH  Override the default `r2-lifecycle.json` location.
+ *
+ * The JSON file is parsed as JSONC-lite: `//` line comments and any object
+ * fields whose name starts with `_` are stripped before the request body is
+ * POSTed. Rules with `enabled: false` are sent as-is — the API honours the
+ * flag. The script is idempotent because PUT replaces the entire rule set.
+ *
+ * The Cloudflare API endpoint is:
+ *   PUT /accounts/{account_id}/r2/buckets/{bucket_name}/lifecycle
+ *
+ * Docs:
+ *   https://developers.cloudflare.com/api/resources/r2/subresources/buckets/subresources/lifecycle/methods/update
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const DEFAULT_CONFIG = resolve(REPO_ROOT, "r2-lifecycle.json");
+
+function parseArgs(argv) {
+  const args = { dryRun: false, file: DEFAULT_CONFIG };
+  for (const raw of argv.slice(2)) {
+    if (raw === "--dry-run") {
+      args.dryRun = true;
+    } else if (raw.startsWith("--file=")) {
+      args.file = resolve(process.cwd(), raw.slice("--file=".length));
+    } else if (raw === "--help" || raw === "-h") {
+      args.help = true;
+    } else {
+      console.error(`Unknown argument: ${raw}`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function printHelpAndExit() {
+  console.log(
+    "Usage: node scripts/apply-r2-lifecycle.mjs [--dry-run] [--file=PATH]\n" +
+      "\n" +
+      "Required env:\n" +
+      "  CLOUDFLARE_ACCOUNT_ID   Cloudflare account that owns the R2 bucket\n" +
+      "  CLOUDFLARE_API_TOKEN    Token with the R2 Edit permission\n" +
+      "  R2_BUCKET_NAME          Target bucket (e.g. webs-alots-uploads-staging)\n",
+  );
+  process.exit(0);
+}
+
+/**
+ * Strip `//` line comments and `/* ... *\/` block comments from a JSONC-ish
+ * string, being careful not to touch sequences inside double-quoted strings.
+ */
+function stripComments(source) {
+  let out = "";
+  let i = 0;
+  const n = source.length;
+  let inString = false;
+  let escape = false;
+
+  while (i < n) {
+    const ch = source[i];
+
+    if (inString) {
+      out += ch;
+      if (escape) {
+        escape = false;
+      } else if (ch === "\\") {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "/" && source[i + 1] === "/") {
+      const nl = source.indexOf("\n", i + 2);
+      i = nl === -1 ? n : nl;
+      continue;
+    }
+
+    if (ch === "/" && source[i + 1] === "*") {
+      const end = source.indexOf("*/", i + 2);
+      i = end === -1 ? n : end + 2;
+      continue;
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  return out;
+}
+
+/** Drop any object field whose name starts with `_` (documentation-only). */
+function stripDocFields(value) {
+  if (Array.isArray(value)) {
+    return value.map(stripDocFields);
+  }
+  if (value !== null && typeof value === "object") {
+    const result = {};
+    for (const [key, v] of Object.entries(value)) {
+      if (key.startsWith("_")) continue;
+      result[key] = stripDocFields(v);
+    }
+    return result;
+  }
+  return value;
+}
+
+function loadConfig(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  const stripped = stripComments(raw);
+  let parsed;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${filePath} as JSONC: ${err.message}. Check for trailing commas.`,
+    );
+  }
+  const cleaned = stripDocFields(parsed);
+  if (!cleaned || !Array.isArray(cleaned.rules)) {
+    throw new Error(
+      `${filePath} must define a top-level "rules" array (got ${typeof cleaned?.rules}).`,
+    );
+  }
+  return cleaned;
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value || !value.trim()) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value.trim();
+}
+
+async function putLifecycle({ accountId, bucketName, apiToken, body }) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${encodeURIComponent(
+    accountId,
+  )}/r2/buckets/${encodeURIComponent(bucketName)}/lifecycle`;
+
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await response.text();
+  let parsed;
+  try {
+    parsed = text ? JSON.parse(text) : null;
+  } catch {
+    parsed = null;
+  }
+
+  if (!response.ok || (parsed && parsed.success === false)) {
+    const detail = parsed ? JSON.stringify(parsed.errors ?? parsed, null, 2) : text;
+    throw new Error(
+      `Cloudflare API returned ${response.status} ${response.statusText}:\n${detail}`,
+    );
+  }
+
+  return parsed ?? {};
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) printHelpAndExit();
+
+  const config = loadConfig(args.file);
+  const ruleCount = config.rules.length;
+  const enabledCount = config.rules.filter((r) => r.enabled !== false).length;
+
+  console.log(
+    `Loaded ${ruleCount} rule(s) from ${args.file} (${enabledCount} enabled).`,
+  );
+
+  if (args.dryRun) {
+    console.log("\n--- dry run: request body ---");
+    console.log(JSON.stringify(config, null, 2));
+    console.log("--- end dry run ---");
+    return;
+  }
+
+  const accountId = requireEnv("CLOUDFLARE_ACCOUNT_ID");
+  const apiToken = requireEnv("CLOUDFLARE_API_TOKEN");
+  const bucketName = requireEnv("R2_BUCKET_NAME");
+
+  console.log(`Applying lifecycle rules to bucket "${bucketName}"...`);
+  const result = await putLifecycle({ accountId, bucketName, apiToken, body: config });
+
+  console.log("Cloudflare API acknowledged the update.");
+  if (result && typeof result === "object" && "messages" in result) {
+    for (const msg of result.messages ?? []) console.log(`  - ${msg}`);
+  }
+  console.log(
+    `\nVerify with:\n  wrangler r2 bucket lifecycle list "${bucketName}"`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Defense-in-depth R2 lifecycle backstop using Cloudflare R2's **native** lifecycle engine, independent of (and purely additive to) the existing cron cleanup and the `expire-abandoned-uploads` rule described at the top of `docs/r2-lifecycle.md`.

Three new artefacts:

- **`r2-lifecycle.json`** — declarative rule set.
  - `abort-incomplete-multipart-1d` (enabled): `AbortIncompleteMultipartUpload` after 24 h, whole-bucket scope. Reclaims storage left behind by multipart producers (`scripts/backup.sh`, `scripts/recover.sh`, `scripts/r2-sync.sh`, SOP tooling, future large-file features). The direct-upload flow is presigned-POST-only so it never starts multipart uploads itself, but any ad-hoc AWS-SDK client can.
  - `expire-pending-uploads-30d` (commented-out stub): 30-day `deleteObjectsTransition` on `clinics/_pending/`. Left commented so it does **not** accidentally delete long-lived assets today — see "Future refactor" in `docs/r2-lifecycle.md`.
  - File is JSONC-ish: `//` line comments and any field whose name starts with `_` (e.g. `_doc`, `_comment`) are stripped by the apply script before the body is POSTed, so the file stays human-annotated.

- **`scripts/apply-r2-lifecycle.mjs`** — Node script that `PUT`s the rule set to `/accounts/{CLOUDFLARE_ACCOUNT_ID}/r2/buckets/{R2_BUCKET_NAME}/lifecycle` using `CLOUDFLARE_API_TOKEN`. All three values come from env. Idempotent (the Cloudflare API replaces the whole rule set per call). Supports `--dry-run` (prints the stripped request body without hitting the API) and `--file=PATH`. Exits non-zero on missing env or API errors, so it is pipeline-safe.

- **`docs/r2-lifecycle.md`** — appended section "Native R2 Lifecycle Backstop (Task 3.3.4)" covering how to run the script, what each rule does, required API-token scopes, verification via `wrangler r2 bucket lifecycle list`, and the `clinics/_pending/` future-refactor plan.

Dry-run output confirms the stripper produces a body that matches the R2 lifecycle API schema:

```json
{
  "rules": [
    {
      "id": "abort-incomplete-multipart-1d",
      "enabled": true,
      "conditions": { "prefix": "" },
      "abortMultipartUploadsTransition": {
        "condition": { "maxAge": 86400, "type": "Age" }
      }
    }
  ]
}
```

Done-when (from task spec): running the script in staging applies the multipart-abort rule and `wrangler r2 bucket lifecycle list` confirms it. Script is ready to run against staging — it needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` + `R2_BUCKET_NAME=webs-alots-uploads-staging` in the caller's env.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Infrastructure / CI

## Security Impact

- [x] No security impact

Notes: the script requires a Cloudflare API token with only `Workers R2 Storage: Edit` scope. No secrets are committed; the script reads them from env and exits non-zero if any are missing. The stub rule is intentionally commented out because enabling it today would delete long-lived assets under `clinics/`.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

Manual verification performed locally:

- `node scripts/apply-r2-lifecycle.mjs --dry-run` → parses the JSONC, strips `_`-prefixed fields and `//` comments, reports `1 rule(s) ... 1 enabled`, and prints a body matching the Cloudflare R2 lifecycle API schema.
- `npx eslint scripts/apply-r2-lifecycle.mjs` → clean.
- `npx tsc --noEmit` → clean.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes (on the new script)
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
