### PR TITLE
security: harden hexToBytes input validation and extend CODEOWNERS to scripts/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,11 @@ supabase/migrations/*           @groupsmix
 wrangler.toml                   @groupsmix
 .github/workflows/*             @groupsmix
 
+# AUDIT A9: Build/deploy scripts run during install (postinstall) and CI.
+# Any change here can introduce a postinstall hijack vector, so require a
+# senior reviewer.
+scripts/*                       @groupsmix
+
 # Sentry config — PII scrubbing
 sentry.server.config.ts         @groupsmix
 sentry.client.config.ts         @groupsmix

--- a/src/lib/__tests__/crypto-utils.test.ts
+++ b/src/lib/__tests__/crypto-utils.test.ts
@@ -1,5 +1,43 @@
 import { describe, it, expect } from "vitest";
-import { timingSafeEqual, sha256Hex, hmacSha256Hex } from "../crypto-utils";
+import {
+  bytesToHex,
+  hexToBytes,
+  hmacSha256Hex,
+  sha256Hex,
+  timingSafeEqual,
+} from "../crypto-utils";
+
+describe("hexToBytes", () => {
+  it("decodes a valid even-length hex string", () => {
+    const bytes = hexToBytes("deadbeef");
+    expect(Array.from(bytes)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it("accepts uppercase hex", () => {
+    const bytes = hexToBytes("DEADBEEF");
+    expect(Array.from(bytes)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+  });
+
+  it("round-trips with bytesToHex", () => {
+    const original = new Uint8Array([0, 1, 127, 128, 255]);
+    expect(Array.from(hexToBytes(bytesToHex(original)))).toEqual(
+      Array.from(original),
+    );
+  });
+
+  it("throws on empty input rather than producing a 500 (A10-07)", () => {
+    expect(() => hexToBytes("")).toThrow(/must not be empty/);
+  });
+
+  it("throws on odd-length input rather than producing a 500 (A10-07)", () => {
+    expect(() => hexToBytes("abc")).toThrow(/even number/);
+  });
+
+  it("throws on non-hex characters (A10-07)", () => {
+    expect(() => hexToBytes("zz")).toThrow(/hex characters/);
+    expect(() => hexToBytes("dead!!")).toThrow(/hex characters/);
+  });
+});
 
 describe("timingSafeEqual", () => {
   it("returns true for identical strings", () => {

--- a/src/lib/crypto-utils.ts
+++ b/src/lib/crypto-utils.ts
@@ -16,11 +16,31 @@ export function bytesToHex(bytes: Uint8Array): string {
 
 /**
  * Convert a hex-encoded string to a Uint8Array backed by a plain ArrayBuffer.
+ *
+ * AUDIT A10-07: Validates input is non-empty, even-length, and contains only
+ * hex characters. The previous implementation used a non-null assertion on the
+ * regex match result, so an attacker-controlled odd-length or empty hex value
+ * (anywhere a secret flowed) would surface as an unhelpful TypeError that
+ * bubbled to a 500 response.
  */
 export function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
-  return new Uint8Array(
-    hex.match(/.{2}/g)!.map((byte) => parseInt(byte, 16)),
-  ) as Uint8Array<ArrayBuffer>;
+  if (typeof hex !== "string") {
+    throw new TypeError("hexToBytes: input must be a string");
+  }
+  if (hex.length === 0) {
+    throw new Error("hexToBytes: input must not be empty");
+  }
+  if (hex.length % 2 !== 0) {
+    throw new Error("hexToBytes: input must have an even number of characters");
+  }
+  if (!/^[0-9a-fA-F]+$/.test(hex)) {
+    throw new Error("hexToBytes: input must contain only hex characters");
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes as Uint8Array<ArrayBuffer>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses two concrete gaps from the latest dependency / TOCTOU / secrets audit (A9–A13). Other items were verified against the current code and found to be already mitigated.

### Changes

**A10-07 — `hexToBytes` exception propagation (`src/lib/crypto-utils.ts`)**

The previous implementation used a non-null assertion on the regex match result. For empty or odd-length hex (anywhere a secret flows — e.g. `PHI_ENCRYPTION_KEY` consumed by `encryption.ts:89`) this would throw an unhelpful `TypeError` and bubble to a 500. `hexToBytes` now validates that the input is a non-empty, even-length, hex-only string and throws a descriptive `Error` otherwise. Decoding switched to a single explicit loop so empty/odd input never reaches `parseInt`. Added unit tests covering round-trip, uppercase hex, empty input, odd-length input, and non-hex characters.

**A9 — CODEOWNERS coverage for `scripts/` (`.github/CODEOWNERS`)**

Added a rule requiring `@groupsmix` review for any change under `scripts/*`. These scripts run during `postinstall` (`patch-opennext.mjs`) and `build:cf` (`post-build-patch.mjs`), so a postinstall-hijack vector here would otherwise slip past the existing security-critical owners list.

### Audit verification notes (no changes needed)

- **A10-02 / A12-04 (subdomain cache):** `src/lib/subdomain-cache.ts` already enforces `MAX_CACHE_SIZE = 500` via `enforceMaxSize()` plus periodic `evictExpiredEntries` on a 30s interval.
- **A12-02 (`userRateBuckets` LRU):** `src/lib/with-auth.ts` already evicts the oldest 25% of entries by `resetAt` when the map reaches `USER_RATE_MAX_KEYS = 10_000`.
- **A13-04 (`wrangler.toml`):** Verified — only `NODE_ENV` and `RATE_LIMIT_BACKEND` are set in `[vars]`. No inline secrets.
- **R11-01 (sanitize-html regex):** Only used on static blog content (`src/app/(public)/blog/[slug]/page.tsx`) and the module already documents the trusted-only contract.

## Testing

`npm run test` → 67 files, 690 passed / 15 skipped. `npx tsc --noEmit` clean. `npm run lint` reports 0 errors (existing warnings unchanged).
