### PR TITLE
fix(security): P0/P1 audit remediation — deploy safety, backup verification, registration hardening

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -192,6 +192,7 @@ jobs:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
+      BACKUP_GPG_PRIVATE_KEY: ${{ secrets.BACKUP_GPG_PRIVATE_KEY }}
     steps:
       - name: Install tools
         run: |
@@ -212,7 +213,17 @@ jobs:
           region=auto
           EOF
 
+      - name: Import GPG private key for decryption
+        run: |
+          if [ -z "${BACKUP_GPG_PRIVATE_KEY}" ]; then
+            echo "::error::BACKUP_GPG_PRIVATE_KEY is not set. Cannot verify encrypted backups."
+            exit 1
+          fi
+          echo "${BACKUP_GPG_PRIVATE_KEY}" | gpg --batch --import
+
       - name: Download latest backup
+        # F-03: Download the actual .sql.gz.gpg file (not .sql.gz).
+        # Backups are encrypted with GPG before upload.
         run: |
           R2_ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
 
@@ -232,7 +243,7 @@ jobs:
 
           echo "Downloading: backups/${PREFIX}/${LATEST}"
           aws s3 cp "s3://${R2_BACKUP_BUCKET}/backups/${PREFIX}/${LATEST}" \
-            /tmp/verify_backup.sql.gz \
+            /tmp/verify_backup.sql.gz.gpg \
             --endpoint-url "${R2_ENDPOINT}"
 
       - name: Start local PostgreSQL
@@ -252,6 +263,14 @@ jobs:
           # Pre-create extensions that Supabase uses so CREATE EXTENSION doesn't fail
           psql backup_verify_test -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;" 2>/dev/null || true
           psql backup_verify_test -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" 2>/dev/null || true
+
+      - name: Decrypt backup
+        # F-03: The backup workflow creates .sql.gz.gpg files (pg_dump | gzip | gpg).
+        # Verification MUST decrypt before decompressing — previously this step
+        # was missing, so verify was testing a corrupt/unreadable file.
+        run: |
+          gpg --batch --yes --decrypt /tmp/verify_backup.sql.gz.gpg > /tmp/verify_backup.sql.gz
+          echo "Decrypted backup successfully ($(du -h /tmp/verify_backup.sql.gz | cut -f1))"
 
       - name: Test restore
         run: |
@@ -284,7 +303,8 @@ jobs:
         if: always()
         run: |
           dropdb backup_verify_test 2>/dev/null || true
-          rm -f /tmp/verify_backup.sql.gz
+          rm -f /tmp/verify_backup.sql.gz /tmp/verify_backup.sql.gz.gpg
+          rm -rf ~/.gnupg
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -174,22 +174,24 @@ jobs:
 
       - name: Preflight — required secrets
         id: preflight
-        # Check whether Supabase secrets are configured. If not, skip
-        # migration steps (no secrets → nothing to migrate against).
-        # The deploy job still proceeds so the app can be deployed.
+        # F-01: Missing migration secrets MUST fail the pipeline in
+        # production. Deploying code that expects new tables/RPCs/RLS
+        # policies while the DB is still on the old schema can cause
+        # 500s or, worse, weaker security policies. Skip is only
+        # allowed for non-production preview environments.
         run: |
           missing=0
           for v in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_REF; do
             if [ -z "${!v:-}" ]; then
-              echo "::warning::Secret '$v' is not set for environment '${{ github.ref_name == 'staging' && 'staging' || 'production' }}'. Skipping DB migrations."
+              echo "::error::Secret '$v' is not set for environment '${{ github.ref_name == 'staging' && 'staging' || 'production' }}'."
               missing=1
             fi
           done
           if [ "$missing" -eq 1 ]; then
-            echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Required Supabase migration secrets are missing. Deploy blocked."
+            exit 1
           fi
