### PR TITLE
feat(cron): hourly R2 abandoned-upload cleanup wiring (Task 3.3.3)

### DIFF
--- a/src/app/api/__tests__/cron-r2-cleanup.test.ts
+++ b/src/app/api/__tests__/cron-r2-cleanup.test.ts
@@ -1,0 +1,414 @@
+/**
+ * Integration tests for `src/app/api/cron/r2-cleanup/route.ts` (Task 3.3.3).
+ *
+ * Verifies:
+ *   1. CRON_SECRET authentication (the standard cron-auth pattern shared
+ *      with `cron-reminders.test.ts` and `billing.test.ts`).
+ *   2. Per-clinic iteration — the route lists active clinics and calls
+ *      the per-clinic primitives in `@/lib/r2-cleanup` once per clinic
+ *      with the correct `clinic_id`-scoped prefix (AGENTS.md rule #6).
+ *   3. Aggregate response shape — `{ scanned, orphans, deleted }` plus
+ *      per-clinic breakdown and the alert flag bubbled up from
+ *      `reconcileOrphans`.
+ *   4. Resilience — a sweep that throws for one clinic must not abort
+ *      the rest of the pass.
+ *   5. Alert propagation — `alertEmitted` reflects whether any clinic's
+ *      orphan rate crossed the configured threshold.
+ */
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+
+/* ─── Module mocks ─── */
+
+const mockCleanupAbandoned = vi.fn();
+const mockReconcileOrphans = vi.fn();
+const mockCreateAdminClient = vi.fn();
+
+vi.mock("@/lib/r2-cleanup", () => ({
+  cleanupAbandonedUploads: (...args: unknown[]) =>
+    mockCleanupAbandoned(...args),
+  reconcileOrphans: (...args: unknown[]) => mockReconcileOrphans(...args),
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createAdminClient: () => mockCreateAdminClient(),
+  createClient: vi.fn(),
+  createTenantClient: vi.fn(),
+}));
+
+vi.mock("@/lib/sentry-cron", () => ({
+  // Pass-through wrapper so the route's GET export is just the handler
+  // — keeps the test focused on route behaviour, not Sentry plumbing.
+  withSentryCron: (
+    _slug: string,
+    _schedule: string,
+    handler: (req: unknown) => unknown,
+  ) => handler,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/assert-tenant", () => ({
+  // The real helper validates UUIDs; the test fixtures use UUID strings,
+  // so just defer to a no-op for the route-level test.
+  assertClinicId: vi.fn(),
+}));
+
+/* ─── Test helpers ─── */
+
+const VALID_UUID_A = "11111111-1111-1111-1111-111111111111";
+const VALID_UUID_B = "22222222-2222-2222-2222-222222222222";
+
+interface ClinicRow {
+  id: string;
+}
+
+function makeAdminClient(clinics: ClinicRow[], queryError: unknown = null) {
+  const eq = vi.fn().mockResolvedValue({ data: clinics, error: queryError });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+  return { from, _select: select, _eq: eq };
+}
+
+function buildAuthorizedRequest(): Request {
+  return new Request("http://localhost/api/cron/r2-cleanup", {
+    headers: {
+      authorization: "Bearer test-secret",
+    },
+  }) as unknown as Request;
+}
+
+/* ─── Tests ─── */
+
+describe("Cron r2-cleanup — authentication", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CRON_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("rejects requests without a bearer token (401)", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const req = new Request(
+      "http://localhost/api/cron/r2-cleanup",
+    ) as unknown as Request;
+    const res = (await GET(req as never)) as Response;
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests with the wrong bearer token (401)", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const req = new Request("http://localhost/api/cron/r2-cleanup", {
+      headers: { authorization: "Bearer not-the-secret" },
+    }) as unknown as Request;
+    const res = (await GET(req as never)) as Response;
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects requests when CRON_SECRET is unset (401)", async () => {
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const req = buildAuthorizedRequest();
+    const res = (await GET(req as never)) as Response;
+    expect(res.status).toBe(401);
+  });
+
+  it("does NOT call any cleanup primitives on a 401", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    await GET(
+      new Request(
+        "http://localhost/api/cron/r2-cleanup",
+      ) as unknown as never,
+    );
+    expect(mockCleanupAbandoned).not.toHaveBeenCalled();
+    expect(mockReconcileOrphans).not.toHaveBeenCalled();
+  });
+});
+
+describe("Cron r2-cleanup — per-clinic iteration (AGENTS.md rule #6)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("queries clinics filtered by status='active'", async () => {
+    const adminClient = makeAdminClient([]);
+    mockCreateAdminClient.mockReturnValue(adminClient);
+
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    await GET(buildAuthorizedRequest() as unknown as never);
+
+    expect(adminClient.from).toHaveBeenCalledWith("clinics");
+    expect(adminClient._select).toHaveBeenCalledWith("id");
+    expect(adminClient._eq).toHaveBeenCalledWith("status", "active");
+  });
+
+  it("calls cleanup primitives once per active clinic with a clinic-scoped prefix", async () => {
+    const adminClient = makeAdminClient([
+      { id: VALID_UUID_A },
+      { id: VALID_UUID_B },
+    ]);
+    mockCreateAdminClient.mockReturnValue(adminClient);
+    mockCleanupAbandoned.mockResolvedValue({
+      scanned: 0,
+      deletedFromR2: 0,
+      removedFromDb: 0,
+      errors: [],
+      dryRun: false,
+    });
+    mockReconcileOrphans.mockResolvedValue({
+      scanned: 0,
+      orphans: 0,
+      deletedFromR2: 0,
+      orphanRate: 0,
+      alerted: false,
+      dryRun: false,
+      errors: [],
+    });
+
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    await GET(buildAuthorizedRequest() as unknown as never);
+
+    expect(mockCleanupAbandoned).toHaveBeenCalledTimes(2);
+    expect(mockReconcileOrphans).toHaveBeenCalledTimes(2);
+
+    // Per AGENTS.md rule #6, every call must pass the clinic_id and a
+    // prefix scoped to that clinic — NEVER a bucket-wide prefix.
+    expect(mockCleanupAbandoned).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      VALID_UUID_A,
+      { prefix: `clinics/${VALID_UUID_A}/` },
+    );
+    expect(mockReconcileOrphans).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      VALID_UUID_A,
+      { prefix: `clinics/${VALID_UUID_A}/` },
+    );
+    expect(mockCleanupAbandoned).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      VALID_UUID_B,
+      { prefix: `clinics/${VALID_UUID_B}/` },
+    );
+    expect(mockReconcileOrphans).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      VALID_UUID_B,
+      { prefix: `clinics/${VALID_UUID_B}/` },
+    );
+  });
+
+  it("returns 500 when the active-clinics query fails", async () => {
+    const adminClient = makeAdminClient([], { message: "boom" });
+    mockCreateAdminClient.mockReturnValue(adminClient);
+
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const res = (await GET(buildAuthorizedRequest() as unknown as never)) as
+      Response;
+    expect(res.status).toBe(500);
+    expect(mockCleanupAbandoned).not.toHaveBeenCalled();
+    expect(mockReconcileOrphans).not.toHaveBeenCalled();
+  });
+});
+
+describe("Cron r2-cleanup — aggregate response", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns { scanned, orphans, deleted } summed across clinics", async () => {
+    mockCreateAdminClient.mockReturnValue(
+      makeAdminClient([{ id: VALID_UUID_A }, { id: VALID_UUID_B }]),
+    );
+    (mockCleanupAbandoned as Mock)
+      .mockResolvedValueOnce({
+        scanned: 3,
+        deletedFromR2: 2,
+        removedFromDb: 2,
+        errors: [],
+        dryRun: false,
+      })
+      .mockResolvedValueOnce({
+        scanned: 1,
+        deletedFromR2: 1,
+        removedFromDb: 1,
+        errors: [{ key: "k", stage: "r2", error: "x" }],
+        dryRun: false,
+      });
+    (mockReconcileOrphans as Mock)
+      .mockResolvedValueOnce({
+        scanned: 10,
+        orphans: 1,
+        deletedFromR2: 1,
+        orphanRate: 0.1,
+        alerted: false,
+        dryRun: false,
+        errors: [],
+      })
+      .mockResolvedValueOnce({
+        scanned: 20,
+        orphans: 4,
+        deletedFromR2: 4,
+        orphanRate: 0.2,
+        alerted: true,
+        dryRun: false,
+        errors: [],
+      });
+
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const res = (await GET(buildAuthorizedRequest() as unknown as never)) as
+      Response;
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      data: {
+        scanned: number;
+        orphans: number;
+        deleted: number;
+        errors: number;
+        clinics: number;
+        alertEmitted: boolean;
+        perClinic: Array<{
+          clinicId: string;
+          scanned: number;
+          orphans: number;
+          deleted: number;
+          alerted: boolean;
+        }>;
+      };
+    };
+
+    expect(body.ok).toBe(true);
+    expect(body.data.clinics).toBe(2);
+    expect(body.data.scanned).toBe(30); // 10 + 20 from reconcileOrphans
+    expect(body.data.orphans).toBe(5); // 1 + 4
+    expect(body.data.deleted).toBe(8); // (2+1) + (1+4)
+    expect(body.data.errors).toBe(1);
+    expect(body.data.alertEmitted).toBe(true);
+    expect(body.data.perClinic).toHaveLength(2);
+    expect(body.data.perClinic[0].clinicId).toBe(VALID_UUID_A);
+    expect(body.data.perClinic[1].alerted).toBe(true);
+  });
+
+  it("alertEmitted is false when no clinic crosses the threshold", async () => {
+    mockCreateAdminClient.mockReturnValue(
+      makeAdminClient([{ id: VALID_UUID_A }]),
+    );
+    mockCleanupAbandoned.mockResolvedValue({
+      scanned: 0,
+      deletedFromR2: 0,
+      removedFromDb: 0,
+      errors: [],
+      dryRun: false,
+    });
+    mockReconcileOrphans.mockResolvedValue({
+      scanned: 100,
+      orphans: 1,
+      deletedFromR2: 1,
+      orphanRate: 0.01,
+      alerted: false,
+      dryRun: false,
+      errors: [],
+    });
+
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const res = (await GET(buildAuthorizedRequest() as unknown as never)) as
+      Response;
+    const body = (await res.json()) as { data: { alertEmitted: boolean } };
+    expect(body.data.alertEmitted).toBe(false);
+  });
+});
+
+describe("Cron r2-cleanup — per-clinic resilience", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "test-secret";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("does not abort the pass when one clinic's sweep throws", async () => {
+    mockCreateAdminClient.mockReturnValue(
+      makeAdminClient([{ id: VALID_UUID_A }, { id: VALID_UUID_B }]),
+    );
+    (mockCleanupAbandoned as Mock)
+      .mockRejectedValueOnce(new Error("kaboom"))
+      .mockResolvedValueOnce({
+        scanned: 1,
+        deletedFromR2: 1,
+        removedFromDb: 1,
+        errors: [],
+        dryRun: false,
+      });
+    mockReconcileOrphans.mockResolvedValue({
+      scanned: 5,
+      orphans: 0,
+      deletedFromR2: 0,
+      orphanRate: 0,
+      alerted: false,
+      dryRun: false,
+      errors: [],
+    });
+
+    const { GET } = await import("@/app/api/cron/r2-cleanup/route");
+    const res = (await GET(buildAuthorizedRequest() as unknown as never)) as
+      Response;
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      data: {
+        clinics: number;
+        errors: number;
+        deleted: number;
+        perClinic: Array<{ clinicId: string; error?: string }>;
+      };
+    };
+    expect(body.data.clinics).toBe(2);
+    expect(body.data.errors).toBeGreaterThanOrEqual(1);
+    expect(body.data.deleted).toBe(1); // only the second clinic's delete counted
+    expect(body.data.perClinic.find((c) => c.clinicId === VALID_UUID_A)?.error).toBe(
+      "kaboom",
+    );
+  });
+});

