### PR TITLE
fix: scrub PHI from Sentry contexts/tags and harden CMI body size cap

### DIFF
--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -19,16 +19,69 @@ import { cmiCallbackFieldsSchema } from "@/lib/validations";
  *  form-encoded payloads; anything larger is suspicious. */
 const MAX_CMI_CALLBACK_BYTES = 10 * 1024;
 
+/**
+ * S-15: Read the request body while enforcing a hard byte cap. Returns null
+ * if the body exceeds the limit. Works even when the client omits the
+ * Content-Length header (e.g. chunked transfer encoding) because we stream
+ * the body and abort as soon as the cumulative byte count exceeds the cap.
+ */
+async function readBodyWithLimit(
+  request: NextRequest,
+  maxBytes: number,
+): Promise<Uint8Array | null> {
+  const reader = request.body?.getReader();
+  if (!reader) return new Uint8Array(0);
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        // best effort
+      }
+      return null;
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
 export async function POST(request: NextRequest) {
   try {
     // S-15: Enforce a body size cap before parsing formData to prevent
-    // memory exhaustion from an attacker-controlled payload.
+    // memory exhaustion from an attacker-controlled payload. We check
+    // Content-Length first for a cheap early reject, but also enforce the
+    // cap on the actual bytes read — Content-Length is optional and a
+    // client using chunked transfer encoding can omit it entirely.
     const contentLength = request.headers.get("content-length");
     if (contentLength && Number(contentLength) > MAX_CMI_CALLBACK_BYTES) {
       return apiError("Payload too large", 413);
     }
 
-    const formData = await request.formData();
+    const body = await readBodyWithLimit(request, MAX_CMI_CALLBACK_BYTES);
+    if (body === null) {
+      return apiError("Payload too large", 413);
+    }
+
+    const contentType =
+      request.headers.get("content-type") || "application/x-www-form-urlencoded";
+    // Re-parse the size-limited body as formData. TextDecoder is safe here
+    // because CMI callbacks are form-urlencoded (ASCII).
+    const bodyText = new TextDecoder().decode(body);
+    const formData = await new Response(bodyText, {
+      headers: { "content-type": contentType },
+    }).formData();
     const params: Record<string, string> = {};
     formData.forEach((value, key) => {
       params[key] = String(value);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -104,17 +104,40 @@ export function register() {
             event.request.headers = safeHeaders;
           }
         }
-        // Strip known PHI field names from extra/context data.
+        // Strip known PHI field names anywhere arbitrary key/value data is
+        // attached to the event — event.extra, event.contexts (walked
+        // recursively; these may be nested via Sentry.setContext()), and
+        // event.tags (flat via Sentry.setTag()).
         const PHI_KEYS = new Set([
-          "phone", "email", "name", "patientName", "patient_name",
+          "phone", "email", "name", "patientname", "patient_name",
           "name_ar", "full_name", "address", "notes", "content",
           "message", "file_name", "date_of_birth", "dob",
           "insurance_number", "cin", "ssn",
         ]);
-        if (event.extra) {
-          for (const key of Object.keys(event.extra)) {
+        const scrubPHI = (value: unknown, depth = 0): unknown => {
+          if (depth > 10 || value === null || value === undefined) return value;
+          if (Array.isArray(value)) {
+            return value.map((v) => scrubPHI(v, depth + 1));
+          }
+          if (typeof value === "object") {
+            const obj = value as Record<string, unknown>;
+            for (const key of Object.keys(obj)) {
+              if (PHI_KEYS.has(key.toLowerCase())) {
+                obj[key] = "[REDACTED]";
+              } else {
+                obj[key] = scrubPHI(obj[key], depth + 1);
+              }
+            }
+            return obj;
+          }
+          return value;
+        };
+        if (event.extra) scrubPHI(event.extra);
+        if (event.contexts) scrubPHI(event.contexts);
+        if (event.tags) {
+          for (const key of Object.keys(event.tags)) {
             if (PHI_KEYS.has(key.toLowerCase())) {
-              event.extra[key] = "[REDACTED]";
+              event.tags[key] = "[REDACTED]";
             }
           }
         }


### PR DESCRIPTION
Addresses two Rooviewer findings on #466:

- S-35: beforeSend now recursively scrubs PHI_KEYS from event.contexts (nested objects set via Sentry.setContext()) and flat event.tags (set via Sentry.setTag()), in addition to the existing event.extra scrubbing.
- S-15: The Content-Length early-reject is kept, but the callback now also streams the body with a hard byte cap so the limit still applies when Content-Length is absent (e.g. chunked transfer encoding). The cap is enforced on the actual bytes read before formData() is called.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
