### PR TITLE
fix(security): enforce PHI_ENCRYPTION_KEY at startup + canonical PHI category list (C-08)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,11 @@
+# Allowlisted gitleaks fingerprints.
+# Format: <commit-sha>:<file>:<rule-id>:<line>
+#
+# These are false positives from the test fixtures used in
+# `src/lib/__tests__/env-phi-encryption.test.ts`. The original commit
+# (a2c1bd63...) contained 16-char hex literals (".repeat(4)") that gitleaks
+# matched as `generic-api-key`. The literals were never real secrets and
+# have since been replaced with `crypto.randomBytes(32).toString("hex")`
+# at runtime, but the historical commit still trips the scanner.
+a2c1bd63387d9939dcda9b3d197c9452cdb60ba0:src/lib/__tests__/env-phi-encryption.test.ts:generic-api-key:60
+a2c1bd63387d9939dcda9b3d197c9452cdb60ba0:src/lib/__tests__/env-phi-encryption.test.ts:generic-api-key:66

--- a/src/lib/__tests__/encryption.test.ts
+++ b/src/lib/__tests__/encryption.test.ts
@@ -103,6 +103,24 @@ describe("encryption - requiresEncryption", () => {
     expect(requiresEncryption("patient-files")).toBe(true);
   });
 
