### PR TITLE
fix: remaining audit remediation — PII scrubbing, filter injection, NaN guard, SHA pinning

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -294,7 +294,7 @@ jobs:
     steps:
       - name: Slack notification
         if: vars.SLACK_BACKUP_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v3.0.2
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         with:
           webhook: ${{ vars.SLACK_BACKUP_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -81,7 +81,7 @@ jobs:
         run: npm ci
 
       - name: Start Local Supabase
-        uses: supabase/setup-cli@v2
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
           version: latest
 

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -58,7 +58,7 @@ jobs:
           gunzip latest_backup.sql.gz
 
       - name: Spin up local Supabase
-        uses: supabase/setup-cli@v2
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
           version: latest
       

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -34,8 +34,12 @@ export async function GET(request: NextRequest) {
   const supabase = await createTenantClient(auth.clinicId);
   const url = new URL(request.url);
   const search = url.searchParams.get("search");
-  const limit = Math.min(Number(url.searchParams.get("limit") || 50), 100);
-  const offset = Number(url.searchParams.get("offset") || 0);
+  // A46.8: Guard against NaN from malformed query params — Number("abc") is NaN,
+  // Math.min(NaN, 100) is NaN, causing undefined Supabase behavior.
+  const rawLimit = Number(url.searchParams.get("limit"));
+  const limit = Math.min(Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 50, 100);
+  const rawOffset = Number(url.searchParams.get("offset"));
+  const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
 
   let query = supabase
     .from("users")
@@ -46,9 +50,11 @@ export async function GET(request: NextRequest) {
     .range(offset, offset + limit - 1);
 
   if (search) {
-    // MED-05: Sanitize search input to prevent PostgREST filter injection.
-    // Strip %, _, comma, parens AND dots (PostgREST uses . as filter separator).
-    const sanitized = search.replace(/[%_,.()]/g, "");
+    // MED-05 + A46.3: Sanitize search input to prevent PostgREST filter injection.
+    // Strip %, _, comma, parens, dots (PostgREST filter separator) AND pipes
+    // (PostgREST OR operator token). Without stripping |, an attacker could
+    // inject additional filter clauses like `role.eq.super_admin`.
+    const sanitized = search.replace(/[%_,.()|]/g, "");
     if (sanitized.length > 0) {
       // B-01: Use `name` (and `name_ar` for Arabic search) instead of the
       // non-existent `full_name` column which caused a 500 on every request.

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -53,9 +53,12 @@ async function sendSlackRegistrationAlert(data: {
   clientIp: string;
 }): Promise<void> {
   if (!SLACK_WEBHOOK_URL) {
+    // A8-01: Never log PII (email, phone, names) — Morocco Law 09-08 / GDPR.
+    // Only log non-PII identifiers; the rest is available via DB lookup.
     logger.info("New clinic registration (no Slack webhook configured)", {
       context: "register-clinic",
-      ...data,
+      verificationMethod: data.verificationMethod,
+      city: data.city,
     });
     return;
   }


### PR DESCRIPTION
## Summary

Addresses the last remaining code-fixable findings from the 2729-line security audit (PRs #545, #546, #547 covered the bulk).

**A8-01 (MEDIUM)** — PII in logs: register-clinic fallback logger.info was spreading email/phone/name. Now only logs non-PII fields (verificationMethod, city).

**A46.3 (CRITICAL)** — PostgREST filter injection: Search sanitizer in v1/patients missed pipe | (OR operator). Attacker could inject filter clauses. Added | to deny list.

**A46.8 (MEDIUM)** — NaN limit/offset: Number(abc) returns NaN causing undefined Supabase range. Now validates with Number.isFinite() and falls back to defaults.

**A34 (HIGH)** — Pin last 3 floating GH Actions to full SHAs (backup.yml slack, migration-check/restore-test supabase-cli).

### Already fixed on main (verified)
A6-13, A14-02/03, A16-03/04/05, A19-04, A34.2/34.3, F-A96-01/02, A101-1/2, A52.7, A56.7/8, F-A93-04, A100-35.

## Review & Testing Checklist for Human
- [ ] Test v1/patients search with pipe: ?search=test|role.eq.super_admin
- [ ] Verify register-clinic logs without Slack webhook
- [ ] Test ?limit=abc&offset=-1 on /api/v1/patients

### Notes
All remaining ~120+ findings are infrastructure/dashboard/legal — not code changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->