### PR TITLE
fix: localize lab report HTML and gate Cloudflare DNS behind feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -144,8 +144,16 @@ GOOGLE_CALENDAR_CLIENT_SECRET=
 GOOGLE_CALENDAR_REDIRECT_URI=
 
 # ---- Custom Domains via Cloudflare [Optional] ----
+# Feature flag: set to "true" to enable the /api/dns/* endpoints and the
+# clinic subdomain / custom-domain provisioning UI. When "false" (or unset):
+#   - /api/dns/* returns 503 (CUSTOM_DOMAINS_DISABLED)
+#   - The Cloudflare env vars below are NOT required at startup
+# When "true" the app refuses to boot unless CLOUDFLARE_API_TOKEN,
+# CLOUDFLARE_ZONE_ID, and CLOUDFLARE_ZONE_NAME are all set.
+NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=false
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ZONE_ID=
+CLOUDFLARE_ZONE_NAME=
 
 # ---- PHI Encryption at Rest [Optional — strongly recommended] ----
 # AES-256-GCM encryption key for patient files (prescriptions, lab results, x-rays).

--- a/README.md
+++ b/README.md
@@ -157,6 +157,17 @@ For local development, subdomains work automatically via `*.localhost` (e.g., `d
 - Client Components use `useTenant()` from `src/components/tenant-provider.tsx`
 - Unknown subdomains redirect to the root domain
 
+### Custom Domains via Cloudflare DNS
+
+Automated subdomain provisioning through the Cloudflare API is gated behind an explicit feature flag so the `/api/dns/*` routes never run with a half-wired Cloudflare integration.
+
+**Enable the feature:**
+
+1. Set `NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=true`
+2. Provide all three Cloudflare env vars: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_ZONE_NAME`
+
+When the flag is `true` the app refuses to boot if any of those vars are missing. When it is `false` (the default) the env vars are optional and the `/api/dns/*` endpoints respond with `503 CUSTOM_DOMAINS_DISABLED`.
+
 ## Per-Client Deployment
 
 To deploy for a new client, only edit `src/config/clinic.config.ts` with their details (name, contact, features, working hours).

--- a/src/app/api/dns/route.ts
+++ b/src/app/api/dns/route.ts
@@ -19,7 +19,25 @@ import {
   removeSubdomain,
   isValidSubdomain,
 } from "@/lib/cloudflare-dns";
+import { isCustomDomainsEnabled } from "@/lib/env";
 import { withAuth, type AuthContext } from "@/lib/with-auth";
+
+/**
+ * Feature-flag guard for every handler in this file.
+ *
+ * Custom-domain provisioning is gated by `NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS`
+ * so the API surface matches the env validation in `src/lib/env.ts`. When the
+ * feature is off we refuse with 503 — same shape as the existing
+ * `STORAGE_NOT_CONFIGURED` / `ENCRYPTION_NOT_CONFIGURED` errors elsewhere —
+ * rather than returning a 200 from a half-wired Cloudflare integration.
+ */
+function customDomainsDisabledResponse() {
+  return apiError(
+    "Custom domain management is not enabled on this deployment.",
+    503,
+    "CUSTOM_DOMAINS_DISABLED",
+  );
+}
 
 // ── Schemas ──
 
@@ -42,6 +60,9 @@ const deleteDnsSchema = z.object({
 
 export const GET = withAuth(
   async (request: NextRequest, _auth: AuthContext) => {
+    if (!isCustomDomainsEnabled()) {
+      return customDomainsDisabledResponse();
+    }
     const slug = request.nextUrl.searchParams.get("slug");
     if (!slug || !isValidSubdomain(slug)) {
       return apiError("Invalid or missing slug parameter", 400, "INVALID_SLUG");
@@ -65,6 +86,9 @@ export const GET = withAuth(
 export const POST = withAuthValidation(
   provisionDnsSchema,
   async (body, _request, auth) => {
+    if (!isCustomDomainsEnabled()) {
+      return customDomainsDisabledResponse();
+    }
     const clinicId = auth.profile.clinic_id;
 
     const result = await provisionSubdomain(body.slug);
@@ -96,6 +120,9 @@ export const POST = withAuthValidation(
 export const DELETE = withAuthValidation(
   deleteDnsSchema,
   async (body, _request, auth) => {
+    if (!isCustomDomainsEnabled()) {
+      return customDomainsDisabledResponse();
+    }
     const clinicId = auth.profile.clinic_id;
 
     const result = await removeSubdomain(body.slug);

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -23,12 +23,36 @@ import { STAFF_ROLES } from "@/lib/auth-roles";
 import { updateLabOrderPdfUrl } from "@/lib/data/server";
 import { isEncryptionConfigured } from "@/lib/encryption";
 import { escapeHtml } from "@/lib/escape-html";
+import { getDirection, isRTL, t, type Locale } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
 import { buildUploadKey } from "@/lib/r2";
 import { encryptAndUpload } from "@/lib/r2-encrypted";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatCurrency, formatNumber, formatDisplayDate } from "@/lib/utils";
 import { labReportSchema } from "@/lib/validations";
+
+const SUPPORTED_LOCALES: readonly Locale[] = ["fr", "ar", "en"] as const;
+const DEFAULT_LOCALE: Locale = "fr";
+
+function normalizeLocale(value: string | null | undefined): Locale {
+  if (!value) return DEFAULT_LOCALE;
+  return SUPPORTED_LOCALES.includes(value as Locale) ? (value as Locale) : DEFAULT_LOCALE;
+}
+
+function resolveLocale(request: Request): Locale {
+  // Priority: explicit cookie set by the locale switcher → tenant default header → fallback.
+  // Stays consistent with src/app/layout.tsx which reads the same sources.
+  const cookieHeader = request.headers.get("cookie") ?? "";
+  const cookieMatch = /(?:^|;\s*)preferred-locale=([^;]+)/.exec(cookieHeader);
+  if (cookieMatch) {
+    return normalizeLocale(decodeURIComponent(cookieMatch[1]));
+  }
+  const tenantLocale = request.headers.get("x-tenant-locale");
+  if (tenantLocale) {
+    return normalizeLocale(tenantLocale);
+  }
+  return DEFAULT_LOCALE;
+}
 
 interface LabResultItem {
   testName: string;
@@ -39,9 +63,20 @@ interface LabResultItem {
   flag: string | null;
 }
 
-function flagLabel(flag: string | null): string {
+function flagLabel(locale: Locale, flag: string | null): string {
   if (!flag || flag === "normal") return "";
-  return flag.replace("_", " ").toUpperCase();
+  switch (flag) {
+    case "high":
+      return t(locale, "lab.report.flagHigh");
+    case "low":
+      return t(locale, "lab.report.flagLow");
+    case "critical_high":
+      return t(locale, "lab.report.flagCriticalHigh");
+    case "critical_low":
+      return t(locale, "lab.report.flagCriticalLow");
+    default:
+      return flag.replace("_", " ").toUpperCase();
+  }
 }
 
 function flagColor(flag: string | null): string {
@@ -56,7 +91,14 @@ function generateLabReportHtml(data: {
   orderNumber: string;
   results: LabResultItem[];
   generatedAt: string;
+  locale: Locale;
 }): string {
+  const { locale } = data;
+  const dir = getDirection(locale);
+  const rtl = isRTL(locale);
+  // CSS logical alignment so RTL renders mirrored without per-property overrides.
+  const textAlign = rtl ? "right" : "left";
+
   const resultRows = data.results
     .map((r) => {
       const ref =
@@ -68,53 +110,66 @@ function generateLabReportHtml(data: {
               ? `<= ${r.referenceMax}`
               : "&mdash;";
 
-      const fl = flagLabel(r.flag);
+      const fl = flagLabel(locale, r.flag);
       const flStyle = fl ? `color: ${flagColor(r.flag)}; font-weight: bold;` : "";
+      const normalLabel = t(locale, "lab.report.flagNormal");
 
       return `<tr>
         <td>${escapeHtml(r.testName)}</td>
         <td>${r.value ? escapeHtml(r.value) : "&mdash;"}</td>
         <td>${r.unit ? escapeHtml(r.unit) : ""}</td>
         <td>${ref}</td>
-        <td style="${flStyle}">${fl || "Normal"}</td>
+        <td style="${flStyle}">${fl || escapeHtml(normalLabel)}</td>
       </tr>`;
     })
     .join("\n");
 
+  const documentTitle = t(locale, "lab.report.documentTitle", { orderNumber: data.orderNumber });
+  const heading = t(locale, "lab.report.title");
+  const labelPatient = t(locale, "lab.report.patient");
+  const labelOrder = t(locale, "lab.report.order");
+  const labelDate = t(locale, "lab.report.date");
+  const colTest = t(locale, "lab.report.colTest");
+  const colValue = t(locale, "lab.report.colValue");
+  const colUnit = t(locale, "lab.report.colUnit");
+  const colReference = t(locale, "lab.report.colReference");
+  const colFlag = t(locale, "lab.report.colFlag");
+  const footer = t(locale, "lab.report.footer", { generatedAt: data.generatedAt });
+
   return `<!DOCTYPE html>
-<html>
+<html lang="${locale}" dir="${dir}">
 <head>
 <meta charset="utf-8">
-<title>Lab Report — ${escapeHtml(data.orderNumber)}</title>
+<title>${escapeHtml(documentTitle)}</title>
 <style>
-  body { font-family: Arial, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; color: #333; }
+  body { font-family: Arial, sans-serif; max-width: 800px; margin: 40px auto; padding: 20px; color: #333; text-align: ${textAlign}; }
   h1 { color: #0d9488; border-bottom: 2px solid #0d9488; padding-bottom: 10px; }
   .meta { background: #f5f5f5; padding: 15px; border-radius: 8px; margin: 20px 0; }
   .meta p { margin: 5px 0; }
   .meta strong { color: #555; }
   table { width: 100%; border-collapse: collapse; margin: 20px 0; }
-  th { background: #f0fdfa; color: #0d9488; text-align: left; padding: 10px 8px; border-bottom: 2px solid #0d9488; font-size: 13px; }
+  th { background: #f0fdfa; color: #0d9488; text-align: ${textAlign}; padding: 10px 8px; border-bottom: 2px solid #0d9488; font-size: 13px; }
   td { padding: 8px; border-bottom: 1px solid #e5e7eb; font-size: 13px; }
   tr:last-child td { border-bottom: none; }
   .footer { margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; font-size: 12px; color: #888; }
 </style>
 </head>
 <body>
-  <h1>Laboratory Report</h1>
+  <h1>${escapeHtml(heading)}</h1>
   <div class="meta">
-    <p><strong>Patient:</strong> ${escapeHtml(data.patientName)}</p>
-    <p><strong>Order:</strong> ${escapeHtml(data.orderNumber)}</p>
-    <p><strong>Date:</strong> ${escapeHtml(data.generatedAt)}</p>
+    <p><strong>${escapeHtml(labelPatient)}:</strong> ${escapeHtml(data.patientName)}</p>
+    <p><strong>${escapeHtml(labelOrder)}:</strong> ${escapeHtml(data.orderNumber)}</p>
+    <p><strong>${escapeHtml(labelDate)}:</strong> ${escapeHtml(data.generatedAt)}</p>
   </div>
 
   <table>
     <thead>
       <tr>
-        <th>Test</th>
-        <th>Value</th>
-        <th>Unit</th>
-        <th>Reference Range</th>
-        <th>Flag</th>
+        <th>${escapeHtml(colTest)}</th>
+        <th>${escapeHtml(colValue)}</th>
+        <th>${escapeHtml(colUnit)}</th>
+        <th>${escapeHtml(colReference)}</th>
+        <th>${escapeHtml(colFlag)}</th>
       </tr>
     </thead>
     <tbody>
@@ -123,7 +178,7 @@ function generateLabReportHtml(data: {
   </table>
 
   <div class="footer">
-    <p>Generated on ${escapeHtml(data.generatedAt)}</p>
+    <p>${escapeHtml(footer)}</p>
   </div>
 </body>
 </html>`;
@@ -166,13 +221,15 @@ export const POST = withAuthValidation(labReportSchema, async (body, request, { 
       );
     }
 
-    const generatedAt = formatDisplayDate(new Date(), "en", "datetime");
+    const locale = resolveLocale(request);
+    const generatedAt = formatDisplayDate(new Date(), locale, "datetime");
 
     const html = generateLabReportHtml({
       patientName,
       orderNumber,
       results: results as LabResultItem[],
       generatedAt,
+      locale,
     });
 
     // Look up the order so we can (1) confirm tenant ownership and (2) audit

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -94,9 +94,38 @@ const ENV_RULES: EnvRule[] = [
   { name: "PROFILE_HEADER_HMAC_KEY", required: process.env.NODE_ENV === "production", description: "HMAC key used to sign x-auth-profile-* headers between middleware and withAuth (required in production)", group: "auth" },
 
   // ── Custom Domains ─────────────────────────────────────────────────
-  { name: "CLOUDFLARE_API_TOKEN", required: false, description: "Cloudflare API token for DNS management", group: "domains" },
-  { name: "CLOUDFLARE_ZONE_ID", required: false, description: "Cloudflare zone ID for DNS management", group: "domains" },
+  // These are gated by NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS — when the flag is
+  // "true" they become required, so the app refuses to boot with a half-wired
+  // custom-domain feature. See `isCustomDomainsEnabled()` below.
+  { name: "CLOUDFLARE_API_TOKEN", required: customDomainsEnabledFromEnv(), description: "Cloudflare API token for DNS management (required when NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=true)", group: "domains" },
+  { name: "CLOUDFLARE_ZONE_ID", required: customDomainsEnabledFromEnv(), description: "Cloudflare zone ID for DNS management (required when NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=true)", group: "domains" },
+  { name: "CLOUDFLARE_ZONE_NAME", required: customDomainsEnabledFromEnv(), description: "Cloudflare zone (root domain) name for DNS management (required when NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=true)", group: "domains" },
 ];
+
+/**
+ * Whether the custom-domain / Cloudflare DNS feature is enabled.
+ *
+ * Toggled by `NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=true`. When disabled, the
+ * `/api/dns/*` handlers refuse with 503 and the related Cloudflare env vars
+ * are *optional*. When enabled, those env vars become required at startup.
+ *
+ * Read it through this helper rather than `process.env` directly so the
+ * gating logic stays in one place.
+ */
+export function isCustomDomainsEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS === "true";
+}
+
+/**
+ * Internal helper used while building `ENV_RULES` so the `required` flag is
+ * evaluated at module load (matching how the other rules use
+ * `process.env.NODE_ENV === "production"` checks). Kept private to avoid
+ * drift between the two readers — call `isCustomDomainsEnabled()` everywhere
+ * else.
+ */
+function customDomainsEnabledFromEnv(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS === "true";
+}
 
 export interface EnvValidationResult {
   valid: boolean;

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -640,5 +640,21 @@
   "superAdmin.manage": "إدارة",
   "superAdmin.recentActivity": "النشاط الأخير",
   "superAdmin.newClinic": "عيادة جديدة",
-  "superAdmin.announce": "إعلان"
+  "superAdmin.announce": "إعلان",
+  "lab.report.title": "تقرير المختبر",
+  "lab.report.documentTitle": "تقرير المختبر — {orderNumber}",
+  "lab.report.patient": "المريض",
+  "lab.report.order": "الطلب",
+  "lab.report.date": "التاريخ",
+  "lab.report.colTest": "التحليل",
+  "lab.report.colValue": "القيمة",
+  "lab.report.colUnit": "الوحدة",
+  "lab.report.colReference": "النطاق المرجعي",
+  "lab.report.colFlag": "المؤشر",
+  "lab.report.flagNormal": "طبيعي",
+  "lab.report.flagHigh": "مرتفع",
+  "lab.report.flagLow": "منخفض",
+  "lab.report.flagCriticalHigh": "مرتفع حرج",
+  "lab.report.flagCriticalLow": "منخفض حرج",
+  "lab.report.footer": "تم الإنشاء في {generatedAt}"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -640,5 +640,21 @@
   "superAdmin.manage": "Manage",
   "superAdmin.recentActivity": "Recent Activity",
   "superAdmin.newClinic": "New Clinic",
-  "superAdmin.announce": "Announce"
+  "superAdmin.announce": "Announce",
+  "lab.report.title": "Laboratory Report",
+  "lab.report.documentTitle": "Lab Report — {orderNumber}",
+  "lab.report.patient": "Patient",
+  "lab.report.order": "Order",
+  "lab.report.date": "Date",
+  "lab.report.colTest": "Test",
+  "lab.report.colValue": "Value",
+  "lab.report.colUnit": "Unit",
+  "lab.report.colReference": "Reference Range",
+  "lab.report.colFlag": "Flag",
+  "lab.report.flagNormal": "Normal",
+  "lab.report.flagHigh": "HIGH",
+  "lab.report.flagLow": "LOW",
+  "lab.report.flagCriticalHigh": "CRITICAL HIGH",
+  "lab.report.flagCriticalLow": "CRITICAL LOW",
+  "lab.report.footer": "Generated on {generatedAt}"
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -640,5 +640,21 @@
   "superAdmin.manage": "Gérer",
   "superAdmin.recentActivity": "Activité récente",
   "superAdmin.newClinic": "Nouvelle clinique",
-  "superAdmin.announce": "Annoncer"
+  "superAdmin.announce": "Annoncer",
+  "lab.report.title": "Rapport de laboratoire",
+  "lab.report.documentTitle": "Rapport de laboratoire — {orderNumber}",
+  "lab.report.patient": "Patient",
+  "lab.report.order": "Commande",
+  "lab.report.date": "Date",
+  "lab.report.colTest": "Analyse",
+  "lab.report.colValue": "Valeur",
+  "lab.report.colUnit": "Unité",
+  "lab.report.colReference": "Valeurs de référence",
+  "lab.report.colFlag": "Indicateur",
+  "lab.report.flagNormal": "Normal",
+  "lab.report.flagHigh": "ÉLEVÉ",
+  "lab.report.flagLow": "BAS",
+  "lab.report.flagCriticalHigh": "CRITIQUE ÉLEVÉ",
+  "lab.report.flagCriticalLow": "CRITIQUE BAS",
+  "lab.report.footer": "Généré le {generatedAt}"
 }


### PR DESCRIPTION
## Summary

Addresses two findings from the audit.

### #8 — Localize the generated lab report HTML (FR / AR / RTL)

`POST /api/lab/report-html` previously rendered hardcoded English labels into clinic-facing reports for a Morocco-focused product. The route now:

- Resolves the locale from the `preferred-locale` cookie (set by the existing locale switcher), falling back to the `x-tenant-locale` header and finally to `fr` — the same precedence used in `src/app/layout.tsx`.
- Renders `<html lang="…" dir="…">` with `dir="rtl"` for Arabic, plus mirrored `text-align` for body and table headers so the report flips correctly when the document is opened standalone.
- Translates the document title, section labels (Patient / Order / Date), all column headers (Test, Value, Unit, Reference Range, Flag), the "Normal" sentinel and every flag label (HIGH / LOW / CRITICAL HIGH / CRITICAL LOW), and the footer through the existing `t(locale, key)` helper backed by `src/locales/{en,fr,ar}.json`.
- Switches the `generatedAt` formatter from a hardcoded `"en"` to the resolved locale.

### #9 — Gate Cloudflare DNS / custom-domain features behind explicit env requirements

The Cloudflare env vars used to be marked optional even though `/api/dns/*` and `src/lib/cloudflare-dns.ts` ship to production, which means the API surface looked available but failed at runtime. Now:

- `NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS=true` is the single feature flag for this subsystem, exposed via `isCustomDomainsEnabled()` in `src/lib/env.ts`.
- When the flag is `true`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`, and `CLOUDFLARE_ZONE_NAME` are all required at startup (matching the existing `validateEnv()` hard-fail pattern). When the flag is `false` or unset, those vars stay optional.
- Every handler in `src/app/api/dns/route.ts` (GET, POST, DELETE) returns `503` with code `CUSTOM_DOMAINS_DISABLED` when the flag is off, mirroring `STORAGE_NOT_CONFIGURED` / `ENCRYPTION_NOT_CONFIGURED` elsewhere.
- Documented the flag in `.env.example` and the deployment runbook section of `README.md`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

The PHI-handling pipeline in `report-html` (encryption + tenant scoping + audit log) is untouched — only the rendered text labels change. The DNS gate strictly tightens the production surface (503 instead of broken 200s) and never relaxes any existing check.

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

`npm run typecheck` passes (clean) and `npm run lint` produces 0 errors (only pre-existing warnings unrelated to these files).

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
