### PR TITLE
ci: harden rate-limit guard, gate cosign on non-fork PRs, drop redundant test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Run unit tests
-        run: npm run test
-
       # CI-08: Coverage thresholds are defined in vitest.config.ts and
       # enforced here. @vitest/coverage-v8 is a devDependency installed by
       # `npm ci` above; failing this step blocks the PR.
@@ -145,7 +142,11 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.1
 
+      # Skip on fork PRs: keyless cosign signing requires an OIDC token,
+      # which GitHub does not issue to workflows triggered by pull_request
+      # events from forks (id-token permissions are read-only there).
       - name: Sign SBOM with cosign (keyless)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           COSIGN_EXPERIMENTAL: "true"
         run: |
@@ -157,7 +158,10 @@ jobs:
       # The attestation is uploaded to the GitHub attestations API and can
       # be verified later with `gh attestation verify bom.json --repo
       # ${{ github.repository }}`.
+      # Same fork-PR limitation as the cosign step above: the build
+      # provenance API needs a writable id-token / attestations token.
       - name: Attest SBOM build provenance (SLSA)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/attest-build-provenance@v3.1.0
         with:
           subject-path: bom.json

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -311,12 +311,15 @@ export function enforceRateLimitBackend(): void {
   if (
     process.env.NODE_ENV === "production" &&
     backend === "memory" &&
-    process.env.CI !== "true"
+    process.env.GITHUB_ACTIONS !== "true"
   ) {
-    // CI runs `next start` (NODE_ENV=production) on a single instance for
-    // E2E tests, where in-memory rate limiting is acceptable. The
-    // production guard still applies to real deployments (no CI=true on
-    // Cloudflare Workers / staging / prod).
+    // GitHub Actions runs `next start` (NODE_ENV=production) on a single
+    // instance for E2E tests, where in-memory rate limiting is acceptable.
+    // We gate on GITHUB_ACTIONS rather than the generic CI variable
+    // because CI=true is easy to set accidentally on a real deployment;
+    // GITHUB_ACTIONS is only set inside GitHub-hosted runners, so the
+    // production guard still applies to Cloudflare Workers / staging /
+    // prod even if a deploy script happens to export CI=true.
     const message =
       "[STARTUP HEALTH CHECK FAILED] RATE_LIMIT_BACKEND=memory is not allowed in production.\n" +
       "In-memory rate limiting is per-isolate and provides no real protection in a " +


### PR DESCRIPTION
## Summary

Follow-up to #473 addressing three Devin Review findings that landed after the merge.

1. **`enforceRateLimitBackend()` (src/lib/env.ts)** — switch the production memory-rate-limit bypass from the generic `CI=true` to `GITHUB_ACTIONS=true`. `CI` is easy to set accidentally on a real deployment; `GITHUB_ACTIONS` is only present inside GitHub-hosted runners, so the production guard still applies to Cloudflare Workers / staging / prod even if a deploy script happens to export `CI=true`.
2. **Cosign + SLSA attestation steps (.github/workflows/ci.yml)** — gate the `Sign SBOM with cosign (keyless)` and `Attest SBOM build provenance (SLSA)` steps on `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`. Pull_request events from forks do not get a writable id-token, so without this gate the security job hard-fails for any external contributor.
3. **Redundant unit-test step (.github/workflows/ci.yml)** — remove the `Run unit tests` step. The next step, `Run coverage check` (`npm run test:coverage` → `vitest run --coverage`), already runs the full Vitest suite *and* enforces the coverage thresholds. Running both was executing every test twice.

## Type of change

- [x] Infrastructure / CI

## Security Impact

- [x] No security impact

The rate-limit guard change *tightens* the production check (narrower bypass condition); it does not weaken any deployment.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npx tsc --noEmit` clean locally.

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
