### PR TITLE
fix(env): remove duplicate enforcePhiEncryptionConfigured (unblocks main typecheck)

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -242,13 +242,6 @@ export function enforceEnvValidation(): void {
   // has set ALLOW_UNMASKED_PHI=true. See SECURITY.md → "PHI Masking Defaults".
   enforcePhiMaskingPolicy();
 
-  // Audit Finding C-08 — refuse to boot in production without a valid PHI
-  // master key. The general ENV_RULES check above already requires the key
-  // to be set, but this guard additionally validates the key shape so an
-  // invalid value (wrong length, non-hex) cannot silently disable the
-  // encryption code path at first use.
-  enforcePhiEncryptionConfigured();
-
   // S-05: Assert PROFILE_HEADER_HMAC_KEY !== CRON_SECRET to prevent a
   // leaked cron token from also forging session headers.
   enforceHmacKeyIndependence();
@@ -258,33 +251,6 @@ export function enforceEnvValidation(): void {
 
   // F-10: Ensure exactly one email provider is configured (not both).
   enforceEmailProviderExclusivity();
-}
-
-/**
- * C-08: Validate PHI_ENCRYPTION_KEY shape in production.
- *
- * The ENV_RULES check ensures the key is set; this validates that the
- * value is actually a 64-character hex string (AES-256-GCM key). An
- * invalid key would silently disable encryption at first use because
- * `encryption.ts` would fail to derive a CryptoKey.
- *
- * Exported for unit tests.
- */
-export function enforcePhiEncryptionConfigured(): void {
-  if (process.env.NODE_ENV !== "production") return;
-
-  const key = process.env.PHI_ENCRYPTION_KEY;
-  if (!key) return; // Already caught by ENV_RULES required check
-
-  const HEX_64_RE = /^[0-9a-fA-F]{64}$/;
-  if (!HEX_64_RE.test(key)) {
-    const message =
-      "[STARTUP HEALTH CHECK FAILED] PHI_ENCRYPTION_KEY must be exactly 64 hex characters " +
-      "(a 256-bit AES key). The current value does not match this format.\n" +
-      "Generate a valid key: `openssl rand -hex 32`";
-    logger.error(message, { context: "env-validation", check: "phi-encryption-key" });
-    throw new Error(message);
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`main` currently fails `npx tsc --noEmit` because `src/lib/env.ts` declares `enforcePhiEncryptionConfigured` twice. The duplicate was introduced when PR #477 ("comprehensive audit remediation", commit `fafbfbfd`) merged two slightly different versions of the same function instead of resolving the conflict. Every PR opened against `main` now fails CI on:

```
src/lib/env.ts(273,17): error TS2323: Cannot redeclare exported variable 'enforcePhiEncryptionConfigured'.
src/lib/env.ts(273,17): error TS2393: Duplicate function implementation.
src/lib/env.ts(333,17): error TS2323: Cannot redeclare exported variable 'enforcePhiEncryptionConfigured'.
src/lib/env.ts(333,17): error TS2393: Duplicate function implementation.
```

This was first seen on PR #478, but the bug is in `main` itself, not that PR.

This PR drops the leaner stub (lines 263-288) and its redundant call site (lines 244-251), keeping the canonical version that throws on missing key - which is what `src/lib/__tests__/env-phi-encryption.test.ts` asserts ("PHI_ENCRYPTION_KEY is required in production").

Net diff: 34 deletions, no new code.

## Type of change

- [x] Bug fix

## Security Impact

- [x] No security impact

The kept implementation is byte-identical to the existing one at lines 333-356 - the C-08 PHI key shape check is unchanged. `enforceEnvValidation` still calls `enforcePhiEncryptionConfigured()` once at line 237, so production startup behavior is preserved. The dropped second call at line 250 was redundant.

## Migration Safety

- [x] N/A - no migrations

## Testing

- [x] Manual testing performed

Locally on this branch:

- `npx tsc --noEmit` -> exit 0 (was failing on `main`)
- `npx vitest run src/lib/__tests__/env-phi-encryption.test.ts` -> 7/7 pass
- `git diff --stat`: `src/lib/env.ts | 34 ----------------------------------`

## Observability

- [x] N/A - no observability changes

## Checklist

- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run typecheck` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
