### PR TITLE
fix(r2-cleanup): scope every query by clinic_id (AGENTS.md tenant-isolation rule 6)

### DIFF
--- a/src/lib/__tests__/r2-cleanup.test.ts
+++ b/src/lib/__tests__/r2-cleanup.test.ts
@@ -85,6 +85,13 @@ function makeSupabaseStub() {
   return { client, builder };
 }
 
+/**
+ * A valid-looking clinic UUID. The library calls `assertClinicId`
+ * (which validates UUID shape) so the test fixture can't use the
+ * `"clinic-a"` shorthand.
+ */
+const TEST_CLINIC_ID = "00000000-0000-0000-0000-000000000001";
+
 const originalEnv = process.env;
 
 beforeEach(() => {
@@ -148,6 +155,7 @@ describe("findAbandonedPendingUploads", () => {
     const before = Date.now();
     const result = await findAbandonedPendingUploads(
       client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+      TEST_CLINIC_ID,
     );
     const after = Date.now();
 
@@ -156,6 +164,7 @@ describe("findAbandonedPendingUploads", () => {
     expect(builder.select).toHaveBeenCalledWith(
       "id, clinic_id, r2_key, content_type, created_at, confirmed_at",
     );
+    expect(builder.eq).toHaveBeenCalledWith("clinic_id", TEST_CLINIC_ID);
     expect(builder.is).toHaveBeenCalledWith("confirmed_at", null);
 
     const [ltColumn, ltValue] = builder.lt.mock.calls[0] as [string, string];
@@ -178,8 +187,11 @@ describe("findAbandonedPendingUploads", () => {
 
     await findAbandonedPendingUploads(
       client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+      TEST_CLINIC_ID,
       { prefix: "clinics/clinic-a/", olderThanHours: 1, limit: 50 },
     );
+
+    expect(builder.eq).toHaveBeenCalledWith("clinic_id", TEST_CLINIC_ID);
 
     expect(builder.like).toHaveBeenCalledWith("r2_key", "clinics/clinic-a/%");
     expect(builder.limit).toHaveBeenCalledWith(50);
@@ -197,6 +209,7 @@ describe("findAbandonedPendingUploads", () => {
     await expect(
       findAbandonedPendingUploads(
         client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+        TEST_CLINIC_ID,
       ),
     ).rejects.toEqual({ message: "boom" });
 
@@ -204,6 +217,64 @@ describe("findAbandonedPendingUploads", () => {
       "findAbandonedPendingUploads query failed",
       expect.objectContaining({ context: "r2-cleanup" }),
     );
+  });
+});
+
+describe("tenant isolation guard", () => {
+  it("findAbandonedPendingUploads rejects a missing clinicId before touching Supabase", async () => {
+    const { findAbandonedPendingUploads } = await import("../r2-cleanup");
+    const { client } = makeSupabaseStub();
+
+    await expect(
+      findAbandonedPendingUploads(
+        client as unknown as Parameters<typeof findAbandonedPendingUploads>[0],
+        "" as unknown as string,
+      ),
+    ).rejects.toThrow(/TENANT SAFETY/);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("findOrphanKeys rejects a non-UUID clinicId before touching Supabase", async () => {
+    const { findOrphanKeys } = await import("../r2-cleanup");
+    const { client } = makeSupabaseStub();
+
+    await expect(
+      findOrphanKeys(
+        client as unknown as Parameters<typeof findOrphanKeys>[0],
+        "not-a-uuid",
+        ["clinics/a/orphan.png"],
+      ),
+    ).rejects.toThrow(/TENANT SAFETY/);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("cleanupAbandonedUploads rejects a missing clinicId before touching Supabase", async () => {
+    const { cleanupAbandonedUploads } = await import("../r2-cleanup");
+    const { client } = makeSupabaseStub();
+
+    await expect(
+      cleanupAbandonedUploads(
+        client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+        undefined as unknown as string,
+      ),
+    ).rejects.toThrow(/TENANT SAFETY/);
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it("reconcileOrphans rejects a missing clinicId before listing R2", async () => {
+    const { reconcileOrphans } = await import("../r2-cleanup");
+    const { listR2Objects } = await import("@/lib/r2");
+    const { client } = makeSupabaseStub();
+
+    await expect(
+      reconcileOrphans(
+        client as unknown as Parameters<typeof reconcileOrphans>[0],
+        "" as unknown as string,
+        { prefix: "clinics/" },
+      ),
+    ).rejects.toThrow(/TENANT SAFETY/);
+    expect(listR2Objects).not.toHaveBeenCalled();
+    expect(client.from).not.toHaveBeenCalled();
   });
 });
 
@@ -216,6 +287,7 @@ describe("findOrphanKeys", () => {
 
     const result = await findOrphanKeys(
       client as unknown as Parameters<typeof findOrphanKeys>[0],
+      TEST_CLINIC_ID,
       [],
     );
 
@@ -239,6 +311,7 @@ describe("findOrphanKeys", () => {
     ];
     const result = await findOrphanKeys(
       client as unknown as Parameters<typeof findOrphanKeys>[0],
+      TEST_CLINIC_ID,
       input,
     );
 
@@ -246,6 +319,7 @@ describe("findOrphanKeys", () => {
       "clinics/a/logos/orphan-1.png",
       "clinics/a/logos/orphan-2.png",
     ]);
+    expect(builder.eq).toHaveBeenCalledWith("clinic_id", TEST_CLINIC_ID);
     expect(builder.in).toHaveBeenCalledWith(
       "r2_key",
       [
@@ -268,6 +342,7 @@ describe("findOrphanKeys", () => {
     await expect(
       findOrphanKeys(
         client as unknown as Parameters<typeof findOrphanKeys>[0],
+        TEST_CLINIC_ID,
         ["k1"],
       ),
     ).rejects.toEqual({ message: "db down" });
@@ -316,6 +391,7 @@ describe("cleanupAbandonedUploads", () => {
 
     const result = await cleanupAbandonedUploads(
       client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+      TEST_CLINIC_ID,
     );
 
     expect(deleteFromR2).toHaveBeenCalledTimes(2);
@@ -323,6 +399,8 @@ describe("cleanupAbandonedUploads", () => {
     expect(deleteFromR2).toHaveBeenNthCalledWith(2, abandoned[1].r2_key);
 
     expect(builder.delete).toHaveBeenCalledTimes(2);
+    // Each delete is scoped by both clinic_id (tenant guard) and id (target row).
+    expect(builder.eq).toHaveBeenCalledWith("clinic_id", TEST_CLINIC_ID);
     expect(builder.eq).toHaveBeenCalledWith("id", "row-1");
     expect(builder.eq).toHaveBeenCalledWith("id", "row-2");
 
@@ -343,6 +421,7 @@ describe("cleanupAbandonedUploads", () => {
 
     const result = await cleanupAbandonedUploads(
       client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+      TEST_CLINIC_ID,
       { dryRun: true },
     );
 
@@ -372,6 +451,7 @@ describe("cleanupAbandonedUploads", () => {
 
     const result = await cleanupAbandonedUploads(
       client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+      TEST_CLINIC_ID,
     );
 
     expect(builder.delete).toHaveBeenCalledTimes(1);
@@ -399,6 +479,7 @@ describe("cleanupAbandonedUploads", () => {
 
     const result = await cleanupAbandonedUploads(
       client as unknown as Parameters<typeof cleanupAbandonedUploads>[0],
+      TEST_CLINIC_ID,
     );
 
     expect(result.deletedFromR2).toBe(1);
@@ -430,8 +511,11 @@ describe("reconcileOrphans", () => {
 
     const result = await reconcileOrphans(
       client as unknown as Parameters<typeof reconcileOrphans>[0],
+      TEST_CLINIC_ID,
       { prefix: "clinics/a/" },
     );
+
+    expect(builder.eq).toHaveBeenCalledWith("clinic_id", TEST_CLINIC_ID);
 
     expect(listR2Objects).toHaveBeenCalledWith("clinics/a/", undefined);
     expect(deleteFromR2).toHaveBeenCalledTimes(2);
@@ -461,6 +545,7 @@ describe("reconcileOrphans", () => {
 
     const result = await reconcileOrphans(
       client as unknown as Parameters<typeof reconcileOrphans>[0],
+      TEST_CLINIC_ID,
       { prefix: "clinics/a/", dryRun: true },
     );
 
@@ -484,6 +569,7 @@ describe("reconcileOrphans", () => {
 
     const result = await reconcileOrphans(
       client as unknown as Parameters<typeof reconcileOrphans>[0],
+      TEST_CLINIC_ID,
       { prefix: "clinics/empty/" },
     );
 
@@ -513,6 +599,7 @@ describe("reconcileOrphans", () => {
 
     const result = await reconcileOrphans(
       client as unknown as Parameters<typeof reconcileOrphans>[0],
+      TEST_CLINIC_ID,
       { prefix: "clinics/a/", alertThreshold: 0.99 },
     );
 
@@ -534,6 +621,7 @@ describe("reconcileOrphans", () => {
 
     await reconcileOrphans(
       client as unknown as Parameters<typeof reconcileOrphans>[0],
+      TEST_CLINIC_ID,
       { prefix: "clinics/", limit: 42 },
     );
 

--- a/src/lib/r2-cleanup.ts
+++ b/src/lib/r2-cleanup.ts
@@ -33,6 +33,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { assertClinicId } from "@/lib/assert-tenant";
 import { logger } from "@/lib/logger";
 import { deleteFromR2, listR2Objects } from "@/lib/r2";
 
@@ -58,7 +59,7 @@ export const DEFAULT_ORPHAN_RATE_THRESHOLD = 0.1;
  */
 export interface PendingUploadRow {
   id: string;
-  clinic_id: string | null;
+  clinic_id: string;
   r2_key: string;
   content_type: string | null;
   created_at: string;
@@ -103,11 +104,18 @@ export interface FindAbandonedOptions {
  * Find pending-upload rows whose confirmation never arrived within the
  * SLA window. Returns rows ordered by creation time so the cron deletes
  * the oldest candidates first.
+ *
+ * The query is scoped to a single tenant — every cron invocation must
+ * iterate over clinics and pass the current `clinicId` (per AGENTS.md
+ * tenant-isolation rule 6).
  */
 export async function findAbandonedPendingUploads(
   supabase: AnySupabase,
+  clinicId: string,
   options: FindAbandonedOptions = {},
 ): Promise<PendingUploadRow[]> {
+  assertClinicId(clinicId, "findAbandonedPendingUploads");
+
   const {
     olderThanHours = DEFAULT_ABANDONED_HOURS,
     prefix,
@@ -121,6 +129,7 @@ export async function findAbandonedPendingUploads(
   let query = supabase
     .from("pending_uploads")
     .select("id, clinic_id, r2_key, content_type, created_at, confirmed_at")
+    .eq("clinic_id", clinicId)
     .is("confirmed_at", null)
     .lt("created_at", cutoffIso)
     .order("created_at", { ascending: true })
@@ -138,6 +147,7 @@ export async function findAbandonedPendingUploads(
     logger.error("findAbandonedPendingUploads query failed", {
       context: "r2-cleanup",
       error,
+      clinicId,
       olderThanHours,
       prefix,
     });
@@ -149,13 +159,20 @@ export async function findAbandonedPendingUploads(
 
 /**
  * Given a batch of R2 keys, return the subset that is NOT referenced by
- * any row in `pending_uploads` (pending or confirmed). An orphan key is
- * therefore one the application has no record of and is safe to delete.
+ * any row in `pending_uploads` (pending or confirmed) for the given
+ * tenant. An orphan key is therefore one the application has no record
+ * of and is safe to delete.
+ *
+ * The query is scoped to `clinicId` so a key tracked under one tenant
+ * cannot mask an orphan reported by another tenant's reconciliation.
  */
 export async function findOrphanKeys(
   supabase: AnySupabase,
+  clinicId: string,
   r2Keys: string[],
 ): Promise<string[]> {
+  assertClinicId(clinicId, "findOrphanKeys");
+
   if (r2Keys.length === 0) return [];
 
   // De-duplicate input so the `in()` filter stays within PostgREST's
@@ -166,12 +183,14 @@ export async function findOrphanKeys(
   const { data, error } = await supabase
     .from("pending_uploads")
     .select("r2_key")
+    .eq("clinic_id", clinicId)
     .in("r2_key", uniqueKeys);
 
   if (error) {
     logger.error("findOrphanKeys query failed", {
       context: "r2-cleanup",
       error,
+      clinicId,
       keyCount: uniqueKeys.length,
     });
     throw error;
@@ -206,13 +225,20 @@ export interface CleanupAbandonedOptions extends FindAbandonedOptions {
  * Delete abandoned pending uploads from R2 and prune the tracking rows.
  * Errors are collected per-key and returned — a transient R2 outage on
  * one object must not abort the rest of the pass.
+ *
+ * Scoped to a single tenant: the SELECT and the row DELETE both filter
+ * on `clinic_id` so a buggy caller cannot accidentally fan out across
+ * the bucket.
  */
 export async function cleanupAbandonedUploads(
   supabase: AnySupabase,
+  clinicId: string,
   options: CleanupAbandonedOptions = {},
 ): Promise<CleanupAbandonedResult> {
+  assertClinicId(clinicId, "cleanupAbandonedUploads");
+
   const dryRun = options.dryRun ?? false;
-  const abandoned = await findAbandonedPendingUploads(supabase, options);
+  const abandoned = await findAbandonedPendingUploads(supabase, clinicId, options);
 
   const errors: CleanupAbandonedResult["errors"] = [];
   let deletedFromR2 = 0;
@@ -228,6 +254,7 @@ export async function cleanupAbandonedUploads(
       errors.push({ key: row.r2_key, stage: "r2", error: err });
       logger.warn("R2 delete failed during abandoned-upload cleanup", {
         context: "r2-cleanup",
+        clinicId,
         key: row.r2_key,
         error: err,
       });
@@ -237,12 +264,14 @@ export async function cleanupAbandonedUploads(
     const { error: deleteError } = await supabase
       .from("pending_uploads")
       .delete()
+      .eq("clinic_id", clinicId)
       .eq("id", row.id);
 
     if (deleteError) {
       errors.push({ key: row.r2_key, stage: "db", error: deleteError });
       logger.warn("pending_uploads row delete failed after R2 delete", {
         context: "r2-cleanup",
+        clinicId,
         key: row.r2_key,
         id: row.id,
         error: deleteError,
@@ -254,6 +283,7 @@ export async function cleanupAbandonedUploads(
 
   logger.info("cleanupAbandonedUploads pass complete", {
     context: "r2-cleanup",
+    clinicId,
     scanned: abandoned.length,
     deletedFromR2,
     removedFromDb,
@@ -306,11 +336,19 @@ export interface ReconcileOrphansResult {
  * that is not tracked in `pending_uploads` as an orphan, delete those
  * objects (unless `dryRun`), and fire the alerting hook when the orphan
  * rate crosses the configured threshold.
+ *
+ * Scoped to a single tenant: callers (the future cron) iterate clinics
+ * and pass the current `clinicId`, which is forwarded to
+ * `findOrphanKeys` so the DB lookup that classifies orphans cannot see
+ * across tenants.
  */
 export async function reconcileOrphans(
   supabase: AnySupabase,
+  clinicId: string,
   options: ReconcileOrphansOptions,
 ): Promise<ReconcileOrphansResult> {
+  assertClinicId(clinicId, "reconcileOrphans");
+
   const {
     prefix,
     dryRun = false,
@@ -319,7 +357,7 @@ export async function reconcileOrphans(
   } = options;
 
   const keys = await listR2Objects(prefix, limit != null ? { limit } : undefined);
-  const orphanKeys = await findOrphanKeys(supabase, keys);
+  const orphanKeys = await findOrphanKeys(supabase, clinicId, keys);
 
   const errors: ReconcileOrphansResult["errors"] = [];
   let deletedFromR2 = 0;
@@ -333,6 +371,7 @@ export async function reconcileOrphans(
         errors.push({ key, error: err });
         logger.warn("R2 delete failed during orphan reconciliation", {
           context: "r2-cleanup",
+          clinicId,
           key,
           error: err,
         });
@@ -351,6 +390,7 @@ export async function reconcileOrphans(
 
   logger.info("reconcileOrphans pass complete", {
     context: "r2-cleanup",
+    clinicId,
     prefix,
     scanned: keys.length,
     orphans: orphanKeys.length,


### PR DESCRIPTION
## Summary

Closes the AGENTS.md **tenant-isolation gap** in `src/lib/r2-cleanup.ts` (Task 3.3.2 follow-up). The library currently issues three Supabase queries with **no `clinic_id` filter**, which violates rule 1 ("Always filter by `clinic_id`") and rule 6 ("Cron jobs iterate per-clinic"). This PR makes the per-tenant scoping a hard, type-level requirement before the future cron handler wires anything up.

### What changed

| Function | Was | Now |
|---|---|---|
| `findAbandonedPendingUploads(supabase, options)` | un-scoped SELECT on `pending_uploads` | requires `clinicId` (validated by `assertClinicId`) and chains `.eq("clinic_id", clinicId)` on the SELECT (`src/lib/r2-cleanup.ts:112-156`) |
| `findOrphanKeys(supabase, r2Keys)` | un-scoped SELECT — could mask an orphan reported under one tenant with a row from another | requires `clinicId` and chains `.eq("clinic_id", clinicId)` on the SELECT (`src/lib/r2-cleanup.ts:169-204`) |
| `cleanupAbandonedUploads(supabase, options)` | un-scoped DELETE-by-id | requires `clinicId`; the DELETE chains `.eq("clinic_id", clinicId).eq("id", row.id)` so a buggy caller cannot fan out across the bucket (`src/lib/r2-cleanup.ts:233-292`) |
| `reconcileOrphans(supabase, options)` | passed un-scoped key list to `findOrphanKeys` | requires `clinicId` and forwards it to the inner call (`src/lib/r2-cleanup.ts:345-400`) |
| `PendingUploadRow.clinic_id` | `string \| null` | `string` — every row must carry a tenant; the cron will never see an unscoped row |

Each public function calls `assertClinicId(clinicId, "<operation>")` before issuing any I/O, matching the pattern used by `audit-log.ts` and `assert-tenant.ts`. A missing or non-UUID `clinicId` now fast-fails with `[TENANT SAFETY] ...` and never touches Supabase or R2.

### Tests

- All 26 existing cases updated to thread the new `clinicId` argument.
- Added 4 new cases under a `tenant isolation guard` describe block — one per public function — that assert the `assertClinicId` short-circuit fires *before* any Supabase / R2 I/O happens (`src/lib/__tests__/r2-cleanup.test.ts:223-279`).
- Existing assertions extended to verify `builder.eq("clinic_id", TEST_CLINIC_ID)` is called on every query path.
- `npx vitest run src/lib/__tests__/r2-cleanup.test.ts` → **30 passed (30)**.
- `npx eslint src/lib/r2-cleanup.ts src/lib/__tests__/r2-cleanup.test.ts` → clean.
- `npx tsc --noEmit` → clean.

### Why this is type-safe to merge before the cron handler

`r2-cleanup.ts` still has no entrypoint, no route, and no scheduler binding. Adding a required `clinicId` parameter is therefore a purely additive type-level guarantee: when the cron handler lands (per-clinic iteration as the AGENTS.md rule 6 mandates) the compiler will refuse to call any of these helpers without a valid clinic UUID.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [x] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated — 4 new tenant-guard cases + 26 existing cases re-threaded with `clinicId`
- [x] Manual testing performed — `npx vitest run src/lib/__tests__/r2-cleanup.test.ts` (30 pass)
- [ ] E2E tests pass locally (no E2E surface — pure library)

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
