### PR TITLE
security: tighten production CSP and fail-closed middleware on missing Supabase config

### DIFF
--- a/src/lib/middleware/security-headers.ts
+++ b/src/lib/middleware/security-headers.ts
@@ -64,9 +64,15 @@ export interface BuildCspOptions {
  *
  * Task 2.2: This policy is now **enforced** (no longer report-only).
  * The legacy broad CSP has been removed.
+ *
+ * Hardened production `script-src`: in production we drop `'unsafe-inline'`,
+ * `https:`, and `http:` and rely on `'self'` + nonce + `'strict-dynamic'`.
+ * Older browsers without `'strict-dynamic'` support fall back to `'self'`
+ * (no inline/eval), so production is fail-closed against XSS via injected
+ * inline or third-party scripts. `'unsafe-eval'` remains dev-only.
  */
 export function buildCsp(nonce: string, _options?: BuildCspOptions): string {
-  const isDev = process.env.NODE_ENV === "development";
+  const isDev = process.env.NODE_ENV !== "production";
   const sbHost = getSupabaseHost();
   const plausibleHost = getPlausibleHost();
 
@@ -83,9 +89,13 @@ export function buildCsp(nonce: string, _options?: BuildCspOptions): string {
     ...(plausibleHost ? [`https://${plausibleHost}`] : []),
   ].join(" ");
 
+  const scriptSrc = isDev
+    ? ["'self'", `'nonce-${nonce}'`, "'strict-dynamic'", "'unsafe-eval'"]
+    : ["'self'", `'nonce-${nonce}'`, "'strict-dynamic'"];
+
   return [
     "default-src 'self'",
-    `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-inline' https: http:${isDev ? " 'unsafe-eval'" : ""}`,
+    `script-src ${scriptSrc.join(" ")}`,
     `style-src 'self' 'nonce-${nonce}'`,
     `img-src 'self' data: blob: ${sbHost} uploads.oltigo.com`,
     "font-src 'self'",
@@ -94,10 +104,27 @@ export function buildCsp(nonce: string, _options?: BuildCspOptions): string {
     "form-action 'self'",
     "base-uri 'self'",
     "frame-ancestors 'none'",
+    "object-src 'none'",
     ...(isDev ? [] : ["upgrade-insecure-requests"]),
     ...(isDev ? [] : [`report-uri ${CSP_REPORT_URI}`]),
     ...(isDev ? [] : ["report-to csp-endpoint"]),
   ].join("; ");
+}
+
+/**
+ * When true, the strict CSP is emitted as `Content-Security-Policy-Report-Only`
+ * instead of the enforcing header. Used for staged rollouts of policy changes:
+ * deploy with `CSP_REPORT_ONLY=true`, watch the CSP report endpoint for 24-72h
+ * for unexpected violations, then unset to enforce.
+ *
+ * Only honored in production — in dev/test the policy is always enforced so
+ * regressions surface immediately.
+ */
+function isCspReportOnly(): boolean {
+  return (
+    process.env.NODE_ENV === "production" &&
+    process.env.CSP_REPORT_ONLY === "true"
+  );
 }
 
 /**
@@ -129,13 +156,16 @@ export interface CspHeaderValues {
 }
 
 /**
- * Build the CSP header values. The strict policy is now enforced directly.
+ * Build the CSP header values. The strict policy is enforced directly
+ * unless `CSP_REPORT_ONLY=true` is set in production, in which case the
+ * same policy is emitted on the Report-Only header for staged rollout.
  */
 export function buildCspHeaderValues(nonce: string): CspHeaderValues {
-  return {
-    enforce: buildCsp(nonce, { reportOnly: false }),
-    reportOnly: "",
-  };
+  const policy = buildCsp(nonce, { reportOnly: false });
+  if (isCspReportOnly()) {
+    return { enforce: "", reportOnly: policy };
+  }
+  return { enforce: policy, reportOnly: "" };
 }
 
 /**
@@ -147,8 +177,13 @@ export function withSecurityHeaders(
   response: NextResponse,
   csp: CspHeaderValues,
 ): NextResponse {
-  response.headers.set("Content-Security-Policy", csp.enforce);
-  response.headers.delete("Content-Security-Policy-Report-Only");
+  if (csp.enforce) {
+    response.headers.set("Content-Security-Policy", csp.enforce);
+    response.headers.delete("Content-Security-Policy-Report-Only");
+  } else if (csp.reportOnly) {
+    response.headers.set("Content-Security-Policy-Report-Only", csp.reportOnly);
+    response.headers.delete("Content-Security-Policy");
+  }
   response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
@@ -177,8 +212,13 @@ export function applyAllSecurityHeaders(
   csp: CspHeaderValues,
   _nonce: string, // Unused but kept for API compatibility
 ): void {
-  response.headers.set("Content-Security-Policy", csp.enforce);
-  response.headers.delete("Content-Security-Policy-Report-Only");
+  if (csp.enforce) {
+    response.headers.set("Content-Security-Policy", csp.enforce);
+    response.headers.delete("Content-Security-Policy-Report-Only");
+  } else if (csp.reportOnly) {
+    response.headers.set("Content-Security-Policy-Report-Only", csp.reportOnly);
+    response.headers.delete("Content-Security-Policy");
+  }
   response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -166,14 +166,33 @@ export async function middleware(request: NextRequest) {
     return rateLimitResponse;
   }
 
-  // If Supabase is not configured, allow all requests through
-  // so the site renders with demo data instead of crashing
-  if (
-    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
-    !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  ) {
-    // For protected routes without Supabase, redirect to login
-    // (login page will show an appropriate message)
+  // Supabase configuration check.
+  //
+  // Production MUST fail closed: if NEXT_PUBLIC_SUPABASE_URL or
+  // NEXT_PUBLIC_SUPABASE_ANON_KEY is missing in a production runtime,
+  // we have a misconfigured deploy that could partially serve the app
+  // without auth (and therefore without tenant scoping / RLS). For a
+  // healthcare platform handling PHI this must never silently degrade —
+  // we return 503 so a failing health check trips deployment rollback
+  // and operators are alerted, instead of leaking a half-functional UI.
+  //
+  // In non-production runtimes we keep the legacy demo-mode behavior:
+  // public routes render with demo data and protected routes redirect
+  // to /login. This preserves the local-dev experience without affecting
+  // production safety.
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  const isSupabaseConfigured = !!supabaseUrl && !!supabaseAnonKey;
+
+  if (!supabaseUrl || !supabaseAnonKey || !isSupabaseConfigured) {
+    if (process.env.NODE_ENV === "production") {
+      return withSecurityHeaders(
+        new NextResponse("Server misconfigured", { status: 503 }),
+        cspHeaders,
+      );
+    }
+
+    // Non-production: allow demo-mode rendering.
     if (isProtectedRoute(pathname)) {
       const loginUrl = new URL("/login", request.url);
       loginUrl.searchParams.set("redirect", pathname);
@@ -195,8 +214,8 @@ export async function middleware(request: NextRequest) {
   // These placeholder headers are omitted to avoid misleading API consumers.
 
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         getAll() {
@@ -244,8 +263,8 @@ export async function middleware(request: NextRequest) {
       // By omitting cookies, the query always runs as unauthenticated,
       // ensuring subdomain resolution works for all users.
       const anonSupabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+        supabaseUrl,
+        supabaseAnonKey,
         {
           cookies: {
             getAll() { return []; },


### PR DESCRIPTION
## Summary

Two HIGH-priority security hardening fixes:

**1. Tighten production `script-src` CSP (`src/lib/middleware/security-headers.ts`)**

Production CSP previously allowed `'unsafe-inline'`, `https:` and `http:` alongside the per-request nonce + `'strict-dynamic'`. While modern CSP3 browsers ignore those when `'strict-dynamic'` is present, they weaken defense-in-depth on legacy clients and fail strict external audits.

Changes:
- Production `script-src` is now `'self' 'nonce-${nonce}' 'strict-dynamic'` only — `'unsafe-inline'`, `https:`, `http:` are dropped.
- `'unsafe-eval'` remains allowed in dev/test only (`NODE_ENV !== "production"`).
- Added explicit `object-src 'none'`. Existing `base-uri 'self'`, `frame-ancestors 'none'`, and `upgrade-insecure-requests` are preserved.
- New `CSP_REPORT_ONLY=true` env flag (production-only) emits the strict policy on `Content-Security-Policy-Report-Only` instead of the enforcing header so operators can ship as report-only first, watch the existing CSP report endpoint for 24–72h, allowlist any unexpected hosts, then unset the flag to enforce. `withSecurityHeaders` and `applyAllSecurityHeaders` honor the flag for both the success and early-return paths.

**2. Middleware fail-closed in production when Supabase is unconfigured (`src/middleware.ts`)**

If `NEXT_PUBLIC_SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_ANON_KEY` were missing in a production runtime, the middleware previously allowed public routes through with demo data. On a healthcare platform handling PHI this must never silently degrade — a misconfigured deploy needs to fail loudly so health checks trigger rollback.

Changes:
- In production, if either Supabase env var is missing the middleware returns `503 "Server misconfigured"` (with the standard security headers applied) for every request.
- Non-production runtimes keep the existing demo-mode behavior (public routes render, protected routes redirect to `/login`) so local development is unaffected.
- Env validation in `src/lib/env.ts` already marks `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` as required and throws at startup via `instrumentation.ts` → `enforceEnvValidation()`. The middleware guard is the runtime backstop in case that boot-time validation is ever bypassed.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR modifies authentication or authorization logic

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npx tsc --noEmit` clean. `npm run lint` clean (0 errors). `npx vitest run` — 629 passed, 24 skipped, 0 failed.

## Rollout

1. Deploy with `CSP_REPORT_ONLY=true` set in the production environment.
2. Watch the existing `/api/csp-report` (or Sentry CSP) endpoint for 24–72h. Allowlist any required external script hosts via `script-src` only when proven necessary.
3. Unset `CSP_REPORT_ONLY` (or set it to anything other than `"true"`) to flip to enforcing CSP.

For the middleware fail-closed: deploy a staging build with the Supabase env vars cleared and verify all routes return `503`. Add a health check that exercises at least one auth-requiring route.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes