### PR TITLE
CI-11: auto-rollback Worker on failed health check + document DB rollback constraints

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,7 @@ jobs:
           STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
 
       - name: Deploy to Cloudflare Workers (Production)
+        id: deploy_production
         if: github.ref_name == 'main'
         uses: cloudflare/wrangler-action@392082e815bfc9e70d4d8011e40fb8779b5c1564 # v3.14.0
         with:
@@ -79,6 +80,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy to Cloudflare Workers (Staging)
+        id: deploy_staging
         if: github.ref_name == 'staging'
         uses: cloudflare/wrangler-action@392082e815bfc9e70d4d8011e40fb8779b5c1564 # v3.14.0
         with:
@@ -88,7 +90,14 @@ jobs:
 
       # CI-07: Post-deploy health check verifies response body markers,
       # not just HTTP status, to catch deploy-but-broken scenarios.
+      #
+      # CI-11: `continue-on-error: true` lets the job proceed to the
+      # auto-rollback step below when this check fails. The final
+      # "Fail workflow on health check failure" step still surfaces the
+      # failure so the deploy run is correctly marked red.
       - name: Health Check
+        id: health
+        continue-on-error: true
         run: |
           SITE_URL="${{ github.ref_name == 'staging' && 'https://staging.oltigo.com' || 'https://oltigo.com' }}"
           echo "Running health check against ${SITE_URL}..."
@@ -104,4 +113,69 @@ jobs:
             sleep 10
           done
           echo "Health check FAILED after 5 attempts — response body did not contain {\"ok\":true}"
+          exit 1
+
+      # CI-11: Auto-rollback to the previous Cloudflare Worker version when
+      # the post-deploy health check fails. `wrangler rollback` defaults to
+      # the immediately previous deployment when no deployment id is given.
+      # Piping `yes` answers the interactive confirmation prompt that
+      # wrangler emits even when --message is supplied.
+      #
+      # IMPORTANT: this only rolls back the Worker (code + bindings). It
+      # does NOT roll back any database migrations that ran as part of the
+      # release — see docs/db-rollback-constraints.md for the manual
+      # procedures that DB changes require.
+      - name: Auto-rollback Worker on failed health check
+        id: rollback
+        if: steps.health.outcome == 'failure'
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ "${{ github.ref_name }}" = "staging" ]; then
+            WORKER_NAME="webs-alots-staging"
+          else
+            WORKER_NAME="webs-alots"
+          fi
+          echo "::warning::Health check failed — rolling back ${WORKER_NAME} to the previous Cloudflare Worker version"
+          yes | npx wrangler rollback \
+            --name "${WORKER_NAME}" \
+            --message "Auto-rollback: post-deploy health check failed (commit ${{ github.sha }}, run ${{ github.run_id }})"
+
+      # CI-11: Confirm the previous version is healthy after rollback.
+      # If the rollback target is also broken, we want the run to clearly
+      # flag that manual intervention is required.
+      - name: Verify rollback health
+        id: rollback_health
+        if: always() && steps.health.outcome == 'failure' && steps.rollback.outcome == 'success'
+        run: |
+          SITE_URL="${{ github.ref_name == 'staging' && 'https://staging.oltigo.com' || 'https://oltigo.com' }}"
+          echo "Verifying rollback health against ${SITE_URL}..."
+          for i in 1 2 3 4 5; do
+            BODY=$(curl -s --max-time 10 "${SITE_URL}/api/health" || echo "")
+            STATUS=$(echo "$BODY" | grep -o '"ok":\s*true' || echo "")
+            HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${SITE_URL}/api/health" || echo "000")
+            if [ -n "$STATUS" ] && [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 400 ]; then
+              echo "Rollback verified — previous version is healthy (HTTP ${HTTP_CODE})"
+              exit 0
+            fi
+            echo "Verify attempt ${i}: HTTP ${HTTP_CODE}, body ok marker: '${STATUS}', retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Rollback completed but the previous version is also unhealthy. Manual intervention required — see docs/db-rollback-constraints.md and docs/incident-response.md."
+          exit 1
+
+      # CI-11: Always fail the workflow if the original health check failed,
+      # regardless of whether the rollback succeeded. The deploy is broken
+      # and on-call needs a red signal even when the Worker has been
+      # automatically reverted.
+      - name: Fail workflow on health check failure
+        if: always() && steps.health.outcome == 'failure'
+        run: |
+          if [ "${{ steps.rollback.outcome }}" = "success" ]; then
+            echo "::error::Deploy was rolled back to the previous Worker version because the post-deploy health check failed. Investigate the failed commit (${{ github.sha }}) before re-deploying. DB migrations from this release are NOT reverted — see docs/db-rollback-constraints.md."
+          else
+            echo "::error::Post-deploy health check FAILED and the automatic rollback also failed. Production may be broken — follow docs/incident-response.md and consider running scripts/staging-swap.sh --rollback manually."
+          fi
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - API route handler tests for booking/cancel and impersonate endpoints (testing actual handlers, not just schemas)
 - Integration tests for prescription-to-notification and clinic onboarding flows
 - "How to obtain" links in `.env.example` for third-party service credentials
