### PR TITLE
fix(security): CSP-harden HTML PHI downloads + fail-closed tenant context

### DIFF
--- a/src/app/api/__tests__/lab-report-encrypted-storage.test.ts
+++ b/src/app/api/__tests__/lab-report-encrypted-storage.test.ts
@@ -336,8 +336,39 @@ describe("GET /api/files/download — auth and tenant scoping", () => {
     expect(response.headers.get("Content-Type")).toMatch(/^text\/html/);
     expect(response.headers.get("Content-Disposition")).toMatch(/^inline/);
     expect(response.headers.get("Cache-Control")).toMatch(/no-store/);
+    // Defense-in-depth XSS hardening: decrypted HTML PHI must be served with a
+    // strict per-response CSP, nosniff, and no-referrer so any future un-escaped
+    // field cannot become an authenticated stored-XSS sink.
+    const csp = response.headers.get("Content-Security-Policy");
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'none'");
+    expect(csp).not.toContain("script-src");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
     expect(downloadAndDecryptMock).toHaveBeenCalledWith(key);
     expect(await response.text()).toBe("<html>secret</html>");
+  });
+
+  it("does not attach a CSP for non-HTML downloads (e.g. PDF)", async () => {
+    authedAs("doctor", CLINIC_ID);
+    downloadAndDecryptMock.mockResolvedValueOnce(Buffer.from("%PDF-1.4", "utf-8"));
+
+    const key = `clinics/${CLINIC_ID}/lab-reports/123.pdf`;
+    const { GET } = await import("@/app/api/files/download/route");
+    const response = await GET(
+      buildGetRequest(`http://t.test/api/files/download?key=${encodeURIComponent(key)}`),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/pdf");
+    // Non-HTML PHI is offered as an attachment so the browser doesn't render
+    // it — a CSP would be a no-op here, so we don't attach one.
+    expect(response.headers.get("Content-Disposition")).toMatch(/^attachment/);
+    expect(response.headers.get("Content-Security-Policy")).toBeNull();
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
   });
 
   it("super_admin can download from any clinic", async () => {

--- a/src/app/api/files/download/route.ts
+++ b/src/app/api/files/download/route.ts
@@ -177,11 +177,45 @@ async function handler(request: NextRequest, { supabase, profile }: AuthContext)
 
   const filename = baseKey.split("/").pop() ?? "download";
   const contentType = contentTypeForKey(baseKey);
+  const isHtml = contentType.startsWith("text/html");
 
-  // Force `inline` for HTML so existing UI flows (window.open) render the
-  // report; everything else is offered as an attachment so the browser
-  // doesn't try to execute or interpret arbitrary PHI bytes.
-  const disposition = contentType.startsWith("text/html") ? "inline" : "attachment";
+  // Lab/radiology reports are HTML and existing UI flows open them in a new
+  // tab via `window.open(downloadUrl)` — that requires `inline`. Everything
+  // else is offered as an attachment so the browser doesn't try to execute
+  // or interpret arbitrary PHI bytes.
+  const disposition = isHtml ? "inline" : "attachment";
+  const safeFilename = filename.replace(/"/g, "");
+
+  // Defense-in-depth: even though report fields are HTML-escaped before
+  // rendering, a future un-escaped field would otherwise become an
+  // authenticated stored-XSS sink on PHI documents. A strict per-response
+  // CSP locks the document down so any injected <script>, inline event
+  // handler, remote stylesheet, or framing attempt is blocked at the
+  // browser level.
+  const csp = [
+    "default-src 'none'",
+    // Reports use a single inline <style> block; no external CSS is loaded.
+    "style-src 'unsafe-inline'",
+    // Allow inline base64/svg for report-embedded images (logos, etc.).
+    "img-src data:",
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'none'",
+  ].join("; ");
+
+  const headers: Record<string, string> = {
+    "Content-Type": contentType,
+    "Content-Length": String(plaintext.byteLength),
+    "Content-Disposition": `${disposition}; filename="${safeFilename}"`,
+    // Short-lived private cache: PHI must not be cached by intermediaries.
+    "Cache-Control": "private, no-store, max-age=0",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+  };
+
+  if (isHtml) {
+    headers["Content-Security-Policy"] = csp;
+  }
 
   // Cast the Node Buffer through `unknown` so it satisfies the Web BodyInit
   // type used by NextResponse — Buffers are streamable in Next.js but TS
@@ -191,14 +225,7 @@ async function handler(request: NextRequest, { supabase, profile }: AuthContext)
   try {
     return new NextResponse(body, {
       status: 200,
-      headers: {
-        "Content-Type": contentType,
-        "Content-Length": String(plaintext.byteLength),
-        "Content-Disposition": `${disposition}; filename="${filename.replace(/"/g, "")}"`,
-        // Short-lived private cache: PHI must not be cached by intermediaries.
-        "Cache-Control": "private, no-store, max-age=0",
-        "X-Content-Type-Options": "nosniff",
-      },
+      headers,
     });
   } catch (err) {
     logger.error("Failed to build download response", {

--- a/src/lib/__tests__/with-auth.test.ts
+++ b/src/lib/__tests__/with-auth.test.ts
@@ -6,6 +6,16 @@ vi.mock("@/lib/supabase-server", () => ({
   createClient: vi.fn(),
 }));
 
+// Default mock keeps tenant-context a no-op so the existing happy-path tests
+// (which use synthetic non-UUID clinic IDs like "clinic-1") don't trip the
+// new fail-closed 503 behavior. Individual tests that need to exercise the
+// fail-closed path override `setTenantContext` per-call.
+const setTenantContextMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/tenant-context", () => ({
+  setTenantContext: (...args: unknown[]) => setTenantContextMock(...args),
+  logTenantContext: vi.fn(),
+}));
+
 function createMockRequest(initialHeaders?: Record<string, string>): {
   headers: Map<string, string>;
   method: string;
@@ -247,6 +257,92 @@ describe("withAuth", () => {
       const response = await wrappedHandler(request as never);
       expect(response.status).toBe(403);
       expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  // Fail-closed tenant context: a `setTenantContext` failure on a tenant-
+  // scoped route MUST abort with 503 by default. Continuing would leave the
+  // request relying on weaker fallback isolation checks (`get_user_clinic_id`
+  // alone), which is unsafe in a multi-tenant RLS model.
+  describe("setTenantContext failure handling", () => {
+    beforeEach(() => {
+      setTenantContextMock.mockReset();
+      setTenantContextMock.mockResolvedValue(undefined);
+    });
+
+    it("returns 503 from withAuth when setTenantContext throws (fail-closed default)", async () => {
+      const mockSupabase = createMockSupabase(
+        { id: "user-1" },
+        { id: "profile-1", role: "clinic_admin", clinic_id: "clinic-1" },
+      );
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+      setTenantContextMock.mockRejectedValueOnce(new Error("RPC unavailable"));
+
+      const handler = vi.fn();
+      const wrappedHandler = withAuth(handler, ["clinic_admin"]);
+
+      const response = await wrappedHandler(createMockRequest() as never);
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.error).toBe("Tenant context unavailable");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("returns 503 from withAuthAnyRole when setTenantContext throws (fail-closed default)", async () => {
+      const mockSupabase = createMockSupabase(
+        { id: "user-1" },
+        { id: "profile-1", role: "patient", clinic_id: "clinic-1" },
+      );
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+      setTenantContextMock.mockRejectedValueOnce(new Error("RPC unavailable"));
+
+      const handler = vi.fn();
+      const wrappedHandler = withAuthAnyRole(handler);
+
+      const response = await wrappedHandler(createMockRequest() as never);
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.error).toBe("Tenant context unavailable");
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("invokes the handler when failOpen=true even if setTenantContext throws", async () => {
+      const mockUser = { id: "user-1" };
+      const mockProfile = { id: "profile-1", role: "clinic_admin", clinic_id: "clinic-1" };
+      const mockSupabase = createMockSupabase(mockUser, mockProfile);
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+      setTenantContextMock.mockRejectedValueOnce(new Error("RPC unavailable"));
+
+      const handler = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
+      const wrappedHandler = withAuth(handler, ["clinic_admin"], { failOpen: true });
+
+      const response = await wrappedHandler(createMockRequest() as never);
+
+      expect(response.status).toBe(200);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call setTenantContext when profile.clinic_id is null (super_admin)", async () => {
+      const mockSupabase = createMockSupabase(
+        { id: "user-1" },
+        { id: "profile-1", role: "super_admin", clinic_id: null },
+      );
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+
+      const handler = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      );
+      const wrappedHandler = withAuth(handler, ["super_admin"]);
+
+      const response = await wrappedHandler(createMockRequest() as never);
+
+      expect(response.status).toBe(200);
+      expect(setTenantContextMock).not.toHaveBeenCalled();
+      expect(handler).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -37,6 +37,24 @@ type AuthenticatedHandler = (
 ) => Promise<NextResponse>;
 
 /**
+ * Options for the `withAuth` / `withAuthAnyRole` wrappers.
+ *
+ * `failOpen` controls behavior when `setTenantContext` cannot be applied to
+ * the Supabase client. The default is **fail-closed** — a failure to set the
+ * Postgres session variable that RLS policies depend on must abort the
+ * request with a 503, because continuing would leave the request relying on
+ * weaker fallback isolation checks (`get_user_clinic_id()` alone) on a route
+ * that the application clearly intended to be tenant-scoped.
+ *
+ * Pass `failOpen: true` ONLY for explicit, read-only routes that never
+ * touch tenant data and where RLS-without-context is acceptable. This must
+ * be a deliberate, audited decision per route — never the default.
+ */
+export interface WithAuthOptions {
+  failOpen?: boolean;
+}
+
+/**
  * Wraps a Next.js API route handler with authentication and role checks.
  *
  * @param handler - The route handler that receives the request and auth context
@@ -50,7 +68,9 @@ type AuthenticatedHandler = (
 export function withAuth(
   handler: AuthenticatedHandler,
   allowedRoles: UserRole[],
+  options: WithAuthOptions = {},
 ) {
+  const failOpen = options.failOpen === true;
   return async (request: NextRequest): Promise<NextResponse> => {
     try {
       const supabase = await createClient();
@@ -142,6 +162,12 @@ export function withAuth(
 
       // Set tenant context on the Supabase client so RLS policies
       // can use app.current_clinic_id as an additional isolation check.
+      // Default behavior is fail-closed: if we cannot establish the tenant
+      // session variable, abort with 503 rather than silently relying on
+      // the weaker `get_user_clinic_id()` fallback for a tenant-scoped
+      // route. Routes that explicitly opt into `failOpen: true` (e.g. a
+      // read-only public endpoint that never touches tenant data) keep
+      // the legacy log-and-continue behavior.
       if (profile.clinic_id) {
         try {
           await setTenantContext(supabase, profile.clinic_id);
@@ -149,9 +175,15 @@ export function withAuth(
           logger.error("Failed to set tenant context in withAuth", {
             context: "with-auth",
             clinicId: profile.clinic_id,
+            failOpen,
             error: tenantErr,
           });
-          // Continue — RLS via get_user_clinic_id() still protects
+          if (!failOpen) {
+            return NextResponse.json(
+              { error: "Tenant context unavailable" },
+              { status: 503 },
+            );
+          }
         }
       }
 
@@ -198,7 +230,11 @@ export function withAuth(
  * Usage:
  *   export const POST = withAuthAnyRole(handler);
  */
-export function withAuthAnyRole(handler: AuthenticatedHandler) {
+export function withAuthAnyRole(
+  handler: AuthenticatedHandler,
+  options: WithAuthOptions = {},
+) {
+  const failOpen = options.failOpen === true;
   // Pass an empty array to withAuth, then check that the user is authenticated
   // without enforcing any specific role. This is a "deny-by-default with
   // explicit allowlist" pattern - every withAuth call must specify roles.
@@ -283,7 +319,7 @@ export function withAuthAnyRole(handler: AuthenticatedHandler) {
         }
       }
 
-      // Set tenant context
+      // Set tenant context (fail-closed by default — see withAuth above).
       if (profile.clinic_id) {
         try {
           await setTenantContext(supabase, profile.clinic_id);
@@ -291,8 +327,15 @@ export function withAuthAnyRole(handler: AuthenticatedHandler) {
           logger.error("Failed to set tenant context in withAuthAnyRole", {
             context: "with-auth",
             clinicId: profile.clinic_id,
+            failOpen,
             error: tenantErr,
           });
+          if (!failOpen) {
+            return NextResponse.json(
+              { error: "Tenant context unavailable" },
+              { status: 503 },
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Two high-priority security hardenings.

### 1. `/api/files/download` — strict CSP on decrypted HTML PHI (Audit #2)

The encrypted-download route returned decrypted HTML lab reports with `Content-Disposition: inline` and **no per-response Content-Security-Policy**. Visible report fields are HTML-escaped today (via `escapeHtml`), but any future un-escaped field would become an authenticated stored-XSS sink on PHI documents — a high-blast-radius vulnerability.

Changes in `src/app/api/files/download/route.ts`:

- Add a strict per-response CSP to HTML responses:
  ```
  default-src 'none'; style-src 'unsafe-inline'; img-src data:;
  base-uri 'none'; form-action 'none'; frame-ancestors 'none'
  ```
  No `script-src` allowance, so any injected `<script>` / inline event handler is blocked at the browser even if escaping is bypassed.
- Add `Referrer-Policy: no-referrer` and keep `X-Content-Type-Options: nosniff` on every download.
- Keep `inline` disposition for HTML reports — the existing UI flow (`window.open(downloadUrl)` in radiology/lab pages) requires inline rendering, and the new CSP is what actually neutralizes the XSS risk. Non-HTML PHI keeps its existing `attachment` disposition.

### 2. `with-auth` — fail-closed `setTenantContext` (Audit #5)

`setTenantContext` failures were logged and swallowed in both `withAuth` and `withAuthAnyRole`. In a multi-tenant RLS model that's unsafe — continuing leaves the request relying on weaker fallback isolation (`get_user_clinic_id()` alone) on a route the application clearly intended to be tenant-scoped.

Changes in `src/lib/with-auth.ts`:

- `withAuth` and `withAuthAnyRole` now **fail closed by default**: a `setTenantContext` failure on a tenant-scoped route returns `503 Tenant context unavailable` and the handler is never invoked.
- Add `WithAuthOptions { failOpen?: boolean }` as an explicit per-route opt-in for read-only routes that don't touch tenant data. Must be a deliberate choice — never the default.

### Note on Audit #1 (upload tenant prefix)

Already merged to `main` in commit `750a20af` ("fix(upload): use clinics/{id}/ prefix for tenant isolation check"). The current code uses `expectedKeyPrefixForProfile()` returning `clinics/${clinicId}/` and is already test-covered by `src/app/api/__tests__/upload-confirm-tenant-prefix.test.ts`. No additional change needed in this PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [x] This PR modifies encryption, audit logging, or PII handling
- [x] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

New / updated tests:

- `src/app/api/__tests__/lab-report-encrypted-storage.test.ts`
  - HTML download branch asserts the CSP, `X-Content-Type-Options`, and `Referrer-Policy` headers and confirms `script-src` is absent (default-src 'none' is sufficient).
  - New non-HTML (PDF) test asserts `attachment` disposition, no CSP header (a CSP would be a no-op since the browser doesn't render PDFs as HTML), and `Referrer-Policy: no-referrer`.
- `src/lib/__tests__/with-auth.test.ts`
  - `withAuth` returns 503 when `setTenantContext` throws (fail-closed default).
  - `withAuthAnyRole` returns 503 when `setTenantContext` throws (fail-closed default).
  - `withAuth` with `failOpen: true` invokes the handler even when `setTenantContext` throws.
  - `setTenantContext` is not called when `profile.clinic_id` is null (super_admin case).

Full suite: `npm run test` → 624 passed / 24 skipped (no regressions). `npm run typecheck` clean. `npm run lint` clean (0 errors).