### PR TITLE
fix(security): deny patient downloads for legacy files without patient_files record

### DIFF
--- a/src/app/api/files/download/route.ts
+++ b/src/app/api/files/download/route.ts
@@ -170,18 +170,18 @@ async function handler(request: NextRequest, { supabase, profile }: AuthContext)
       .eq("r2_key", baseKey)
       .maybeSingle();
 
-    // M-02/A7-01: If a patient_files record exists, enforce ownership.
-    // Legacy files (uploaded before patient_files table) are allowed within
-    // the patient's own clinic (already verified above) but logged so the
-    // admin can backfill records over time.
+    // M-02/A7-01: Patients must have a patient_files record linking the
+    // file to their profile. Legacy files without records are NOT accessible
+    // to patients — they must be backfilled by an admin or accessed via
+    // staff roles (doctor, clinic_admin, receptionist).
     if (!fileRecord) {
-      logger.warn("Legacy file access: no patient_files record — consider backfilling", {
+      logger.warn("Patient denied access to file without patient_files record", {
         context: "api/files/download",
         role: profile.role,
         profileId: profile.id,
         keyPrefix: baseKey.split("/").slice(0, 2).join("/"),
       });
-      // Allow through — clinic-level isolation is already enforced above
+      return apiForbidden("You do not have access to this file");
     } else if (fileRecord.patient_id !== profile.id) {
       logger.warn("Patient attempted to download another patient's file", {
         context: "api/files/download",


### PR DESCRIPTION
## Summary

Closes the same-clinic patient IDOR risk for legacy PHI files.

**Before:** When a patient requested a file download and no `patient_files` record existed for that R2 key, the code logged a warning ("Legacy file access") but **allowed the download through**. This meant any patient within the same clinic could guess/enumerate R2 keys and access another patient's files if those files predated the `patient_files` table.

**After:** Patients are **denied by default** (403) when no `patient_files` record links the file to their profile. The file must either:
- Have a `patient_files` record with matching `patient_id`, or
- Be accessed by staff roles (doctor, clinic_admin, receptionist) which have legitimate clinic-wide access

Legacy files should be backfilled via admin migration to create the missing `patient_files` records.

## Review & Testing Checklist for Human

- [ ] Verify that patients can still download files that DO have a `patient_files` record linking to their profile
- [ ] Verify that staff roles (doctor, clinic_admin, receptionist) can still download any file within their clinic regardless of `patient_files` records
- [ ] If you have legacy files without `patient_files` records, run a backfill migration before deploying (or accept that patients will lose access to those files until backfilled)

### Notes

- Single-line change in `src/app/api/files/download/route.ts` (lines 173-184)
- No database migration needed — this is a logic change only
- Staff/admin access is unchanged
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->