### PR TITLE
fix(security): audit launch blockers — role map fail-closed + wrangler IaC

### DIFF
--- a/src/lib/middleware/routes.ts
+++ b/src/lib/middleware/routes.ts
@@ -53,13 +53,30 @@ export const LIGHTWEIGHT_API_PATHS = new Set([
   "/api/health",
 ]);
 
-/** Role to allowed route prefix mapping */
+/**
+ * Role to allowed route prefix mapping.
+ *
+ * AUDIT-LB2: Every role that has a PROTECTED_PREFIXES entry MUST appear
+ * here. If a role is missing, the middleware check fails open and the
+ * user bypasses route scoping. Unknown roles are denied in middleware
+ * (see fail-closed block in middleware.ts).
+ */
 export const ROLE_ROUTE_MAP: Record<string, string> = {
   super_admin: "/super-admin",
   clinic_admin: "/admin",
   receptionist: "/receptionist",
   doctor: "/doctor",
   patient: "/patient",
+  pharmacist: "/pharmacist",
+  nutritionist: "/nutritionist",
+  optician: "/optician",
+  parapharmacy: "/parapharmacy",
+  physiotherapist: "/physiotherapist",
+  psychologist: "/psychologist",
+  radiology: "/radiology",
+  speech_therapist: "/speech-therapist",
+  equipment: "/equipment",
+  lab: "/lab-panel",
 };
 
 /** Role to dashboard path mapping */
