### PR TITLE
fix(security): drop plaintext API keys, harden checkin tenant scoping & auth trigger (S-01/S-02/S-03)

### DIFF
--- a/src/app/api/__tests__/checkin-tenant-isolation.test.ts
+++ b/src/app/api/__tests__/checkin-tenant-isolation.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Route handler tests for /api/checkin/* — S-02 cross-tenant rejection.
+ *
+ * The check-in routes are unauthenticated kiosk endpoints. They MUST
+ * derive `clinicId` from the subdomain (via getTenant()) and reject any
+ * request whose URL/body `clinicId` disagrees with the resolved tenant,
+ * preventing cross-tenant enumeration / writes.
+ */
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks (must be declared before route imports) ────────────────────
+
+const mockChainable = {
+  select: vi.fn().mockReturnThis(),
+  insert: vi.fn().mockReturnThis(),
+  update: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  order: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  single: vi.fn(),
+};
+
+const mockSupabase = {
+  from: vi.fn(() => mockChainable),
+};
+
+vi.mock("@/lib/supabase-server", () => ({
+  createTenantClient: vi.fn(async () => mockSupabase),
+}));
+
+const getTenantMock = vi.fn();
+vi.mock("@/lib/tenant", () => ({
+  getTenant: () => getTenantMock(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const TENANT_CLINIC_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_CLINIC_ID = "22222222-2222-2222-2222-222222222222";
+
+const TENANT = {
+  clinicId: TENANT_CLINIC_ID,
+  clinicName: "Test Clinic",
+  subdomain: "test",
+  clinicType: "doctor",
+  clinicTier: "pro",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getTenantMock.mockResolvedValue(TENANT);
+  // Default: kiosk lookup chain returns no rows
+  mockChainable.single.mockResolvedValue({ data: null, error: null });
+  // Default: order/in returns no appointments
+  // (mockChainable returns itself so callers `.then` resolves to whatever
+  //  we set on the last leaf; callers in the routes use the result of
+  //  .order(...) directly, so we configure that per-test where needed.)
+  mockChainable.order.mockResolvedValue({ data: [], error: null });
+});
+
+// ── /api/checkin/status ──────────────────────────────────────────────
+
+describe("GET /api/checkin/status", () => {
+  it("rejects when no tenant is resolved (root domain)", async () => {
+    getTenantMock.mockResolvedValueOnce(null);
+
+    const { GET } = await import("@/app/api/checkin/status/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/checkin/status?clinicId=${TENANT_CLINIC_ID}`,
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("TENANT_REQUIRED");
+  });
+
+  it("rejects when URL clinicId disagrees with subdomain tenant", async () => {
+    const { GET } = await import("@/app/api/checkin/status/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/checkin/status?clinicId=${OTHER_CLINIC_ID}`,
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.code).toBe("TENANT_MISMATCH");
+  });
+
+  it("uses subdomain-resolved clinicId when no query clinicId is supplied", async () => {
+    mockChainable.single.mockResolvedValueOnce({
+      data: { kiosk_mode_enabled: true },
+      error: null,
+    });
+
+    const { GET } = await import("@/app/api/checkin/status/route");
+    const request = new NextRequest("http://localhost:3000/api/checkin/status");
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.enabled).toBe(true);
+    // Confirm we never used a foreign clinic id when scoping the query.
+    expect(mockChainable.eq).toHaveBeenCalledWith("id", TENANT_CLINIC_ID);
+  });
+});
+
+// ── /api/checkin/lookup ──────────────────────────────────────────────
+
+describe("GET /api/checkin/lookup", () => {
+  it("rejects when no tenant is resolved", async () => {
+    getTenantMock.mockResolvedValueOnce(null);
+
+    const { GET } = await import("@/app/api/checkin/lookup/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/checkin/lookup?phone=%2B212600000000&clinicId=${TENANT_CLINIC_ID}`,
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("TENANT_REQUIRED");
+  });
+
+  it("rejects when URL clinicId disagrees with subdomain tenant", async () => {
+    const { GET } = await import("@/app/api/checkin/lookup/route");
+    const request = new NextRequest(
+      `http://localhost:3000/api/checkin/lookup?phone=%2B212600000000&clinicId=${OTHER_CLINIC_ID}`,
+    );
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.code).toBe("TENANT_MISMATCH");
+  });
+
+  it("returns 400 when phone is missing", async () => {
+    const { GET } = await import("@/app/api/checkin/lookup/route");
+    const request = new NextRequest("http://localhost:3000/api/checkin/lookup");
+    const response = await GET(request);
+    expect(response.status).toBe(400);
+  });
+});
+
+// ── /api/checkin/confirm ─────────────────────────────────────────────
+
+describe("POST /api/checkin/confirm", () => {
+  function buildRequest(body: Record<string, unknown>): NextRequest {
+    return new NextRequest("http://localhost:3000/api/checkin/confirm", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("rejects when no tenant is resolved", async () => {
+    getTenantMock.mockResolvedValueOnce(null);
+
+    const { POST } = await import("@/app/api/checkin/confirm/route");
+    const response = await POST(
+      buildRequest({ appointmentId: "appt-1", clinicId: TENANT_CLINIC_ID }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("TENANT_REQUIRED");
+  });
+
+  it("rejects when body clinicId disagrees with subdomain tenant", async () => {
+    const { POST } = await import("@/app/api/checkin/confirm/route");
+    const response = await POST(
+      buildRequest({ appointmentId: "appt-1", clinicId: OTHER_CLINIC_ID }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.code).toBe("TENANT_MISMATCH");
+  });
+
+  it("scopes the appointment update by the subdomain-resolved clinicId", async () => {
+    // appointment update returns no error
+    const updateChain = {
+      eq: vi.fn().mockReturnThis(),
+    };
+    // last .eq() must resolve the promise
+    let updateCallCount = 0;
+    updateChain.eq.mockImplementation(() => {
+      updateCallCount++;
+      return updateCallCount >= 2
+        ? Promise.resolve({ error: null })
+        : updateChain;
+    });
+
+    mockChainable.update.mockReturnValueOnce(updateChain);
+
+    // checked-in queue lookup returns empty
+    mockChainable.order.mockResolvedValueOnce({ data: [], error: null });
+
+    const { POST } = await import("@/app/api/checkin/confirm/route");
+    const response = await POST(
+      buildRequest({ appointmentId: "appt-1", clinicId: TENANT_CLINIC_ID }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.checkedIn).toBe(true);
+    // The update chain must have scoped by both id and the resolved clinic_id.
+    expect(updateChain.eq).toHaveBeenCalledWith("id", "appt-1");
+    expect(updateChain.eq).toHaveBeenCalledWith("clinic_id", TENANT_CLINIC_ID);
+  });
+});

--- a/src/app/api/checkin/confirm/route.ts
+++ b/src/app/api/checkin/confirm/route.ts
@@ -1,7 +1,8 @@
-import { apiSuccess, apiInternalError } from "@/lib/api-response";
+import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 import { withValidation } from "@/lib/api-validate";
 import { logger } from "@/lib/logger";
 import { createTenantClient } from "@/lib/supabase-server";
+import { getTenant } from "@/lib/tenant";
 import { checkinConfirmSchema } from "@/lib/validations";
 
 /**
@@ -9,9 +10,29 @@ import { checkinConfirmSchema } from "@/lib/validations";
  *
  * Confirm patient arrival: update appointment status to "checked_in"
  * and calculate queue position / estimated wait.
+ *
+ * S-02: clinicId is derived from the subdomain via getTenant() — it is
+ * never trusted from the request body. A body-supplied `clinicId` is
+ * accepted only if it matches the subdomain-resolved tenant; otherwise
+ * the request is rejected to prevent unauthenticated cross-tenant writes.
  */
 export const POST = withValidation(checkinConfirmSchema, async (body) => {
-    const { appointmentId, clinicId } = body;
+    const { appointmentId, clinicId: bodyClinicId } = body;
+
+    const tenant = await getTenant();
+    if (!tenant?.clinicId) {
+      return apiError("Tenant context is required", 400, "TENANT_REQUIRED");
+    }
+    const clinicId = tenant.clinicId;
+
+    if (bodyClinicId && bodyClinicId !== clinicId) {
+      logger.warn("Rejected check-in confirm with mismatched clinicId", {
+        context: "api/checkin/confirm",
+        tenantClinicId: clinicId,
+        bodyClinicId,
+      });
+      return apiError("clinicId mismatch", 403, "TENANT_MISMATCH");
+    }
 
     const supabase = await createTenantClient(clinicId);
 

--- a/src/app/api/checkin/lookup/route.ts
+++ b/src/app/api/checkin/lookup/route.ts
@@ -2,18 +2,40 @@ import { NextRequest } from "next/server";
 import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { createTenantClient } from "@/lib/supabase-server";
+import { getTenant } from "@/lib/tenant";
 
 /**
- * GET /api/checkin/lookup?phone=...&clinicId=...
+ * GET /api/checkin/lookup?phone=...
  *
  * Look up today's appointments for a patient by phone number.
+ *
+ * S-02: clinicId is derived from the subdomain via getTenant() — it is
+ * never read from the URL/body. If a caller still supplies a `clinicId`
+ * query param (legacy clients, manual probing) it must agree with the
+ * subdomain-resolved tenant or the request is rejected. This prevents
+ * unauthenticated cross-tenant enumeration.
  */
 export async function GET(request: NextRequest) {
   const phone = request.nextUrl.searchParams.get("phone");
-  const clinicId = request.nextUrl.searchParams.get("clinicId");
+  const suppliedClinicId = request.nextUrl.searchParams.get("clinicId");
 
-  if (!phone || !clinicId) {
-    return apiError("Missing phone or clinicId", 400);
+  if (!phone) {
+    return apiError("Missing phone", 400);
+  }
+
+  const tenant = await getTenant();
+  if (!tenant?.clinicId) {
+    return apiError("Tenant context is required", 400, "TENANT_REQUIRED");
+  }
+  const clinicId = tenant.clinicId;
+
+  if (suppliedClinicId && suppliedClinicId !== clinicId) {
+    logger.warn("Rejected check-in lookup with mismatched clinicId", {
+      context: "api/checkin/lookup",
+      tenantClinicId: clinicId,
+      suppliedClinicId,
+    });
+    return apiError("clinicId mismatch", 403, "TENANT_MISMATCH");
   }
 
   try {

--- a/src/app/api/checkin/status/route.ts
+++ b/src/app/api/checkin/status/route.ts
@@ -2,16 +2,33 @@ import { NextRequest } from "next/server";
 import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { createTenantClient } from "@/lib/supabase-server";
+import { getTenant } from "@/lib/tenant";
 
 /**
- * GET /api/checkin/status?clinicId=...
+ * GET /api/checkin/status
  *
- * Check whether kiosk mode is enabled for the given clinic.
+ * Check whether kiosk mode is enabled for the current clinic.
+ *
+ * S-02: clinicId is derived from the subdomain via getTenant() — it is
+ * never read from the URL. A legacy `clinicId` query param is accepted
+ * only if it matches the subdomain-resolved tenant; otherwise the request
+ * is rejected to prevent unauthenticated cross-tenant probing.
  */
 export async function GET(request: NextRequest) {
-  const clinicId = request.nextUrl.searchParams.get("clinicId");
-  if (!clinicId) {
-    return apiError("Missing clinicId", 400);
+  const tenant = await getTenant();
+  if (!tenant?.clinicId) {
+    return apiError("Tenant context is required", 400, "TENANT_REQUIRED");
+  }
+  const clinicId = tenant.clinicId;
+
+  const suppliedClinicId = request.nextUrl.searchParams.get("clinicId");
+  if (suppliedClinicId && suppliedClinicId !== clinicId) {
+    logger.warn("Rejected check-in status with mismatched clinicId", {
+      context: "api/checkin/status",
+      tenantClinicId: clinicId,
+      suppliedClinicId,
+    });
+    return apiError("clinicId mismatch", 403, "TENANT_MISMATCH");
   }
 
   try {

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -901,7 +901,6 @@ export type Database = {
           clinic_id: string
           created_at: string | null
           id: string
-          key: string | null
           key_hash: string
           label: string | null
           last_used_at: string | null
@@ -912,7 +911,6 @@ export type Database = {
           clinic_id: string
           created_at?: string | null
           id?: string
-          key?: string | null
           key_hash: string
           label?: string | null
           last_used_at?: string | null
@@ -923,7 +921,6 @@ export type Database = {
           clinic_id?: string
           created_at?: string | null
           id?: string
-          key?: string | null
           key_hash?: string
           label?: string | null
           last_used_at?: string | null

--- a/supabase/migrations/00068_drop_clinic_api_key_plaintext.sql
+++ b/supabase/migrations/00068_drop_clinic_api_key_plaintext.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- Migration 00068: Drop plaintext API key column (S-01)
+--
+-- Problem (audit A1: F-01):
+--   `clinic_api_keys.key` is a plaintext column persisting the raw
+--   API key forever, and `idx_clinic_api_keys_key` is a btree index
+--   over it. A DB compromise (or any role with read access to the
+--   table) leaks every clinic's bearer credential.
+--
+-- Fix:
+--   * Drop the index `idx_clinic_api_keys_key`.
+--   * Drop the `key` column itself.
+--
+--   Going forward only `key_hash` (SHA-256) is persisted. The raw
+--   key is shown to the operator exactly once in-memory at creation
+--   time and must never be stored. `authenticateApiKey()` already
+--   relies solely on `key_hash` + `key_prefix`, so dropping `key`
+--   is safe at the application layer.
+-- ============================================================
+
+DROP INDEX IF EXISTS idx_clinic_api_keys_key;
+
+ALTER TABLE clinic_api_keys
+  DROP COLUMN IF EXISTS key;

--- a/supabase/migrations/00069_harden_auth_trigger.sql
+++ b/supabase/migrations/00069_harden_auth_trigger.sql
@@ -1,0 +1,198 @@
+-- ============================================================
+-- Migration 00069: Harden handle_new_auth_user trigger and
+--                  register_new_clinic RPC (S-03)
+--
+-- Problem (audits A2: §4.4, A5: #8):
+--   `raw_user_meta_data` is set client-side via supabase.auth.signUp's
+--   `options.data` field, so any value there is fully attacker-controlled.
+--   Migrations 00028 and 00045 still read role / clinic_id / is_super_admin
+--   out of `raw_user_meta_data` for the "service-role created user"
+--   heuristic in handle_new_auth_user(). The heuristic
+--   (email_confirmed_at IS NOT NULL AND created_at = email_confirmed_at)
+--   is unreliable and the audit recommends never trusting that JSON
+--   blob for privileged claims at all.
+--
+-- Fix:
+--   1. handle_new_auth_user() ignores role / clinic_id / is_super_admin in
+--      raw_user_meta_data entirely. Self-signup paths always default to
+--      role='patient' with clinic_id=NULL. Privileged role + clinic
+--      assignment may only come from `raw_app_meta_data.invited_to_clinic`
+--      / `raw_app_meta_data.invited_role` (set server-side by GoTrue
+--      during admin invitation flows), and only `receptionist | doctor |
+--      patient` are accepted there — never `clinic_admin` or `super_admin`.
+--   2. The trigger upserts with `ON CONFLICT (auth_id) DO NOTHING` so a
+--      privileged service-role insert (e.g. register_new_clinic,
+--      super-admin admin-create) running before/after the trigger is
+--      never downgraded to 'patient'.
+--   3. Re-affirm the UNIQUE constraint on `public.users.auth_id`. It
+--      already exists since 00001, but enforcing it explicitly here makes
+--      the assumption load-bearing and self-documenting.
+--   4. register_new_clinic() now uses `INSERT … ON CONFLICT (auth_id) DO
+--      UPDATE` so that the privileged service-role row created by the
+--      RPC always wins over whatever 'patient' row the trigger left.
+-- ============================================================
+
+-- ---------- 1. UNIQUE (auth_id) on public.users (idempotent) ----------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'users'
+      AND c.contype = 'u'
+      AND (
+        SELECT array_agg(a.attname ORDER BY a.attname)
+        FROM unnest(c.conkey) k
+        JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k
+      ) = ARRAY['auth_id']
+  ) THEN
+    BEGIN
+      ALTER TABLE public.users
+        ADD CONSTRAINT users_auth_id_key UNIQUE (auth_id);
+    EXCEPTION
+      -- A unique index named users_auth_id_key (or equivalent) may already
+      -- back the column without a matching pg_constraint row. Tolerate it.
+      WHEN duplicate_table THEN NULL;
+      WHEN duplicate_object THEN NULL;
+    END;
+  END IF;
+END $$;
+
+-- ---------- 2. Hardened auth trigger ----------
+CREATE OR REPLACE FUNCTION handle_new_auth_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_clinic_id UUID;
+  v_role TEXT := 'patient';  -- ALWAYS default to least-privileged role
+BEGIN
+  -- Privileged role + clinic claims may ONLY come from raw_app_meta_data,
+  -- which is set server-side by GoTrue during admin invitation flows and
+  -- is NOT writeable from supabase.auth.signUp(). raw_user_meta_data is
+  -- attacker-controlled, so any role / clinic_id / is_super_admin keys
+  -- present there are ignored entirely.
+  IF NEW.raw_app_meta_data ? 'invited_to_clinic' THEN
+    BEGIN
+      v_clinic_id := (NEW.raw_app_meta_data->>'invited_to_clinic')::UUID;
+    EXCEPTION WHEN OTHERS THEN
+      v_clinic_id := NULL;
+    END;
+    v_role := COALESCE(
+      NULLIF(NEW.raw_app_meta_data->>'invited_role', ''),
+      'patient'
+    );
+    -- Invitation cannot escalate to clinic_admin or super_admin. Those
+    -- privileged roles are created exclusively via service-role inserts
+    -- (e.g. register_new_clinic, super-admin onboarding endpoints) which
+    -- bypass the trigger via the ON CONFLICT (auth_id) DO NOTHING below.
+    IF v_role NOT IN ('receptionist', 'doctor', 'patient') THEN
+      v_role := 'patient';
+    END IF;
+  END IF;
+
+  -- ON CONFLICT (auth_id) DO NOTHING: a privileged service-role insert
+  -- may have already created the public.users row (e.g. register_new_clinic
+  -- ran INSERT … ON CONFLICT DO UPDATE before the trigger committed, or
+  -- a follow-up RPC will overwrite this row). In either case the trigger
+  -- must never downgrade the privileged row to 'patient' / NULL clinic.
+  INSERT INTO public.users (auth_id, role, name, phone, email, clinic_id)
+  VALUES (
+    NEW.id,
+    v_role,
+    COALESCE(
+      NEW.raw_user_meta_data->>'name',
+      NEW.raw_user_meta_data->>'full_name',
+      NEW.phone,
+      NEW.email,
+      'New User'
+    ),
+    COALESCE(NEW.phone, NEW.raw_user_meta_data->>'phone'),
+    NEW.email,
+    v_clinic_id
+  )
+  ON CONFLICT (auth_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
+
+-- ---------- 3. register_new_clinic upserts on auth_id ----------
+CREATE OR REPLACE FUNCTION register_new_clinic(
+  p_clinic_name TEXT,
+  p_subdomain TEXT,
+  p_phone TEXT,
+  p_doctor_name TEXT,
+  p_email TEXT,
+  p_city TEXT,
+  p_specialty TEXT,
+  p_auth_id UUID
+) RETURNS UUID AS $$
+DECLARE
+  v_clinic_id UUID;
+BEGIN
+  -- 1. Insert the clinic
+  INSERT INTO clinics (
+    name,
+    type,
+    tier,
+    status,
+    subdomain,
+    phone,
+    owner_name,
+    owner_email,
+    city,
+    config
+  ) VALUES (
+    p_clinic_name,
+    'doctor',
+    'vitrine',
+    'active',
+    p_subdomain,
+    p_phone,
+    p_doctor_name,
+    p_email,
+    p_city,
+    jsonb_build_object(
+      'specialty', p_specialty,
+      'city', p_city,
+      'phone', p_phone,
+      'email', p_email,
+      'onboarding_completed', false
+    )
+  ) RETURNING id INTO v_clinic_id;
+
+  -- 2. Upsert the clinic_admin user profile.
+  --    handle_new_auth_user() may have already inserted a row with
+  --    role='patient' and clinic_id=NULL; this UPSERT promotes it
+  --    atomically to the correct privileged values.
+  INSERT INTO users (
+    auth_id,
+    clinic_id,
+    role,
+    name,
+    phone,
+    email
+  ) VALUES (
+    p_auth_id,
+    v_clinic_id,
+    'clinic_admin',
+    p_doctor_name,
+    p_phone,
+    p_email
+  )
+  ON CONFLICT (auth_id) DO UPDATE SET
+    clinic_id = EXCLUDED.clinic_id,
+    role      = EXCLUDED.role,
+    name      = COALESCE(EXCLUDED.name, public.users.name),
+    phone     = COALESCE(EXCLUDED.phone, public.users.phone),
+    email     = COALESCE(EXCLUDED.email, public.users.email);
+
+  RETURN v_clinic_id;
+EXCEPTION
+  WHEN OTHERS THEN
+    -- If any step fails, PostgreSQL will automatically roll back the transaction.
+    RAISE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;


### PR DESCRIPTION
## Summary

Implements the three CRITICAL items from the consolidated audit list:

### S-01 — `clinic_api_keys.key` plaintext column dropped (A1: F-01)
- New migration `supabase/migrations/00068_drop_clinic_api_key_plaintext.sql` runs `DROP INDEX IF EXISTS idx_clinic_api_keys_key; ALTER TABLE clinic_api_keys DROP COLUMN IF EXISTS key;`.
- Generated DB types updated to remove `key` from `clinic_api_keys`.
- No app code reads `clinic_api_keys.key` — `authenticateApiKey()` already authenticates exclusively via `key_hash` (SHA-256) + `key_prefix`. The raw key must be surfaced once in-memory at creation time and never persisted.

### S-02 — `/api/checkin/*` no longer trusts client-supplied `clinicId` (A2: §3.1)
The three unauthenticated kiosk endpoints used to feed the URL/body `clinicId` straight into `createTenantClient`, allowing cross-tenant enumeration / writes. They now derive `clinicId` from the subdomain via `getTenant()` (set by middleware) and reject the request if a URL/body `clinicId` is supplied that disagrees with the resolved tenant:

- `src/app/api/checkin/lookup/route.ts`
- `src/app/api/checkin/status/route.ts`
- `src/app/api/checkin/confirm/route.ts`

Mismatches return `403` with `code: "TENANT_MISMATCH"`; missing tenant context returns `400` with `code: "TENANT_REQUIRED"`. New route-handler tests in `src/app/api/__tests__/checkin-tenant-isolation.test.ts` (9 cases) cover both rejections and assert the queries scope by the subdomain-resolved `clinic_id`.

### S-03 — `handle_new_auth_user` no longer trusts `raw_user_meta_data`; RPC upserts on `auth_id` (A2: §4.4, A5: #8)
New migration `supabase/migrations/00069_harden_auth_trigger.sql`:

1. **Re-affirms `UNIQUE (auth_id)` on `public.users`** with an idempotent guarded `ALTER TABLE … ADD CONSTRAINT users_auth_id_key UNIQUE (auth_id)`. The constraint already exists since `00001` but is now load-bearing for the upserts below.
2. **Replaces `handle_new_auth_user()`** so it ignores `role / clinic_id / is_super_admin` keys in `raw_user_meta_data` entirely (that JSON is set client-side via `supabase.auth.signUp options.data` and is fully attacker-controlled). Self-signup paths are forced to `role='patient'` with `clinic_id=NULL`. Privileged role + clinic claims may only come from `raw_app_meta_data.invited_to_clinic` / `raw_app_meta_data.invited_role` (set server-side by GoTrue admin-invitation flows), and the invitation role is restricted to `receptionist | doctor | patient` — `clinic_admin` and `super_admin` cannot be assigned via the trigger at all.
3. **Trigger insert uses `ON CONFLICT (auth_id) DO NOTHING`** so a privileged service-role row created by `register_new_clinic` (or future super-admin admin-create paths) is never silently downgraded to `patient`.
4. **Replaces `register_new_clinic()`** so its `INSERT INTO users` becomes `… ON CONFLICT (auth_id) DO UPDATE SET clinic_id, role, name, phone, email`. The privileged service-role insert thus always wins over whatever row the trigger left, and the function remains race-safe regardless of which side commits first. Both functions keep the `SECURITY DEFINER … SET search_path = public, pg_temp` posture from `00066`.

## Type of change
- [x] Bug fix

## Security Impact
- [x] This PR modifies authentication or authorization logic
- [x] This PR changes RLS policies or database migrations
- [x] This PR changes tenant isolation or multi-tenant scoping

## Migration Safety
- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes beyond the intentional `clinic_api_keys.key` drop, which is the fix)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [x] `00069` is fully idempotent (`CREATE OR REPLACE FUNCTION`, constraint guarded by a `pg_constraint` lookup)

## Testing
- [x] Unit tests added — `src/app/api/__tests__/checkin-tenant-isolation.test.ts` (9 new cases)
- [x] `npm run test` — 661 passed / 24 skipped (full suite)
- [x] `npm run lint` — 0 errors (only pre-existing `i18next/no-literal-string` warnings)
- [x] `npm run typecheck` — clean

## Checklist
- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
