### PR TITLE
security: stop leaking signed profile headers and harden CSP report endpoint (Audit #6, #7)

### DIFF
--- a/src/app/api/__tests__/csp-report.test.ts
+++ b/src/app/api/__tests__/csp-report.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Route handler tests for POST /api/csp-report.
+ *
+ * Verifies the hardening from Audit #7:
+ * - Hard cap on body size (16 KiB → 413)
+ * - Per-IP rate limiting (60 req / 60s → 429)
+ * - Field truncation on logged report values
+ * - Invalid JSON / missing report still returns 204
+ */
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const loggerError = vi.fn();
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: (...args: unknown[]) => loggerError(...args),
+    debug: vi.fn(),
+  },
+}));
+
+const limiterCheck = vi.fn().mockResolvedValue(true);
+vi.mock("@/lib/rate-limit", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/rate-limit")>(
+    "@/lib/rate-limit",
+  );
+  return {
+    ...actual,
+    createRateLimiter: () => ({ check: limiterCheck }),
+  };
+});
+
+function makeRequest(body: string, headers: Record<string, string> = {}) {
+  return new NextRequest("https://example.com/api/csp-report", {
+    method: "POST",
+    headers: {
+      "content-type": "application/csp-report",
+      "cf-connecting-ip": "203.0.113.10",
+      ...headers,
+    },
+    body,
+  });
+}
+
+describe("POST /api/csp-report — hardening", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    limiterCheck.mockResolvedValue(true);
+  });
+
+  it("rejects payloads larger than 16 KiB with 413 before parsing", async () => {
+    const { POST } = await import("@/app/api/csp-report/route");
+    const oversized = "x".repeat(16 * 1024 + 1);
+    const res = await POST(makeRequest(oversized));
+    expect(res.status).toBe(413);
+    expect(loggerError).not.toHaveBeenCalled();
+    expect(limiterCheck).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the per-IP rate limit is exceeded", async () => {
+    limiterCheck.mockResolvedValueOnce(false);
+    const { POST } = await import("@/app/api/csp-report/route");
+    const res = await POST(
+      makeRequest(JSON.stringify({ "csp-report": { "blocked-uri": "https://x" } })),
+    );
+    expect(res.status).toBe(429);
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
+  it("returns 204 and logs truncated fields for a valid violation", async () => {
+    const { POST } = await import("@/app/api/csp-report/route");
+    const longValue = "a".repeat(2000);
+    const body = JSON.stringify({
+      "csp-report": {
+        "blocked-uri": longValue,
+        "violated-directive": "script-src",
+        "document-uri": "https://app.example.com/page",
+        referrer: "",
+        "original-policy": longValue,
+      },
+    });
+
+    const res = await POST(makeRequest(body));
+    expect(res.status).toBe(204);
+    expect(loggerError).toHaveBeenCalledTimes(1);
+
+    const [, payload] = loggerError.mock.calls[0] as [string, Record<string, unknown>];
+    expect(payload.context).toBe("csp-report");
+    expect(payload.alert).toBe(true);
+    expect((payload.blockedUri as string).length).toBe(500);
+    expect(payload.violatedDirective).toBe("script-src");
+    expect(payload.documentUri).toBe("https://app.example.com/page");
+    // original-policy is intentionally not forwarded to the logger
+    expect(payload).not.toHaveProperty("originalPolicy");
+  });
+
+  it("returns 204 silently for invalid JSON without logging", async () => {
+    const { POST } = await import("@/app/api/csp-report/route");
+    const res = await POST(makeRequest("{not json"));
+    expect(res.status).toBe(204);
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
+  it("returns 204 silently when the payload is missing csp-report", async () => {
+    const { POST } = await import("@/app/api/csp-report/route");
+    const res = await POST(makeRequest(JSON.stringify({ other: "value" })));
+    expect(res.status).toBe(204);
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-string fields rather than logging undefined or coerced values", async () => {
+    const { POST } = await import("@/app/api/csp-report/route");
+    const body = JSON.stringify({
+      "csp-report": {
+        "blocked-uri": { malicious: "object" },
+        "violated-directive": ["array"],
+        "document-uri": 42,
+      },
+    });
+    const res = await POST(makeRequest(body));
+    expect(res.status).toBe(204);
+    expect(loggerError).toHaveBeenCalledTimes(1);
+    const [, payload] = loggerError.mock.calls[0] as [string, Record<string, unknown>];
+    expect(payload.blockedUri).toBeUndefined();
+    expect(payload.violatedDirective).toBeUndefined();
+    expect(payload.documentUri).toBeUndefined();
+  });
+
+  it("GET returns 204 No Content", async () => {
+    const { GET } = await import("@/app/api/csp-report/route");
+    const res = await GET();
+    expect(res.status).toBe(204);
+  });
+});

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,55 +1,114 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
+import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
 
 /**
  * CSP Violation Report Endpoint
- * 
+ *
  * Receives CSP violation reports from browsers when policy is violated.
  * These are silently logged for security monitoring - we don't want to
  * leak information to attackers about our security setup.
- * 
+ *
  * Receives reports from the enforced Content-Security-Policy header
  * via report-uri / report-to directives.
+ *
+ * Hardening (Audit #7):
+ * - Hard cap the request body at 16 KiB to prevent log/cost amplification
+ *   from attacker-controlled payloads.
+ * - Truncate every logged field to 500 chars so a single oversized field
+ *   cannot dominate the structured log.
+ * - Per-IP rate limit (60 req / 60s) so a single client cannot drown
+ *   real violations in noise.
  */
 
-/**
- * Parse and sanitize CSP violation report for logging
- */
+const MAX_CSP_REPORT_BYTES = 16 * 1024;
+const MAX_FIELD_CHARS = 500;
+
 interface CspViolationReport {
   "csp-report"?: {
-    "blocked-uri"?: string;
-    "violated-directive"?: string;
-    "document-uri"?: string;
-    "referrer"?: string;
-    "original-policy"?: string;
+    "blocked-uri"?: unknown;
+    "violated-directive"?: unknown;
+    "document-uri"?: unknown;
+    referrer?: unknown;
+    "original-policy"?: unknown;
   };
 }
 
+/**
+ * Per-IP rate limiter for the CSP report endpoint.
+ *
+ * 60 req / 60s mirrors a typical legitimate violation cadence (page loads
+ * usually emit a single report) while throttling clients that are firing
+ * synthetic reports. Fail-open is fine here: this endpoint is a logging
+ * sink and degrading to "log everything" during a backend outage is safer
+ * than dropping real violations.
+ */
+const cspReportLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 60,
+});
+
+/**
+ * Coerce a value to a string and truncate to MAX_FIELD_CHARS so a single
+ * oversized field cannot dominate the structured log.
+ */
+function truncateField(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.length > MAX_FIELD_CHARS ? value.slice(0, MAX_FIELD_CHARS) : value;
+}
+
 export async function POST(request: NextRequest) {
+  // Read the raw body first so we can enforce a hard size cap before
+  // parsing. `request.text()` materialises the entire body, but the
+  // length check below caps the worst-case work at MAX_CSP_REPORT_BYTES
+  // worth of UTF-16 code units.
+  let raw: string;
   try {
-    const body = await request.json() as CspViolationReport;
-    const report = body["csp-report"];
-
-    if (report) {
-      // Log CSP violation for security monitoring
-      // Elevated to error with alert: true to ensure Sentry catches it
-      // and triggers a dashboard/alert rule (Audit 3.4 Fix)
-      logger.error("CSP violation detected", {
-        context: "csp-report",
-        blockedUri: report["blocked-uri"],
-        violatedDirective: report["violated-directive"],
-        documentUri: report["document-uri"],
-        referrer: report["referrer"],
-        alert: true,
-      });
-    }
-
-    // Always return 204 No Content - we don't want to acknowledge receipt
-    return new NextResponse(null, { status: 204 });
+    raw = await request.text();
   } catch {
-    // Invalid report - still return success to not leak info
+    return new NextResponse(null, { status: 400 });
+  }
+
+  if (raw.length > MAX_CSP_REPORT_BYTES) {
+    return new NextResponse(null, { status: 413 });
+  }
+
+  // Per-IP rate limit. Applied after the size check so a flood of large
+  // bodies is rejected by the cheaper guard first.
+  const ip = extractClientIp(request);
+  const allowed = await cspReportLimiter.check(`csp-report:${ip}`);
+  if (!allowed) {
+    return new NextResponse(null, { status: 429 });
+  }
+
+  let parsed: CspViolationReport;
+  try {
+    parsed = JSON.parse(raw) as CspViolationReport;
+  } catch {
+    // Invalid JSON — return 204 to avoid leaking parser behaviour to
+    // attackers probing the endpoint.
     return new NextResponse(null, { status: 204 });
   }
+
+  const report = parsed?.["csp-report"];
+  if (report && typeof report === "object") {
+    // Log CSP violation for security monitoring. Elevated to error with
+    // alert: true to ensure Sentry catches it and triggers a dashboard /
+    // alert rule (Audit 3.4 Fix). Every field is truncated and the
+    // original-policy is intentionally dropped — it is large, low-signal,
+    // and attacker-influenced via document-uri reflection.
+    logger.error("CSP violation detected", {
+      context: "csp-report",
+      blockedUri: truncateField(report["blocked-uri"]),
+      violatedDirective: truncateField(report["violated-directive"]),
+      documentUri: truncateField(report["document-uri"]),
+      referrer: truncateField(report.referrer),
+      alert: true,
+    });
+  }
+
+  // Always return 204 No Content — we don't want to acknowledge receipt.
+  return new NextResponse(null, { status: 204 });
 }
 
 // GET requests are not meaningful for CSP reports

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -372,15 +372,13 @@ export async function middleware(request: NextRequest) {
             }
           });
 