+- CI-11: Auto-rollback to the previous Cloudflare Worker version when the post-deploy health check fails. The deploy workflow runs `wrangler rollback`, verifies the previous version is healthy, and still fails the run so on-call gets a red signal.
+- `docs/db-rollback-constraints.md` documenting why database migrations are forward-only, what the auto-rollback does and does not revert, the expand-migrate-contract pattern required for schema changes, and the manual recovery procedures when a Worker rollback is insufficient.
 
 ### Changed
 

--- a/docs/db-rollback-constraints.md
+++ b/docs/db-rollback-constraints.md
@@ -1,0 +1,187 @@
+# Database Rollback Constraints
+
+> **Audience:** Platform operators, on-call engineers, agents shipping schema changes
+> **Last updated:** April 2026
+> **Related:** [`backup-recovery-runbook.md`](./backup-recovery-runbook.md), [`incident-response.md`](./incident-response.md), [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml), [`scripts/staging-swap.sh`](../scripts/staging-swap.sh)
+
+---
+
+## TL;DR
+
+- **Worker code is rolled back automatically** by the deploy pipeline (CI-11) when the post-deploy health check fails.
+- **Database migrations are NOT rolled back automatically.** Migrations in `supabase/migrations/` are append-only and forward-only.
+- A Worker rollback **may leave the previous Worker code running against a newer database schema**. The application contract therefore requires every migration to be backwards-compatible with the previous Worker version (expand → migrate → contract).
+- If a release introduces a migration that is incompatible with the previous Worker, an automatic Worker rollback **will not restore service**; on-call must follow the manual procedures in this doc.
+
+---
+
+## 1. Why Migrations Are Forward-Only
+
+The `supabase/migrations/` directory uses sequential, immutable filenames (`00060_…`, `00061_…`, …). The platform applies migrations through Supabase's standard migration tooling, which:
+
+1. Tracks applied migrations in `supabase_migrations.schema_migrations`.
+2. Has **no `down`/`revert` step** — there is no symmetric `00060_revert.sql`.
+3. Relies on application-level coordination for compatibility, not transactional schema swaps.
+
+Auto-generated reverse migrations are **not safe** in this codebase because:
+
+- **PHI is encrypted column-by-column.** Reversing a column rename or type change can desynchronise ciphertext from the IV/key metadata stored alongside it.
+- **RLS policies depend on column names and shapes.** Reversing a schema change without simultaneously reverting the corresponding RLS policy migration leaves rows either unreachable (over-restrictive) or globally readable (under-restrictive).
+- **Multi-tenant data has no global rollback target.** Different clinics may have written tenant-scoped rows under the new schema before the rollback fires; reversing the schema would lose or corrupt those writes.
+- **Cron and Worker bindings are versioned with the schema.** A `wrangler rollback` reverts only the Worker; the database remains on the new schema.
+
+For these reasons, **every migration in this repo must be designed so that the previous Worker version continues to function against it**. This is enforced by code review and by the migration check workflow (`.github/workflows/migration-check.yml`).
+
+---
+
+## 2. What an Auto-Rollback Does and Does NOT Do
+
+The deploy pipeline (`.github/workflows/deploy.yml`, CI-11) takes the following actions when the post-deploy health check fails:
+
+| Action | Reverted? | Notes |
+|---|---|---|
+| Worker code (JS bundle from `npm run build:cf`) | ✅ Yes | `wrangler rollback` restores the immediately previous Worker version. |
+| Worker bindings declared in `wrangler.toml` (R2, KV, Queues) | ✅ Yes | Rolled back as part of the Worker version. |
+| Worker secrets (`wrangler secret put`) | ❌ **No** | Secrets are stored separately and persist across rollbacks. Re-running `update-secrets.yml` is required if a release changed secret values. |
+| Cron triggers in `wrangler.toml` | ✅ Yes | Bound to the Worker version. |
+| Cloudflare KV / R2 contents written during the bad release | ❌ **No** | Stored externally; not versioned with the Worker. |
+| Supabase schema migrations applied during the release | ❌ **No** | Forward-only — see Section 3 for manual procedures. |
+| Supabase row data written during the bad release | ❌ **No** | Restore from the nightly pg_dump (see [`backup-recovery-runbook.md`](./backup-recovery-runbook.md) §4.1) if corruption is suspected. |
+| WhatsApp / Twilio template approvals | ❌ **No** | External provider state. |
+| R2 lifecycle rules (`scripts/apply-r2-lifecycle.mjs`) | ❌ **No** | Applied imperatively, not versioned with the Worker. |
+
+**Implication:** the auto-rollback is sufficient when a release contains only Worker code changes. As soon as a release also contains a schema migration, secret rotation, KV write, or R2 lifecycle change, the rollback is **partial** and on-call must finish the rollback by hand using the procedures below.
+
+---
+
+## 3. Required Migration Patterns (Expand → Migrate → Contract)
+
+To keep auto-rollback safe, every migration that changes a published surface (table column, RLS policy, RPC, enum) must be split across **at least two releases**:
+
+### 3.1 Adding a column
+
+1. **Release N (expand):** add the column as `NULL`able with a default. Do not yet read it from the application.
+2. **Release N+1 (migrate):** start writing to the column from the application. Backfill old rows in a separate, idempotent migration.
+3. **Release N+2 (contract):** if the column should be `NOT NULL`, add the constraint only after the backfill is verified.
+
+A rollback at any stage leaves the previous Worker reading either no data (stage 1 → 0) or the same data it always read (stage 2 → 1).
+
+### 3.2 Renaming a column
+
+1. **Release N:** add the new column. Write to **both** old and new columns from the application. Read from the old column.
+2. **Release N+1:** backfill the new column. Switch reads to the new column. Continue dual-writing.
+3. **Release N+2:** stop writing to the old column.
+4. **Release N+3:** drop the old column.
+
+A rollback from N+1 → N is safe because both columns still exist and the old column is still authoritative for the previous Worker.
+
+### 3.3 Changing a column type
+
+Treat as a rename: add a new column with the new type, dual-write, backfill, switch reads, drop the old column. Never `ALTER COLUMN … TYPE` in place — that is not reversible without data loss.
+
+### 3.4 Modifying RLS policies
+
+1. **Release N:** add the new policy alongside the old one (`CREATE POLICY` is additive — `OR` semantics apply).
+2. **Release N+1:** drop the old policy.
+
+Rolling back from N+1 → N restores the old policy automatically because it never moved. Rolling back from N → N-1 is safe because the new policy was strictly additive.
+
+### 3.5 Dropping a table or column
+
+Never drop in the same release that stops writing to the table/column. Always wait at least one full release cycle, and document the contract change in `CHANGELOG.md` under **Removed**.
+
+### 3.6 Enums
+
+`ALTER TYPE … ADD VALUE` is forward-only and **cannot be removed** in PostgreSQL without recreating the type. Adding enum values is therefore safe; removing them is not. If a value must be deprecated, retire it at the application layer first and leave the enum value in place indefinitely.
+
+### 3.7 Tenant-scoped tables
+
+Every new table must include `clinic_id` and an RLS policy in the **same** migration file (audit requirement). A rollback that reverts only the Worker leaves the table in place; this is acceptable because the RLS policy keeps it inaccessible across tenants.
+
+---
+
+## 4. Manual Recovery Procedures
+
+When the auto-rollback fires but a migration in the failed release is incompatible with the previous Worker, the previous Worker will start serving but errors will continue (e.g. `column does not exist`, RLS denials, RPC `function not found`). Follow this decision tree:
+
+### 4.1 Decision tree
+
+```
+post-deploy health check failed
+        │
+        ▼
+auto-rollback ran  ──── no  ──▶  run scripts/staging-swap.sh --rollback manually
+        │ yes
+        ▼
+verify rollback health
+        │
+        ▼
+healthy?  ──── yes ──▶ investigate failed commit, fix forward, redeploy
+        │ no
+        ▼
+did the failed release include a migration?
+        │
+        ▼
+yes ──▶ §4.2 (forward-fix migration) — DO NOT pg_restore unless data corruption is confirmed
+        │
+no  ──▶ §4.3 (rollback target is also broken — pre-existing bug)
+```
+
+### 4.2 Forward-fix a broken migration
+
+1. **Stop writes** if the schema is causing data corruption (toggle the maintenance flag in `FEATURE_FLAGS_KV` or scale Worker invocations to zero — see [`docs/incident-response.md`](./incident-response.md)).
+2. **Diagnose** the incompatibility:
+   ```bash
+   # Inspect the most recent migrations applied to production
+   psql "$SUPABASE_DB_URL" -c \
+     "SELECT version, name, executed_at FROM supabase_migrations.schema_migrations
+      ORDER BY executed_at DESC LIMIT 5;"
+   ```
+3. **Write a compensating migration** under a new, higher number (`00069_fix_<thing>.sql`). For example, if the bad migration renamed a column the previous Worker still reads, the fix is to **re-add** the old column as a generated/aliased column and backfill from the new column.
+4. **Deploy the fix** through the normal pipeline. The auto-rollback will not fire again because the previous (now current) Worker is healthy against the patched schema.
+5. **Never edit or delete the offending migration file.** Migration history is append-only — editing it desyncs `schema_migrations` across environments.
+
+### 4.3 Restore from backup (data corruption only)
+
+Use this only when you have confirmed that the failed release wrote corrupt or PII-leaking data that cannot be quarantined at the application layer. **Schema problems alone do not justify a restore — fix forward instead.**
+
+Follow the procedure in [`backup-recovery-runbook.md`](./backup-recovery-runbook.md) §4.1 (R2 nightly dump) or §4.2 (Supabase PITR). Both procedures restore the **entire database to a point in time** — all writes after the restore point will be lost across **all clinics**, so this is a last resort.
+
+### 4.4 Secret rotation rollback
+
+`wrangler rollback` does not revert secrets. If the failed release also rotated a secret (e.g. PHI key, WhatsApp token, Stripe webhook secret), follow the SOP that owns that secret:
+
+- PHI key: [`docs/SOP-PHI-KEY-ROTATION.md`](./SOP-PHI-KEY-ROTATION.md)
+- General secrets: [`docs/SOP-SECRET-ROTATION.md`](./SOP-SECRET-ROTATION.md)
+- VAPID (web push): [`docs/SOP-VAPID-ROTATION.md`](./SOP-VAPID-ROTATION.md)
+
+Rotating back to the previous secret is usually possible only if the old secret value was preserved (it should be — see the SOPs).
+
+---
+
+## 5. Pre-Release Checklist for Schema Changes
+
+Before merging a PR that touches `supabase/migrations/`, confirm:
+
+- [ ] The migration is **additive** or follows the expand-migrate-contract pattern (§3).
+- [ ] The previous Worker version (one commit behind `main` / `staging`) **continues to function** against the new schema.
+- [ ] New tables include `clinic_id` and an RLS policy in the same migration.
+- [ ] No `ALTER COLUMN … TYPE` in place; no `DROP COLUMN` in the same release that stops writing to it.
+- [ ] No enum values are removed (only added).
+- [ ] The `CHANGELOG.md` entry calls out any contract change so on-call knows the auto-rollback may be insufficient.
+- [ ] If the change is destructive (`DROP TABLE`, `DROP COLUMN`), the PR description includes a **manual rollback plan** the on-call can execute.
+
+---
+
+## 6. Why We Don't Auto-Revert Migrations
+
+Several alternatives were considered and rejected:
+
+| Approach | Why it was rejected |
+|---|---|
+| Symmetric `down` migrations | Cannot reliably reverse PHI re-encryption, enum additions, RLS policy interactions, or tenant-scoped writes that occurred between the migration and the rollback. |
+| Snapshot-and-restore on every deploy | Supabase Pro does not offer per-deploy snapshots; PITR is minute-granular at best and restoring drops cross-tenant data. |
+| Blue/green schema (parallel databases) | Would require dual-writing all PHI, doubling encryption-key surface area and breaking single-source-of-truth audit logs. |
+| `wrangler rollback` extended to drive Supabase | Cloudflare Workers cannot transactionally coordinate with Postgres; partial failures would leave the system in a worse state than a Worker-only rollback. |
+
+The chosen contract — **forward-only migrations + Worker-only auto-rollback + expand-migrate-contract discipline** — keeps the rollback fast and side-effect-free in the common case, and pushes the rare incompatible-schema case to a documented manual procedure.


