### PR TITLE
fix(security): audit batch 2 — AI prompt sanitization, cron safety, maintenance mode

### DIFF
--- a/src/app/api/ai/whatsapp-receptionist/route.ts
+++ b/src/app/api/ai/whatsapp-receptionist/route.ts
@@ -204,8 +204,8 @@ INFORMATIONS DE LA CLINIQUE:
 - Téléphone: ${ctx.phone}
 ${ctx.address ? `- Adresse: ${ctx.address}` : ""}
 ${ctx.openingHours ? `- Horaires: ${ctx.openingHours}` : ""}
-${ctx.services.length > 0 ? `- Services: ${ctx.services.join(", ")}` : ""}
-${ctx.doctors.length > 0 ? `- Médecins: ${ctx.doctors.join(", ")}` : ""}
+${ctx.services.length > 0 ? `- Services: ${ctx.services.map(sanitizeUntrustedText).join(", ")}` : ""}
+${ctx.doctors.length > 0 ? `- Médecins: ${ctx.doctors.map(sanitizeUntrustedText).join(", ")}` : ""}
 
 RÈGLES:
 1. Réponds TOUJOURS en français.

--- a/src/lib/ai/sanitize.ts
+++ b/src/lib/ai/sanitize.ts
@@ -18,7 +18,11 @@ export function sanitizeUntrustedText(s: string | null | undefined): string {
     .normalize("NFKC")
     // Strip zero-width / invisible characters
     .replace(/[\u200B-\u200F\u2028-\u202F\uFEFF\u00AD]/g, "")
-    // F-AI-06: Strip UNTRUSTED delimiter markers
+    // F-AI-06 / A101-2: Strip ALL UNTRUSTED delimiter marker variants.
+    // The prompt templates use <<UNTRUSTED_PATIENT_INPUT_BEGIN/END>> to
+    // fence user content. If an attacker injects these markers they can
+    // close the fence early and inject trusted-mode instructions.
+    .replace(/<<\s*UNTRUSTED[^>]*>>/gi, "")
     .replace(/---\s*UNTRUSTED\s*---/gi, "")
     .replace(/---\s*END\s*UNTRUSTED\s*---/gi, "")
     .replace(/\[UNTRUSTED\]/gi, "")

--- a/src/lib/chatbot-data.ts
+++ b/src/lib/chatbot-data.ts
@@ -162,13 +162,13 @@ export function buildSystemPrompt(ctx: ChatbotClinicContext): string {
         .map((s) => {
           const price = s.price != null ? `${s.price} MAD` : "Prix sur demande";
           const cat = s.category ? ` (${s.category})` : "";
-          return `- ${s.name}${cat}: ${price} — ${s.duration_minutes} min`;
+          return `- ${sanitizeUntrustedText(s.name)}${cat}: ${price} — ${s.duration_minutes} min`;
         })
         .join("\n")
     : "Aucun service configuré";
 
   const doctorsText = doctors.length > 0
-    ? doctors.map((d) => `- Dr. ${d.name}`).join("\n")
+    ? doctors.map((d) => `- Dr. ${sanitizeUntrustedText(d.name)}`).join("\n")
     : "Aucun médecin configuré";
 
   // F-AI-02: Sanitize stored FAQ answers to prevent prompt injection via

--- a/src/lib/chatbot-data.ts
+++ b/src/lib/chatbot-data.ts
@@ -161,7 +161,7 @@ export function buildSystemPrompt(ctx: ChatbotClinicContext): string {
     ? services
         .map((s) => {
           const price = s.price != null ? `${s.price} MAD` : "Prix sur demande";
-          const cat = s.category ? ` (${s.category})` : "";
+          const cat = s.category ? ` (${sanitizeUntrustedText(s.category)})` : "";
           return `- ${sanitizeUntrustedText(s.name)}${cat}: ${price} — ${s.duration_minutes} min`;
         })
         .join("\n")

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -79,6 +79,17 @@ export async function middleware(request: NextRequest) {
   const hostname = request.headers.get("host") ?? "";
   const rootDomain = process.env.ROOT_DOMAIN;
 
+  // --- A45.6: Global maintenance-mode kill-switch ---
+  // Set MAINTENANCE_MODE=1 in env to immediately return 503 for all traffic
+  // without redeploying the Worker. Health-check endpoint is exempted so
+  // monitoring can detect when maintenance ends.
+  if (process.env.MAINTENANCE_MODE === "1" && pathname !== "/api/health") {
+    return new NextResponse("Service temporarily unavailable for maintenance", {
+      status: 503,
+      headers: { "Retry-After": "300", "Content-Type": "text/plain" },
+    });
+  }
+
   // --- F-A198 / F-A160: Sanctioned country block ---
   const sanctionBlock = checkSanctionedCountry(request);
   if (sanctionBlock) return sanctionBlock;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -86,7 +86,14 @@ export async function middleware(request: NextRequest) {
   if (process.env.MAINTENANCE_MODE === "1" && pathname !== "/api/health") {
     return new NextResponse("Service temporarily unavailable for maintenance", {
       status: 503,
-      headers: { "Retry-After": "300", "Content-Type": "text/plain" },
+      headers: {
+        "Retry-After": "300",
+        "Content-Type": "text/plain",
+        "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+      },
     });
   }
 

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -57,10 +57,14 @@ export default {
       return;
     }
 
-    // B-03: Build requests to the Next.js API routes via the same Worker fetch handler.
-    // Use a configurable base URL (defaulted to the prod host) so downstream
-    // subdomain/CSRF/signed-URL helpers see the real host instead of localhost.
-    const cronBaseUrl = env.CRON_SELF_BASE_URL || `https://${env.ROOT_DOMAIN || "oltigo.com"}`;
+    // B-03 / A43.5: Build requests to the Next.js API routes via the same
+    // Worker fetch handler.  CRON_SELF_BASE_URL (or ROOT_DOMAIN) must be set
+    // per-environment so staging crons never accidentally hit production.
+    const cronBaseUrl = env.CRON_SELF_BASE_URL || (env.ROOT_DOMAIN ? `https://${env.ROOT_DOMAIN}` : null);
+    if (!cronBaseUrl) {
+      console.error(`[Cron] Neither CRON_SELF_BASE_URL nor ROOT_DOMAIN is set — refusing to fire ${controller.cron} to avoid cross-environment request`);
+      return;
+    }
 
     for (const route of routes) {
       console.log(`[Cron] Firing ${controller.cron} → ${route}`);


### PR DESCRIPTION
## Summary

Addresses 4 findings from the comprehensive audit:

**A101-2 — UNTRUSTED delimiter injection**: `sanitizeUntrustedText()` now strips the actual `<<UNTRUSTED_PATIENT_INPUT_BEGIN/END>>` markers used by prompt templates.

**A101-1 — Stored injection via DB fields**: `services.name` and `doctors.name` now pass through `sanitizeUntrustedText()` before system prompt interpolation in chatbot-data.ts and whatsapp-receptionist.

**A43.5 — Cron cross-environment safety**: worker-cron-handler.ts no longer falls back to oltigo.com when env vars are missing. Refuses to fire instead.

**A45.6 — Maintenance mode kill-switch**: `MAINTENANCE_MODE=1` env var returns 503 for all traffic except /api/health.

## Review & Testing Checklist

- [ ] A101-2: Verify `<<UNTRUSTED_PATIENT_INPUT_END>>` in chat input gets stripped
- [ ] A43.5: Ensure staging Workers have ROOT_DOMAIN or CRON_SELF_BASE_URL set
- [ ] A45.6: Test maintenance mode (set MAINTENANCE_MODE=1, confirm 503)
- [ ] Review sanitizeUntrustedText on service/doctor names in prompts

### Notes

- 82 test files / 814 tests / 0 failures
- Lint and typecheck clean
- ~230+ findings already resolved in PRs #554-#558
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->