### PR TITLE
fix(landing,gdpr): apply --font-sans-landing token; preserve consent_logs on clinic delete

### DIFF
--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -34,9 +34,13 @@ export function LandingPage() {
     <LandingLocaleProvider>
       <div
         className="flex min-h-screen flex-col"
-        style={{ backgroundColor: "var(--bone)", color: "var(--ink)" }}
+        style={{
+          backgroundColor: "var(--bone)",
+          color: "var(--ink)",
+          fontFamily: "var(--font-sans-landing)",
+        }}
       >
-        {/* eslint-disable-next-line i18next/no-literal-string -- skip-to-content is a standard accessibility pattern */}
+        {/* eslint-disable i18next/no-literal-string -- skip-to-content is a standard accessibility pattern */}
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-medium"
@@ -47,6 +51,7 @@ export function LandingPage() {
         >
           Aller au contenu principal
         </a>
+        {/* eslint-enable i18next/no-literal-string */}
         <LandingHeader />
         <main id="main-content" className="flex-1">
           <HeroSection />

--- a/supabase/migrations/00075_consent_logs_clinic_id.sql
+++ b/supabase/migrations/00075_consent_logs_clinic_id.sql
@@ -11,10 +11,18 @@
 -- an index for per-clinic queries. The INSERT RLS policies are not
 -- modified — anonymous INSERTs (user_id NULL) remain allowed, and
 -- authenticated INSERTs still require user_id match per 00057.
+--
+-- The FK uses ON DELETE SET NULL (not CASCADE) to preserve the GDPR /
+-- Loi 09-08 audit trail when a clinic is deleted. This matches the
+-- existing user_id FK on this table (00047_gdpr_compliance.sql:15)
+-- and the GDPR purge cron (src/app/api/cron/gdpr-purge/route.ts),
+-- which anonymizes consent rows rather than deleting them. Cascading
+-- deletes from clinics would silently destroy compliance records that
+-- the rest of the codebase is designed to retain.
 -- ============================================================
 
 ALTER TABLE consent_logs
-  ADD COLUMN IF NOT EXISTS clinic_id uuid REFERENCES clinics(id) ON DELETE CASCADE;
+  ADD COLUMN IF NOT EXISTS clinic_id uuid REFERENCES clinics(id) ON DELETE SET NULL;
 
 CREATE INDEX IF NOT EXISTS idx_consent_logs_clinic_id
   ON consent_logs(clinic_id)


### PR DESCRIPTION
## Summary

Two follow-up review fixes against `main`:

### 1. Apply `--font-sans-landing` on the landing page root

The `--font-sans-landing` token was added to `src/app/tokens.css:55` (in the recent token-namespacing change) but never consumed by any component. The landing page sans-serif text (headings, body, links) previously inherited Inter via the old `--font-sans` token; once that was namespaced for landing only, nothing on the landing tree applied it, so the page silently fell back to the app-wide Geist stack defined in `globals.css`.

Fix: add `fontFamily: "var(--font-sans-landing)"` to the inline style on the outer wrapper in `src/components/landing/landing-page.tsx`. All descendant landing sections inherit it. The admin / patient / auth surfaces are unaffected because they don't render `<LandingPage>`.

Drive-by: the existing `eslint-disable-next-line i18next/no-literal-string` directive on the skip-to-content `<a>` was relying on the next line being a single-line opening tag. The style-object change shifted line numbers, so the directive was reported as "unused" while the literal-string warning re-surfaced. Replaced with a paired `eslint-disable` / `eslint-enable` block so the suppression is robust to formatting changes inside the element.

### 2. Change `consent_logs.clinic_id` FK to `ON DELETE SET NULL`

Migration `00075_consent_logs_clinic_id.sql` originally added the new `clinic_id` column with `ON DELETE CASCADE`, which would silently destroy GDPR / Loi 09-08 consent records whenever a clinic row is deleted. That contradicts the rest of the codebase's design for this table:

- The original `user_id` FK uses `ON DELETE SET NULL` (`supabase/migrations/00047_gdpr_compliance.sql:15`).
- Migration `00057` added an `anonymized_user_id` column specifically so consent rows could survive user deletion.
- The GDPR purge cron (`src/app/api/cron/gdpr-purge/route.ts:136-143`) explicitly anonymizes `consent_logs` (`update({ user_id: null })`) rather than deleting them.

Cascading from `clinics` would create a path where clinic deletion silently destroys the audit trail the rest of the system is designed to preserve. Switched the FK to `ON DELETE SET NULL` and expanded the migration's header comment to record the rationale so a future reviewer can't re-introduce CASCADE without seeing the GDPR context.

Migration 00075 is not yet in production (the deploy-time `supabase db push` workflow is still being introduced in PR #470), so editing the existing migration in place — rather than adding a follow-up migration — is the right call here.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR changes RLS policies or database migrations

  *Changes the FK ON DELETE behavior on `consent_logs.clinic_id` from CASCADE to SET NULL. This is a strict relaxation of destructive behavior — no rows that were previously preserved are now deleted; rows that would have been cascaded are now retained with `clinic_id = NULL`. RLS policies are unchanged.*

- [x] This PR modifies encryption, audit logging, or PII handling

  *Preserves the GDPR / Loi 09-08 consent audit trail through clinic deletion, matching the existing user-deletion preservation path.*

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards

## Testing

- [x] Manual testing performed

  *`npm run lint` → 0 errors. `npm run typecheck` → clean.*

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