### PR DESCRIPTION
## Summary

Adds automatic rollback of the Cloudflare Worker to its previous version when the post-deploy health check fails, and documents why database migrations are NOT rolled back automatically along with the manual procedures required when a Worker rollback alone is insufficient.

### `.github/workflows/deploy.yml`

The post-deploy `Health Check` step (CI-07) used to simply `exit 1` on failure, leaving a broken Worker live until on-call ran `scripts/staging-swap.sh --rollback` by hand. The deploy job now:

1. Runs the existing health check with `continue-on-error: true` and `id: health` so the job can react to its outcome.
2. **Auto-rollback Worker on failed health check** — when `steps.health.outcome == 'failure'`, runs `npx wrangler rollback --name <worker> --message "Auto-rollback: ..."` for `webs-alots` (production) or `webs-alots-staging` (staging). `yes |` answers the interactive confirmation prompt that wrangler emits in CI even when `--message` is supplied.
3. **Verify rollback health** — re-runs the same `/api/health` body-marker check (5 attempts × 10 s) against the rolled-back Worker. If the previous version is also unhealthy, an `::error::` annotation tells on-call manual intervention is required.
4. **Fail workflow on health check failure** — uses `if: always() && steps.health.outcome == 'failure'` to ensure the run is still marked red even when the rollback succeeds, so on-call gets a clear signal.