--- a/src/app/api/cron/r2-cleanup/route.ts
+++ b/src/app/api/cron/r2-cleanup/route.ts
@@ -1,0 +1,168 @@
+/**
+ * Cron Route — R2 Abandoned-Upload Cleanup (Task 3.3.3).
+ *
+ * Runs every hour (Cloudflare Cron Trigger `0 * * * *`) to reconcile the
+ * R2 bucket against the `pending_uploads` tracking table, deleting:
+ *   1. Tracking rows whose `confirmed_at` is still null after the SLA
+ *      window (default 24 h) — and the corresponding R2 object.
+ *   2. Orphan R2 keys — objects under `clinics/{id}/` that no
+ *      `pending_uploads` row references.
+ *
+ * Tenant isolation (AGENTS.md rule #6): the route iterates active
+ * clinics and scopes every R2 list/delete and DB query to the current
+ * `clinic_id` via the per-clinic primitives in `@/lib/r2-cleanup`.
+ *
+ * Protected by CRON_SECRET via `Authorization: Bearer` header.
+ */
+
+import { NextRequest } from "next/server";
+import { apiInternalError, apiSuccess } from "@/lib/api-response";
+import { assertClinicId } from "@/lib/assert-tenant";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import {
+  cleanupAbandonedUploads,
+  reconcileOrphans,
+} from "@/lib/r2-cleanup";
+import { withSentryCron } from "@/lib/sentry-cron";
+import { createAdminClient } from "@/lib/supabase-server";
+
+interface PerClinicResult {
+  clinicId: string;
+  scanned: number;
+  orphans: number;
+  deleted: number;
+  errors: number;
+  alerted: boolean;
+  error?: string;
+}
+
+async function handler(request: NextRequest) {
+  const authError = verifyCronSecret(request);
+  if (authError) return authError;
+
+  try {
+    // Cron has no tenant subdomain context — use the admin client to
+    // enumerate clinics, then re-scope every per-clinic operation via
+    // the library primitives that take an explicit `clinicId`.
+    const supabase = createAdminClient();
+
+    const { data: clinics, error: clinicsError } = await supabase
+      .from("clinics")
+      .select("id")
+      .eq("status", "active");
+
+    if (clinicsError) {
+      logger.error("r2-cleanup: failed to list active clinics", {
+        context: "cron/r2-cleanup",
+        error: clinicsError,
+      });
+      return apiInternalError("Failed to list active clinics");
+    }
+
+    const perClinic: PerClinicResult[] = [];
+    let totalScanned = 0;
+    let totalOrphans = 0;
+    let totalDeleted = 0;
+    let totalErrors = 0;
+    let alertEmitted = false;
+
+    for (const clinic of clinics ?? []) {
+      // Defense-in-depth — never let a malformed clinic row leak across
+      // tenants (per AGENTS.md rule #6). Skip rather than fail the pass.
+      if (!clinic.id) {
+        logger.warn("r2-cleanup: clinic row missing id — skipping", {
+          context: "cron/r2-cleanup",
+        });
+        continue;
+      }
+      try {
+        assertClinicId(clinic.id, "cron/r2-cleanup:clinic");
+      } catch {
+        logger.warn("r2-cleanup: invalid clinic_id format — skipping", {
+          context: "cron/r2-cleanup",
+          clinicId: clinic.id,
+        });
+        continue;
+      }
+
+      const prefix = `clinics/${clinic.id}/`;
+
+      try {
+        const abandoned = await cleanupAbandonedUploads(supabase, clinic.id, {
+          prefix,
+        });
+        const orphans = await reconcileOrphans(supabase, clinic.id, {
+          prefix,
+        });
+
+        const scanned = orphans.scanned;
+        const orphanCount = orphans.orphans;
+        const deleted = abandoned.deletedFromR2 + orphans.deletedFromR2;
+        const errors = abandoned.errors.length + orphans.errors.length;
+
+        totalScanned += scanned;
+        totalOrphans += orphanCount;
+        totalDeleted += deleted;
+        totalErrors += errors;
+        alertEmitted = alertEmitted || orphans.alerted;
+
+        perClinic.push({
+          clinicId: clinic.id,
+          scanned,
+          orphans: orphanCount,
+          deleted,
+          errors,
+          alerted: orphans.alerted,
+        });
+      } catch (err) {
+        // A failure for one clinic must not abort the rest of the pass.
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error("r2-cleanup: per-clinic sweep failed", {
+          context: "cron/r2-cleanup",
+          clinicId: clinic.id,
+          error: message,
+        });
+        perClinic.push({
+          clinicId: clinic.id,
+          scanned: 0,
+          orphans: 0,
+          deleted: 0,
+          errors: 1,
+          alerted: false,
+          error: message,
+        });
+        totalErrors += 1;
+      }
+    }
+
+    logger.info("r2-cleanup cron completed", {
+      context: "cron/r2-cleanup",
+      clinics: perClinic.length,
+      scanned: totalScanned,
+      orphans: totalOrphans,
+      deleted: totalDeleted,
+      errors: totalErrors,
+      alertEmitted,
+    });
+
+    return apiSuccess({
+      clinics: perClinic.length,
+      scanned: totalScanned,
+      orphans: totalOrphans,
+      deleted: totalDeleted,
+      errors: totalErrors,
+      alertEmitted,
+      perClinic,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.error("r2-cleanup cron failed", {
+      context: "cron/r2-cleanup",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return apiInternalError("R2 cleanup failed");
+  }
+}
+
+export const GET = withSentryCron("r2-cleanup-hourly", "0 * * * *", handler);

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -6,8 +6,10 @@
  * the Next.js cron API routes with the correct CRON_SECRET auth.
  *
  * Cron schedule (from wrangler.toml):
- *   - Every 30 min  →  /api/cron/reminders  (appointment reminders)
- *   - Daily at 2 AM →  /api/cron/billing    (subscription renewals)
+ *   - Every 30 min  →  /api/cron/reminders     (appointment reminders)
+ *   - Every 15 min  →  /api/cron/notifications (queued notifications)
+ *   - Hourly        →  /api/cron/r2-cleanup    (abandoned R2 uploads)
+ *   - Daily at 2 AM →  /api/cron/billing       (subscription renewals)
  *
  * @see https://opennext.js.org/cloudflare/howtos/custom-worker
  */
@@ -23,6 +25,7 @@ import { default as handler } from "./.open-next/worker.js";
 const CRON_ROUTES: Record<string, string> = {
   "*/30 * * * *": "/api/cron/reminders",
   "*/15 * * * *": "/api/cron/notifications",
+  "0 * * * *": "/api/cron/r2-cleanup",
   "0 2 * * *": "/api/cron/billing",
 };
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -71,7 +71,8 @@ routes = [
 # Audit 8.8 — Changed second cron from every 5 min to every 15 min to
 # reduce unnecessary Worker invocations. Appointment reminders (*/30) and
 # daily subscription check (0 2 * * *) remain unchanged.
-crons = ["*/30 * * * *", "*/15 * * * *", "0 2 * * *"]
+# Task 3.3.3 — Added hourly R2 abandoned-upload cleanup (0 * * * *).
+crons = ["*/30 * * * *", "*/15 * * * *", "0 * * * *", "0 2 * * *"]
 
 # ---- Staging Environment ----
 # Deploy with: wrangler deploy --env staging
@@ -138,8 +139,9 @@ SELF_SERVICE_REGISTRATION_ENABLED = "false"
 
 # ---- Staging Cron Triggers ----
 # Audit 8.8 — Less aggressive schedule for staging (was */5, now */15)
+# Task 3.3.3 — Added hourly R2 abandoned-upload cleanup (0 * * * *).
 [env.staging.triggers]
-crons = ["*/30 * * * *", "*/15 * * * *", "0 2 * * *"]
+crons = ["*/30 * * * *", "*/15 * * * *", "0 * * * *", "0 2 * * *"]
 
 # ---- Cloudflare Queues (R-14 Fix) ----
 # Provision queues for reliable webhook/cron retry + DLQ.


### PR DESCRIPTION
## Summary

Task 3.3.3 — wires the existing `src/lib/r2-cleanup.ts` library (Task 3.3.2, already on `main`) to a Cloudflare Cron Trigger so the hourly sweep actually runs in staging/production and starts deleting abandoned R2 objects.

### Changes

- **`src/app/api/cron/r2-cleanup/route.ts` (new)** — `verifyCronSecret` + `withSentryCron("r2-cleanup-hourly", "0 * * * *", handler)`. Uses `createAdminClient()` to enumerate `clinics` filtered by `status = 'active'`, then iterates per-clinic (AGENTS.md tenant-isolation rule #6) and calls:
  - `cleanupAbandonedUploads(supabase, clinicId, { prefix: "clinics/{id}/" })` — deletes tracking rows (and matching R2 objects) whose `confirmed_at` is still null after the 24h SLA window.
  - `reconcileOrphans(supabase, clinicId, { prefix: "clinics/{id}/" })` — lists R2 keys under the clinic's prefix, classifies orphans against `pending_uploads`, deletes them, and emits the orphan-rate Sentry alert when the configured threshold is exceeded.
  - Returns aggregate `{ scanned, orphans, deleted, errors, alertEmitted, perClinic }` so an operator can see per-clinic counts without losing the rollup.
  - Per-clinic exceptions are caught and recorded — one bad clinic must not abort the rest of the pass.

- **`worker-cron-handler.ts`** — adds `"0 * * * *" -> "/api/cron/r2-cleanup"` to the `CRON_ROUTES` map so the Worker forwards the new trigger to the Next.js route with the standard `Authorization: Bearer ${CRON_SECRET}` header.

- **`wrangler.toml`** — adds `"0 * * * *"` to both `[triggers].crons` (production) and `[env.staging.triggers].crons` (staging) so the cron actually fires hourly in both environments.

- **`src/app/api/__tests__/cron-r2-cleanup.test.ts` (new)** — standard cron-auth pattern (mirrors `cron-reminders.test.ts` / `billing.test.ts`):
  - 401 paths: missing header, wrong token, unset `CRON_SECRET`, and "no cleanup primitives invoked on auth failure".
  - Per-clinic iteration: queries clinics with `status = "active"`, calls each primitive once per clinic with the correct `clinics/{id}/` prefix, and 500s when the clinic query itself fails.
  - Aggregate response: sums `scanned / orphans / deleted` across clinics, propagates `alertEmitted` upward, and surfaces per-clinic breakdown.
  - Resilience: a sweep that throws for one clinic still completes the rest of the pass and records the error in `perClinic`.

### Done when

- [x] Cron route returns `{ scanned, orphans, deleted }` aggregates.
- [x] Worker maps `0 * * * *` -> `/api/cron/r2-cleanup` with the bearer auth header.
- [x] `0 * * * *` added to `wrangler.toml` `[triggers].crons` and `[env.staging.triggers].crons`.
- [x] Unit tests cover auth, per-clinic iteration, aggregates, alert propagation, and per-clinic error resilience.
- [x] Emits the Sentry orphan-rate alert (via `reconcileOrphans` -> `emitOrphanRateAlert`) when the synthetic orphan rate is exceeded.

## Type of change

- [x] New feature
- [x] Infrastructure / CI

## Security Impact

- [x] This PR changes tenant isolation or multi-tenant scoping

The cron route is the new tenant-scoping boundary for the R2 cleanup library. Every per-clinic operation goes through the existing primitives in `src/lib/r2-cleanup.ts`, which `assertClinicId()` and filter `pending_uploads` queries on `clinic_id` (AGENTS.md rule #6).

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated — `src/app/api/__tests__/cron-r2-cleanup.test.ts` (10 tests, all passing locally).
- [x] Manual testing performed — full vitest run for `src/app/api/__tests__/` and `src/lib/__tests__/r2-cleanup.test.ts` passes (201 tests).

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
