### PR TITLE
fix(P0): align cron wiring, unblock deploys, fail-closed env validation

### DIFF
--- a/scripts/check-cron-mapping.ts
+++ b/scripts/check-cron-mapping.ts
@@ -1,6 +1,6 @@
 /**
  * CI guard: verify every cron expression declared in wrangler.toml
- * has a matching entry in worker-cron-handler.ts.
+ * has a matching entry in worker-cron-handler.ts, and vice-versa.
  *
  * Prevents silent cron misfires caused by schedule changes in one
  * file but not the other.
@@ -10,19 +10,31 @@ import { readFileSync } from "node:fs";
 const wrangler = readFileSync("wrangler.toml", "utf8");
 const handler = readFileSync("worker-cron-handler.ts", "utf8");
 
-// Extract cron expressions from the *top-level* [triggers] block only.
-// Staging/env-specific blocks use identical schedules and are managed separately.
-const declared = [
-  ...(wrangler.match(/^\s*crons\s*=\s*\[(.*)\]/m)?.[1] ?? "").matchAll(
-    /"([^"]+)"/g,
-  ),
-].map((m) => m[1]);
+// Extract cron expressions from the [triggers] crons array.
+// The array can be multiline, so we first extract the full array content
+// between `crons = [` and `]`, then pull out quoted strings.
+const cronsBlockMatch = wrangler.match(/crons\s*=\s*\[([\s\S]*?)\]/);
+const cronsBlock = cronsBlockMatch?.[1] ?? "";
+const declared = [...cronsBlock.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
 
-const missing = declared.filter((c) => !handler.includes(`"${c}"`));
-
-if (missing.length) {
-  console.error("Cron mismatch — these wrangler.toml schedules have no handler mapping:", missing);
+if (declared.length === 0) {
+  console.error("No cron schedules found in wrangler.toml [triggers].crons");
   process.exit(1);
 }
 
-console.log(`Cron mapping OK — ${declared.length} schedule(s) verified.`);
+// Check wrangler → handler direction
+const missingInHandler = declared.filter((c) => !handler.includes(`"${c}"`));
+if (missingInHandler.length) {
+  console.error("Cron mismatch — these wrangler.toml schedules have no handler mapping:", missingInHandler);
+  process.exit(1);
+}
+
+// Check handler → wrangler direction: extract schedule keys from CRON_ROUTES
+const handlerSchedules = [...handler.matchAll(/"([*/\d ]+\*)":\s/g)].map((m) => m[1]);
+const missingInWrangler = handlerSchedules.filter((c) => !cronsBlock.includes(`"${c}"`));
+if (missingInWrangler.length) {
+  console.error("Cron mismatch — these handler schedules are not in wrangler.toml:", missingInWrangler);
+  process.exit(1);
+}
+
+console.log(`Cron mapping OK — ${declared.length} wrangler schedule(s), ${handlerSchedules.length} handler schedule(s) verified.`);

--- a/scripts/check-cron-mapping.ts
+++ b/scripts/check-cron-mapping.ts
@@ -30,7 +30,7 @@ if (missingInHandler.length) {
 }
 
 // Check handler → wrangler direction: extract schedule keys from CRON_ROUTES