### `docs/db-rollback-constraints.md` (new)

Captures the contract that the auto-rollback relies on:

- Why migrations are forward-only (PHI re-encryption, RLS coupling, multi-tenant writes, no transactional schema swap with Workers).
- Exactly what `wrangler rollback` reverts and what it does **not** (secrets, KV/R2 contents, schema migrations, external provider state).
- The expand → migrate → contract pattern required for safe schema changes (adding columns, renaming, type changes, RLS policies, drops, enums, tenant-scoped tables).
- Decision tree and procedures for manual recovery when a release contains an incompatible migration: forward-fix migrations, restore from R2 nightly dump (last resort), and secret-rotation rollback links.
- Pre-release checklist for migration PRs.
- Why alternatives (symmetric `down` migrations, blue/green schema, snapshot-and-restore on every deploy) were rejected.

The deploy workflow comments cross-reference this doc so on-call can find it from a failed run.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

Manual verification:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — workflow YAML parses.
- Walked the step-id graph to confirm `if:` guards (`always()` where required) make the rollback / verify / final-fail steps run on the correct outcomes.
- `npm run lint` passes (0 errors, only pre-existing warnings; YAML and Markdown changes don't affect ESLint).

End-to-end behaviour can only be exercised against a real Cloudflare account, so it is not unit-tested. The wrangler invocation matches the existing `scripts/staging-swap.sh --rollback` pattern (`npx wrangler rollback --name <worker>`), which is already in production use for manual rollbacks.

## Observability

- [ ] This PR adds/modifies logging (structured via `@/lib/logger`)
- [ ] This PR changes Sentry configuration or error handling
- [x] N/A — no observability changes

The rollback step emits `::warning::` and `::error::` annotations so the GitHub Actions UI surfaces the rollback events at the top of the run.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (no TS files changed)
- [x] Coverage thresholds still met (`npm run test:coverage`) — no test files changed
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints) — no API endpoints added

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/472" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