+          echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Install Supabase CLI
         if: steps.preflight.outputs.secrets_ok == 'true'

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -19,28 +19,38 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Fetch Latest Encrypted Backup
+        # F-03: Aligned to use R2_BACKUP_BUCKET (same as backup.yml) and
+        # search the backups/daily/ prefix where nightly backups are stored.
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_REGION: auto
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_BACKUP_BUCKET: ${{ secrets.R2_BACKUP_BUCKET }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          aws s3api list-objects-v2 --bucket "$R2_BUCKET" \
-            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
-            --query "sort_by(Contents, &LastModified)[-1].Key" \
-            --output text > latest_key.txt
-          
-          LATEST_KEY=$(cat latest_key.txt)
-          echo "Latest backup key: $LATEST_KEY"
-          
-          if [[ "$LATEST_KEY" == "None" || -z "$LATEST_KEY" ]]; then
+          R2_ENDPOINT="https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Look in backups/daily/ first (matches backup.yml upload path),
+          # then fall back to backups/weekly/ and backups/monthly/.
+          LATEST=""
+          for PREFIX in daily weekly monthly; do
+            LATEST=$(aws s3 ls "s3://${R2_BACKUP_BUCKET}/backups/${PREFIX}/" \
+              --endpoint-url "${R2_ENDPOINT}" 2>/dev/null \
+              | sort -r | head -1 | awk '{print $4}' || true)
+            if [ -n "${LATEST}" ]; then
+              LATEST_PATH="backups/${PREFIX}/${LATEST}"
+              break
+            fi
+          done
+
+          if [ -z "${LATEST}" ]; then
             echo "::error::No backups found in R2 bucket."
             exit 1
           fi
 
-          aws s3 cp "s3://${R2_BUCKET}/${LATEST_KEY}" latest_backup.sql.gz.gpg \
-            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          echo "Downloading: ${LATEST_PATH}"
+          aws s3 cp "s3://${R2_BACKUP_BUCKET}/${LATEST_PATH}" latest_backup.sql.gz.gpg \
+            --endpoint-url "${R2_ENDPOINT}"
 
       - name: Decrypt and Decompress Backup
         env:

--- a/next.config.ts
+++ b/next.config.ts
@@ -91,8 +91,14 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        // Audit P2 #17: Pin to project instead of allowing **.supabase.co
-        hostname: process.env.NEXT_PUBLIC_SUPABASE_URL ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname : "**.supabase.co",
+        // Audit P2 #17: Pin to project instead of allowing **.supabase.co.
+        // F-05: No wildcard fallback — if NEXT_PUBLIC_SUPABASE_URL is missing,
+        // restrict to a non-matching placeholder so the build succeeds but
+        // no external Supabase images are optimized. The env validation in
+        // lib/env.ts will catch the missing URL at runtime.
+        hostname: process.env.NEXT_PUBLIC_SUPABASE_URL
+          ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+          : "supabase-url-not-configured.invalid",
         pathname: "/storage/v1/object/public/**",
       },
       {

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -32,7 +32,8 @@ import { sendTextMessage } from "@/lib/whatsapp";
 // Anti-Abuse Rate Limiter
 // ---------------------------------------------------------------------------
 // Extremely strict rate limit for public registration (2 per hour per IP)
-const registerLimiter = createRateLimiter({ windowMs: 60 * 60 * 1000, max: 2 });
+// F-06: failClosed prevents mass tenant creation when rate-limit backend degrades.
+const registerLimiter = createRateLimiter({ windowMs: 60 * 60 * 1000, max: 2, failClosed: true });
 
 // ---------------------------------------------------------------------------
 // Slack webhook for registration alerts (R-12 fix)
@@ -332,7 +333,10 @@ export async function POST(request: NextRequest) {
         context: "register-clinic",
         error: err,
       });
-      // Fail open on Turnstile service outage to avoid blocking all registrations
+      // F-06: Fail closed — this endpoint creates privileged users and real
+      // tenants. Allowing registration when Turnstile is unreachable exposes
+      // the system to mass fake-clinic creation.
+      return apiError("Bot verification is temporarily unavailable. Please try again later.", 503);
     }
   }
 

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -17,6 +17,7 @@
  */
 
 import { type NextRequest } from "next/server";
