### PR TITLE
fix(ci): install esbuild binary after --ignore-scripts, add PHONE_AUTH_ACK to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,10 @@ jobs:
           RATE_LIMIT_BACKEND: memory
           SEED_PASSWORDS_ROTATED: "true"
           SEED_USERS_DELETED: "true"
+          # F-ACK: NEXT_PUBLIC_PHONE_AUTH_ENABLED=true requires an explicit
+          # acknowledgement env var to pass the security-posture startup
+          # health check (enforceFlagAcknowledgements in src/lib/env.ts).
+          PHONE_AUTH_ACK: "true"
 
       - name: Upload Playwright report
         # F-19: Pin to SHA for supply-chain hardening
@@ -241,6 +245,7 @@ jobs:
         run: |
           npm config set ignore-scripts true
           npm ci
+          node node_modules/esbuild/install.js || true
           node scripts/patch-opennext.mjs || true
 
       - name: Build for Cloudflare

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           npm config set ignore-scripts true
           npm ci
+          node node_modules/esbuild/install.js || true
           node scripts/patch-opennext.mjs || true
 
       # Same build that deploy.yml runs before `wrangler deploy`.


### PR DESCRIPTION
## Summary

Fixes two CI workflow issues causing failures in PR Preview (Cloudflare Workers Build) and deploy pipeline.

### Changes

**1. esbuild binary install (pr-preview.yml + deploy.yml)**

Both workflows use `npm ci --ignore-scripts` for security (C-04: prevents malicious postinstall). But this also blocks esbuild's legitimate postinstall script that downloads the platform-specific native binary. The `opennextjs-cloudflare build` command then fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'esbuild'
```

Fix: explicitly run `node node_modules/esbuild/install.js` after `npm ci`, same pattern as `patch-opennext.mjs`.

**2. PHONE_AUTH_ACK env var (deploy.yml)**

The deploy E2E step sets `NEXT_PUBLIC_PHONE_AUTH_ENABLED=true` but was missing the corresponding `PHONE_AUTH_ACK=true` env var that `enforceFlagAcknowledgements()` in `src/lib/env.ts` requires at startup. Already present in `ci.yml` but missing in `deploy.yml`.

**3. Stale branch cleanup (done)**

Deleted 91 stale `devin/*` branches that were accumulating from previous sessions.

### Remaining failures (not fixable in code)

- **Deploy to Cloudflare Workers on main**: Correctly fails because `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, `SUPABASE_PROJECT_REF` secrets are not configured in the GitHub `production` environment. This is the F-01 fail-closed behavior working as designed.
- **Monthly Database Restore Drill**: Fails because R2/GPG secrets are not configured.
- **github_actions Update**: Dependabot internal error trying to update `cloudflare/wrangler-action`. Not actionable.

## Review & Testing Checklist for Human

- [ ] Verify the Cloudflare Workers Build check passes on this PR
- [ ] After merge, configure GitHub Secrets in the `production` environment to stop deploy failures
- [ ] Configure R2/backup secrets to fix restore drill failures

### Notes
- 91 stale devin/* branches cleaned up
- Only 1 open PR remaining (#570 opennextjs/cloudflare)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/groupsmix/webs-alots/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->