@@ -69,6 +86,16 @@ export const ROLE_DASHBOARD_MAP: Record<string, string> = {
   receptionist: "/receptionist/dashboard",
   doctor: "/doctor/dashboard",
   patient: "/patient/dashboard",
+  pharmacist: "/pharmacist/dashboard",
+  nutritionist: "/nutritionist/dashboard",
+  optician: "/optician/dashboard",
+  parapharmacy: "/parapharmacy/dashboard",
+  physiotherapist: "/physiotherapist/dashboard",
+  psychologist: "/psychologist/dashboard",
+  radiology: "/radiology/dashboard",
+  speech_therapist: "/speech-therapist/dashboard",
+  equipment: "/equipment/dashboard",
+  lab: "/lab-panel/dashboard",
 };
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -483,6 +483,14 @@ export async function middleware(request: NextRequest) {
   if (user && isProtectedRoute(pathname) && profile) {
     const allowedPrefix = ROLE_ROUTE_MAP[profile.role];
 
+    // AUDIT-LB2: Fail-closed for unmapped roles. If a role is not in
+    // ROLE_ROUTE_MAP, deny access entirely rather than silently allowing
+    // through. This prevents users with unexpected roles from bypassing
+    // route scoping.
+    if (!allowedPrefix) {
+      return secureRedirect(new URL("/login?error=unauthorized_role", request.url));
+    }
+
     // Super admin and doctor can access their routes, but MUST complete MFA if configured
     if (profile.role === "super_admin" || profile.role === "doctor") {
       const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
@@ -503,9 +511,9 @@ export async function middleware(request: NextRequest) {
     }
 
     // Check if user is accessing their allowed routes
-    if (allowedPrefix && !pathname.startsWith(allowedPrefix)) {
+    if (!pathname.startsWith(allowedPrefix)) {
       const dashboardPath =
-        ROLE_DASHBOARD_MAP[profile.role] || "/patient/dashboard";
+        ROLE_DASHBOARD_MAP[profile.role] || allowedPrefix;
       return secureRedirect(new URL(dashboardPath, request.url));
     }
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -448,9 +448,11 @@ export async function middleware(request: NextRequest) {
   if (isPublicRoute(pathname)) {
     // If authenticated user visits login/register, redirect to their dashboard
     if (user && (pathname === "/login" || pathname === "/register") && profile) {
-      const dashboardPath =
-        ROLE_DASHBOARD_MAP[profile.role] || "/patient/dashboard";
-      return secureRedirect(new URL(dashboardPath, request.url));
+      const dashboardPath = ROLE_DASHBOARD_MAP[profile.role];
+      if (dashboardPath) {
+        return secureRedirect(new URL(dashboardPath, request.url));
+      }
+      // Unknown role with no dashboard — let them stay on login/register
     }
     return supabaseResponse;
   }
@@ -484,10 +486,12 @@ export async function middleware(request: NextRequest) {
     const allowedPrefix = ROLE_ROUTE_MAP[profile.role];
 
     // AUDIT-LB2: Fail-closed for unmapped roles. If a role is not in
-    // ROLE_ROUTE_MAP, deny access entirely rather than silently allowing
-    // through. This prevents users with unexpected roles from bypassing
-    // route scoping.
+    // ROLE_ROUTE_MAP, sign the user out and redirect to login. Without
+    // the sign-out, the authenticated-user-on-login handler (below)
+    // would bounce them to /patient/dashboard, creating an infinite
+    // redirect loop.
     if (!allowedPrefix) {
+      await supabase.auth.signOut();
       return secureRedirect(new URL("/login?error=unauthorized_role", request.url));
     }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -24,29 +24,27 @@ compatibility_flags = ["nodejs_compat"]
 # cloudflare/wrangler-action in CI to avoid leaking it in the repo.
 
 # ── Routes ────────────────────────────────────────────────────────────
-# The Worker serves all requests for the root domain and all subdomains.
-# Wildcard routing is configured in Cloudflare DNS (CNAME * -> Workers).
-# routes = [
-#   { pattern = "oltigo.com/*", zone_name = "oltigo.com" },
-#   { pattern = "*.oltigo.com/*", zone_name = "oltigo.com" },
-# ]
+# AUDIT-LB3: The Worker serves all requests for the root domain and all
+# subdomains. These routes are deploy-verifiable IaC — if they are
+# missing from wrangler.toml, the Worker will not receive traffic.
+routes = [
+  { pattern = "oltigo.com/*", zone_name = "oltigo.com" },
+  { pattern = "*.oltigo.com/*", zone_name = "oltigo.com" },
+]
 
 # ── KV Namespaces ─────────────────────────────────────────────────────
-# 31.15: IaC — rate-limiting counters (shared across all edge locations).
-# Wrangler requires a non-empty namespace ID at build time, so the actual
-# binding is configured via Cloudflare dashboard per-environment.
-# The binding configuration is:
-#   [[kv_namespaces]]
-#   binding = "RATE_LIMIT_KV"
-#   id = "<KV_NAMESPACE_ID>"     # from `wrangler kv namespace list`
+# AUDIT-LB3: IaC — rate-limiting counters (shared across all edge
+# locations). Replace the placeholder ID with the actual KV namespace ID
+# from `wrangler kv namespace list` before first deploy.
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "REPLACE_WITH_PROD_KV_NAMESPACE_ID"
 
 # ── R2 Buckets ────────────────────────────────────────────────────────
-# 31.15: IaC — PHI file storage (encrypted uploads).
-# R2 binding is configured via Cloudflare dashboard per-environment.
-# The binding configuration is:
-#   [[r2_buckets]]
-#   binding = "UPLOADS_BUCKET"
-#   bucket_name = "webs-alots-uploads"
+# AUDIT-LB3: IaC — PHI file storage (encrypted uploads).
+[[r2_buckets]]
+binding = "UPLOADS_BUCKET"
+bucket_name = "webs-alots-uploads"
 
 # ── Environment Variables (non-secret) ────────────────────────────────
 # Secrets (API keys, encryption keys) are set via `wrangler secret put`
@@ -73,17 +71,14 @@ cpu_ms = 50  # Default: 50ms CPU time per request (Workers Paid plan)
 enabled = true
 
 # ── Cron Triggers ─────────────────────────────────────────────────────
-# 31.18: IaC — scheduled jobs (GDPR purge, reminders, stale-booking sweep).
-# Cron triggers are configured via Cloudflare dashboard because
-# opennextjs-cloudflare generates its own wrangler config at build time
-# and may conflict with user-defined triggers.
-# The intended schedule is:
-#   [triggers]
-#   crons = [
-#     "0 2 * * *",    # 02:00 UTC daily — GDPR patient data purge
-#     "0 8 * * *",    # 08:00 UTC daily — appointment reminders
-#     "*/15 * * * *", # every 15 min — stale booking sweep
-#   ]
+# AUDIT-LB3: IaC — scheduled jobs (GDPR purge, reminders, stale-booking
+# sweep). Defined here so `wrangler deploy` registers them automatically.
+[triggers]
+crons = [
+  "0 2 * * *",    # 02:00 UTC daily — GDPR patient data purge
+  "0 8 * * *",    # 08:00 UTC daily — appointment reminders
+  "*/15 * * * *", # every 15 min — stale booking sweep
+]
 
 # ── Build ─────────────────────────────────────────────────────────────
 # The build command is handled by CI (npm run build:cf), not by wrangler.


### PR DESCRIPTION
## Summary

Fixes the remaining audit launch blockers identified in the recheck report.

### Finding 1: Non-public API routes not middleware-protected
**Status: Already implemented.** The middleware already has fail-closed API protection at lines 458-473 (`AUDIT-12` block). The `isPublicRoute()` function in `routes.ts` classifies `/api/*` routes via the `PUBLIC_API_ROUTES` allowlist, and any non-public API route returns 401 for unauthenticated callers. No code change needed — the auditor may have missed this existing block.

### Finding 2: Role map fails open for unmapped roles (CRITICAL)
**Fixed.** Two changes:
1. Added all 10 missing roles to `ROLE_ROUTE_MAP` and `ROLE_DASHBOARD_MAP`: pharmacist, nutritionist, optician, parapharmacy, physiotherapist, psychologist, radiology, speech_therapist, equipment, lab
2. Added fail-closed block: if an authenticated user's role is NOT in `ROLE_ROUTE_MAP`, they are redirected to `/login?error=unauthorized_role` instead of silently passing through

### Finding 3: Cloudflare bindings not codified (HIGH)
**Fixed.** Uncommented and activated in `wrangler.toml`:
- Routes: `oltigo.com/*` and `*.oltigo.com/*`
- KV: `RATE_LIMIT_KV` binding (placeholder ID — must be replaced before first deploy)
- R2: `UPLOADS_BUCKET` binding
- Cron triggers: GDPR purge (02:00 UTC), reminders (08:00 UTC), booking sweep (every 15 min)

### Finding 4: Build/lint/typecheck/tests unverified (HIGH)
**Verified locally:**
- `npm run lint` — passes (exit 0, only pre-existing i18n warnings)
- `npx tsc --noEmit` — passes (exit 0, no type errors)
- `npm run test` — 81 test files, 797 tests passed, 16 skipped
- CI already runs all of these on every PR

### Finding 5: CSP unsafe-inline (MEDIUM)
**Tracked for post-launch.** The `style-src 'unsafe-inline'` is currently necessary because many React components use inline `style={{}}`. Removing it requires migrating all inline styles to Tailwind/CSS modules — tracked as a hardening item, not a launch blocker.

## Review & Testing Checklist for Human
- [ ] Verify that users with unmapped roles (e.g., a hypothetical `intern` role) are redirected to `/login?error=unauthorized_role` when accessing any protected route
- [ ] Verify that pharmacist, nutritionist, lab, and other newly-mapped roles can only access their designated route prefix (e.g., pharmacist can only access `/pharmacist/*`)
- [ ] Verify that the wrangler.toml KV placeholder `REPLACE_WITH_PROD_KV_NAMESPACE_ID` is replaced with the actual KV namespace ID before production deploy
- [ ] Confirm API routes like `/api/chat`, `/api/ai/auto-suggest` return 401 for unauthenticated requests (already enforced by existing AUDIT-12 block)

### Notes
- The `REPLACE_WITH_PROD_KV_NAMESPACE_ID` in wrangler.toml is intentional — it must be replaced with the real KV namespace ID from `wrangler kv namespace list`
- super_admin bypasses prefix enforcement (returns supabaseResponse directly after MFA check) — this is intentional and unchanged
- CSP `unsafe-inline` removal is tracked as post-launch hardening
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->