### PR TITLE
fix: make migration preflight fail-closed when secrets are missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,39 +176,30 @@ jobs:
 
       - name: Preflight — check migration secrets
         id: preflight
-        # Check if Supabase CLI secrets are configured. If not, skip
-        # migrations with a warning — this allows deploy to proceed
-        # for initial setup before a Supabase project is linked.
-        # Once SUPABASE_ACCESS_TOKEN, SUPABASE_DB_PASSWORD, and
-        # SUPABASE_PROJECT_REF are set, migrations run automatically.
         run: |
           missing=0
           for v in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_REF; do
             if [ -z "${!v:-}" ]; then
-              echo "::warning::Secret '$v' is not set — migrations will be skipped."
+              echo "::error::Secret '$v' is not set — migrations cannot run."
               missing=1
             fi
           done
           if [ "$missing" -eq 1 ]; then
-            echo "::warning::Supabase migration secrets not configured. Skipping migrations."
-            echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Blocking deploy because database migration secrets are missing."
+            exit 1
           fi
+          echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
 
       - name: Install Supabase CLI
-        if: steps.preflight.outputs.secrets_ok == 'true'
         # F-19: Pin to SHA for supply-chain hardening
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
           version: latest
 
       - name: Link to Supabase project
-        if: steps.preflight.outputs.secrets_ok == 'true'
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
 
       - name: Dry-run — show pending migrations
-        if: steps.preflight.outputs.secrets_ok == 'true'
         # `db push --dry-run --include-all` prints the SQL the CLI
         # would execute without applying it, so an operator can
         # inspect the diff in the job log before the real push runs.
@@ -217,7 +208,6 @@ jobs:
         run: supabase db push --include-all --dry-run
 
       - name: Apply migrations (blocking)
-        if: steps.preflight.outputs.secrets_ok == 'true'
         # Real push. Keep --include-all so repair-only / out-of-order
         # migrations are applied in their declared order. Failure
         # here blocks the downstream deploy job.


### PR DESCRIPTION
## Summary

The migration job was labeled "DB Migrations (Supabase, blocking)" but missing secrets only emitted warnings and set `secrets_ok=false`, allowing the downstream deploy job to proceed without applying schema changes. A release with schema-dependent code could deploy without the required database migrations.

Now the preflight step `exit 1`s when any of `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, or `SUPABASE_PROJECT_REF` is missing, which fails the migrate job and blocks the downstream deploy job.

Also removed the now-unnecessary `if: steps.preflight.outputs.secrets_ok == 'true'` guards from downstream migration steps since the job will have already failed.

## Review & Testing Checklist for Human

- [ ] Ensure `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, and `SUPABASE_PROJECT_REF` are set in GitHub repo secrets before merging (deploy will fail without them)
- [ ] Verify deploy pipeline still passes after merge

### Notes
- This was the last remaining concrete launch blocker identified in the audit
- Once Supabase secrets are configured, this is a no-op change for normal deploys