-          // Set the auth-profile response headers (informational; the request
-          // headers above are what `withAuth` reads). Re-apply security and
-          // tenant headers since the response was just recreated.
-          supabaseResponse.headers.set(PROFILE_HEADER_NAMES.id, profile.id);
-          supabaseResponse.headers.set(PROFILE_HEADER_NAMES.role, profile.role);
-          if (profile.clinic_id) {
-            supabaseResponse.headers.set(PROFILE_HEADER_NAMES.clinic, profile.clinic_id);
-          }
-          supabaseResponse.headers.set(PROFILE_HEADER_NAMES.sig, sigHex);
+          // Do NOT mirror the signed x-auth-profile-* headers onto the
+          // outgoing response. They are an internal trust contract between
+          // middleware and `withAuth` carried via the forwarded *request*
+          // headers; emitting them on the response leaks the user id, role,
+          // clinic id and HMAC signature to the browser and any
+          // intermediaries. Re-apply security and tenant headers since the
+          // response was just recreated.
           applyAllSecurityHeaders(supabaseResponse, cspHeaders, nonce);
           if (resolvedClinic) setTenantHeaders(supabaseResponse, resolvedClinic);
         }


### PR DESCRIPTION
## Summary

Addresses two MEDIUM-priority security audit findings.

### #6 — Signed internal profile headers leaked to the browser response (`src/middleware.ts`)