-const handlerSchedules = [...handler.matchAll(/"([*/\d ]+\*)":\s/g)].map((m) => m[1]);
+const handlerSchedules = [...handler.matchAll(/"([^"]+)":\s/g)].map((m) => m[1]).filter((s) => /^[\d*/,\- a-zA-Z]+$/.test(s));
 const missingInWrangler = handlerSchedules.filter((c) => !cronsBlock.includes(`"${c}"`));
 if (missingInWrangler.length) {
   console.error("Cron mismatch — these handler schedules are not in wrangler.toml:", missingInWrangler);

--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -4,8 +4,9 @@ set -e
 
 echo "Checking for PLACEHOLDER values in configuration..."
 
-if grep -q "PLACEHOLDER" wrangler.toml; then
-  echo "::error::Found PLACEHOLDER values in wrangler.toml. Please update with actual IDs before deploying."
+# Only check uncommented lines for PLACEHOLDER values
+if grep -v '^\s*#' wrangler.toml | grep -q "PLACEHOLDER"; then
+  echo "::error::Found PLACEHOLDER values in uncommented wrangler.toml lines. Please update with actual IDs before deploying."
   exit 1
 fi
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -159,8 +159,15 @@ export function register() {
   // config is surfaced immediately rather than at runtime.
   // Dynamic import avoids pulling logger into the module graph before
   // Next.js has finished bootstrapping.
+  // AUDIT P1-5: The .then() must re-throw so the error propagates as an
+  // unhandled rejection that crashes the Worker, rather than being swallowed.
   import("@/lib/env").then(({ enforceEnvValidation }) => {
     enforceEnvValidation();
+  }).catch((err) => {
+    // Re-throw to ensure the Worker/server process crashes on missing
+    // required env vars instead of silently serving traffic.
+    console.error("[FATAL] Environment validation failed:", err);
+    throw err;
   });
 
   // F-12: Fatal throw when staging env uses production Supabase.

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -5,11 +5,14 @@
  * so that Cloudflare Cron Triggers (defined in wrangler.toml) can invoke
  * the Next.js cron API routes with the correct CRON_SECRET auth.
  *
- * Cron schedule (from wrangler.toml):
- *   - Every 30 min  →  /api/cron/reminders     (appointment reminders)
- *   - Every 15 min  →  /api/cron/notifications (queued notifications)
- *   - Hourly        →  /api/cron/r2-cleanup    (abandoned R2 uploads)
- *   - Daily at 2 AM →  /api/cron/billing       (subscription renewals)
+ * Cron schedule (must match wrangler.toml [triggers].crons exactly):
+ *   - every 15 min   →  /api/cron/notifications (queued notifications)
+ *   - every 30 min   →  /api/cron/reminders     (appointment reminders)
+ *   - hourly         →  /api/cron/r2-cleanup    (abandoned R2 uploads)
+ *                        /api/cron/feedback      (post-appointment feedback)
+ *                        /api/cron/rebooking-reminders (rebooking prompts)
+ *   - daily 02:00    →  /api/cron/billing       (subscription renewals)
+ *   - daily 03:00    →  /api/cron/gdpr-purge    (GDPR patient data purge)
  *
  * @see https://opennext.js.org/cloudflare/howtos/custom-worker
  */
@@ -20,13 +23,17 @@ import { default as handler } from "./.open-next/worker.js";
 
 /**
  * Map cron expressions to their corresponding API routes.
- * The cron value comes from controller.cron and matches wrangler.toml.
+ * The cron value comes from controller.cron and matches wrangler.toml [triggers].crons.
+ *
+ * Some schedules fan out to multiple routes (e.g. the hourly trigger fires
+ * r2-cleanup, feedback, and rebooking-reminders in parallel).
  */
-const CRON_ROUTES: Record<string, string> = {
-  "*/30 * * * *": "/api/cron/reminders",
-  "*/15 * * * *": "/api/cron/notifications",
-  "0 * * * *": "/api/cron/r2-cleanup",
-  "0 2 * * *": "/api/cron/billing",
+const CRON_ROUTES: Record<string, string[]> = {
+  "*/15 * * * *": ["/api/cron/notifications"],
+  "*/30 * * * *": ["/api/cron/reminders"],
+  "0 * * * *":    ["/api/cron/r2-cleanup", "/api/cron/feedback", "/api/cron/rebooking-reminders"],
+  "0 2 * * *":    ["/api/cron/billing"],
+  "0 3 * * *":    ["/api/cron/gdpr-purge"],
 };
 
 export default {
@@ -37,41 +44,43 @@ export default {
     env: Record<string, string>,
     ctx: ExecutionContext,
   ) {
-    const route = CRON_ROUTES[controller.cron] ?? null;
+    const routes = CRON_ROUTES[controller.cron] ?? null;
 
-    if (!route) {
+    if (!routes) {
       console.error(`[Cron] Unknown cron expression: ${controller.cron}`);
       return;
     }
 
-    console.log(`[Cron] Firing ${controller.cron} → ${route}`);
+    const cronSecret = env.CRON_SECRET;
+    if (!cronSecret) {
+      console.error(`[Cron] CRON_SECRET is not set — skipping ${controller.cron} to prevent unauthenticated requests`);
+      return;
+    }
 
-    // B-03: Build a request to the Next.js API route via the same Worker fetch handler.
+    // B-03: Build requests to the Next.js API routes via the same Worker fetch handler.
     // Use a configurable base URL (defaulted to the prod host) so downstream
     // subdomain/CSRF/signed-URL helpers see the real host instead of localhost.
     const cronBaseUrl = env.CRON_SELF_BASE_URL || `https://${env.ROOT_DOMAIN || "oltigo.com"}`;
-    const url = new URL(route, cronBaseUrl);
-    const headers: HeadersInit = {};
 
-    const cronSecret = env.CRON_SECRET;
-    if (!cronSecret) {
-      console.error(`[Cron] CRON_SECRET is not set — skipping ${route} to prevent unauthenticated requests`);
-      return;
+    for (const route of routes) {
+      console.log(`[Cron] Firing ${controller.cron} → ${route}`);
+
+      const url = new URL(route, cronBaseUrl);
+      const request = new Request(url.toString(), {
+        headers: { Authorization: `Bearer ${cronSecret}` },
+      });
+
+      ctx.waitUntil(
+        handler
+          .fetch(request, env, ctx)
+          .then(async (res: Response) => {
+            const body = await res.text();
+            console.log(`[Cron] ${route} responded ${res.status}: ${body}`);
+          })
+          .catch((err: unknown) => {
+            console.error(`[Cron] ${route} failed:`, err);
+          }),
+      );
     }
-    headers["Authorization"] = `Bearer ${cronSecret}`;
-
-    const request = new Request(url.toString(), { headers });
-
-    ctx.waitUntil(
-      handler
-        .fetch(request, env, ctx)
-        .then(async (res: Response) => {
-          const body = await res.text();
-          console.log(`[Cron] ${route} responded ${res.status}: ${body}`);
-        })
-        .catch((err: unknown) => {
-          console.error(`[Cron] ${route} failed:`, err);
-        }),
-    );
   },
 } satisfies ExportedHandler;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -33,12 +33,17 @@ routes = [
 ]
 
 # ── KV Namespaces ─────────────────────────────────────────────────────
-# AUDIT-LB3: IaC — rate-limiting counters (shared across all edge
-# locations). Replace the placeholder ID with the actual KV namespace ID
-# from `wrangler kv namespace list` before first deploy.
-[[kv_namespaces]]
-binding = "RATE_LIMIT_KV"
-id = "REPLACE_WITH_PROD_KV_NAMESPACE_ID"
+# Rate-limiting counters (shared across all edge locations).
+# Currently production uses RATE_LIMIT_BACKEND=supabase, so the KV binding
+# is not required for deploy. Uncomment and set the real namespace ID when
+# migrating to KV-backed rate limiting:
+#
+#   wrangler kv namespace create RATE_LIMIT_KV
+#   # Copy the returned ID below
+#
+# [[kv_namespaces]]
+# binding = "RATE_LIMIT_KV"
+# id = "<paste-real-kv-namespace-id-here>"
 
 # ── R2 Buckets ────────────────────────────────────────────────────────
 # AUDIT-LB3: IaC — PHI file storage (encrypted uploads).
@@ -71,13 +76,16 @@ cpu_ms = 50  # Default: 50ms CPU time per request (Workers Paid plan)
 enabled = true
 
 # ── Cron Triggers ─────────────────────────────────────────────────────
-# AUDIT-LB3: IaC — scheduled jobs (GDPR purge, reminders, stale-booking
-# sweep). Defined here so `wrangler deploy` registers them automatically.
+# IaC — scheduled jobs. These must match worker-cron-handler.ts CRON_ROUTES
+# exactly. `wrangler deploy` registers them with Cloudflare automatically.
+# See also: scripts/check-cron-mapping.ts (CI guard).
 [triggers]
 crons = [
-  "0 2 * * *",    # 02:00 UTC daily — GDPR patient data purge
-  "0 8 * * *",    # 08:00 UTC daily — appointment reminders
-  "*/15 * * * *", # every 15 min — stale booking sweep
+  "*/15 * * * *", # every 15 min — notification queue flush
+  "*/30 * * * *", # every 30 min — appointment reminders
+  "0 * * * *",    # hourly — R2 cleanup + feedback + rebooking reminders
+  "0 2 * * *",    # 02:00 UTC daily — subscription billing
+  "0 3 * * *",    # 03:00 UTC daily — GDPR patient data purge
 ]
 
 # ── Build ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the top 3 confirmed findings from the latest audit. 2 findings (#3 E2E blocking, #4 iat passthrough) were already resolved.

### P0 #1 — Cron wiring aligned

**Before:** wrangler.toml had 3 wrong schedules, handler had 4 different ones, actual routes had 7.

**After:** 5 unique schedules covering all 7 cron routes:

| Schedule | Routes |
|----------|--------|
| `*/15 * * * *` | notifications |
| `*/30 * * * *` | reminders |
| `0 * * * *` | r2-cleanup, feedback, rebooking-reminders |
| `0 2 * * *` | billing |
| `0 3 * * *` | gdpr-purge |

Handler uses `string[]` per schedule to fan out hourly triggers. `check-cron-mapping.ts` verifies bidirectionally.

### P0 #2 — Deploy unblocked

KV binding commented out (production uses `RATE_LIMIT_BACKEND=supabase`). Instructions for enabling KV included. `pre-deploy-check.sh` only scans uncommented lines.

### P1 #5 — Env validation fail-closed

Added `.catch()` re-throw on async env validation so missing required env vars crash the Worker.

### Already Fixed

- **#3 E2E blocking:** `continue-on-error: true` already removed
- **#4 iat passthrough:** already passed in withAuth (L159) and withAuthAnyRole (L343)

### Pre-Launch

Branch protection enabled on `main`: require 1 PR review + CI checks.

## Review & Testing Checklist for Human

- [ ] Verify cron mapping: `npx tsx scripts/check-cron-mapping.ts` should report 5/5 OK
- [ ] Deploy test: `wrangler deploy --dry-run` passes without KV placeholder errors
- [ ] Env validation: missing required env var on staging crashes the Worker
- [ ] Branch protection: direct push to main is blocked

### Notes

- KV binding is commented out, not deleted. Run `wrangler kv namespace create RATE_LIMIT_KV` when ready for KV rate limiting.
- 82 test files / 814 tests / 0 failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->