### PR TITLE
Address A14/A15/A16 audit findings (input validation, output encoding, schema constraints)

### DIFF
--- a/src/app/api/booking/verify/route.ts
+++ b/src/app/api/booking/verify/route.ts
@@ -21,8 +21,12 @@ import { withValidation } from "@/lib/api-validate";
 import { logger } from "@/lib/logger";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
 import { requireTenantWithConfig } from "@/lib/tenant";
+// A14-02: enforce a syntactic phone regex. The previous min(6)/max(30)-only
+// schema accepted strings like "!@#$%^" — clearly not dialable. The regex
+// allows leading "+", digits, parens, whitespace, and hyphens, which matches
+// every form (E.164, national, hyphenated) seen in production data.
 const bookingVerifySchema = z.object({
-  phone: z.string().min(6).max(30),
+  phone: z.string().min(6).max(30).regex(/^\+?[0-9()\s-]+$/, "Invalid phone format"),
 });
 
 /** Token validity period: 15 minutes. */

--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -45,7 +45,16 @@ function resolveLocale(request: Request): Locale {
   const cookieHeader = request.headers.get("cookie") ?? "";
   const cookieMatch = /(?:^|;\s*)preferred-locale=([^;]+)/.exec(cookieHeader);
   if (cookieMatch) {
-    return normalizeLocale(decodeURIComponent(cookieMatch[1]));
+    // A14-06: decodeURIComponent throws URIError on malformed escape
+    // sequences (e.g. a stray "%" or unpaired surrogate). A request that
+    // produces a 500 here would also bypass the locale-switcher entirely,
+    // so fall through to the default locale instead of letting the route
+    // crash.
+    try {
+      return normalizeLocale(decodeURIComponent(cookieMatch[1]));
+    } catch {
+      // fall through to header / default below
+    }
   }
   const tenantLocale = request.headers.get("x-tenant-locale");
   if (tenantLocale) {

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -20,12 +20,13 @@ import {
   isDnsVerificationConfigured,
   normalizeDomain,
 } from "@/lib/dns-verification";
+import { escapeSlackMrkdwn } from "@/lib/escape-slack";
 import { generateSubdomain } from "@/lib/generate-subdomain";
 import { logger } from "@/lib/logger";
 import { phoneToWhatsApp } from "@/lib/morocco";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
 import { createAdminClient } from "@/lib/supabase-server";
-import { safeParse } from "@/lib/validations";
+import { normalizeText, safeParse } from "@/lib/validations";
 import { sendTextMessage } from "@/lib/whatsapp";
 
 // ---------------------------------------------------------------------------
@@ -60,6 +61,9 @@ async function sendSlackRegistrationAlert(data: {
     return;
   }
 
+  // A15 fix: every interpolated value is user-supplied and reaches a
+  // `mrkdwn` block, so escape `<`, `>`, and `&` to neutralise mention /
+  // link injection (`<!channel>`, `<@U123>`, `<https://evil|x>`).
   const message = {
     text: "New clinic registration",
     blocks: [
@@ -70,14 +74,17 @@ async function sendSlackRegistrationAlert(data: {
       {
         type: "section",
         fields: [
-          { type: "mrkdwn", text: `*Clinic:*\n${data.clinicName}` },
-          { type: "mrkdwn", text: `*Doctor:*\n${data.doctorName}` },
-          { type: "mrkdwn", text: `*Email:*\n${data.email}` },
-          { type: "mrkdwn", text: `*Phone:*\n${data.phone}` },
-          { type: "mrkdwn", text: `*Specialty:*\n${data.specialty}` },
-          { type: "mrkdwn", text: `*City:*\n${data.city || "N/A"}` },
-          { type: "mrkdwn", text: `*Verification:*\n${data.verificationMethod}` },
-          { type: "mrkdwn", text: `*IP:*\n${data.clientIp}` },
+          { type: "mrkdwn", text: `*Clinic:*\n${escapeSlackMrkdwn(data.clinicName)}` },
+          { type: "mrkdwn", text: `*Doctor:*\n${escapeSlackMrkdwn(data.doctorName)}` },
+          { type: "mrkdwn", text: `*Email:*\n${escapeSlackMrkdwn(data.email)}` },
+          { type: "mrkdwn", text: `*Phone:*\n${escapeSlackMrkdwn(data.phone)}` },
+          { type: "mrkdwn", text: `*Specialty:*\n${escapeSlackMrkdwn(data.specialty)}` },
+          { type: "mrkdwn", text: `*City:*\n${escapeSlackMrkdwn(data.city) || "N/A"}` },
+          {
+            type: "mrkdwn",
+            text: `*Verification:*\n${escapeSlackMrkdwn(data.verificationMethod)}`,
+          },
+          { type: "mrkdwn", text: `*IP:*\n${escapeSlackMrkdwn(data.clientIp)}` },
         ],
       },
     ],
@@ -154,13 +161,30 @@ async function verifyDnsTxtRecord(hostname: string, token: string): Promise<bool
 // Validation schema
 // ---------------------------------------------------------------------------
 
+// A14-04 / A14-05: name fields are normalized to NFC and stripped of NUL
+// bytes before length checks, so attackers cannot register two visually
+// identical clinics using composed-vs-decomposed Unicode and cannot smuggle
+// `\u0000` past downstream consumers.
 const registerClinicSchema = z.object({
-  clinic_name: z.string().min(2, "Le nom de la clinique est requis").max(200),
-  doctor_name: z.string().min(2, "Le nom du docteur est requis").max(200),
+  clinic_name: z
+    .string()
+    .transform(normalizeText)
+    .pipe(z.string().min(2, "Le nom de la clinique est requis").max(200)),
+  doctor_name: z
+    .string()
+    .transform(normalizeText)
+    .pipe(z.string().min(2, "Le nom du docteur est requis").max(200)),
   email: z.string().email("Email invalide").max(254),
   phone: z.string().min(8, "Numéro de téléphone invalide").max(30),
-  specialty: z.string().min(1, "La spécialité est requise").max(200),
-  city: z.string().max(200).optional(),
+  specialty: z
+    .string()
+    .transform(normalizeText)
+    .pipe(z.string().min(1, "La spécialité est requise").max(200)),
+  city: z
+    .string()
+    .transform(normalizeText)
+    .pipe(z.string().max(200))
+    .optional(),
   // F-28: Cloudflare Turnstile token for bot protection
   turnstile_token: z.string().min(1, "Turnstile verification required").optional(),
   // R-12: Identity verification

--- a/src/lib/__tests__/escape-slack.test.ts
+++ b/src/lib/__tests__/escape-slack.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { escapeSlackMrkdwn } from "@/lib/escape-slack";
+
+describe("escapeSlackMrkdwn (A15)", () => {
+  it("returns empty string for nullish input", () => {
+    expect(escapeSlackMrkdwn(null)).toBe("");
+    expect(escapeSlackMrkdwn(undefined)).toBe("");
+    expect(escapeSlackMrkdwn("")).toBe("");
+  });
+
+  it("neutralises mention syntax", () => {
+    expect(escapeSlackMrkdwn("<!channel>")).toBe("&lt;!channel&gt;");
+    expect(escapeSlackMrkdwn("<!here>")).toBe("&lt;!here&gt;");
+    expect(escapeSlackMrkdwn("<@U12345>")).toBe("&lt;@U12345&gt;");
+  });
+
+  it("neutralises link injection", () => {
+    expect(escapeSlackMrkdwn("<https://evil.example|click me>")).toBe(
+      "&lt;https://evil.example|click me&gt;",
+    );
+  });
+
+  it("escapes ampersands without double-encoding the angle-bracket entities", () => {
+    expect(escapeSlackMrkdwn("Tom & <Jerry>")).toBe("Tom &amp; &lt;Jerry&gt;");
+  });
+
+  it("leaves benign formatting characters untouched", () => {
+    // *, _, ~, ` are formatting only — leave them alone so legitimate
+    // names and notes still read naturally.
+    expect(escapeSlackMrkdwn("*bold* _italic_ ~strike~ `code`")).toBe(
+      "*bold* _italic_ ~strike~ `code`",
+    );
+  });
+});

--- a/src/lib/__tests__/validations-a14.test.ts
+++ b/src/lib/__tests__/validations-a14.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_MESSAGE_CONTENT_MAX,
+  chatRequestSchema,
+  labReportSchema,
+  normalizeText,
+  safeName,
+  safeText,
+} from "@/lib/validations";
+
+describe("normalizeText (A14-04, A14-05)", () => {
+  it("strips ASCII NUL bytes", () => {
+    expect(normalizeText("foo\u0000bar")).toBe("foobar");
+    expect(normalizeText("\u0000\u0000")).toBe("");
+  });
+
+  it("normalizes to NFC so composed and decomposed forms match", () => {
+    // "é" as NFD (e + COMBINING ACUTE ACCENT) vs NFC ("é").
+    const nfd = "Cafe\u0301";
+    const nfc = "Café";
+    expect(normalizeText(nfd)).toBe(nfc);
+    expect(normalizeText(nfd)).toBe(normalizeText(nfc));
+  });
+
+  it("is a no-op for ASCII text without control characters", () => {
+    expect(normalizeText("plain ascii")).toBe("plain ascii");
+  });
+});
+
+describe("safeText / safeName transforms", () => {
+  it("safeText preserves surrounding whitespace", () => {
+    expect(safeText.parse("  hello  ")).toBe("  hello  ");
+  });
+
+  it("safeName trims surrounding whitespace after normalization", () => {
+    expect(safeName.parse("   Dr. House   ")).toBe("Dr. House");
+  });
+
+  it("both reject non-strings", () => {
+    expect(safeText.safeParse(42 as unknown as string).success).toBe(false);
+    expect(safeName.safeParse({} as unknown as string).success).toBe(false);
+  });
+});
+
+describe("chatRequestSchema (A14-01)", () => {
+  it("accepts a message at exactly the max length", () => {
+    const content = "x".repeat(CHAT_MESSAGE_CONTENT_MAX);
+    const result = chatRequestSchema.safeParse({
+      messages: [{ role: "user", content }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a message longer than the max", () => {
+    const content = "x".repeat(CHAT_MESSAGE_CONTENT_MAX + 1);
+    const result = chatRequestSchema.safeParse({
+      messages: [{ role: "user", content }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty message", () => {
+    const result = chatRequestSchema.safeParse({
+      messages: [{ role: "user", content: "" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("strips NUL bytes before length check", () => {
+    const result = chatRequestSchema.safeParse({
+      messages: [{ role: "user", content: "hi\u0000there" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.messages[0].content).toBe("hithere");
+    }
+  });
+});
+
+describe("labReportSchema testName (A14-03)", () => {
+  const baseInput = {
+    orderId: "ord-1",
+    patientName: "Jane Doe",
+    orderNumber: "ON-0001",
+  };
+
+  it("accepts a 200-char testName", () => {
+    const result = labReportSchema.safeParse({
+      ...baseInput,
+      results: [
+        {
+          testName: "T".repeat(200),
+          value: null,
+          unit: null,
+          referenceMin: null,
+          referenceMax: null,
+          flag: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a 201-char testName", () => {
+    const result = labReportSchema.safeParse({
+      ...baseInput,
+      results: [
+        {
+          testName: "T".repeat(201),
+          value: null,
+          unit: null,
+          referenceMin: null,
+          referenceMax: null,
+          flag: null,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/escape-slack.ts
+++ b/src/lib/escape-slack.ts
@@ -1,0 +1,25 @@
+/**
+ * Escape user-controlled strings before interpolating them into Slack
+ * `mrkdwn` blocks.
+ *
+ * A15 fix — without this, an attacker could submit a clinic / doctor /
+ * specialty name containing `<!channel>`, `<!here>`, `<@U…>`, or
+ * `<https://evil.example|click me>` and have those tokens rendered as
+ * pings or formatted links in our internal Slack alert channel.
+ *
+ * Slack only requires three replacements (officially documented in
+ * https://api.slack.com/reference/surfaces/formatting#escaping):
+ *   - `&` → `&amp;`
+ *   - `<` → `&lt;`
+ *   - `>` → `&gt;`
+ * Order matters: `&` MUST be replaced first, otherwise we'd double-encode
+ * the entities introduced by the other replacements.
+ *
+ * Other mrkdwn tokens (`*`, `_`, `~`, `` ` ``) only affect visual
+ * formatting and are intentionally left intact so legitimate names that
+ * happen to contain them still read naturally.
+ */
+export function escapeSlackMrkdwn(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -27,6 +27,32 @@ const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Expected YYYY-MM-DD");
 /** Time string HH:MM */
 const timeHHMM = z.string().regex(/^\d{2}:\d{2}$/, "Expected HH:MM");
 
+/**
+ * A14-04 / A14-05: canonical text normalization.
+ *
+ * - Strips ASCII NUL (`\u0000`) bytes, which Postgres TEXT accepts but which
+ *   confuse downstream consumers (logs, JSON, CLI tooling) and can be used
+ *   to truncate values in C-string–based code paths.
+ * - Normalizes to Unicode NFC. Without this, attackers can register two
+ *   visually identical names (e.g. composed vs. decomposed accents) that
+ *   compare unequal byte-for-byte, defeating uniqueness checks and
+ *   user-recognition workflows.
+ *
+ * Use `safeText` for free-form fields and `safeName` for short identifiers.
+ */
+function normalizeText(value: string): string {
+  return value.replace(/\u0000/g, "").normalize("NFC");
+}
+
+/** Free-form user-supplied text (notes, content, descriptions). */
+export const safeText = z.string().transform(normalizeText);
+
+/** Short identifying text (names, titles). Trims surrounding whitespace. */
+export const safeName = z.string().transform((v) => normalizeText(v).trim());
+
+/** Direct access to the normalization function for callers outside Zod. */
+export { normalizeText };
+
 // ── Booking ─────────────────────────────────────────────────────────────
 
 export const bookingCancelSchema = z.object({
@@ -315,7 +341,9 @@ export const labReportSchema = z.object({
   results: z
     .array(
       z.object({
-        testName: z.string().min(1),
+        // A14-03: bound testName to 200 chars and normalize so identical
+        // composed/decomposed Unicode does not bypass downstream comparisons.
+        testName: safeName.pipe(z.string().min(1).max(200)),
         value: z.string().nullable(),
         unit: z.string().nullable(),
         referenceMin: z.number().nullable(),
@@ -416,13 +444,20 @@ export type AiPrescriptionRequest = z.infer<typeof aiPrescriptionRequestSchema>;
 
 // ── Chat ────────────────────────────────────────────────────────────────
 
+/**
+ * A14-01: bound `content` to 4 000 chars to prevent unbounded payloads
+ * being forwarded to the upstream LLM. Keeps cost and latency predictable
+ * and protects against memory-exhaustion vectors in the chat handler.
+ */
+export const CHAT_MESSAGE_CONTENT_MAX = 4000;
+
 export const chatRequestSchema = z.object({
   clinicId: z.string().optional(),
   messages: z
     .array(
       z.object({
         role: z.enum(["user", "assistant"]),
-        content: z.string(),
+        content: safeText.pipe(z.string().min(1).max(CHAT_MESSAGE_CONTENT_MAX)),
       }),
     )
     .min(1),

--- a/supabase/migrations/00076_a16_schema_constraints.sql
+++ b/supabase/migrations/00076_a16_schema_constraints.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- Migration 00076: A16 — Schema review remediation (A16-04, A16-05)
+--
+-- A16-04 (MEDIUM): services.price has no CHECK preventing negative values.
+-- A16-05 (MEDIUM): time_slots is missing a UNIQUE on
+--                  (doctor_id, day_of_week, start_time), so the same slot
+--                  can be inserted twice and the booking flow's "first
+--                  available" lookup becomes non-deterministic.
+--
+-- A16-03 (slot_end > slot_start) was previously enforced in 00070 and is
+-- intentionally not duplicated here.
+--
+-- Same defensive pattern as 00070: scan for legacy violations first so we
+-- fail fast with a clear message instead of leaving the operator with an
+-- opaque ALTER TABLE error.
+-- =============================================================================
+
+BEGIN;
+
+-- ── A16-04: services.price >= 0 ────────────────────────────────────────────
+DO $$
+DECLARE
+  v_violations INT;
+BEGIN
+  SELECT COUNT(*) INTO v_violations FROM services WHERE price < 0;
+  IF v_violations > 0 THEN
+    RAISE EXCEPTION
+      'A16-04: Found % services rows with price < 0. '
+      'Correct or null these rows before enforcing services_price_non_negative.',
+      v_violations
+      USING ERRCODE = 'check_violation';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE  conname  = 'services_price_non_negative'
+      AND  conrelid = 'services'::regclass
+  ) THEN
+    ALTER TABLE services
+      ADD CONSTRAINT services_price_non_negative
+      CHECK (price IS NULL OR price >= 0);
+    RAISE NOTICE 'A16-04: Added services_price_non_negative CHECK constraint';
+  END IF;
+END $$;
+
+COMMENT ON CONSTRAINT services_price_non_negative ON services IS
+  'A16-04 (added in 00076): price must be NULL or non-negative. '
+  'Prevents accidental negative pricing from billing/import bugs.';
+
+-- ── A16-05: UNIQUE (doctor_id, day_of_week, start_time) on time_slots ──────
+-- A duplicate row with the same (doctor, day, start_time) silently
+-- shadows the original — the booking flow's `.eq().limit(1)` lookup picks
+-- whichever the planner returns first, so an admin importing a duplicate
+-- effectively rewrites availability for that doctor.
+DO $$
+DECLARE
+  v_dupes INT;
+BEGIN
+  SELECT COUNT(*) INTO v_dupes FROM (
+    SELECT 1
+    FROM   time_slots
+    GROUP  BY doctor_id, day_of_week, start_time
+    HAVING COUNT(*) > 1
+  ) dupes;
+
+  IF v_dupes > 0 THEN
+    RAISE EXCEPTION
+      'A16-05: Found % duplicate (doctor_id, day_of_week, start_time) groups in time_slots. '
+      'Deduplicate via supabase/migrations data scripts before enforcing the UNIQUE index.',
+      v_dupes
+      USING ERRCODE = 'unique_violation';
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE  indexname = 'time_slots_doctor_day_start_unique'
+  ) THEN
+    CREATE UNIQUE INDEX time_slots_doctor_day_start_unique
+      ON time_slots (doctor_id, day_of_week, start_time);
+    RAISE NOTICE 'A16-05: Created UNIQUE index time_slots_doctor_day_start_unique';
+  END IF;
+END $$;
+
+COMMENT ON INDEX time_slots_doctor_day_start_unique IS
+  'A16-05 (added in 00076): prevents two time_slots rows for the same '
+  'doctor/day-of-week/start-time, which would otherwise cause '
+  'non-deterministic availability lookups in the booking flow.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes the actionable items from the A14 (input validation), A15 (output encoding) and A16 (schema review) audit blocks.

### A14 — Input validation
- **A14-01** `chatRequestSchema.messages[].content` — was unbounded. Now `.min(1).max(4000)` (constant exported as `CHAT_MESSAGE_CONTENT_MAX`) and routed through `safeText` so NUL bytes / non-NFC sequences are scrubbed before the length check.
- **A14-02** `bookingVerifySchema.phone` — added `.regex(/^\+?[0-9()\\s-]+$/)`. The previous `min(6).max(30)` accepted strings like `!@#$%^`, none of which are dialable.
- **A14-03** `labReportSchema.results[].testName` — added `.max(200)` and routed through `safeName`.
- **A14-04 / A14-05** Added a shared `normalizeText` helper in `src/lib/validations.ts` that strips `\u0000` and normalises to Unicode NFC, plus typed `safeText` / `safeName` Zod transforms. Applied to `clinic_name`, `doctor_name`, `specialty`, `city` in the public clinic registration schema and to the chat / lab schemas above. Universal application across every Zod schema is intentionally out of scope for this PR — the helper is exported and ready to be threaded through the remaining text fields incrementally.
- **A14-06** `src/app/api/lab/report-html/route.ts::resolveLocale` — wrapped `decodeURIComponent` in `try/catch` so a malformed `preferred-locale` cookie falls back to `DEFAULT_LOCALE` instead of throwing a `URIError` and 500-ing the report endpoint.

### A15 — Output encoding (Slack mrkdwn)
- New `src/lib/escape-slack.ts` exporting `escapeSlackMrkdwn` which performs the documented Slack escape (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`).
- `src/app/api/v1/register-clinic/route.ts::sendSlackRegistrationAlert` now passes every interpolated value through `escapeSlackMrkdwn`, neutralising `<!channel>`, `<!here>`, `<@U…>` and `<https://evil|x>` injection through the public registration form.

### A16 — Schema review
New migration `supabase/migrations/00076_a16_schema_constraints.sql` (idempotent, fail-fast on existing violators):
- **A16-04** `services_price_non_negative` CHECK (price IS NULL OR price >= 0).
- **A16-05** `time_slots_doctor_day_start_unique` UNIQUE (doctor_id, day_of_week, start_time).

A16-03 (slot_end > slot_start) was already enforced in `00070_appointments_slot_well_ordered.sql`. A16-06/07/10 are marked "no fix" or already correct on `main`.

#### A16-08 — FK index audit (informational)

A16-08 is an ops/audit task rather than a code change. Recommended periodic query:

```sql
SELECT c.conrelid::regclass AS table_name,
       a.attname              AS fk_column,
       c.conname              AS constraint_name
FROM   pg_constraint c
JOIN   pg_attribute a
       ON a.attrelid = c.conrelid
      AND a.attnum   = ANY (c.conkey)
WHERE  c.contype = 'f'
  AND  NOT EXISTS (
         SELECT 1 FROM pg_index i
         WHERE  i.indrelid = c.conrelid
           AND  a.attnum   = ANY (i.indkey)
       )
ORDER  BY 1, 2;
```

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR changes RLS policies or database migrations
- [x] This PR modifies encryption, audit logging, or PII handling

The migration only adds CHECK + UNIQUE constraints; no RLS changes. The Slack escape and locale-cookie fix close two minor injection / DoS vectors flagged in the audit.

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards

00076 is additive only and fails fast with a clear `RAISE EXCEPTION` if pre-existing rows violate the new invariant.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

New tests: `src/lib/__tests__/escape-slack.test.ts` (5 cases) and `src/lib/__tests__/validations-a14.test.ts` (12 cases).

```
$ npx vitest run
 Test Files  69 passed (69)
      Tests  701 passed | 15 skipped (716)

$ npx tsc --noEmit
# clean

$ npx eslint <changed files>
# clean
```

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
