### PR TITLE
fix(security-headers): guard against empty CSP value when forwarding header

### DIFF
--- a/src/lib/middleware/__tests__/security-headers.test.ts
+++ b/src/lib/middleware/__tests__/security-headers.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression tests for the empty-CSP guard in
+ * `withSecurityHeaders` and `applyAllSecurityHeaders`.
+ *
+ * Bug: when `CspHeaderValues.enforce` is an empty string (e.g. a future
+ * report-only-only mode), the helpers were unconditionally setting a
+ * blank `Content-Security-Policy` header. Code that checks for the
+ * header's presence (e.g. `headers.has("Content-Security-Policy")`)
+ * would see the blank header instead of either no header or the actual
+ * policy. The middleware-side request-header forwarding has the same
+ * guard for the same reason — see `src/middleware.ts:115`.
+ */
+import { NextResponse } from "next/server";
+import { describe, it, expect } from "vitest";
+import {
+  withSecurityHeaders,
+  applyAllSecurityHeaders,
+  buildCspHeaderValues,
+  type CspHeaderValues,
+} from "../security-headers";
+
+describe("withSecurityHeaders — CSP guard", () => {
+  it("sets Content-Security-Policy when enforce is non-empty", () => {
+    const response = NextResponse.json({ ok: true });
+    const csp = buildCspHeaderValues("test-nonce");
+
+    withSecurityHeaders(response, csp);
+
+    expect(response.headers.get("Content-Security-Policy")).toBe(csp.enforce);
+    expect(response.headers.has("Content-Security-Policy-Report-Only")).toBe(
+      false,
+    );
+  });
+
+  it("does not forward an empty Content-Security-Policy header", () => {
+    const response = NextResponse.json({ ok: true });
+    // Pre-populate with a stale value to prove the helper deletes it.
+    response.headers.set("Content-Security-Policy", "stale");
+
+    const csp: CspHeaderValues = { enforce: "", reportOnly: "" };
+    withSecurityHeaders(response, csp);
+
+    expect(response.headers.has("Content-Security-Policy")).toBe(false);
+    // Sibling defense-in-depth headers must still be applied.
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+});
+
+describe("applyAllSecurityHeaders — CSP guard", () => {
+  it("sets Content-Security-Policy when enforce is non-empty", () => {
+    const response = NextResponse.json({ ok: true });
+    const csp = buildCspHeaderValues("test-nonce");
+
+    applyAllSecurityHeaders(response, csp, "test-nonce");
+
+    expect(response.headers.get("Content-Security-Policy")).toBe(csp.enforce);
+  });
+
+  it("does not forward an empty Content-Security-Policy header", () => {
+    const response = NextResponse.json({ ok: true });
+    response.headers.set("Content-Security-Policy", "stale");
+
+    const csp: CspHeaderValues = { enforce: "", reportOnly: "" };
+    applyAllSecurityHeaders(response, csp, "test-nonce");
+
+    expect(response.headers.has("Content-Security-Policy")).toBe(false);
+    expect(response.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+  });
+});

--- a/src/lib/middleware/security-headers.ts
+++ b/src/lib/middleware/security-headers.ts
@@ -147,7 +147,11 @@ export function withSecurityHeaders(
   response: NextResponse,
   csp: CspHeaderValues,
 ): NextResponse {
-  response.headers.set("Content-Security-Policy", csp.enforce);
+  if (csp.enforce) {
+    response.headers.set("Content-Security-Policy", csp.enforce);
+  } else {
+    response.headers.delete("Content-Security-Policy");
+  }
   response.headers.delete("Content-Security-Policy-Report-Only");
   response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");
@@ -177,7 +181,11 @@ export function applyAllSecurityHeaders(
   csp: CspHeaderValues,
   _nonce: string, // Unused but kept for API compatibility
 ): void {
-  response.headers.set("Content-Security-Policy", csp.enforce);
+  if (csp.enforce) {
+    response.headers.set("Content-Security-Policy", csp.enforce);
+  } else {
+    response.headers.delete("Content-Security-Policy");
+  }
   response.headers.delete("Content-Security-Policy-Report-Only");
   response.headers.set("Strict-Transport-Security", HSTS_VALUE);
   response.headers.set("X-Content-Type-Options", "nosniff");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -111,8 +111,18 @@ export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-nonce", nonce);
   // Forward the enforcing CSP so Server Components that introspect the request
-  // headers see the same policy the browser will enforce.
-  requestHeaders.set("Content-Security-Policy", cspHeaders.enforce);
+  // headers see the same policy the browser will enforce. Guard against an
+  // empty `enforce` value (e.g. a future report-only-only mode) so we never
+  // forward a `Content-Security-Policy: ` header with a blank value — Server
+  // Components that check for the header's presence would otherwise see an
+  // empty string instead of either no header or the actual policy. This
+  // mirrors the response-side guards in `withSecurityHeaders` and
+  // `applyAllSecurityHeaders`.
+  if (cspHeaders.enforce) {
+    requestHeaders.set("Content-Security-Policy", cspHeaders.enforce);
+  } else {
+    requestHeaders.delete("Content-Security-Policy");
+  }
   requestHeaders.set(TRACE_ID_HEADER, traceId);
 
   // --- SECURITY: Strip all tenant headers from the incoming request ---


### PR DESCRIPTION
## Summary

Defense-in-depth: never forward a `Content-Security-Policy:` header with a blank value.

### Reported behaviour

> When `CSP_REPORT_ONLY=true` is set in production, `buildCspHeaderValues` returns `{ enforce: "", reportOnly: "<policy>" }`. At `src/middleware.ts:115`, the code unconditionally does `requestHeaders.set("Content-Security-Policy", cspHeaders.enforce)`, which sets an empty `Content-Security-Policy:` header on all forwarded requests. The response-side functions (`withSecurityHeaders` and `applyAllSecurityHeaders`) correctly guard with `if (csp.enforce)`, but the request-header forwarding lacks this guard.

### What this PR does

Follow-up to issue #459 (Task 2.2 — strict CSP is now enforced). I audited the current state of the code and found two related items:

1. **Today, `buildCspHeaderValues()` always returns a non-empty `enforce`** (`src/lib/middleware/security-headers.ts:134-139`) and there is no `CSP_REPORT_ONLY` env switch — so the empty-header bug is not currently reachable through the public API. **However, the response-side helpers also lack the guard** (`response.headers.set("Content-Security-Policy", csp.enforce)` runs unconditionally in both `withSecurityHeaders` and `applyAllSecurityHeaders`), so the contract was inconsistent in the opposite direction from the report.

2. To make the contract consistent and defensive against any future change that re-introduces a report-only-only mode, this PR adds the same `if (csp.enforce)` guard everywhere a `Content-Security-Policy` header could be written from `CspHeaderValues`:
   - `src/middleware.ts:113-125` — request-header forwarding now skips the header (and deletes any pre-existing one) when `enforce` is empty.
   - `src/lib/middleware/security-headers.ts` — `withSecurityHeaders` and `applyAllSecurityHeaders` now apply the same guard. When `enforce` is empty they `delete("Content-Security-Policy")` so a stale header from an upstream layer cannot leak through as a blank value.

3. Added regression tests — `src/lib/middleware/__tests__/security-headers.test.ts` covers both helpers, asserting they (a) set the CSP when `enforce` is non-empty and (b) do not write a blank header when `enforce` is empty (and clear any stale one).

This is a no-op for the current production policy (which always enforces) but prevents the reported failure mode from regressing in the future.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact (defense-in-depth only — the production CSP value is unchanged)

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

```
NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit  # exit 0
npx vitest run src/lib/middleware/__tests__/security-headers.test.ts  # 4 passed
```

Full launch-gate (`npm test`, `npm run build`, `npm audit`, `npm run build:cf`) was already green on the issue #10 PR base; rerunning here as part of CI.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
