### PR TITLE
fix: remaining audit remediation — select(*) whitelisting, CI hardening, env validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main, staging]
 
+# A34.12: Cancel redundant runs for the same PR — prevents duplicate
+# CodeQL/Gitleaks/Semgrep jobs from racing and wasting runner minutes.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege permissions (only what each job needs)
 permissions:
   contents: read
@@ -233,7 +239,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Start Supabase (ephemeral CI project)
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@ab058987d8d6c725971f6cf9d0b5c98467e30bd1 # v1.7.1
         with:
           version: latest
 
@@ -332,7 +338,7 @@ jobs:
           SEED_USERS_DELETED: "true"
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: playwright-report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   # ---------- MinIO (S3-compatible, replaces R2 locally) ----------
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-05-01T22-06-42Z
     ports:
       # A31.7: Bind MinIO API to localhost only
       - "127.0.0.1:9000:9000"

--- a/src/app/api/menus/[id]/route.ts
+++ b/src/app/api/menus/[id]/route.ts
@@ -36,7 +36,7 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   const { data, error } = await auth.supabase
     .from("menus")
-    .select("*, menu_items(*)")
+    .select("id, clinic_id, name, description, is_active, sort_order, created_at, updated_at, menu_items(id, category, name, description, price, photo_url, is_available, allergens, is_halal, sort_order)")
     .eq("id", id)
     .eq("clinic_id", clinicId)
     .single();

--- a/src/app/api/menus/items/route.ts
+++ b/src/app/api/menus/items/route.ts
@@ -36,9 +36,10 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   let query = auth.supabase
     .from("menu_items")
-    .select("*")
+    .select("id, menu_id, clinic_id, category, name, description, price, photo_url, is_available, allergens, is_halal, sort_order, created_at, updated_at")
     .eq("clinic_id", clinicId)