+  // Audit Finding C-08: hyphen / underscore / case variants must all
+  // resolve to the same encryption decision so a typo or stray
+  // capitalization does not bypass PHI encryption.
+  it("normalizes hyphens, underscores, and case for PHI categories", async () => {
+    const { requiresEncryption } = await import("../encryption");
+
+    expect(requiresEncryption("X-Rays")).toBe(true);
+    expect(requiresEncryption("X_RAYS")).toBe(true);
+    expect(requiresEncryption("xrays")).toBe(true); // legacy no-separator form
+    expect(requiresEncryption("Lab-Results")).toBe(true);
+    expect(requiresEncryption("PATIENT_FILES")).toBe(true);
+    // Categories shared with LIMITS_BY_CATEGORY in upload route that were
+    // historically missing from the PHI set:
+    expect(requiresEncryption("lab_report")).toBe(true);
+    expect(requiresEncryption("lab-report")).toBe(true);
+    expect(requiresEncryption("radiology")).toBe(true);
+  });
+
   it("does not encrypt non-PHI categories", async () => {
     const { requiresEncryption } = await import("../encryption");
 

--- a/src/lib/__tests__/env-phi-encryption.test.ts
+++ b/src/lib/__tests__/env-phi-encryption.test.ts
@@ -1,5 +1,12 @@
+import { randomBytes } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { enforcePhiEncryptionConfigured } from "../env";
+
+// Generate hex keys at runtime so no high-entropy literal lives in the source
+// tree (keeps gitleaks happy on this test file).
+const makeHexKey = (): string => randomBytes(32).toString("hex");
+const makeUpperHexKey = (): string =>
+  randomBytes(32).toString("hex").toUpperCase();
 
 vi.mock("../logger", () => ({
   logger: {
@@ -57,13 +64,13 @@ describe("enforcePhiEncryptionConfigured (Audit C-08)", () => {
 
   it("accepts a 64-char hex key in production", () => {
     vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("PHI_ENCRYPTION_KEY", "0123456789abcdef".repeat(4));
+    vi.stubEnv("PHI_ENCRYPTION_KEY", makeHexKey());
     expect(() => enforcePhiEncryptionConfigured()).not.toThrow();
   });
 
   it("accepts a mixed-case hex key", () => {
     vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("PHI_ENCRYPTION_KEY", "ABCDEF0123456789".repeat(4));
+    vi.stubEnv("PHI_ENCRYPTION_KEY", makeUpperHexKey());
     expect(() => enforcePhiEncryptionConfigured()).not.toThrow();
   });
 });

--- a/src/lib/__tests__/env-phi-encryption.test.ts
+++ b/src/lib/__tests__/env-phi-encryption.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { enforcePhiEncryptionConfigured } from "../env";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("enforcePhiEncryptionConfigured (Audit C-08)", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not throw outside production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "");
+    expect(() => enforcePhiEncryptionConfigured()).not.toThrow();
+  });
+
+  it("does not throw outside production even when key is invalid", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "not-hex");
+    expect(() => enforcePhiEncryptionConfigured()).not.toThrow();
+  });
+
+  it("throws in production when PHI_ENCRYPTION_KEY is unset", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "");
+    expect(() => enforcePhiEncryptionConfigured()).toThrow(
+      /PHI_ENCRYPTION_KEY is required in production/,
+    );
+  });
+
+  it("throws in production when key is the wrong length", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "a".repeat(32));
+    expect(() => enforcePhiEncryptionConfigured()).toThrow(
+      /must be exactly 64 hex characters/,
+    );
+  });
+
+  it("throws in production when key contains non-hex characters", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "z".repeat(64));
+    expect(() => enforcePhiEncryptionConfigured()).toThrow(
+      /must be exactly 64 hex characters/,
+    );
+  });
+
+  it("accepts a 64-char hex key in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "0123456789abcdef".repeat(4));
+    expect(() => enforcePhiEncryptionConfigured()).not.toThrow();
+  });
+
+  it("accepts a mixed-case hex key", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("PHI_ENCRYPTION_KEY", "ABCDEF0123456789".repeat(4));
+    expect(() => enforcePhiEncryptionConfigured()).not.toThrow();
+  });
+});

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -181,25 +181,49 @@ export async function decryptBuffer(
 // ── Patient File Categories Requiring Encryption ──
 
 /**
+ * Normalize a category key to a single canonical form: lowercase + all
+ * hyphens folded to underscores. Mirrors `normalizeCategory()` in the
+ * upload route so the per-category size limits and the PHI-encryption
+ * decision can never disagree on what e.g. `"X-Rays"` means.
+ *
+ * Audit Finding C-08: keeping two separate normalizations (one lowercase-
+ * only here, one hyphen-folding in upload route) meant a category like
+ * `x_rays` had a 25 MB limit but bypassed encryption because the PHI set
+ * only listed `x-rays` / `xrays`.
+ */
+export function normalizePhiCategory(category: string): string {
+  return category.trim().toLowerCase().replace(/-/g, "_");
+}
+
+/**
  * Upload categories that contain Protected Health Information (PHI)
  * and must be encrypted at rest per Moroccan Law 09-08.
+ *
+ * Stored in canonical normalized form (lowercase, underscores). Callers
+ * must look up via `requiresEncryption()` rather than directly reading
+ * this set, since `requiresEncryption()` applies the same normalization
+ * to the input.
  */
 export const PHI_CATEGORIES = new Set([
   "documents",
   "prescriptions",
-  "lab-results",
+  "lab_report",
   "lab_results",
-  "x-rays",
+  "x_rays",
+  // `xrays` (no separator) intentionally listed separately because the
+  // hyphen-fold normalization does not collapse "xrays" → "x_rays".
+  // Both forms appear in LIMITS_BY_CATEGORY and must mirror that set.
   "xrays",
-  "medical-records",
+  "radiology",
   "medical_records",
-  "patient-files",
   "patient_files",
 ]);
 
 /**
- * Determine if a file upload category requires encryption.
+ * Determine if a file upload category requires encryption. Applies the
+ * same normalization as `LIMITS_BY_CATEGORY` so `lab-results`,
+ * `lab_results`, `Lab-Results` etc. all resolve to the same decision.
  */
 export function requiresEncryption(category: string): boolean {
-  return PHI_CATEGORIES.has(category.toLowerCase());
+  return PHI_CATEGORIES.has(normalizePhiCategory(category));
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -97,6 +97,13 @@ const ENV_RULES: EnvRule[] = [
   // CRON_SECRET only as a transitional measure (see profile-header-hmac.ts).
   { name: "PROFILE_HEADER_HMAC_KEY", required: process.env.NODE_ENV === "production", description: "HMAC key used to sign x-auth-profile-* headers between middleware and withAuth (required in production)", group: "auth" },
 
+  // ── PHI Encryption (Audit C-08) ──────────────────────────────────
+  // AES-256-GCM master key for patient files at rest on R2 (Moroccan
+  // Law 09-08). Required at startup in production so a misconfigured
+  // deploy fails fast instead of silently storing plaintext PHI through
+  // a code path that bypasses the encryptAndUpload chokepoint.
+  { name: "PHI_ENCRYPTION_KEY", required: process.env.NODE_ENV === "production", description: "Hex-encoded 256-bit AES-GCM key for PHI file encryption (required in production; `openssl rand -hex 32`)", group: "encryption" },
+
   // ── Custom Domains ─────────────────────────────────────────────────
   // These are gated by NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS — when the flag is
   // "true" they become required, so the app refuses to boot with a half-wired
@@ -223,6 +230,13 @@ export function enforceEnvValidation(): void {
   // has set ALLOW_UNMASKED_PHI=true. See SECURITY.md → "PHI Masking Defaults".
   enforcePhiMaskingPolicy();
 
+  // Audit Finding C-08 — refuse to boot in production without a valid PHI
+  // master key. The general ENV_RULES check above already requires the key
+  // to be set, but this guard additionally validates the key shape so an
+  // invalid value (wrong length, non-hex) cannot silently disable the
+  // encryption code path at first use.
+  enforcePhiEncryptionConfigured();
+
   // S-05: Assert PROFILE_HEADER_HMAC_KEY !== CRON_SECRET to prevent a
   // leaked cron token from also forging session headers.
   enforceHmacKeyIndependence();
@@ -263,6 +277,40 @@ export function enforcePhiMaskingPolicy(): void {
         "This must be approved by the Security Officer / DPO and documented.",
       { context: "env-validation", check: "phi-masking" },
     );
+  }
+}
+
+/**
+ * Audit Finding C-08: Refuse to boot in production when PHI_ENCRYPTION_KEY
+ * is missing or malformed. The general required-vars gate above already
+ * blocks an unset key in production; this guard additionally rejects keys
+ * that do not match the AES-256-GCM 64-hex-char shape consumed by
+ * `src/lib/encryption.ts`. Catching the bad shape at startup avoids a
+ * scenario where the key is "set" but every encrypt call silently returns
+ * null and writes through plaintext.
+ *
+ * Exported for unit tests.
+ */
+export function enforcePhiEncryptionConfigured(): void {
+  if (process.env.NODE_ENV !== "production") return;
+
+  const key = process.env.PHI_ENCRYPTION_KEY;
+  if (!key) {
+    // Already handled by enforceEnvValidation() but guard explicitly so
+    // the error message is specific.
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] PHI_ENCRYPTION_KEY is required in production.\n" +
+      "Patient files (Moroccan Law 09-08 PHI) cannot be encrypted without it. Generate a key with: openssl rand -hex 32";
+    logger.error(message, { context: "env-validation", check: "phi-encryption" });
+    throw new Error(message);
+  }
+
+  if (!/^[0-9a-fA-F]{64}$/.test(key)) {
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] PHI_ENCRYPTION_KEY must be exactly 64 hex characters (256 bits).\n" +
+      "Generate a valid key with: openssl rand -hex 32";
+    logger.error(message, { context: "env-validation", check: "phi-encryption" });
+    throw new Error(message);
   }
 }
 


### PR DESCRIPTION
## Summary

Audit Finding **C-08 [HIGH]** — closes the highest-leverage gap from the pre-acquisition security audit.

Two related issues that combined could result in plaintext PHI on R2:

1. **`PHI_ENCRYPTION_KEY` was not enforced at startup.** It was missing from `ENV_RULES` in `src/lib/env.ts`. The server would happily boot in production without a key. The encryption library handled the missing key gracefully (encrypt returns `null`, upload aborts) but only for code paths that actually went through `encryptAndUpload`. Any new code path calling `uploadToR2` directly with PHI bytes would silently store plaintext.

2. **`PHI_CATEGORIES` and `LIMITS_BY_CATEGORY` used different normalization rules.** `LIMITS_BY_CATEGORY` (in the upload route) folds hyphens to underscores via `normalizeCategory()`; `PHI_CATEGORIES` only lowercased. Categories that `LIMITS` knew about but `PHI_CATEGORIES` did not — `lab_report`, `radiology`, `x_rays` — passed the size limit but skipped encryption. One typo (e.g. `lab_report` vs `lab_results`) was the difference between encrypted PHI and plaintext PHI on R2.

### Changes

- **`src/lib/env.ts`**
  - Add `PHI_ENCRYPTION_KEY` to `ENV_RULES` with `required` set when `NODE_ENV === "production"`.
  - New `enforcePhiEncryptionConfigured()` that additionally validates the key is exactly 64 hex characters (the AES-256-GCM shape consumed by `src/lib/encryption.ts`). Without the shape check, an invalid key would silently disable encryption at first use.
  - Wired into `enforceEnvValidation()` next to `enforcePhiMaskingPolicy()`.

- **`src/lib/encryption.ts`**
  - New `normalizePhiCategory()` (lowercase + hyphen→underscore) that mirrors the upload route's `normalizeCategory()`.
  - `PHI_CATEGORIES` rewritten as the canonical normalized set with the missing entries added (`lab_report`, `radiology`, `x_rays`). `xrays` (no separator) kept as a legacy alias to preserve current behaviour for the existing `LIMITS_BY_CATEGORY["xrays"]` key.
  - `requiresEncryption()` now applies normalization, so `Lab-Results`, `lab_results`, `LAB_RESULTS` all resolve to the same decision.

- **Tests**
  - New `src/lib/__tests__/env-phi-encryption.test.ts` (7 cases): missing/short/non-hex/valid/mixed-case key handling, plus the non-production no-op.
  - Extended `src/lib/__tests__/encryption.test.ts` with normalization coverage for the previously-bypassed categories.

### Reference

Audit excerpt: *"C-08 PHI encryption optional at boot, gated by string match — one typo away from regulator-grade plaintext PHI on R2. Highest-leverage fix in the report."*

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [x] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

`npm run typecheck` passes. `npm run test` (vitest) passes — `Test Files 65 passed | 1 skipped (66) / Tests 671 passed | 24 skipped (695)`. Lint clean for the touched files.

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met
- [ ] New API endpoints have rate limiting — N/A

## Operator action

After this merges, ensure `PHI_ENCRYPTION_KEY` is set in **production** and **staging** Cloudflare Worker secrets:

```bash
wrangler secret put PHI_ENCRYPTION_KEY --env production
wrangler secret put PHI_ENCRYPTION_KEY --env staging
```

Without it, the next deploy will fail the startup health check, by design.

---

_Devin run: https://app.devin.ai/sessions/4abc97b3c6944b92883b75b1fd5e1b4b — Requested by groupsmix (pee2ring99@mediaeast.uk)_