The middleware was mirroring the signed `x-auth-profile-{id,role,clinic,sig}` headers onto **both** the forwarded request and the outgoing response. These headers are an internal trust contract between the middleware and `withAuth` (so handlers can avoid a second DB query), and they include the user id, role, clinic id, and the HMAC signature. Emitting them on the response leaked all of that to the browser and any intermediaries (proxies, CDNs, browser extensions, error trackers).

**Fix:** Remove the response-side `supabaseResponse.headers.set(PROFILE_HEADER_NAMES.*)` calls. The forwarded request headers (which downstream `withAuth` reads) are unchanged, so the trust contract is preserved.

### #7 — CSP report endpoint hardening (`src/app/api/csp-report/route.ts`)

The endpoint accepted and logged attacker-controlled fields with only a generic large-body cap, allowing log flooding / cost amplification and drowning real violations in noise.

**Fix:**
- Read the raw body with `request.text()` and reject anything larger than **16 KiB** with `413 Payload Too Large` *before* JSON parsing.
- Per-IP rate limit of **60 req / 60s** via `createRateLimiter` (returns `429`). Fail-open is acceptable for a logging sink — degrading to "log everything" during a backend outage is safer than dropping real violations.
- Truncate every logged field to **500 chars**; non-string values are dropped rather than coerced.
- Drop `original-policy` from the structured log entirely (large, low-signal, and reflects attacker-controlled `document-uri`).
- Invalid JSON still returns `204` to avoid leaking parser behaviour.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

The middleware change removes a header leak — it does not change *how* `withAuth` trusts requests; the forwarded request-side headers (the only ones `withAuth` reads) are untouched.

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

New test file `src/app/api/__tests__/csp-report.test.ts` covers:

- Oversized payloads (`> 16 KiB`) → `413`, rate limiter not consulted, nothing logged
- Rate-limit miss → `429`, nothing logged
- Valid violation → `204`, fields logged with truncation to 500 chars and `original-policy` omitted
- Invalid JSON → `204`, nothing logged
- Missing `csp-report` key → `204`, nothing logged
- Non-string fields (objects, arrays, numbers) → dropped rather than coerced
- `GET` → `204`

Full suite results locally:

```
Test Files  60 passed | 1 skipped (61)
     Tests  636 passed | 24 skipped (660)
```

`npx tsc --noEmit` and `npm run lint` are both clean (no new errors; pre-existing i18n warnings unchanged).

No middleware unit-test infrastructure exists in the repo and the change is a pure deletion of 6 lines of `response.headers.set(...)`. A grep across the repo confirmed no test asserted the response-side `x-auth-profile-*` headers.

### Verification (per the audit recommendation)

A response header snapshot test can be added later, but in the meantime the assertion can be made manually: hit any authenticated route and confirm no `x-auth-profile-*` keys appear in the response.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
