### PR TITLE
cleanup(C6): remove duplicate _resetForTesting alias in cors.ts

### DIFF
--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -103,10 +103,4 @@ export function resetCorsCache(): void {
   _parsedOrigins = undefined;
 }
 
-/**
- * Test-only alias for `resetCorsCache()`.
- *
- * Exported with the underscore-prefixed name so test files can import a
- * clearly-marked test utility without pulling in production-sounding helpers.
- */
-export const _resetForTesting = resetCorsCache;
+


### PR DESCRIPTION
## Summary

Removes the `_resetForTesting` export from `src/lib/cors.ts`. It is a verbatim alias of `resetCorsCache()` that is never imported anywhere in the codebase (verified via grep across all test and source files).

`resetCorsCache()` remains exported for any future test that needs it.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes