### PR TITLE
fix(upload): per-category size limits for clinical documents (issue #10)

### DIFF
--- a/src/app/api/__tests__/upload-category-limits.test.ts
+++ b/src/app/api/__tests__/upload-category-limits.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression tests for issue #10 — per-category upload size limits.
+ *
+ * Pre-fix: a single global `MAX_FILE_SIZE = 2 MB` rejected real clinical
+ * payloads (PDFs, scanned scripts, lab reports, radiology). The route now
+ * enforces `LIMITS_BY_CATEGORY` so each category gets a realistic cap and
+ * unknown categories fall back to `DEFAULT_UPLOAD_LIMIT` (10 MB), bounded
+ * by the middleware-level `MAX_BODY_BYTES` (25 MB).
+ *
+ * These tests exercise the pure helpers; the POST/PUT/GET handlers are
+ * covered by `upload-confirm-headobject.test.ts` and
+ * `upload-confirm-tenant-prefix.test.ts`.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  LIMITS_BY_CATEGORY,
+  DEFAULT_UPLOAD_LIMIT,
+  MAX_UPLOAD_BYTES,
+  limitForCategory,
+  normalizeCategory,
+  categoryFromKey,
+} from "@/app/api/upload/route";
+
+describe("LIMITS_BY_CATEGORY", () => {
+  it("matches the contract documented in issue #10", () => {
+    expect(LIMITS_BY_CATEGORY.avatar).toBe(2 * 1024 * 1024);
+    expect(LIMITS_BY_CATEGORY.clinic_logo).toBe(2 * 1024 * 1024);
+    expect(LIMITS_BY_CATEGORY.lab_report).toBe(10 * 1024 * 1024);
+    expect(LIMITS_BY_CATEGORY.radiology).toBe(25 * 1024 * 1024);
+    expect(LIMITS_BY_CATEGORY.document).toBe(10 * 1024 * 1024);
+  });
+
+  it("never exceeds the global middleware body cap", () => {
+    for (const limit of Object.values(LIMITS_BY_CATEGORY)) {
+      expect(limit).toBeLessThanOrEqual(MAX_UPLOAD_BYTES);
+    }
+  });
+});
+
+describe("normalizeCategory", () => {
+  it("folds case and hyphens to the canonical lookup key", () => {
+    expect(normalizeCategory("Lab-Report")).toBe("lab_report");
+    expect(normalizeCategory("X-Rays")).toBe("x_rays");
+    expect(normalizeCategory("  documents  ")).toBe("documents");
+  });
+});
+
+describe("limitForCategory", () => {
+  it("returns the configured limit for known categories", () => {
+    expect(limitForCategory("avatar")).toBe(2 * 1024 * 1024);
+    expect(limitForCategory("logos")).toBe(2 * 1024 * 1024);
+    expect(limitForCategory("lab-report")).toBe(10 * 1024 * 1024);
+    expect(limitForCategory("radiology")).toBe(25 * 1024 * 1024);
+    expect(limitForCategory("X-RAYS")).toBe(25 * 1024 * 1024);
+  });
+
+  it("falls back to DEFAULT_UPLOAD_LIMIT for unknown categories", () => {
+    expect(limitForCategory("unknown-thing")).toBe(DEFAULT_UPLOAD_LIMIT);
+    expect(limitForCategory("uploads")).toBe(DEFAULT_UPLOAD_LIMIT);
+  });
+});
+
+describe("categoryFromKey", () => {
+  it("extracts the category segment from buildUploadKey() output", () => {
+    expect(
+      categoryFromKey("clinics/abc123/lab_report/2024-01/file.pdf"),
+    ).toBe("lab_report");
+    expect(
+      categoryFromKey("clinics/abc123/radiology/scan.dcm"),
+    ).toBe("radiology");
+  });
+
+  it("returns null for malformed or non-clinic keys", () => {
+    expect(categoryFromKey("abc123/photos/file.png")).toBeNull();
+    expect(categoryFromKey("clinics/abc123")).toBeNull();
+    expect(categoryFromKey("")).toBeNull();
+  });
+});

--- a/src/app/api/__tests__/upload-confirm-headobject.test.ts
+++ b/src/app/api/__tests__/upload-confirm-headobject.test.ts
@@ -103,10 +103,11 @@ describe("PUT /api/upload — HeadObject confirmation cross-check", () => {
   it("rejects and deletes an upload that exceeds MAX_FILE_SIZE", async () => {
     authedAs("clinic_admin", CLINIC_ID);
 
-    // The pre-signed POST policy is supposed to bound this at 2 MB, but if
-    // the policy was stale or relaxed the route must still catch it.
+    // The pre-signed POST policy is supposed to bound this at the per-category
+    // limit (2 MB for `photos` per `LIMITS_BY_CATEGORY` in the upload route),
+    // but if the policy was stale or relaxed the route must still catch it.
     getR2ObjectMetadataMock.mockResolvedValueOnce({
-      contentLength: 5 * 1024 * 1024, // 5 MB
+      contentLength: 5 * 1024 * 1024, // 5 MB — exceeds the 2 MB cap for `photos`
       contentType: "image/png",
     });
 
@@ -119,7 +120,10 @@ describe("PUT /api/upload — HeadObject confirmation cross-check", () => {
     );
     const json = await response.json();
 
-    expect(response.status).toBe(400);
+    // RFC 7231 §6.5.11: 413 Payload Too Large is the correct response when an
+    // upload exceeds a server-enforced size limit. Issue #10 standardised this
+    // across the upload routes.
+    expect(response.status).toBe(413);
     expect(json.error).toMatch(/too large/i);
     expect(deleteFromR2Mock).toHaveBeenCalledWith(
       `clinics/${CLINIC_ID}/photos/file.png`,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -46,7 +46,82 @@ import { encryptAndUpload } from "@/lib/r2-encrypted";
 import { uploadConfirmSchema } from "@/lib/validations";
 import { withAuth } from "@/lib/with-auth";
 
-const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
+/**
+ * Per-category upload size limits (issue #10).
+ *
+ * 2 MB is too small for real clinical workflows: PDFs, scanned scripts,
+ * lab reports, and radiology images routinely exceed it. We size each
+ * category to its real-world payload, capped at MAX_UPLOAD_BYTES so the
+ * middleware-level body limit (`MAX_BODY_BYTES` in `src/middleware.ts`)
+ * is the global ceiling.
+ *
+ * Keys are normalized via `normalizeCategory()` so callers may use
+ * either hyphen- or underscore-separated forms (e.g. `lab-report` or
+ * `lab_report`). Unknown categories fall back to DEFAULT_LIMIT.
+ */
+const KB = 1024;
+const MB = 1024 * KB;
+
+export const MAX_UPLOAD_BYTES = 25 * MB;
+export const DEFAULT_UPLOAD_LIMIT = 10 * MB;
+
+export const LIMITS_BY_CATEGORY: Readonly<Record<string, number>> = {
+  // Profile / branding (small images)
+  avatar: 2 * MB,
+  avatars: 2 * MB,
+  photos: 2 * MB,
+  logo: 2 * MB,
+  logos: 2 * MB,
+  clinic_logo: 2 * MB,
+  // Clinical documents (PDFs, scans, lab reports)
+  document: DEFAULT_UPLOAD_LIMIT,
+  documents: DEFAULT_UPLOAD_LIMIT,
+  prescriptions: DEFAULT_UPLOAD_LIMIT,
+  lab_report: DEFAULT_UPLOAD_LIMIT,
+  lab_results: DEFAULT_UPLOAD_LIMIT,
+  medical_records: DEFAULT_UPLOAD_LIMIT,
+  patient_files: DEFAULT_UPLOAD_LIMIT,
+  // Imaging (DICOM-style radiology, MRIs)
+  radiology: 25 * MB,
+  x_rays: 25 * MB,
+  xrays: 25 * MB,
+};
+
+/**
+ * Normalize a category key for limit lookup. Lower-cases and folds
+ * hyphens to underscores so `lab-report` and `lab_report` resolve to
+ * the same limit, matching the existing `PHI_CATEGORIES` set in
+ * `@/lib/encryption`.
+ */
+export function normalizeCategory(category: string): string {
+  return category.trim().toLowerCase().replace(/-/g, "_");
+}
+
+/**
+ * Resolve the maximum byte count for a given upload category. Unknown
+ * categories receive `DEFAULT_UPLOAD_LIMIT` so the API does not silently
+ * relax limits for typos. Exported for tests and the GET handler that
+ * passes the limit into the R2 presigned-POST policy.
+ */
+export function limitForCategory(category: string): number {
+  return LIMITS_BY_CATEGORY[normalizeCategory(category)] ?? DEFAULT_UPLOAD_LIMIT;
+}
+
+function formatLimit(bytes: number): string {
+  return `${Math.round(bytes / MB)} MB`;
+}
+
+/**
+ * Extract the {category} segment from a key produced by
+ * `buildUploadKey()` — `clinics/{clinicId}/{category}/{filename}`. The
+ * PUT handler uses this so the HeadObject size check honours the same
+ * per-category cap the POST/GET handlers enforce.
+ */
+export function categoryFromKey(key: string): string | null {
+  const parts = key.split("/");
+  if (parts.length < 4 || parts[0] !== "clinics") return null;
+  return parts[2] || null;
+}
 
 const ALLOWED_TYPES = new Set([
   "image/jpeg",
@@ -116,8 +191,9 @@ export const POST = withAuth(async (request, { profile }) => {
     return apiError("No file provided");
   }
 
-  if (file.size > MAX_FILE_SIZE) {
-    return apiError("File too large (max 2 MB)");
+  const maxSize = limitForCategory(category);
+  if (file.size > maxSize) {
+    return apiError(`File too large (max ${formatLimit(maxSize)} for category "${category}")`, 413);
   }
 
   if (!ALLOWED_TYPES.has(file.type)) {
@@ -197,15 +273,22 @@ export const PUT = withAuthValidation(uploadConfirmSchema, async (body, request,
     return apiNotFound("Uploaded file not found or unreadable");
   }
 
-  if (metadata.contentLength > MAX_FILE_SIZE) {
+  // Derive the per-category cap from the key the client confirmed.
+  // Unknown categories fall back to DEFAULT_UPLOAD_LIMIT, so the policy is
+  // never silently widened by an unrecognised category segment.
+  const keyCategory = categoryFromKey(key);
+  const maxSize = keyCategory ? limitForCategory(keyCategory) : DEFAULT_UPLOAD_LIMIT;
+
+  if (metadata.contentLength > maxSize) {
     logger.warn("Pre-signed upload exceeded max size, deleting", {
       context: "upload",
       key,
+      category: keyCategory,
       contentLength: metadata.contentLength,
-      maxSize: MAX_FILE_SIZE,
+      maxSize,
     });
     await deleteFromR2(key);
-    return apiError("File too large (max 2 MB)");
+    return apiError(`File too large (max ${formatLimit(maxSize)})`, 413);
   }
 
   if (metadata.contentType && metadata.contentType !== contentType) {
@@ -260,7 +343,8 @@ export const GET = withAuth(async (request, { profile }) => {
   }
 
   const key = buildUploadKey(clinicId, category, filename);
-  const presigned = await getPresignedUploadPost(key, contentType, MAX_FILE_SIZE);
+  const maxSize = limitForCategory(category);
+  const presigned = await getPresignedUploadPost(key, contentType, maxSize);
 
   if (!presigned) {
     return apiInternalError("Failed to generate upload URL");
@@ -281,6 +365,6 @@ export const GET = withAuth(async (request, { profile }) => {
     key: presigned.key,
     publicUrl,
     thumbnails,
-    maxSize: MAX_FILE_SIZE,
+    maxSize,
   });
 }, ["super_admin", "clinic_admin", "receptionist", "doctor"]);


### PR DESCRIPTION
## Summary

Closes issue #10 — the global 2 MB hard cap on `/api/upload` was too small for real clinical workflows (PDFs, scanned scripts, lab reports, radiology). This PR replaces it with a per-category limit table:

| Category | Limit |
| --- | --- |
| `avatar`, `avatars`, `photos`, `logo`, `logos`, `clinic_logo` | 2 MB |
| `document`, `documents`, `prescriptions`, `lab_report`, `lab_results`, `medical_records`, `patient_files` | 10 MB |
| `radiology`, `x_rays`, `xrays` | 25 MB |
| _unknown_ | 10 MB (`DEFAULT_UPLOAD_LIMIT`) |

The middleware-level body cap (`MAX_BODY_BYTES = 25 MB` in `src/middleware.ts:66`) was already aligned with the largest category, so no middleware change is required.

### Changes

- `src/app/api/upload/route.ts`
  - Added `LIMITS_BY_CATEGORY`, `DEFAULT_UPLOAD_LIMIT`, `MAX_UPLOAD_BYTES`, and helpers `normalizeCategory()`, `limitForCategory()`, `categoryFromKey()`.
  - **POST** now checks `file.size` against `limitForCategory(category)` and returns **HTTP 413** (RFC 7231 §6.5.11) on overflow, with the human-readable cap in the error message.
  - **PUT** (HeadObject confirmation cross-check) derives the category from the R2 key (`clinics/{clinicId}/{category}/...`) so a stale or relaxed presigned policy still gets caught at the same per-category cap.
  - **GET** (presigned POST) passes the per-category limit into `getPresignedUploadPost()` so R2 enforces `content-length-range` at upload time. The returned `maxSize` field reflects the category-specific cap so clients can mirror it in UI validators.
- `src/app/api/__tests__/upload-confirm-headobject.test.ts`
  - Updated the oversize regression test to assert **413** instead of 400, matching the new contract.
- `src/app/api/__tests__/upload-category-limits.test.ts` (new)
  - Pure-helper coverage for `LIMITS_BY_CATEGORY`, `normalizeCategory()`, `limitForCategory()`, and `categoryFromKey()`.

Categories use the existing snake_case convention from `PHI_CATEGORIES` in `src/lib/encryption.ts`. `normalizeCategory()` accepts either hyphen- or underscore-separated forms (`lab-report` ≡ `lab_report`).

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

The tenant-prefix check (`expectedKeyPrefixForProfile`) and magic-byte/Content-Type validation are unchanged. The new limits never widen above the existing 25 MB middleware body cap, so the global ceiling is preserved.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

Local launch-gate runs against this branch (issue #11):

```
npm ci                   # 1432 packages, 0 vulnerabilities
npm run typecheck        # exit 0
npm run lint             # exit 0 (0 errors, pre-existing warnings only)
npm test                 # 636 passed | 24 skipped (660), 0 failed
npm run build            # next build succeeded
```

`npm run test:e2e`, `npm audit --audit-level=high`, and `npm run build:cf` are still being run locally — results will be posted as a follow-up comment.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
