### PR TITLE
fix(db): I-04 enforce slot_end > slot_start CHECK on appointments

### DIFF
--- a/supabase/migrations/00070_appointments_slot_well_ordered.sql
+++ b/supabase/migrations/00070_appointments_slot_well_ordered.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- Migration 00070: I-04 — Enforce slot_end > slot_start on appointments
+--
+-- Audit finding I-04 (LOW): the appointments table accepts a row with
+-- slot_end <= slot_start because no CHECK constraint asserts the well-
+-- ordered invariant. A bug in the booking handler (negative duration,
+-- date arithmetic underflow, mistakenly swapped variables) would produce
+-- silently invalid rows that the analytics layer, calendar render, and
+-- overlap-prevention exclusion constraint (migration 00057) all rely on.
+--
+-- This migration adds the missing CHECK as defense-in-depth alongside the
+-- application-level validation in src/lib/validations.ts. Same pattern as
+-- the D-08 invariant added in migration 00069: scan for legacy violations
+-- first, fail fast if any exist, then add the constraint idempotently.
+-- =============================================================================
+
+BEGIN;
+
+-- 1. Refuse to add the CHECK if any existing row violates it. Operators must
+--    triage these before re-running. We list a sample in the exception so the
+--    on-call engineer has something to grep for.
+DO $$
+DECLARE
+  v_violations INT;
+  v_sample_id  UUID;
+BEGIN
+  SELECT COUNT(*), MIN(id)
+  INTO   v_violations, v_sample_id
+  FROM   appointments
+  WHERE  slot_end <= slot_start;
+
+  IF v_violations > 0 THEN
+    RAISE EXCEPTION
+      'I-04: Found % appointments rows with slot_end <= slot_start (sample id: %). '
+      'Fix or hard-delete these rows before enforcing appointments_slot_well_ordered.',
+      v_violations, v_sample_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+END $$;
+
+-- 2. Add the CHECK constraint itself (idempotent).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE  conname  = 'appointments_slot_well_ordered'
+      AND  conrelid = 'appointments'::regclass
+  ) THEN
+    ALTER TABLE appointments
+      ADD CONSTRAINT appointments_slot_well_ordered
+      CHECK (slot_end > slot_start);
+    RAISE NOTICE 'I-04: Added appointments_slot_well_ordered CHECK constraint';
+  END IF;
+END $$;
+
+-- 3. Refresh the table comment so future auditors see the DB-level enforcement.
+COMMENT ON CONSTRAINT appointments_slot_well_ordered ON appointments IS
+  'I-04 (added in 00070): slot_end must be strictly greater than slot_start. '
+  'Defense-in-depth alongside application-level booking validation.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Audit Finding **I-04 [LOW]** from the pre-acquisition security audit (Phase 3 / D4 — Database & data model):

> `appointments` lacks `CHECK (slot_end > slot_start)`. A booking with reversed times is accepted silently.

The application layer already prevents this in the happy path (`computeEndTime()` in `src/app/api/booking/route.ts:263` rejects appointments that would extend past midnight, and downstream paths derive `slot_end` from `slot_start + duration`). But there is no database-layer guard — a future code path that omits the duration math, a service-role script, or a manual SQL fix could insert a row with `slot_end <= slot_start` and break the existing analytics, calendar render, and the overlap-prevention exclusion constraint added in migration `00057`.

This PR adds the missing CHECK as **defense-in-depth** alongside the existing application-level validation. Same shape as the D-08 invariant added in `00069`:

1. Scan for legacy violations first; raise a clear error listing the count + a sample row id if any are found, so the operator can triage before re-running.
2. Add the CHECK constraint idempotently inside a single transaction (no-op if it already exists).
3. Refresh the constraint comment so future auditors see the DB-level enforcement.

### Files

- **`supabase/migrations/00070_appointments_slot_well_ordered.sql`** — new migration, 61 lines, follows the project's standard pattern (`BEGIN`/`COMMIT`, `IF NOT EXISTS` guard, `RAISE NOTICE` on success, comment on the constraint for posterity).

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR changes RLS policies or database migrations

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards

The migration is wrapped in a transaction and short-circuits with a clear error message **before** touching the schema if any existing row violates the new constraint. Operators can safely re-run after triage.

## Testing

- N/A unit tests (pure SQL DDL; the existing `migration-check.yml` workflow validates SQL syntax + sequential numbering)
- `npm run lint` clean for this diff (baseline 4855 warnings unchanged)
- `npm run typecheck` clean

## Observability

The migration emits a `RAISE NOTICE` on success and a structured `RAISE EXCEPTION` (`ERRCODE = 'check_violation'`) on data violations.

## Operator action

After this merges and is applied via `supabase db push` (or the migration job in `deploy.yml`), no further action is required. If the safety check fires (`I-04: Found N appointments rows with slot_end <= slot_start`), triage the offending rows in `appointments` before re-running the migration — the migration intentionally refuses to silently coerce data.