+import { logAuditEvent } from "@/lib/audit-log";
 import { sha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase-server";
@@ -121,6 +122,20 @@ export async function authenticateApiKey(
         .then(({ error }) => {
           if (error) logger.warn("Failed to update API key last_used_at", { context: "api-auth", error });
         });
+
+      // Append-only audit log for API key usage (durable forensics).
+      logAuditEvent({
+        supabase,
+        action: "api_key_used",
+        type: "security",
+        clinicId: candidate.clinic_id,
+        description: `API key (prefix: ${keyPrefix}) authenticated`,
+        metadata: {
+          key_prefix: keyPrefix,
+          scopes: Array.isArray(scopes) ? scopes : null,
+          required_scope: requiredScope ?? null,
+        },
+      }).catch(() => {});
 
       return {
         clinicId: candidate.clinic_id,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,10 +70,9 @@ const MAX_BODY_BYTES = 25 * 1024 * 1024;
 
 export async function middleware(request: NextRequest) {
   // AUDIT-25: Record middleware start time for CPU telemetry.
-  // Cloudflare Workers "bundled" plan has a 10ms CPU limit per invocation.
+  // Cloudflare Workers CPU budget is set to 50ms in wrangler.toml (Paid plan).
   // This timing helps identify when middleware complexity approaches that
-  // threshold so the team can optimize or switch to "unbound" before p99
-  // latency degrades.
+  // threshold so the team can optimize before p99 latency degrades.
   const mwStart = Date.now();
 
   const { pathname } = request.nextUrl;
@@ -523,8 +522,8 @@ export async function middleware(request: NextRequest) {
   }
 
   // AUDIT-25: Log middleware execution time for CPU budget monitoring.
-  // On Cloudflare Workers "bundled" plan (10ms CPU limit), sustained p95
-  // above ~7ms should trigger investigation or migration to "unbound".
+  // CPU budget is 50ms per request (wrangler.toml). Sustained p95 above
+  // ~35ms should trigger investigation and optimization.
   const mwDuration = Date.now() - mwStart;
   if (mwDuration > 5) {
     // Only log slow requests to avoid noise. Threshold tuned for edge.


### PR DESCRIPTION
## Summary

Fixes P0 and P1 findings from the second comprehensive audit report. Seven files changed across CI/CD workflows, middleware, registration, API auth, and build config.

### F-01 (P0): Deploy pipeline now fails on missing migration secrets
Previously, missing Supabase secrets produced a warning and skipped migrations while the Worker deploy continued. Now it hard-fails with `exit 1`, preventing code/schema drift where new code runs against an old database.

### F-03 (P0): Backup verification actually decrypts before restoring
The nightly verify job downloaded `.sql.gz.gpg` but ran `gunzip` without GPG decryption — giving false "backup verified" confidence. Now:
- Imports `BACKUP_GPG_PRIVATE_KEY` and decrypts before decompressing
- Downloads to `.sql.gz.gpg` (correct extension)
- Cleans up GPG keyring after verification
- `restore-test.yml` aligned to use `R2_BACKUP_BUCKET` (was `R2_BUCKET`) and searches `backups/daily|weekly|monthly/` prefixes matching the backup workflow's upload paths

### F-06 (P1): Registration anti-abuse now fails closed
- Rate limiter: `failClosed: true` — denies registration when rate-limit backend is degraded
- Turnstile: `catch` block now returns 503 instead of silently allowing through. This endpoint creates privileged admin users and real tenants — fail-open is unacceptable.

### F-11: CPU budget documentation aligned
Middleware comments referenced "bundled plan 10ms CPU limit" but `wrangler.toml` sets `cpu_ms = 50` (Paid plan). Updated comments to match the actual config.

### Image domain wildcard removed
`next.config.ts` fell back to `**.supabase.co` when `NEXT_PUBLIC_SUPABASE_URL` was missing. Replaced with `supabase-url-not-configured.invalid` so a misconfigured deploy can't optimize images from arbitrary Supabase projects.

### API key audit logging
Added `logAuditEvent()` call on every successful API key authentication — provides durable, append-only forensic evidence beyond the fire-and-forget `last_used_at` row update.

### Already implemented (no changes needed)
- **F-07**: Booking token phone binding already at `src/app/api/booking/route.ts:237-243`
- **Cron heartbeats**: All 7 cron jobs already use `withSentryCron` with check-in/check-out, 5-min miss margin, 10-min timeout
- **API key scopes/expiry**: Already enforced via AUDIT-13 (`expires_at` + `scopes` checks)

## Review & Testing Checklist for Human
- [ ] Verify `BACKUP_GPG_PRIVATE_KEY` secret is configured in GitHub → Settings → Secrets for the backup verify job to decrypt
- [ ] Verify `R2_BACKUP_BUCKET` secret is set (restore-test.yml was changed from `R2_BUCKET`)
- [ ] Verify Supabase migration secrets are set in both `production` and `staging` GitHub environments — deploy will now hard-fail without them
- [ ] If self-service registration is enabled, test that Turnstile failure returns 503 (not silent pass-through)
- [ ] Test a production build with `NEXT_PUBLIC_SUPABASE_URL` set — verify images from Supabase storage still load correctly

### Notes
- The deploy workflow change is safe: if migration secrets are already configured, behavior is identical. It only changes the failure mode from "skip silently" to "fail loudly."
- The `supabase-url-not-configured.invalid` fallback uses a reserved TLD (`.invalid` per RFC 2606) — no DNS resolution is possible, so it cannot match any real hostname.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->