### PR TITLE
feat(r2): add r2-cleanup library for abandoned uploads + orphan reconciliation (Task 3.3.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,10 @@ R2_REPLICA_PUBLIC_URL=
 # Generate with: openssl rand -hex 32
 # Rotation procedure: docs/SOP-SECRET-ROTATION.md §8
 R2_SIGNED_URL_SECRET=
+# Orphan-rate alert threshold (0..1) for the R2 cleanup cron. A reconciliation
+# pass that classifies this fraction of scanned keys as orphans fires a Sentry
+# alert. Default: 0.1 (10%). See src/lib/r2-cleanup.ts.
+R2_ORPHAN_RATE_ALERT_THRESHOLD=0.1
 
 # ---- WhatsApp Business API [Optional] ----
 # See docs/whatsapp-template-approval.md for template submission and approval guide.

--- a/src/lib/__tests__/r2-cleanup.test.ts
+++ b/src/lib/__tests__/r2-cleanup.test.ts
@@ -1,0 +1,690 @@
+/**
+ * Unit tests for `src/lib/r2-cleanup.ts` (Task 3.3.2).
+ *
+ * Covers:
+ *   1. `findAbandonedPendingUploads` — builds the correct PostgREST query
+ *      (confirmed_at IS NULL + created_at < cutoff + limit + optional
+ *      prefix filter) and surfaces errors.
+ *   2. `findOrphanKeys` — returns only keys not present in
+ *      `pending_uploads`, de-duplicates input, and short-circuits on an
+ *      empty input array.
+ *   3. `cleanupAbandonedUploads` — deletes each row from R2 and the DB,
+ *      honours `dryRun`, and aggregates per-key errors without aborting.
+ *   4. `reconcileOrphans` — enumerates R2, classifies orphans via the DB
+ *      query, deletes the orphans (unless `dryRun`), computes the orphan
+ *      rate, and fires `emitOrphanRateAlert` exactly once per pass.
+ *   5. `emitOrphanRateAlert` — verifies both the threshold-exceeded path
+ *      (logger.error + Sentry.captureMessage with the expected tags) and
+ *      the sub-threshold / zero-total no-op paths.
+ *   6. `readOrphanRateAlertThreshold` — honours the env override and
+ *      falls back to the 0.1 default when the value is missing or
+ *      invalid.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { Mock } from "vitest";
+
+/* ─── Module mocks ─── */
+
+vi.mock("@sentry/nextjs", () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/r2", () => ({
+  listR2Objects: vi.fn(),
+  deleteFromR2: vi.fn(),
+}));
+
+/* ─── Test helpers ─── */
+
+type QueryResult<T> = { data: T | null; error: { message: string } | null };
+
+/**
+ * Build a chainable Supabase mock for the `pending_uploads` table.
+ * Chainable query methods return the same stub; the final `resolver`
+ * decides what `await` resolves to, which lets tests assert on the
+ * exact filters applied.
+ */
+function makeSupabaseStub() {
+  const builder = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    like: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    // Awaiting the builder resolves with whatever the current resolver
+    // returns. Tests can swap the resolver per scenario.
+    _resolver: vi.fn<() => Promise<QueryResult<unknown>>>().mockResolvedValue({
+      data: [],
+      error: null,
+    }),
+    then<T>(onFulfilled: (value: QueryResult<unknown>) => T) {
+      return builder._resolver().then(onFulfilled);
+    },
+  };
+
+  const client = {
+    from: vi.fn().mockReturnValue(builder),
+  };
+
+  return { client, builder };
+}
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env = { ...originalEnv };
+  delete process.env.R2_ORPHAN_RATE_ALERT_THRESHOLD;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+/* ─── readOrphanRateAlertThreshold ─── */
+
+describe("readOrphanRateAlertThreshold", () => {
+  it("returns the default (0.1) when the env var is unset", async () => {
+    const { readOrphanRateAlertThreshold, DEFAULT_ORPHAN_RATE_THRESHOLD } =
+      await import("../r2-cleanup");
+    expect(readOrphanRateAlertThreshold()).toBe(DEFAULT_ORPHAN_RATE_THRESHOLD);
+  });
+
+  it("honours a valid override in [0, 1]", async () => {
+    process.env.R2_ORPHAN_RATE_ALERT_THRESHOLD = "0.25";
+    const { readOrphanRateAlertThreshold } = await import("../r2-cleanup");
+    expect(readOrphanRateAlertThreshold()).toBe(0.25);
+  });
+
+  it("falls back to the default when the value is non-numeric", async () => {
+    process.env.R2_ORPHAN_RATE_ALERT_THRESHOLD = "abc";
+    const { readOrphanRateAlertThreshold, DEFAULT_ORPHAN_RATE_THRESHOLD } =
+      await import("../r2-cleanup");
+    expect(readOrphanRateAlertThreshold()).toBe(DEFAULT_ORPHAN_RATE_THRESHOLD);
+  });
+
+  it("falls back to the default when the value is out of range", async () => {
+    process.env.R2_ORPHAN_RATE_ALERT_THRESHOLD = "2.5";
+    const { readOrphanRateAlertThreshold, DEFAULT_ORPHAN_RATE_THRESHOLD } =
+      await import("../r2-cleanup");
+    expect(readOrphanRateAlertThreshold()).toBe(DEFAULT_ORPHAN_RATE_THRESHOLD);
+  });
+});
+
+/* ─── findAbandonedPendingUploads ─── */
+
+describe("findAbandonedPendingUploads", () => {
+  it("builds the cutoff query with default 24 h window and selects the tracked columns", async () => {
+    const { findAbandonedPendingUploads } = await import("../r2-cleanup");
+    const { client, builder } = makeSupabaseStub();
+    const rows = [
+      {
+        id: "row-1",
+        clinic_id: "clinic-a",
+        r2_key: "clinics/clinic-a/logos/abc.png",
+        content_type: "image/png",
+        created_at: "2024-01-01T00:00:00Z",
+        confirmed_at: null,
+      },
+    ];
+    builder._resolver.mockResolvedValueOnce({ data: rows, error: null });
+
+    const before = Date.now();
+    const result = await findAbandonedPendingUploads(
+      client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+    );
+    const after = Date.now();
+
+    expect(result).toEqual(rows);
+    expect(client.from).toHaveBeenCalledWith("pending_uploads");
+    expect(builder.select).toHaveBeenCalledWith(
+      "id, clinic_id, r2_key, content_type, created_at, confirmed_at",
+    );
+    expect(builder.is).toHaveBeenCalledWith("confirmed_at", null);
+
+    const [ltColumn, ltValue] = builder.lt.mock.calls[0] as [string, string];
+    expect(ltColumn).toBe("created_at");
+    const cutoffMs = new Date(ltValue).getTime();
+    const windowMs = 24 * 60 * 60 * 1000;
+    expect(cutoffMs).toBeGreaterThanOrEqual(before - windowMs - 5);
+    expect(cutoffMs).toBeLessThanOrEqual(after - windowMs + 5);
+
+    expect(builder.order).toHaveBeenCalledWith("created_at", { ascending: true });
+    expect(builder.limit).toHaveBeenCalledWith(1000);
+    // No prefix → no like filter
+    expect(builder.like).not.toHaveBeenCalled();
+  });
+
+  it("applies a prefix filter when provided", async () => {
+    const { findAbandonedPendingUploads } = await import("../r2-cleanup");
+    const { client, builder } = makeSupabaseStub();
+    builder._resolver.mockResolvedValueOnce({ data: [], error: null });
+
+    await findAbandonedPendingUploads(
+      client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+      { prefix: "clinics/clinic-a/", olderThanHours: 1, limit: 50 },
+    );
+
+    expect(builder.like).toHaveBeenCalledWith("r2_key", "clinics/clinic-a/%");
+    expect(builder.limit).toHaveBeenCalledWith(50);
+  });
+
+  it("throws when the Supabase query returns an error", async () => {
+    const { findAbandonedPendingUploads } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+    const { client, builder } = makeSupabaseStub();
+    builder._resolver.mockResolvedValueOnce({
+      data: null,
+      error: { message: "boom" },
+    });
+
+    await expect(
+      findAbandonedPendingUploads(
+        client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+      ),
+    ).rejects.toEqual({ message: "boom" });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "findAbandonedPendingUploads query failed",
+      expect.objectContaining({ context: "r2-cleanup" }),
+    );
+  });
+});
+
+/* ─── findOrphanKeys ─── */
+
+describe("findOrphanKeys", () => {
+  it("short-circuits on an empty input without querying Supabase", async () => {
+    const { findOrphanKeys } = await import("../r2-cleanup");
+    const { client } = makeSupabaseStub();
+
+    const result = await findOrphanKeys(
+      client as unknown as Parameters<typeof findOrphanKeys>[0],
+      [],
+    );
+
+    expect(result).toEqual([]);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("returns keys not present in pending_uploads, de-duplicating input", async () => {
+    const { findOrphanKeys } = await import("../r2-cleanup");
+    const { client, builder } = makeSupabaseStub();
+    builder._resolver.mockResolvedValueOnce({
+      data: [{ r2_key: "clinics/a/logos/known.png" }],
+      error: null,
+    });
+
+    const input = [
+      "clinics/a/logos/known.png",
+      "clinics/a/logos/known.png", // duplicate
+      "clinics/a/logos/orphan-1.png",
+      "clinics/a/logos/orphan-2.png",
+    ];
+    const result = await findOrphanKeys(
+      client as unknown as Parameters<typeof findOrphanKeys>[0],
+      input,
+    );
+
+    expect(result).toEqual([
+      "clinics/a/logos/orphan-1.png",
+      "clinics/a/logos/orphan-2.png",
+    ]);
+    expect(builder.in).toHaveBeenCalledWith(
+      "r2_key",
+      [
+        "clinics/a/logos/known.png",
+        "clinics/a/logos/orphan-1.png",
+        "clinics/a/logos/orphan-2.png",
+      ],
+    );
+  });
+
+  it("throws and logs when the Supabase query errors", async () => {
+    const { findOrphanKeys } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+    const { client, builder } = makeSupabaseStub();
+    builder._resolver.mockResolvedValueOnce({
+      data: null,
+      error: { message: "db down" },
+    });
+
+    await expect(
+      findOrphanKeys(
+        client as unknown as Parameters<typeof findOrphanKeys>[0],
+        ["k1"],
+      ),
+    ).rejects.toEqual({ message: "db down" });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "findOrphanKeys query failed",
+      expect.objectContaining({ context: "r2-cleanup", keyCount: 1 }),
+    );
+  });
+});
+
+/* ─── cleanupAbandonedUploads ─── */
+
+describe("cleanupAbandonedUploads", () => {
+  const abandoned = [
+    {
+      id: "row-1",
+      clinic_id: "clinic-a",
+      r2_key: "clinics/a/logos/abandoned-1.png",
+      content_type: "image/png",
+      created_at: "2024-01-01T00:00:00Z",
+      confirmed_at: null,
+    },
+    {
+      id: "row-2",
+      clinic_id: "clinic-a",
+      r2_key: "clinics/a/logos/abandoned-2.png",
+      content_type: "image/png",
+      created_at: "2024-01-01T01:00:00Z",
+      confirmed_at: null,
+    },
+  ];
+
+  it("deletes each abandoned key from R2 and the DB row on success", async () => {
+    const { cleanupAbandonedUploads } = await import("../r2-cleanup");
+    const { deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    // First await (select) returns abandoned rows; each subsequent await
+    // (one per row's delete().eq()) returns a successful delete result.
+    builder._resolver
+      .mockResolvedValueOnce({ data: abandoned, error: null })
+      .mockResolvedValue({ data: null, error: null });
+
+    (deleteFromR2 as Mock).mockResolvedValue(undefined);
+
+    const result = await cleanupAbandonedUploads(
+      client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+    );
+
+    expect(deleteFromR2).toHaveBeenCalledTimes(2);
+    expect(deleteFromR2).toHaveBeenNthCalledWith(1, abandoned[0].r2_key);
+    expect(deleteFromR2).toHaveBeenNthCalledWith(2, abandoned[1].r2_key);
+
+    expect(builder.delete).toHaveBeenCalledTimes(2);
+    expect(builder.eq).toHaveBeenCalledWith("id", "row-1");
+    expect(builder.eq).toHaveBeenCalledWith("id", "row-2");
+
+    expect(result).toEqual({
+      scanned: 2,
+      deletedFromR2: 2,
+      removedFromDb: 2,
+      errors: [],
+      dryRun: false,
+    });
+  });
+
+  it("dryRun skips all mutating calls and returns zero counters", async () => {
+    const { cleanupAbandonedUploads } = await import("../r2-cleanup");
+    const { deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+    builder._resolver.mockResolvedValueOnce({ data: abandoned, error: null });
+
+    const result = await cleanupAbandonedUploads(
+      client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+      { dryRun: true },
+    );
+
+    expect(deleteFromR2).not.toHaveBeenCalled();
+    expect(builder.delete).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      scanned: 2,
+      deletedFromR2: 0,
+      removedFromDb: 0,
+      dryRun: true,
+    });
+  });
+
+  it("records R2 delete failures and skips the DB delete for that row", async () => {
+    const { cleanupAbandonedUploads } = await import("../r2-cleanup");
+    const { deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    builder._resolver
+      .mockResolvedValueOnce({ data: abandoned, error: null })
+      // Only one DB delete will be issued — for the second (successful) R2 delete.
+      .mockResolvedValueOnce({ data: null, error: null });
+
+    (deleteFromR2 as Mock)
+      .mockRejectedValueOnce(new Error("r2 timeout"))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await cleanupAbandonedUploads(
+      client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+    );
+
+    expect(builder.delete).toHaveBeenCalledTimes(1);
+    expect(result.scanned).toBe(2);
+    expect(result.deletedFromR2).toBe(1);
+    expect(result.removedFromDb).toBe(1);
+    expect(result.errors).toEqual([
+      expect.objectContaining({ key: abandoned[0].r2_key, stage: "r2" }),
+    ]);
+  });
+
+  it("records DB delete failures after a successful R2 delete", async () => {
+    const { cleanupAbandonedUploads } = await import("../r2-cleanup");
+    const { deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    builder._resolver
+      .mockResolvedValueOnce({ data: [abandoned[0]], error: null })
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: "db write failed" },
+      });
+
+    (deleteFromR2 as Mock).mockResolvedValue(undefined);
+
+    const result = await cleanupAbandonedUploads(
+      client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+    );
+
+    expect(result.deletedFromR2).toBe(1);
+    expect(result.removedFromDb).toBe(0);
+    expect(result.errors).toEqual([
+      expect.objectContaining({ key: abandoned[0].r2_key, stage: "db" }),
+    ]);
+  });
+});
+
+/* ─── reconcileOrphans ─── */
+
+describe("reconcileOrphans", () => {
+  it("lists R2, deletes orphans, and returns accurate counters", async () => {
+    const { reconcileOrphans } = await import("../r2-cleanup");
+    const { listR2Objects, deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    (listR2Objects as Mock).mockResolvedValue([
+      "clinics/a/logos/known.png",
+      "clinics/a/logos/orphan-1.png",
+      "clinics/a/logos/orphan-2.png",
+    ]);
+    builder._resolver.mockResolvedValueOnce({
+      data: [{ r2_key: "clinics/a/logos/known.png" }],
+      error: null,
+    });
+    (deleteFromR2 as Mock).mockResolvedValue(undefined);
+
+    const result = await reconcileOrphans(
+      client as unknown as Parameters<typeof reconcileOrphans>[0],
+      { prefix: "clinics/a/" },
+    );
+
+    expect(listR2Objects).toHaveBeenCalledWith("clinics/a/", undefined);
+    expect(deleteFromR2).toHaveBeenCalledTimes(2);
+    expect(deleteFromR2).toHaveBeenCalledWith("clinics/a/logos/orphan-1.png");
+    expect(deleteFromR2).toHaveBeenCalledWith("clinics/a/logos/orphan-2.png");
+
+    expect(result).toMatchObject({
+      scanned: 3,
+      orphans: 2,
+      deletedFromR2: 2,
+      orphanRate: 2 / 3,
+      alerted: true,
+      dryRun: false,
+      errors: [],
+    });
+  });
+
+  it("dryRun does not delete any R2 objects", async () => {
+    const { reconcileOrphans } = await import("../r2-cleanup");
+    const { listR2Objects, deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    (listR2Objects as Mock).mockResolvedValue([
+      "clinics/a/logos/orphan.png",
+    ]);
+    builder._resolver.mockResolvedValueOnce({ data: [], error: null });
+
+    const result = await reconcileOrphans(
+      client as unknown as Parameters<typeof reconcileOrphans>[0],
+      { prefix: "clinics/a/", dryRun: true },
+    );
+
+    expect(deleteFromR2).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      scanned: 1,
+      orphans: 1,
+      deletedFromR2: 0,
+      orphanRate: 1,
+      alerted: true,
+      dryRun: true,
+    });
+  });
+
+  it("returns scanned=0 and orphanRate=0 when the prefix is empty", async () => {
+    const { reconcileOrphans } = await import("../r2-cleanup");
+    const { listR2Objects } = await import("@/lib/r2");
+    const { client } = makeSupabaseStub();
+
+    (listR2Objects as Mock).mockResolvedValue([]);
+
+    const result = await reconcileOrphans(
+      client as unknown as Parameters<typeof reconcileOrphans>[0],
+      { prefix: "clinics/empty/" },
+    );
+
+    expect(result).toMatchObject({
+      scanned: 0,
+      orphans: 0,
+      deletedFromR2: 0,
+      orphanRate: 0,
+      alerted: false,
+      errors: [],
+    });
+  });
+
+  it("records per-key R2 delete errors without aborting the pass", async () => {
+    const { reconcileOrphans } = await import("../r2-cleanup");
+    const { listR2Objects, deleteFromR2 } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    (listR2Objects as Mock).mockResolvedValue([
+      "clinics/a/orphan-1.png",
+      "clinics/a/orphan-2.png",
+    ]);
+    builder._resolver.mockResolvedValueOnce({ data: [], error: null });
+    (deleteFromR2 as Mock)
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await reconcileOrphans(
+      client as unknown as Parameters<typeof reconcileOrphans>[0],
+      { prefix: "clinics/a/", alertThreshold: 0.99 },
+    );
+
+    expect(result.scanned).toBe(2);
+    expect(result.orphans).toBe(2);
+    expect(result.deletedFromR2).toBe(1);
+    expect(result.errors).toEqual([
+      expect.objectContaining({ key: "clinics/a/orphan-1.png" }),
+    ]);
+  });
+
+  it("forwards the limit option to listR2Objects when supplied", async () => {
+    const { reconcileOrphans } = await import("../r2-cleanup");
+    const { listR2Objects } = await import("@/lib/r2");
+    const { client, builder } = makeSupabaseStub();
+
+    (listR2Objects as Mock).mockResolvedValue([]);
+    builder._resolver.mockResolvedValueOnce({ data: [], error: null });
+
+    await reconcileOrphans(
+      client as unknown as Parameters<typeof reconcileOrphans>[0],
+      { prefix: "clinics/", limit: 42 },
+    );
+
+    expect(listR2Objects).toHaveBeenCalledWith("clinics/", { limit: 42 });
+  });
+});
+
+/* ─── emitOrphanRateAlert ─── */
+
+describe("emitOrphanRateAlert", () => {
+  it("fires logger.error AND Sentry.captureMessage when the rate is above the threshold", async () => {
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+    const Sentry = await import("@sentry/nextjs");
+
+    const fired = emitOrphanRateAlert({
+      orphanCount: 30,
+      totalCount: 100,
+      threshold: 0.1,
+      prefix: "clinics/",
+    });
+
+    expect(fired).toBe(true);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      "R2 orphan rate exceeded threshold",
+      expect.objectContaining({
+        context: "r2-cleanup",
+        orphanCount: 30,
+        totalCount: 100,
+        orphanRate: 0.3,
+        threshold: 0.1,
+        prefix: "clinics/",
+        tags: { alert: "r2_orphan_rate" },
+      }),
+    );
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "R2 orphan rate exceeded threshold",
+      expect.objectContaining({
+        level: "warning",
+        tags: { alert: "r2_orphan_rate", prefix: "clinics/" },
+        extra: expect.objectContaining({
+          orphanCount: 30,
+          totalCount: 100,
+          orphanRate: 0.3,
+          threshold: 0.1,
+          prefix: "clinics/",
+        }),
+      }),
+    );
+  });
+
+  it("fires at exactly the threshold boundary (>= comparison)", async () => {
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+
+    const fired = emitOrphanRateAlert({
+      orphanCount: 1,
+      totalCount: 10,
+      threshold: 0.1,
+    });
+
+    expect(fired).toBe(true);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when the orphan rate is below the threshold", async () => {
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+    const Sentry = await import("@sentry/nextjs");
+
+    const fired = emitOrphanRateAlert({
+      orphanCount: 1,
+      totalCount: 100,
+      threshold: 0.1,
+    });
+
+    expect(fired).toBe(false);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when totalCount is zero (prevents divide-by-zero alerts)", async () => {
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+    const Sentry = await import("@sentry/nextjs");
+
+    const fired = emitOrphanRateAlert({
+      orphanCount: 0,
+      totalCount: 0,
+      threshold: 0.1,
+    });
+
+    expect(fired).toBe(false);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("tags Sentry with 'unknown' when prefix is omitted", async () => {
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+    const Sentry = await import("@sentry/nextjs");
+
+    emitOrphanRateAlert({
+      orphanCount: 5,
+      totalCount: 10,
+      threshold: 0.1,
+    });
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      "R2 orphan rate exceeded threshold",
+      expect.objectContaining({
+        tags: { alert: "r2_orphan_rate", prefix: "unknown" },
+      }),
+    );
+  });
+
+  it("still reports success when Sentry.captureMessage throws", async () => {
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+    const { logger } = await import("@/lib/logger");
+    const Sentry = await import("@sentry/nextjs");
+
+    (Sentry.captureMessage as unknown as Mock).mockImplementationOnce(() => {
+      throw new Error("sentry offline");
+    });
+
+    const fired = emitOrphanRateAlert({
+      orphanCount: 5,
+      totalCount: 10,
+      threshold: 0.1,
+    });
+
+    expect(fired).toBe(true);
+    // The durable logger.error call is the primary alert signal.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the env-derived threshold when none is passed", async () => {
+    process.env.R2_ORPHAN_RATE_ALERT_THRESHOLD = "0.5";
+    const { emitOrphanRateAlert } = await import("../r2-cleanup");
+
+    // 4/10 = 0.4 < 0.5 → no alert
+    expect(
+      emitOrphanRateAlert({ orphanCount: 4, totalCount: 10 }),
+    ).toBe(false);
+
+    // 6/10 = 0.6 >= 0.5 → alert
+    expect(
+      emitOrphanRateAlert({ orphanCount: 6, totalCount: 10 }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -59,6 +59,12 @@ const ENV_RULES: EnvRule[] = [
   // secret. A hardcoded fallback ("default-salt") is never acceptable in
   // production, so we refuse to boot without a dedicated R2_SIGNED_URL_SECRET.
   { name: "R2_SIGNED_URL_SECRET", required: process.env.NODE_ENV === "production", description: "HMAC secret for R2 signed URLs and upload filename hashing (required in production; `openssl rand -hex 32`)", group: "storage" },
+  // Consumed by `src/lib/r2-cleanup.ts` — the fraction (0..1) of keys in a
+  // reconciliation pass that, when classified as orphans, triggers a
+  // Sentry alert and an error-level log line. Optional: defaults to 0.1
+  // (10 %) when unset. The library ignores out-of-range or non-numeric
+  // values rather than failing closed — see `readOrphanRateAlertThreshold`.
+  { name: "R2_ORPHAN_RATE_ALERT_THRESHOLD", required: false, description: "Orphan-rate threshold (0..1) above which the R2 cleanup cron emits a Sentry alert. Default: 0.1", group: "storage" },
 
   // ── Payments ───────────────────────────────────────────────────────
   { name: "STRIPE_SECRET_KEY", required: false, description: "Stripe secret key", group: "payments" },

--- a/src/lib/r2-cleanup.ts
+++ b/src/lib/r2-cleanup.ts
@@ -1,0 +1,431 @@
+/**
+ * R2 cleanup library — reusable primitives for the scheduled job that
+ * reconciles the `pending_uploads` tracking table against the contents of
+ * the R2 bucket (Task 3.3.2).
+ *
+ * This module intentionally ships **without any entrypoint** (no route, no
+ * cron binding). It exposes pure functions that the future cron handler
+ * will call once the orchestration tasks land. Designing the library
+ * upfront — with a full unit-test suite and threshold-based alerting —
+ * lets us merge the behaviour safely behind feature-less code.
+ *
+ * ── Failure modes it covers ──
+ *   1. **Abandoned uploads** — rows in `pending_uploads` whose
+ *      `confirmed_at` is still null after an SLA window (default 24 h).
+ *      We delete the object from R2 and prune the tracking row.
+ *   2. **Orphan R2 objects** — keys present in the bucket that no row in
+ *      `pending_uploads` (pending *or* confirmed) references. Can happen
+ *      when a confirmation-route deletion fails or the row insert races
+ *      with the browser giving up.
+ *
+ * ── Alerting ──
+ *   After a reconciliation pass we compute `orphans / totalScanned` and,
+ *   if it crosses `R2_ORPHAN_RATE_ALERT_THRESHOLD` (default 0.1 = 10 %),
+ *   log a structured error and emit a Sentry `captureMessage` so
+ *   operations can investigate a leaky upload path rather than letting
+ *   the cron quietly delete thousands of objects.
+ *
+ * The library deliberately takes the Supabase client as a parameter
+ * instead of constructing one itself — this mirrors the convention in
+ * `audit-log.ts` and keeps the Vitest suite fully mockable without
+ * hitting Supabase's singleton caches.
+ */
+
+import * as Sentry from "@sentry/nextjs";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
+import { deleteFromR2, listR2Objects } from "@/lib/r2";
+
+/**
+ * Default SLA after which a pending upload is considered abandoned.
+ * Matches the R2 lifecycle rule (`docs/r2-lifecycle.md`) so the cron
+ * and the bucket policy agree on the same cutoff.
+ */
+export const DEFAULT_ABANDONED_HOURS = 24;
+
+/**
+ * Default threshold for `emitOrphanRateAlert`. A reconciliation pass
+ * that classifies ≥ 10 % of scanned keys as orphaned is almost always
+ * a code bug, not an operational anomaly — we want a loud alert.
+ */
+export const DEFAULT_ORPHAN_RATE_THRESHOLD = 0.1;
+
+/**
+ * Row shape used by the cleanup library. Mirrors the logical columns of
+ * the `pending_uploads` tracking table. Kept as an explicit interface
+ * (rather than inferred from the generated `Database` type) so the
+ * library is safe to merge before the companion migration lands.
+ */
+export interface PendingUploadRow {
+  id: string;
+  clinic_id: string | null;
+  r2_key: string;
+  content_type: string | null;
+  created_at: string;
+  confirmed_at: string | null;
+}
+
+/**
+ * The cleanup library queries a table that is not part of the generated
+ * `Database` type yet (the migration is tracked under Task 3.3.1). We
+ * accept any Supabase client and perform narrow type assertions on the
+ * query results so the library is typesafe at its public boundary.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnySupabase = SupabaseClient<any, any, any>;
+
+/** Resolve the orphan-rate alert threshold from env with safe fallbacks. */
+export function readOrphanRateAlertThreshold(): number {
+  const raw = process.env.R2_ORPHAN_RATE_ALERT_THRESHOLD;
+  if (!raw) return DEFAULT_ORPHAN_RATE_THRESHOLD;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+    logger.warn("Ignoring invalid R2_ORPHAN_RATE_ALERT_THRESHOLD, using default", {
+      context: "r2-cleanup",
+      raw,
+      default: DEFAULT_ORPHAN_RATE_THRESHOLD,
+    });
+    return DEFAULT_ORPHAN_RATE_THRESHOLD;
+  }
+  return parsed;
+}
+
+export interface FindAbandonedOptions {
+  /** SLA window; rows older than this with `confirmed_at IS NULL` are abandoned. */
+  olderThanHours?: number;
+  /** Optional R2 key prefix filter (e.g. `"clinics/{id}/"`). */
+  prefix?: string;
+  /** Hard cap on rows returned in a single pass (default: 1 000). */
+  limit?: number;
+}
+
+/**
+ * Find pending-upload rows whose confirmation never arrived within the
+ * SLA window. Returns rows ordered by creation time so the cron deletes
+ * the oldest candidates first.
+ */
+export async function findAbandonedPendingUploads(
+  supabase: AnySupabase,
+  options: FindAbandonedOptions = {},
+): Promise<PendingUploadRow[]> {
+  const {
+    olderThanHours = DEFAULT_ABANDONED_HOURS,
+    prefix,
+    limit = 1000,
+  } = options;
+
+  const cutoffIso = new Date(
+    Date.now() - olderThanHours * 60 * 60 * 1000,
+  ).toISOString();
+
+  let query = supabase
+    .from("pending_uploads")
+    .select("id, clinic_id, r2_key, content_type, created_at, confirmed_at")
+    .is("confirmed_at", null)
+    .lt("created_at", cutoffIso)
+    .order("created_at", { ascending: true })
+    .limit(limit);
+
+  if (prefix) {
+    // `like` is intentional — the prefix is a server-chosen constant, never
+    // user-controlled, so PostgREST's like syntax is safe here.
+    query = query.like("r2_key", `${prefix}%`);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    logger.error("findAbandonedPendingUploads query failed", {
+      context: "r2-cleanup",
+      error,
+      olderThanHours,
+      prefix,
+    });
+    throw error;
+  }
+
+  return (data ?? []) as PendingUploadRow[];
+}
+
+/**
+ * Given a batch of R2 keys, return the subset that is NOT referenced by
+ * any row in `pending_uploads` (pending or confirmed). An orphan key is
+ * therefore one the application has no record of and is safe to delete.
+ */
+export async function findOrphanKeys(
+  supabase: AnySupabase,
+  r2Keys: string[],
+): Promise<string[]> {
+  if (r2Keys.length === 0) return [];
+
+  // De-duplicate input so the `in()` filter stays within PostgREST's
+  // practical limit and we don't over-report orphans when callers pass
+  // duplicate keys (rare, but cheap to defend against).
+  const uniqueKeys = Array.from(new Set(r2Keys));
+
+  const { data, error } = await supabase
+    .from("pending_uploads")
+    .select("r2_key")
+    .in("r2_key", uniqueKeys);
+
+  if (error) {
+    logger.error("findOrphanKeys query failed", {
+      context: "r2-cleanup",
+      error,
+      keyCount: uniqueKeys.length,
+    });
+    throw error;
+  }
+
+  const known = new Set<string>(
+    ((data ?? []) as { r2_key: string }[]).map((row) => row.r2_key),
+  );
+
+  return uniqueKeys.filter((key) => !known.has(key));
+}
+
+export interface CleanupAbandonedResult {
+  /** Rows matched by the abandoned-pending query. */
+  scanned: number;
+  /** Objects successfully removed from R2 during this pass. */
+  deletedFromR2: number;
+  /** Rows deleted from `pending_uploads` after a successful R2 delete. */
+  removedFromDb: number;
+  /** Failures encountered while deleting the R2 object or DB row. */
+  errors: Array<{ key: string; stage: "r2" | "db"; error: unknown }>;
+  /** Echoed from the caller so downstream log pipelines can filter. */
+  dryRun: boolean;
+}
+
+export interface CleanupAbandonedOptions extends FindAbandonedOptions {
+  /** When true, logs the would-be deletions without mutating state. */
+  dryRun?: boolean;
+}
+
+/**
+ * Delete abandoned pending uploads from R2 and prune the tracking rows.
+ * Errors are collected per-key and returned — a transient R2 outage on
+ * one object must not abort the rest of the pass.
+ */
+export async function cleanupAbandonedUploads(
+  supabase: AnySupabase,
+  options: CleanupAbandonedOptions = {},
+): Promise<CleanupAbandonedResult> {
+  const dryRun = options.dryRun ?? false;
+  const abandoned = await findAbandonedPendingUploads(supabase, options);
+
+  const errors: CleanupAbandonedResult["errors"] = [];
+  let deletedFromR2 = 0;
+  let removedFromDb = 0;
+
+  for (const row of abandoned) {
+    if (dryRun) continue;
+
+    try {
+      await deleteFromR2(row.r2_key);
+      deletedFromR2++;
+    } catch (err) {
+      errors.push({ key: row.r2_key, stage: "r2", error: err });
+      logger.warn("R2 delete failed during abandoned-upload cleanup", {
+        context: "r2-cleanup",
+        key: row.r2_key,
+        error: err,
+      });
+      continue;
+    }
+
+    const { error: deleteError } = await supabase
+      .from("pending_uploads")
+      .delete()
+      .eq("id", row.id);
+
+    if (deleteError) {
+      errors.push({ key: row.r2_key, stage: "db", error: deleteError });
+      logger.warn("pending_uploads row delete failed after R2 delete", {
+        context: "r2-cleanup",
+        key: row.r2_key,
+        id: row.id,
+        error: deleteError,
+      });
+    } else {
+      removedFromDb++;
+    }
+  }
+
+  logger.info("cleanupAbandonedUploads pass complete", {
+    context: "r2-cleanup",
+    scanned: abandoned.length,
+    deletedFromR2,
+    removedFromDb,
+    errorCount: errors.length,
+    dryRun,
+  });
+
+  return {
+    scanned: abandoned.length,
+    deletedFromR2,
+    removedFromDb,
+    errors,
+    dryRun,
+  };
+}
+
+export interface ReconcileOrphansOptions {
+  /** R2 key prefix to enumerate (e.g. `"clinics/"`). */
+  prefix: string;
+  /** When true, logs the would-be deletions without mutating state. */
+  dryRun?: boolean;
+  /** Override the env-derived alert threshold (mostly for tests). */
+  alertThreshold?: number;
+  /**
+   * Optional cap on keys scanned in a single pass. Useful when the cron
+   * wants to bound how much work happens per invocation.
+   */
+  limit?: number;
+}
+
+export interface ReconcileOrphansResult {
+  /** Total keys returned by `listR2Objects`. */
+  scanned: number;
+  /** Keys with no row in `pending_uploads`. */
+  orphans: number;
+  /** Orphans successfully removed from R2. */
+  deletedFromR2: number;
+  /** `orphans / scanned`; `0` when `scanned === 0`. */
+  orphanRate: number;
+  /** Whether `emitOrphanRateAlert` fired. */
+  alerted: boolean;
+  /** Echoed from caller — useful for log correlation. */
+  dryRun: boolean;
+  /** Per-key R2 delete failures. */
+  errors: Array<{ key: string; error: unknown }>;
+}
+
+/**
+ * Enumerate objects under the configured R2 prefix, classify any key
+ * that is not tracked in `pending_uploads` as an orphan, delete those
+ * objects (unless `dryRun`), and fire the alerting hook when the orphan
+ * rate crosses the configured threshold.
+ */
+export async function reconcileOrphans(
+  supabase: AnySupabase,
+  options: ReconcileOrphansOptions,
+): Promise<ReconcileOrphansResult> {
+  const {
+    prefix,
+    dryRun = false,
+    alertThreshold = readOrphanRateAlertThreshold(),
+    limit,
+  } = options;
+
+  const keys = await listR2Objects(prefix, limit ? { limit } : undefined);
+  const orphanKeys = await findOrphanKeys(supabase, keys);
+
+  const errors: ReconcileOrphansResult["errors"] = [];
+  let deletedFromR2 = 0;
+
+  if (!dryRun) {
+    for (const key of orphanKeys) {
+      try {
+        await deleteFromR2(key);
+        deletedFromR2++;
+      } catch (err) {
+        errors.push({ key, error: err });
+        logger.warn("R2 delete failed during orphan reconciliation", {
+          context: "r2-cleanup",
+          key,
+          error: err,
+        });
+      }
+    }
+  }
+
+  const alerted = emitOrphanRateAlert({
+    orphanCount: orphanKeys.length,
+    totalCount: keys.length,
+    threshold: alertThreshold,
+    prefix,
+  });
+
+  const orphanRate = keys.length === 0 ? 0 : orphanKeys.length / keys.length;
+
+  logger.info("reconcileOrphans pass complete", {
+    context: "r2-cleanup",
+    prefix,
+    scanned: keys.length,
+    orphans: orphanKeys.length,
+    deletedFromR2,
+    orphanRate,
+    alerted,
+    dryRun,
+    errorCount: errors.length,
+  });
+
+  return {
+    scanned: keys.length,
+    orphans: orphanKeys.length,
+    deletedFromR2,
+    orphanRate,
+    alerted,
+    dryRun,
+    errors,
+  };
+}
+
+export interface EmitOrphanRateAlertArgs {
+  orphanCount: number;
+  totalCount: number;
+  /** Override the env-derived threshold (mostly for tests). */
+  threshold?: number;
+  /** Prefix being reconciled — surfaced as a Sentry tag. */
+  prefix?: string;
+}
+
+/**
+ * Alerting hook called from `reconcileOrphans`. Returns `true` if the
+ * alert fired so callers can include it in their structured result.
+ *
+ * The function intentionally logs via `logger.error` (not `warn`) so
+ * that Datadog / LogTail alarms on error-level log lines catch this
+ * even when Sentry is unreachable.
+ */
+export function emitOrphanRateAlert(args: EmitOrphanRateAlertArgs): boolean {
+  const { orphanCount, totalCount, prefix } = args;
+  const threshold = args.threshold ?? readOrphanRateAlertThreshold();
+
+  if (totalCount <= 0) return false;
+  const orphanRate = orphanCount / totalCount;
+  if (orphanRate < threshold) return false;
+
+  logger.error("R2 orphan rate exceeded threshold", {
+    context: "r2-cleanup",
+    orphanCount,
+    totalCount,
+    orphanRate,
+    threshold,
+    prefix,
+    tags: { alert: "r2_orphan_rate" },
+  });
+
+  try {
+    Sentry.captureMessage("R2 orphan rate exceeded threshold", {
+      level: "warning",
+      tags: {
+        alert: "r2_orphan_rate",
+        prefix: prefix ?? "unknown",
+      },
+      extra: {
+        orphanCount,
+        totalCount,
+        orphanRate,
+        threshold,
+        prefix,
+      },
+    });
+  } catch {
+    // Sentry unavailable — the structured logger.error above is the
+    // durable signal, so swallowing is safe.
+  }
+
+  return true;
+}

--- a/src/lib/r2-cleanup.ts
+++ b/src/lib/r2-cleanup.ts
@@ -318,7 +318,7 @@ export async function reconcileOrphans(
     limit,
   } = options;
 
-  const keys = await listR2Objects(prefix, limit ? { limit } : undefined);
+  const keys = await listR2Objects(prefix, limit != null ? { limit } : undefined);
   const orphanKeys = await findOrphanKeys(supabase, keys);
 
   const errors: ReconcileOrphansResult["errors"] = [];

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -472,6 +472,62 @@ export async function getR2ObjectMetadata(
 }
 
 /**
+ * List objects stored in R2 under the given key prefix, paginating over every
+ * page returned by `ListObjectsV2`. Used by the cleanup library
+ * (`r2-cleanup.ts`) to enumerate uploads for orphan reconciliation without
+ * caring about the 1 000-key page limit enforced by S3-compatible APIs.
+ *
+ * Returns an empty array when R2 is not configured so callers can safely
+ * invoke it during smoke runs without triggering credential errors.
+ *
+ * @param prefix    R2 key prefix to scan (e.g. `"clinics/"`). Required — an
+ *                  empty prefix would enumerate the entire bucket.
+ * @param opts.limit     Optional hard cap on the total number of keys
+ *                       returned across all pages. Defaults to no cap.
+ * @param opts.pageSize  Page size forwarded as `MaxKeys` (default: 1 000,
+ *                       the S3 maximum).
+ */
+export async function listR2Objects(
+  prefix: string,
+  opts: { limit?: number; pageSize?: number } = {},
+): Promise<string[]> {
+  const client = await getClient();
+  const config = getR2Config();
+  if (!client || !config) return [];
+
+  const limit = opts.limit ?? Number.POSITIVE_INFINITY;
+  const pageSize = opts.pageSize ?? 1000;
+  if (limit <= 0) return [];
+
+  const { ListObjectsV2Command } = await import("@aws-sdk/client-s3");
+
+  const keys: string[] = [];
+  let continuationToken: string | undefined;
+
+  do {
+    const response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: config.bucketName,
+        Prefix: prefix,
+        MaxKeys: pageSize,
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    for (const obj of response.Contents ?? []) {
+      if (typeof obj.Key === "string") {
+        keys.push(obj.Key);
+        if (keys.length >= limit) return keys;
+      }
+    }
+
+    continuationToken = response.IsTruncated ? response.NextContinuationToken ?? undefined : undefined;
+  } while (continuationToken);
+
+  return keys;
+}
+
+/**
  * Read the first N bytes of an object from R2 for content validation.
  *
  * @param key      Object key


### PR DESCRIPTION
## Summary

Task 3.3.2 — ships the reusable R2-cleanup library that a future cron will call. No entrypoint, no route, no schedule binding — the module is pure and can be merged safely behind zero call-sites.

### What landed

| File | Change |
|---|---|
| `src/lib/r2.ts` | Added `listR2Objects(prefix, opts?)` — paginated `ListObjectsV2` wrapper returning every key (transparently following `ContinuationToken`). Returns `[]` when R2 isn't configured. |
| `src/lib/r2-cleanup.ts` (new) | Pure library: `findAbandonedPendingUploads`, `findOrphanKeys`, `cleanupAbandonedUploads`, `reconcileOrphans`, `emitOrphanRateAlert`, plus `readOrphanRateAlertThreshold` env resolver. |
| `src/lib/env.ts` | Documented `R2_ORPHAN_RATE_ALERT_THRESHOLD` (optional, default `0.1`). Added to the `storage` group so startup validation reports it alongside other R2 vars. |
| `.env.example` | Added `R2_ORPHAN_RATE_ALERT_THRESHOLD=0.1` with a comment pointing to `src/lib/r2-cleanup.ts`. |
| `src/lib/__tests__/r2-cleanup.test.ts` (new) | 26 Vitest cases with mocked Supabase (`vi.mock` + chainable builder) and mocked `@/lib/r2` + `@sentry/nextjs` + `@/lib/logger`. |

### Alert behaviour (the key acceptance criterion)

`emitOrphanRateAlert` is verified to:

- log `logger.error("R2 orphan rate exceeded threshold", …)` with `tags: { alert: "r2_orphan_rate" }` and every relevant numeric field,
- call `Sentry.captureMessage("R2 orphan rate exceeded threshold", { level: "warning", tags: { alert: "r2_orphan_rate", prefix } })`,
- no-op when `totalCount === 0` (divide-by-zero guard),
- no-op when the rate is strictly below the threshold,
- still return `true` if Sentry throws — the `logger.error` call is the durable signal.

### Deliberate design choices

- **Supabase client is a parameter** (not constructed inside the library) — mirrors `audit-log.ts` and keeps the Vitest suite fully mockable.
- **`pending_uploads` row shape is an explicit interface**, not inferred from the generated `Database` type. The companion migration lands in a sibling task (3.3.1); this library stays safe to merge before then without coupling to the generated types.
- **Library logs but does not throw on partial failures** — R2/DB errors are collected per-key so a single transient failure never aborts a full reconciliation pass.
- **Env threshold is soft-validated** — invalid / out-of-range values log a warning and fall back to `0.1`; the cron must not fail-closed on operator typos.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

The new library targets the `pending_uploads` tracking table plus the R2 object store; it does not expose a route, cron, or client-facing surface. Tenant scoping is preserved via the optional `prefix` filter (`clinics/{id}/`) that callers pass in.

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated — 26 new cases in `src/lib/__tests__/r2-cleanup.test.ts`
- [x] Full Vitest suite passes locally: **615 passed, 24 skipped (58 files)**
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on all touched files

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