-    .order("sort_order", { ascending: true });
+    .order("sort_order", { ascending: true })
+    .limit(500);
 
   if (menuId) {
     query = query.eq("menu_id", menuId);

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -40,7 +40,7 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   const { data, error } = await auth.supabase
     .from("orders")
-    .select("*")
+    .select("id, clinic_id, reservation_id, table_id, items, subtotal, tax_amount, total, status, order_source, created_at, updated_at")
     .eq("id", id)
     .eq("clinic_id", clinicId)
     .single();

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -38,9 +38,10 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   let query = auth.supabase
     .from("orders")
-    .select("*")
+    .select("id, clinic_id, reservation_id, table_id, items, subtotal, tax_amount, total, status, order_source, created_at, updated_at")
     .eq("clinic_id", clinicId)
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .limit(200);
 
   if (status) {
     query = query.eq("status", status);

--- a/src/app/api/pets/[id]/route.ts
+++ b/src/app/api/pets/[id]/route.ts
@@ -39,7 +39,7 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   const { data, error } = await auth.supabase
     .from("pet_profiles")
-    .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, is_active, created_at, updated_at")
+    .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, notes, is_active, created_at, updated_at")
     .eq("id", id)
     .eq("clinic_id", clinicId)
     .single();

--- a/src/app/api/pets/[id]/route.ts
+++ b/src/app/api/pets/[id]/route.ts
@@ -39,7 +39,7 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   const { data, error } = await auth.supabase
     .from("pet_profiles")
-    .select("*")
+    .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, is_active, created_at, updated_at")
     .eq("id", id)
     .eq("clinic_id", clinicId)
     .single();

--- a/src/app/api/pets/route.ts
+++ b/src/app/api/pets/route.ts
@@ -35,7 +35,7 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
     if (petId) {
       const { data, error } = await supabase
         .from("pet_profiles")
-        .select("*")
+        .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, is_active, created_at, updated_at")
         .eq("id", petId)
         .eq("clinic_id", profile.clinic_id ?? "")
         .single();
@@ -50,9 +50,10 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
     // List pets
     let query = supabase
       .from("pet_profiles")
-      .select("*")
+      .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, is_active, created_at, updated_at")
       .eq("clinic_id", profile.clinic_id ?? "")
       .eq("is_active", true)
+      .limit(100)
       .order("created_at", { ascending: false });
 
     if (ownerId) {

--- a/src/app/api/pets/route.ts
+++ b/src/app/api/pets/route.ts
@@ -35,7 +35,7 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
     if (petId) {
       const { data, error } = await supabase
         .from("pet_profiles")
-        .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, is_active, created_at, updated_at")
+        .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, notes, is_active, created_at, updated_at")
         .eq("id", petId)
         .eq("clinic_id", profile.clinic_id ?? "")
         .single();
@@ -50,7 +50,7 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
     // List pets
     let query = supabase
       .from("pet_profiles")
-      .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, is_active, created_at, updated_at")
+      .select("id, clinic_id, owner_id, name, species, breed, weight_kg, date_of_birth, photo_url, notes, is_active, created_at, updated_at")
       .eq("clinic_id", profile.clinic_id ?? "")
       .eq("is_active", true)
       .limit(100)

--- a/src/app/api/restaurant-orders/route.ts
+++ b/src/app/api/restaurant-orders/route.ts
@@ -34,9 +34,10 @@ export const GET = withAuth(async (request, { supabase, profile }) => {
 
     let query = supabase
       .from("restaurant_orders")
-      .select("*")
+      .select("id, clinic_id, table_id, appointment_id, items, subtotal, tax, total, status, notes, created_at, updated_at")
       .eq("clinic_id", profile.clinic_id)
-      .order("created_at", { ascending: false });
+      .order("created_at", { ascending: false })
+      .limit(200);
 
     if (status) {
       query = query.eq("status", status);

--- a/src/app/api/restaurant-tables/[id]/route.ts
+++ b/src/app/api/restaurant-tables/[id]/route.ts
@@ -37,7 +37,7 @@ export const GET = withAuth(async (request: NextRequest, auth: AuthContext) => {
 
   const { data, error } = await auth.supabase
     .from("restaurant_tables")
-    .select("*")
+    .select("id, clinic_id, name, capacity, zone, is_active, qr_code_url, sort_order, created_at, updated_at")
     .eq("id", id)
     .eq("clinic_id", clinicId)
     .single();

--- a/src/app/api/restaurant-tables/route.ts
+++ b/src/app/api/restaurant-tables/route.ts
@@ -29,9 +29,10 @@ export const GET = withAuth(async (_request: NextRequest, auth: AuthContext) => 
 
   const { data, error } = await auth.supabase
     .from("restaurant_tables")
-    .select("*")
+    .select("id, clinic_id, name, capacity, zone, is_active, qr_code_url, sort_order, created_at, updated_at")
     .eq("clinic_id", clinicId)
-    .order("sort_order", { ascending: true });
+    .order("sort_order", { ascending: true })
+    .limit(200);
 
   if (error) return apiSupabaseError(error, "restaurant-tables/list");
 

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest) {
   // extra round-trip or a COUNT query.
   let query = supabase
     .from("appointments")
-    .select("*")
+    .select("id, clinic_id, patient_id, doctor_id, service_id, appointment_date, start_time, end_time, slot_start, slot_end, status, is_first_visit, insurance_flag, is_emergency, is_walk_in, booking_source, source, recurrence_group_id, recurrence_index, recurrence_pattern, rescheduled_from, created_at, updated_at")
     .eq("clinic_id", auth.clinicId)
     .order("appointment_date", { ascending: false })
     .order("start_time", { ascending: false })

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest) {
   // extra round-trip or a COUNT query.
   let query = supabase
     .from("appointments")
-    .select("id, clinic_id, patient_id, doctor_id, service_id, appointment_date, start_time, end_time, slot_start, slot_end, status, is_first_visit, insurance_flag, is_emergency, is_walk_in, booking_source, source, recurrence_group_id, recurrence_index, recurrence_pattern, rescheduled_from, created_at, updated_at")
+    .select("id, clinic_id, patient_id, doctor_id, service_id, appointment_date, start_time, end_time, slot_start, slot_end, status, is_first_visit, insurance_flag, is_emergency, is_walk_in, booking_source, source, notes, cancellation_reason, cancelled_at, recurrence_group_id, recurrence_index, recurrence_pattern, rescheduled_from, created_at, updated_at")
     .eq("clinic_id", auth.clinicId)
     .order("appointment_date", { ascending: false })
     .order("start_time", { ascending: false })

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -239,6 +239,9 @@ export function enforceEnvValidation(): void {
   // has set ALLOW_UNMASKED_PHI=true. See SECURITY.md → "PHI Masking Defaults".
   enforcePhiMaskingPolicy();
 
+  // A100-35: Reject CRON_SECRET shorter than 32 chars in production.
+  enforceCronSecretMinLength();
+
   // S-05: Assert PROFILE_HEADER_HMAC_KEY !== CRON_SECRET to prevent a
   // leaked cron token from also forging session headers.
   enforceHmacKeyIndependence();
@@ -381,6 +384,29 @@ export function enforcePhiEncryptionConfigured(): void {
       "[STARTUP HEALTH CHECK FAILED] PHI_ENCRYPTION_KEY must be exactly 64 hex characters (256 bits).\n" +
       "Generate a valid key with: openssl rand -hex 32";
     logger.error(message, { context: "env-validation", check: "phi-encryption" });
+    throw new Error(message);
+  }
+}
+
+/**
+ * A100-35: Reject CRON_SECRET shorter than 32 characters in production.
+ * A weak or empty secret would allow unauthenticated cron execution
+ * (timingSafeEqual("", "") can return true on some implementations).
+ *
+ * Mirrors the MIN_CRON_SECRET_LENGTH guard in cron-auth.ts but at startup
+ * so operators get a clear boot error instead of silent 401s.
+ *
+ * Exported for unit tests.
+ */
+export function enforceCronSecretMinLength(): void {
+  if (process.env.NODE_ENV !== "production") return;
+
+  const secret = process.env.CRON_SECRET;
+  if (secret && secret.length < 32) {
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] CRON_SECRET must be at least 32 characters.\n" +
+      "A short secret is vulnerable to brute-force. Generate one: `openssl rand -hex 32`.";
+    logger.error(message, { context: "env-validation", check: "cron-secret-length" });
     throw new Error(message);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #545 (merged). Addresses the remaining code-fixable audit findings:

### A23-01/02: Replace `select("*")` with explicit column whitelists
- **10 API routes** updated: menus, menu_items, restaurant-tables, orders, restaurant-orders, pets, v1/appointments
- Prevents accidental exposure of new columns added later
- Added `.limit()` guards on unbounded list endpoints (100-500 depending on entity)

### A34.12: CI concurrency group
- Added `concurrency:` block to cancel redundant CI runs for the same PR
- Saves runner minutes and prevents duplicate CodeQL/Gitleaks/Semgrep jobs

### C-14 (remaining): Pin last 2 floating-tag GitHub Actions
- `supabase/setup-cli@v1` → pinned to SHA (v1.7.1)
- `actions/upload-artifact@v7` → pinned to SHA

### A31.6: Pin MinIO Docker image
- `minio/minio:latest` → `minio/minio:RELEASE.2025-05-01T22-06-42Z`

### A100-35: CRON_SECRET min-length startup validation
- New `enforceCronSecretMinLength()` in `env.ts` — rejects < 32 chars in production
- Mirrors the runtime guard in `cron-auth.ts` but catches it at boot time

## Review & Testing Checklist for Human
- [ ] Verify column whitelists match your frontend expectations
- [ ] Confirm `orders` table has `tax_amount` column
- [ ] Test concurrency group with two quick pushes to same PR

### Notes
- All `select("*")` calls in `src/app/api/` routes are now replaced with explicit column lists
- TypeCheck and ESLint both pass locally with zero errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->