### PR TITLE
cleanup(C2): remove unused eslint-disable directive in landing-header

### DIFF
--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -57,7 +57,6 @@ export function LandingHeader() {
             textDecoration: "none",
           }}
         >
-          {/* eslint-disable-next-line i18next/no-literal-string -- brand wordmark is not translatable */}
           Oltigo
         </Link>
 


### PR DESCRIPTION
## Summary

Removes the only `--fix`-safe ESLint warning in the codebase: an unused `eslint-disable-next-line i18next/no-literal-string` directive in `src/components/landing/landing-header.tsx:60`.

The `i18next/no-literal-string` rule no longer fires on the "Oltigo" brand wordmark, so the disable comment is stale.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes