### PR TITLE
fix(env): remove duplicate enforcePhiEncryptionConfigured definition

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -230,12 +230,6 @@ export function enforceEnvValidation(): void {
     throw new Error(message);
   }
 
-  // C-08: Validate PHI_ENCRYPTION_KEY shape (64 hex chars = AES-256-GCM).
-  // The ENV_RULES check above only ensures the key is set; this validates
-  // that the value is actually usable for encryption. An invalid key would
-  // silently disable encryption at first use.
-  enforcePhiEncryptionConfigured();
-
   // Audit Finding #7 — enforce safe PHI masking defaults in production.
   // Production must default to a masked view of PHI ("partial" or "full").
   // Explicitly disabling masking ("none") is only permitted when the operator
@@ -258,33 +252,6 @@ export function enforceEnvValidation(): void {
 
   // F-10: Ensure exactly one email provider is configured (not both).
   enforceEmailProviderExclusivity();
-}
-
-/**
- * C-08: Validate PHI_ENCRYPTION_KEY shape in production.
- *
- * The ENV_RULES check ensures the key is set; this validates that the
- * value is actually a 64-character hex string (AES-256-GCM key). An
- * invalid key would silently disable encryption at first use because
- * `encryption.ts` would fail to derive a CryptoKey.
- *
- * Exported for unit tests.
- */
-export function enforcePhiEncryptionConfigured(): void {
-  if (process.env.NODE_ENV !== "production") return;
-
-  const key = process.env.PHI_ENCRYPTION_KEY;
-  if (!key) return; // Already caught by ENV_RULES required check
-
-  const HEX_64_RE = /^[0-9a-fA-F]{64}$/;
-  if (!HEX_64_RE.test(key)) {
-    const message =
-      "[STARTUP HEALTH CHECK FAILED] PHI_ENCRYPTION_KEY must be exactly 64 hex characters " +
-      "(a 256-bit AES key). The current value does not match this format.\n" +
-      "Generate a valid key: `openssl rand -hex 32`";
-    logger.error(message, { context: "env-validation", check: "phi-encryption-key" });
-    throw new Error(message);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`src/lib/env.ts` on `main` has two exported functions named `enforcePhiEncryptionConfigured` — one added by PR #475 (`devin/…-c08-enforce-phi-encryption-startup`) and another added by PR #477 (`fix/audit-remediation-comprehensive`). When #477 merged on top of #475 the duplicate slipped in, breaking `tsc --noEmit` and thus the "Lint, Type Check & Tests" CI job on every PR targeting `main` (e.g. #479).

```
src/lib/env.ts(273,17): error TS2323: Cannot redeclare exported variable 'enforcePhiEncryptionConfigured'.
src/lib/env.ts(273,17): error TS2393: Duplicate function implementation.
src/lib/env.ts(333,17): error TS2323: Cannot redeclare exported variable 'enforcePhiEncryptionConfigured'.
src/lib/env.ts(333,17): error TS2393: Duplicate function implementation.
```

This PR keeps the **stricter** version (from #477) which:
- Explicitly throws with a precise message when `PHI_ENCRYPTION_KEY` is unset in production (defense-in-depth even if the `ENV_RULES` required-check is ever bypassed), **and**
- Validates the 64-hex-char AES-256-GCM shape (same as the removed copy).

The removed copy (from #475) early-returned on an unset key, which is strictly less defensive and is inconsistent with the existing test `src/lib/__tests__/env-phi-encryption.test.ts` that asserts the function **throws** with `/PHI_ENCRYPTION_KEY is required in production/` when the key is unset.

Also drops the duplicate call site inside `enforceEnvValidation()` — the function was being called twice back-to-back.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR modifies encryption, audit logging, or PII handling

Behavior is preserved/strengthened: only the stricter of two identically-named startup guards is kept. In production, `PHI_ENCRYPTION_KEY` is still required (ENV_RULES) and still shape-validated (64 hex chars).

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests — existing `src/lib/__tests__/env-phi-encryption.test.ts` (7 tests) passes against the kept implementation.
- [x] Manual — `npx tsc --noEmit` now passes; `npx eslint src/lib/env.ts` passes.

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes (on changed file)
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
