### PR TITLE
Address S-24, F-10, O-04 checklist remediations

### DIFF
--- a/src/app/api/__tests__/health-handler.test.ts
+++ b/src/app/api/__tests__/health-handler.test.ts
@@ -36,8 +36,10 @@ describe("GET /api/health — route handler", () => {
     vi.unstubAllEnvs();
   });
 
-  it("returns 200 with degraded status when env vars are missing", async () => {
-    // Ensure Supabase env vars are NOT set
+  it("returns 200 with ok:true when degraded but not down", async () => {
+    // Ensure Supabase env vars are NOT set — this puts the database
+    // check in a "degraded" state, but the overall endpoint still
+    // returns 200 because nothing is fully down.
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
 
@@ -48,11 +50,7 @@ describe("GET /api/health — route handler", () => {
 
     expect(response.status).toBe(200);
     expect(body.ok).toBe(true);
-    // O-04: Public health endpoint returns only ok, status, timestamp
-    // Detailed checks are only exposed via /api/health/internal
-    expect(body.data.ok).toBeDefined();
-    expect(body.data.status).toBeDefined();
-    expect(body.data.timestamp).toBeDefined();
+    expect(body.data.ok).toBe(true);
   });
 
   it("returns response with correct Cache-Control header", async () => {
@@ -65,7 +63,7 @@ describe("GET /api/health — route handler", () => {
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=30");
   });
 
-  it("O-04: does NOT expose granular dependency status to anon callers", async () => {
+  it("O-04: anon response is exactly { ok: boolean } with no extra fields", async () => {
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
     vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
 
@@ -73,22 +71,12 @@ describe("GET /api/health — route handler", () => {
     const response = await GET();
     const body = await response.json();
 
-    // O-04: checks object should NOT be present in public response
-    expect(body.data.checks).toBeUndefined();
-    expect(body.data.ok).toBeDefined();
-    expect(body.data.status).toBeDefined();
-  });
-
-  it("returns ok:true or ok:false based on overall status", async () => {
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "");
-    vi.stubEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "");
-
-    const { GET } = await import("@/app/api/health/route");
-    const response = await GET();
-    const body = await response.json();
-
-    // With missing env vars, status is "degraded" which still means ok:true
-    // (only "down" means ok:false)
+    // O-04: data payload must be exactly { ok: boolean } — no granular
+    // dependency status, no overall status string, and no timestamp.
     expect(typeof body.data.ok).toBe("boolean");
+    expect(Object.keys(body.data)).toEqual(["ok"]);
+    expect(body.data.checks).toBeUndefined();
+    expect(body.data.status).toBeUndefined();
+    expect(body.data.timestamp).toBeUndefined();
   });
 });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -96,15 +96,13 @@ export async function GET() {
       ? "down"
       : "degraded";
 
-  // O-04: Anon /api/health returns only {ok: true/false} and status code.
-  // Detailed dependency checks are exposed only via /api/health/internal
-  // (gated on CRON_SECRET) to prevent information leakage to anon callers.
+  // O-04: Anon /api/health returns only `{ ok: boolean }` plus the HTTP
+  // status code (200 when healthy/degraded, 503 when down). Status
+  // strings, timestamps, and per-dependency detail are reserved for the
+  // gated /api/health/internal endpoint so unauthenticated callers cannot
+  // fingerprint our infrastructure.
   return apiSuccess(
-    {
-      ok: overallStatus !== "down",
-      status: overallStatus,
-      timestamp: new Date().toISOString(),
-    },
+    { ok: overallStatus !== "down" },
     overallStatus === "down" ? 503 : 200,
     { "Cache-Control": "public, max-age=30" },
   );

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -5,6 +5,13 @@
  * POST /api/v1/appointments — Create an appointment
  *
  * Authentication: Bearer token via API key stored in clinic settings.
+ *
+ * S-24 — Pagination: this endpoint uses keyset (cursor) pagination over
+ * `(appointment_date, start_time, id)` rather than offset pagination.
+ * Clients pass the opaque `cursor` returned in `pagination.next_cursor`
+ * back on the following request to fetch the next page. Offset
+ * pagination is no longer supported and the `offset` query parameter is
+ * ignored.
  */
 
 import { NextRequest } from "next/server";
@@ -13,6 +20,7 @@ import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 import { withValidation } from "@/lib/api-validate";
 import { getCorsHeaders, handlePreflight } from "@/lib/cors";
 import { logger } from "@/lib/logger";
+import { decodeCursor, encodeCursor } from "@/lib/pagination";
 import { createTenantClient } from "@/lib/supabase-server";
 import { logTenantContext } from "@/lib/tenant-context";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
@@ -35,17 +43,31 @@ export async function GET(request: NextRequest) {
   const url = new URL(request.url);
   const date = url.searchParams.get("date");
   const status = url.searchParams.get("status");
-  const limit = Math.min(Number(url.searchParams.get("limit") || 50), 100);
-  // S-24: Cap offset to prevent unbounded pagination abuse
-  const rawOffset = Number(url.searchParams.get("offset") || 0);
-  const offset = Math.min(Math.max(0, rawOffset), 10000);
+  const limit = Math.min(Math.max(1, Number(url.searchParams.get("limit") || 50)), 100);
 
+  // S-24: Keyset pagination over (appointment_date, start_time, id).
+  // The cursor is opaque to clients; we encode the last row's sort key
+  // and the next request narrows the result set to rows strictly "older"
+  // than that key in the descending sort order.
+  const cursorParam = url.searchParams.get("cursor");
+  let cursor = null;
+  if (cursorParam) {
+    cursor = decodeCursor(cursorParam);
+    if (!cursor) {
+      return apiError("Invalid cursor", 400, "INVALID_CURSOR", cors);
+    }
+  }
+
+  // Fetch limit+1 so we can tell whether another page exists without an
+  // extra round-trip or a COUNT query.
   let query = supabase
     .from("appointments")
-    .select("*", { count: "exact" })
+    .select("*")
     .eq("clinic_id", auth.clinicId)
     .order("appointment_date", { ascending: false })
-    .range(offset, offset + limit - 1);
+    .order("start_time", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(limit + 1);
 
   if (date) {
     query = query.eq("appointment_date", date);
@@ -54,14 +76,54 @@ export async function GET(request: NextRequest) {
     query = query.eq("status", status);
   }
 
-  const { data, count, error } = await query;
+  if (cursor) {
+    // Row-tuple comparison `(appointment_date, start_time, id) < (cd, ct, ci)`
+    // expressed as the disjunction PostgREST supports via `.or()`.
+    const { appointment_date: cd, start_time: ct, id: ci } = cursor;
+    query = query.or(
+      [
+        `appointment_date.lt.${cd}`,
+        `and(appointment_date.eq.${cd},start_time.lt.${ct})`,
+        `and(appointment_date.eq.${cd},start_time.eq.${ct},id.lt.${ci})`,
+      ].join(","),
+    );
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     logger.warn("Operation failed", { context: "v1/appointments", error });
     return apiInternalError("Failed to fetch appointments");
   }
 
-  return apiSuccess({ data, pagination: { total: count, limit, offset } }, 200, cors);
+  const rows = data ?? [];
+  const hasMore = rows.length > limit;
+  const pageRows = hasMore ? rows.slice(0, limit) : rows;
+  const lastRow = pageRows[pageRows.length - 1];
+  // Guard against the (schema-impossible but type-allowed) case of a
+  // nullable sort key — the columns are ORDER BY targets and rows
+  // missing them cannot meaningfully participate in a cursor.
+  const nextCursor =
+    hasMore &&
+    lastRow &&
+    lastRow.appointment_date &&
+    lastRow.start_time &&
+    lastRow.id
+      ? encodeCursor({
+          appointment_date: lastRow.appointment_date,
+          start_time: lastRow.start_time,
+          id: lastRow.id,
+        })
+      : null;
+
+  return apiSuccess(
+    {
+      data: pageRows,
+      pagination: { limit, next_cursor: nextCursor, has_more: hasMore },
+    },
+    200,
+    cors,
+  );
 }
 
 export const POST = withValidation(v1AppointmentCreateSchema, async (body, request: NextRequest) => {

--- a/src/lib/__tests__/env-email-provider.test.ts
+++ b/src/lib/__tests__/env-email-provider.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { enforceEmailProviderExclusivity } from "../env";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const EMAIL_VARS = [
+  "RESEND_API_KEY",
+  "EMAIL_RELAY_HOST",
+  "EMAIL_RELAY_USER",
+  "EMAIL_RELAY_PASS",
+  "SMTP_HOST",
+  "SMTP_USER",
+  "SMTP_PASS",
+];
+
+function clearEmailEnv() {
+  for (const name of EMAIL_VARS) vi.stubEnv(name, "");
+}
+
+describe("enforceEmailProviderExclusivity (F-10)", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does nothing outside production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    clearEmailEnv();
+    expect(() => enforceEmailProviderExclusivity()).not.toThrow();
+  });
+
+  it("passes in production with only Resend configured", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    clearEmailEnv();
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    expect(() => enforceEmailProviderExclusivity()).not.toThrow();
+  });
+
+  it("passes in production with only the legacy SMTP_* relay configured", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    clearEmailEnv();
+    vi.stubEnv("SMTP_HOST", "smtp.example.com");
+    vi.stubEnv("SMTP_USER", "user");
+    vi.stubEnv("SMTP_PASS", "pass");
+    expect(() => enforceEmailProviderExclusivity()).not.toThrow();
+  });
+
+  it("passes in production with only the EMAIL_RELAY_* relay configured", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    clearEmailEnv();
+    vi.stubEnv("EMAIL_RELAY_HOST", "api.mailgun.net/v3/mg.example.com");
+    vi.stubEnv("EMAIL_RELAY_USER", "user");
+    vi.stubEnv("EMAIL_RELAY_PASS", "pass");
+    expect(() => enforceEmailProviderExclusivity()).not.toThrow();
+  });
+
+  it("throws in production when both Resend and SMTP are configured", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    clearEmailEnv();
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
+    vi.stubEnv("SMTP_HOST", "smtp.example.com");
+    vi.stubEnv("SMTP_USER", "user");
+    vi.stubEnv("SMTP_PASS", "pass");
+    expect(() => enforceEmailProviderExclusivity()).toThrow(
+      /Both Resend[\s\S]*relay[\s\S]*are configured/,
+    );
+  });
+
+  it("throws in production when neither provider is configured", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    clearEmailEnv();
+    expect(() => enforceEmailProviderExclusivity()).toThrow(
+      /No email provider is configured/,
+    );
+  });
+
+  it("treats the relay as unconfigured when only SMTP_HOST is set without credentials", () => {
+    // A partially-configured relay is unusable at runtime, so production
+    // boot must reject this as effectively having no provider.
+    vi.stubEnv("NODE_ENV", "production");
+    clearEmailEnv();
+    vi.stubEnv("SMTP_HOST", "smtp.example.com");
+    expect(() => enforceEmailProviderExclusivity()).toThrow(
+      /No email provider is configured/,
+    );
+  });
+});

--- a/src/lib/__tests__/pagination.test.ts
+++ b/src/lib/__tests__/pagination.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { decodeCursor, encodeCursor } from "../pagination";
+
+describe("encodeCursor / decodeCursor (S-24 keyset pagination)", () => {
+  it("round-trips a valid cursor", () => {
+    const cursor = {
+      appointment_date: "2026-04-15",
+      start_time: "10:00:00",
+      id: "00000000-0000-0000-0000-000000000001",
+    };
+    const encoded = encodeCursor(cursor);
+    expect(decodeCursor(encoded)).toEqual(cursor);
+  });
+
+  it("produces a URL-safe encoding (no '+', '/', or '=')", () => {
+    // Use a payload that, in standard base64, would contain padding and
+    // the URL-unsafe characters.
+    const cursor = {
+      appointment_date: "2026-04-15",
+      start_time: "10:00:00",
+      id: "????>>>><<<<",
+    };
+    const encoded = encodeCursor(cursor);
+    expect(encoded).not.toMatch(/[+/=]/);
+  });
+
+  it("returns null for a malformed cursor", () => {
+    expect(decodeCursor("not-base64!@#")).toBeNull();
+  });
+
+  it("returns null for a base64 string that is not JSON", () => {
+    expect(decodeCursor(Buffer.from("not json").toString("base64url"))).toBeNull();
+  });
+
+  it("returns null when required fields are missing", () => {
+    const partial = Buffer.from(JSON.stringify({ appointment_date: "2026-04-15" })).toString(
+      "base64url",
+    );
+    expect(decodeCursor(partial)).toBeNull();
+  });
+
+  it("rejects cursors that contain PostgREST filter delimiters", () => {
+    // S-24: cursor values are interpolated into a PostgREST `or()` filter.
+    // The decoder must reject `,`, `(`, `)` so a hostile cursor cannot
+    // smuggle additional filters into the query.
+    const malicious = Buffer.from(
+      JSON.stringify({
+        appointment_date: "2026-04-15",
+        start_time: "10:00:00",
+        id: "abc),or(clinic_id.eq.other",
+      }),
+    ).toString("base64url");
+    expect(decodeCursor(malicious)).toBeNull();
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -319,8 +319,14 @@ export function enforceRateLimitBackend(): void {
 }
 
 /**
- * F-10: Ensure exactly one email provider is configured. Having both
- * RESEND_API_KEY and SMTP_HOST set risks duplicate emails.
+ * F-10: Ensure exactly one email provider is configured at production boot.
+ *
+ * Refuses to start when both Resend and the HTTP relay (SMTP_HOST /
+ * EMAIL_RELAY_HOST) are configured (risks duplicate sends and ambiguous
+ * routing) or when neither is configured (transactional email silently
+ * fails). The "configured" check for the HTTP relay matches the runtime
+ * detection in `src/lib/email.ts` — host + user + pass must all be set,
+ * since any single one is unusable on its own.
  *
  * Exported for unit tests.
  */
@@ -328,13 +334,27 @@ export function enforceEmailProviderExclusivity(): void {
   if (process.env.NODE_ENV !== "production") return;
 
   const hasResend = !!process.env.RESEND_API_KEY;
-  const hasSmtp = !!process.env.SMTP_HOST;
+  const hasSmtp = !!(
+    (process.env.EMAIL_RELAY_HOST || process.env.SMTP_HOST) &&
+    (process.env.EMAIL_RELAY_USER || process.env.SMTP_USER) &&
+    (process.env.EMAIL_RELAY_PASS || process.env.SMTP_PASS)
+  );
 
   if (hasResend && hasSmtp) {
     const message =
-      "[STARTUP HEALTH CHECK WARNING] Both RESEND_API_KEY and SMTP_HOST are configured.\n" +
-      "This risks sending duplicate emails. Configure exactly one email provider.";
-    logger.warn(message, { context: "env-validation", check: "email-provider-exclusivity" });
-    // Warn rather than throw — this is a configuration smell, not a security failure.
+      "[STARTUP HEALTH CHECK FAILED] Both Resend (RESEND_API_KEY) and the HTTP email relay\n" +
+      "(EMAIL_RELAY_HOST/SMTP_HOST + USER + PASS) are configured. Configure exactly one email\n" +
+      "provider — having both risks duplicate sends and ambiguous routing.";
+    logger.error(message, { context: "env-validation", check: "email-provider-exclusivity" });
+    throw new Error(message);
+  }
+
+  if (!hasResend && !hasSmtp) {
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] No email provider is configured. Set either\n" +
+      "RESEND_API_KEY or the HTTP email relay credentials\n" +
+      "(EMAIL_RELAY_HOST/SMTP_HOST + EMAIL_RELAY_USER/SMTP_USER + EMAIL_RELAY_PASS/SMTP_PASS).";
+    logger.error(message, { context: "env-validation", check: "email-provider-exclusivity" });
+    throw new Error(message);
   }
 }

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,73 @@
+/**
+ * Keyset (cursor) pagination helpers for the public REST API.
+ *
+ * Offset pagination has two well-known problems on healthcare workloads:
+ *
+ *   1. Performance — `OFFSET N` forces Postgres to read and discard N rows
+ *      before returning a page, which is O(N) per request.
+ *   2. Correctness — concurrent inserts/deletes shift items between pages,
+ *      so clients can see duplicates or miss rows entirely as they paginate.
+ *
+ * Keyset pagination encodes the sort key of the last row as an opaque
+ * cursor and uses a row-comparison predicate to fetch strictly "older"
+ * rows on the next page.
+ *
+ * For appointments the natural sort key is the tuple
+ * `(appointment_date, start_time, id)` — `id` is the tiebreaker so the
+ * predicate is total even when two appointments share a date and time.
+ */
+
+export interface AppointmentCursor {
+  /** ISO date string `YYYY-MM-DD` (matches `appointments.appointment_date`). */
+  appointment_date: string;
+  /** Time string `HH:MM[:SS]` (matches `appointments.start_time`). */
+  start_time: string;
+  /** Row primary key — tiebreaker for rows with identical date+time. */
+  id: string;
+}
+
+/**
+ * Encode a cursor as a URL-safe base64 string. Opaque to clients — they
+ * should treat the value as a black box and only round-trip it back as
+ * the `cursor` query parameter on the next request.
+ */
+export function encodeCursor(cursor: AppointmentCursor): string {
+  const json = JSON.stringify(cursor);
+  return Buffer.from(json, "utf8")
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Decode a cursor produced by `encodeCursor`. Returns `null` when the
+ * value is malformed so the route can respond with 400 rather than
+ * leaking parser errors to the client.
+ */
+export function decodeCursor(value: string): AppointmentCursor | null {
+  try {
+    const padded = value.replaceAll("-", "+").replaceAll("_", "/");
+    const json = Buffer.from(padded, "base64").toString("utf8");
+    const parsed: unknown = JSON.parse(json);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as Record<string, unknown>).appointment_date === "string" &&
+      typeof (parsed as Record<string, unknown>).start_time === "string" &&
+      typeof (parsed as Record<string, unknown>).id === "string"
+    ) {
+      const c = parsed as AppointmentCursor;
+      // Defensive validation — these values are interpolated into a
+      // PostgREST `or()` filter, so reject anything that contains the
+      // delimiters PostgREST uses to separate filters.
+      if (/[,()]/.test(c.appointment_date) || /[,()]/.test(c.start_time) || /[,()]/.test(c.id)) {
+        return null;
+      }
+      return c;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Three checklist items called out as "Partial" are upgraded to fully match the remediation specs.

- **S-24** — `GET /api/v1/appointments` now uses keyset (cursor) pagination over the natural sort tuple `(appointment_date, start_time, id)` instead of offset pagination. The cursor is opaque, URL-safe base64 (`encodeCursor` / `decodeCursor` in `src/lib/pagination.ts`). The 10 000-row offset cap and the `offset` parameter are gone; the response shape is `{ data, pagination: { limit, next_cursor, has_more } }`. The decoder rejects values containing PostgREST filter delimiters (`,`, `(`, `)`) so a hostile cursor cannot smuggle additional filters into the `or()` clause used for the row-tuple comparison.
- **F-10** — `enforceEmailProviderExclusivity` (called from `enforceEnvValidation` in `src/lib/env.ts`) now **throws at production boot** when both Resend and the HTTP email relay are configured, *or* when neither is configured. It previously only logged a warning. The "relay configured" check matches the runtime detection in `src/lib/email.ts` (host + user + pass — any partial set is unusable and treated as no provider).
- **O-04** — `GET /api/health` (anon) now returns exactly `{ ok: boolean }` with HTTP 200 (healthy/degraded) or 503 (down). The `status` string and `timestamp` were stripped along with the previously-removed per-dependency detail. Granular checks remain on the `CRON_SECRET`-gated `GET /api/health/internal`.

## Type of change

- [x] Bug fix

## Security Impact

- [x] No security impact

The changes are defense-in-depth (less surface info via `/api/health`, hostile cursor rejection, fail-fast on email-provider misconfiguration). Tenant isolation is unchanged — the appointments query still chains `.eq("clinic_id", auth.clinicId)` exactly as before.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated

- New: `src/lib/__tests__/pagination.test.ts` — round-trip, URL-safety, malformed-cursor, and PostgREST-injection-rejection cases for the cursor codec.
- New: `src/lib/__tests__/env-email-provider.test.ts` — covers production-only enforcement, single-provider success cases (Resend, legacy `SMTP_*`, `EMAIL_RELAY_*`), and the new throw-on-both / throw-on-neither / partial-relay cases.
- Updated: `src/app/api/__tests__/health-handler.test.ts` — asserts the public response is exactly `{ ok: boolean }` with no extra keys.

Local results: `npx tsc --noEmit` clean, `npm run lint` clean (existing `i18next/no-literal-string` warnings only — no new errors), `npx vitest run` 663 passed / 24 skipped.

## Observability

- [x] N/A — no observability changes

The new env-validation failures use `logger.error` and throw, matching the surrounding `enforce*` helpers.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints)

### Client migration note (S-24)

`GET /api/v1/appointments` previously accepted `?offset=N` and returned `{ data, pagination: { total, limit, offset } }`. The `offset` parameter is now ignored and `total` is no longer returned (it required a separate `count: "exact"` query that is unnecessary for keyset pagination). Clients should:

1. Read `pagination.next_cursor` from each response.
2. Pass it back as `?cursor=<value>` on the following request.
3. Stop when `next_cursor` is `null` (or `pagination.has_more` is `false`).
