### PR TITLE
cleanup(C3): unexport 162 unused exports from utility/component files

### DIFF
--- a/src/components/layouts/clinic-dashboard-layout.tsx
+++ b/src/components/layouts/clinic-dashboard-layout.tsx
@@ -11,7 +11,7 @@ import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
 import { SignOutButton } from "@/components/sign-out-button";
 import type { ClinicFeatureKey } from "@/lib/features";
 
-export interface DashboardNavItem {
+interface DashboardNavItem {
   href: string;
   label: string;
   icon: LucideIcon;

--- a/src/components/marketing/comparison-table.tsx
+++ b/src/components/marketing/comparison-table.tsx
@@ -41,7 +41,7 @@ function SupportIcon({ value }: { value: FeatureSupport }) {
  * Compact comparison section for the landing page.
  * Shows a subset of features with a link to the full comparison.
  */
-export function ComparisonSection() {
+function ComparisonSection() {
   const grouped = getFeaturesByCategory();
   const highlightCategories: ComparisonCategory[] = [
     "pricing",

--- a/src/components/public/footers/index.ts
+++ b/src/components/public/footers/index.ts
@@ -17,8 +17,6 @@ export interface FooterProps {
   template?: TemplateDefinition;
 }
 
-export { FooterClassic, FooterMinimal, FooterCentered };
-
 /** Footer component map for dynamic selection. */
 export const FOOTER_COMPONENTS: Record<FooterVariant, ComponentType<FooterProps> | null> = {
   "classic-3col": FooterClassic,

--- a/src/components/public/headers/index.ts
+++ b/src/components/public/headers/index.ts
@@ -21,12 +21,10 @@ export interface HeaderProps {
 }
 
 /** Navigation item for header/footer navigation. */
-export interface NavItem {
+interface NavItem {
   label: string;
   href: string;
 }
-
-export { HeaderTopSticky, HeaderTransparent, HeaderBottomBar, HeaderFloating };
 
 /** Header component map for dynamic selection. */
 export const HEADER_COMPONENTS: Record<HeaderVariant, ComponentType<HeaderProps>> = {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -30,4 +30,4 @@ function Badge({
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/loading-skeleton.tsx
+++ b/src/components/ui/loading-skeleton.tsx
@@ -52,7 +52,7 @@ interface FormSkeletonProps {
   className?: string;
 }
 
-export function FormSkeleton({ fields = 4, className }: FormSkeletonProps) {
+function FormSkeleton({ fields = 4, className }: FormSkeletonProps) {
   return (
     <div className={cn("space-y-6", className)}>
       {Array.from({ length: fields }).map((_, i) => (
@@ -70,7 +70,7 @@ interface ProfileSkeletonProps {
   className?: string;
 }
 
-export function ProfileSkeleton({ className }: ProfileSkeletonProps) {
+function ProfileSkeleton({ className }: ProfileSkeletonProps) {
   return (
     <div className={cn("flex items-start gap-4", className)}>
       <Skeleton className="h-16 w-16 rounded-full shrink-0" />

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -72,4 +72,4 @@ function SheetDescription({ className, ...props }: React.ComponentProps<"p">) {
   return <p className={cn("text-sm text-muted-foreground", className)} {...props} />
 }
 
-export { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle, SheetDescription }
+export { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription }

--- a/src/lib/__fixtures__/notifications.fixtures.ts
+++ b/src/lib/__fixtures__/notifications.fixtures.ts
@@ -182,7 +182,7 @@ export const demoNotificationLog: NotificationLogEntry[] = [
   },
 ];
 
-export const demoInAppNotifications: InAppNotification[] = [
+const demoInAppNotifications: InAppNotification[] = [
   {
     id: "ian1",
     userId: "p1",

--- a/src/lib/ai-disclaimer.ts
+++ b/src/lib/ai-disclaimer.ts
@@ -10,7 +10,7 @@
  */
 
 /** Plain-text disclaimer for API JSON responses and WhatsApp messages. */
-export const AI_DISCLAIMER =
+const AI_DISCLAIMER =
   "⚠️ AI-generated draft — review before use. This content was produced by an AI model and may contain errors.";
 
 /** French-language variant for the default UI locale. */
@@ -18,11 +18,11 @@ export const AI_DISCLAIMER_FR =
   "⚠️ Brouillon généré par IA — à vérifier avant utilisation. Ce contenu a été produit par un modèle d'IA et peut contenir des erreurs.";
 
 /** Arabic-language variant. */
-export const AI_DISCLAIMER_AR =
+const AI_DISCLAIMER_AR =
   "⚠️ مسودة مُنشأة بالذكاء الاصطناعي — يُرجى المراجعة قبل الاستخدام. قد يحتوي هذا المحتوى على أخطاء.";
 
 /** Map of locale to disclaimer string. */
-export const AI_DISCLAIMER_I18N: Record<string, string> = {
+const AI_DISCLAIMER_I18N: Record<string, string> = {
   en: AI_DISCLAIMER,
   fr: AI_DISCLAIMER_FR,
   ar: AI_DISCLAIMER_AR,
@@ -32,6 +32,6 @@ export const AI_DISCLAIMER_I18N: Record<string, string> = {
  * Get the appropriate AI disclaimer for a given locale.
  * Falls back to French (default UI language).
  */
-export function getAIDisclaimer(locale: string): string {
+function getAIDisclaimer(locale: string): string {
   return AI_DISCLAIMER_I18N[locale] ?? AI_DISCLAIMER_FR;
 }

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -109,7 +109,7 @@ export async function resolveAIConfig(): Promise<
  * F-A199: Standard disclaimer to include in all AI response payloads.
  * Consumers should spread this into their response objects.
  */
-export const AI_RESPONSE_DISCLAIMER = {
+const AI_RESPONSE_DISCLAIMER = {
   disclaimer: AI_DISCLAIMER_FR,
   aiGenerated: true,
 } as const;

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -110,7 +110,7 @@ export function apiInternalError(message = "Internal server error"): NextRespons
  *   if (error) return handleSupabaseError(error, "Failed to fetch patients", "patients");
  */
 // F-A93-03: Use logger.error for actual database failures, not logger.warn
-export function handleSupabaseError(
+function handleSupabaseError(
   error: { message: string; code?: string; details?: string },
   clientMessage: string,
   context: string,

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -70,12 +70,12 @@ export function getCategories(): BlogCategory[] {
 }
 
 /** Filter posts by category. */
-export function getPostsByCategory(category: BlogCategory): BlogPost[] {
+function getPostsByCategory(category: BlogCategory): BlogPost[] {
   return getAllPosts().filter((p) => p.category === category);
 }
 
 /** Simple search across title, excerpt, tags. */
-export function searchPosts(query: string): BlogPost[] {
+function searchPosts(query: string): BlogPost[] {
   const q = query.toLowerCase().trim();
   if (!q) return getAllPosts();
   return getAllPosts().filter(

--- a/src/lib/cloudflare-dns.ts
+++ b/src/lib/cloudflare-dns.ts
@@ -25,7 +25,7 @@ import { logger } from "@/lib/logger";
 
 // ── Types ────────────────────────────────────────────────────────────
 
-export interface CloudflareConfig {
+interface CloudflareConfig {
   zoneId: string;
   zoneName: string;
   auth:
@@ -241,7 +241,7 @@ export async function getDnsRecord(
 /**
  * Update an existing DNS record (e.g. change target or proxy settings).
  */
-export async function updateDnsRecord(
+async function updateDnsRecord(
   slug: string,
   updates: { content?: string; proxied?: boolean },
 ): Promise<CloudflareResult<DnsRecord>> {
@@ -355,7 +355,7 @@ export async function removeSubdomain(
 /**
  * List all auto-provisioned subdomain records for the zone.
  */
-export async function listSubdomains(): Promise<CloudflareResult<DnsRecord[]>> {
+async function listSubdomains(): Promise<CloudflareResult<DnsRecord[]>> {
   const config = getConfig();
   if (!config) {
     return { success: false, error: "Cloudflare DNS not configured" };

--- a/src/lib/competitor-comparison.ts
+++ b/src/lib/competitor-comparison.ts
@@ -5,7 +5,7 @@
  * in the Moroccan healthcare SaaS market.
  */
 
-export type CompetitorId = "oltigo" | "iyada" | "smartdoc" | "cabidoc" | "pratisoft";
+type CompetitorId = "oltigo" | "iyada" | "smartdoc" | "cabidoc" | "pratisoft";
 
 export interface CompetitorInfo {
   id: CompetitorId;
@@ -205,7 +205,7 @@ export function getFeaturesByCategory(): Record<ComparisonCategory, ComparisonFe
 /**
  * Count how many "full" or "partial" features each competitor supports.
  */
-export function getCompetitorScores(): Record<CompetitorId, { full: number; partial: number; total: number }> {
+function getCompetitorScores(): Record<CompetitorId, { full: number; partial: number; total: number }> {
   const scores = {} as Record<CompetitorId, { full: number; partial: number; total: number }>;
   for (const competitor of COMPETITORS) {
     scores[competitor.id] = { full: 0, partial: 0, total: COMPARISON_FEATURES.length };

--- a/src/lib/config/clinic-types.ts
+++ b/src/lib/config/clinic-types.ts
@@ -89,7 +89,7 @@ export interface ClinicTypeEntry {
   vertical_id?: string;
 }
 
-export const CLINIC_TYPES: ClinicTypeEntry[] = [
+const CLINIC_TYPES: ClinicTypeEntry[] = [
   // ---- MEDICAL ----
   { type_key: "general_medicine",  name_fr: "Médecine Générale",           name_ar: "الطب العام",                    category: "medical", icon: "Stethoscope" },
   { type_key: "cardiology",        name_fr: "Cardiologie",                  name_ar: "أمراض القلب",                   category: "medical", icon: "Heart" },
@@ -157,11 +157,11 @@ export function getTypesByCategory(category: ClinicTypeCategory): ClinicTypeEntr
 }
 
 /** Find a single clinic type by its key */
-export function getClinicType(typeKey: string): ClinicTypeEntry | undefined {
+function getClinicType(typeKey: string): ClinicTypeEntry | undefined {
   return CLINIC_TYPES.find((t) => t.type_key === typeKey);
 }
 
 /** Find the category metadata for a given category key */
-export function getCategoryMeta(category: ClinicTypeCategory): ClinicCategory | undefined {
+function getCategoryMeta(category: ClinicTypeCategory): ClinicCategory | undefined {
   return CLINIC_CATEGORIES.find((c) => c.key === category);
 }

--- a/src/lib/contrast.ts
+++ b/src/lib/contrast.ts
@@ -11,7 +11,7 @@
  * Calculate WCAG 2.1 relative luminance from a hex color.
  * @see https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
  */
-export function luminance(hex: string): number {
+function luminance(hex: string): number {
   const rgb = hex
     .replace(/^#/, "")
     .match(/.{2}/g)

--- a/src/lib/dci-drug-database.ts
+++ b/src/lib/dci-drug-database.ts
@@ -419,7 +419,7 @@ function ensureDrugIndex(): Map<string, DrugIndexEntry[]> {
  * A73-F5: Uses pre-built prefix index for fast lookups instead of
  * scanning the entire 43k-line database on every request.
  */
-export function searchDrugs(query: string, limit = 20): DCIDrug[] {
+function searchDrugs(query: string, limit = 20): DCIDrug[] {
   if (!query || query.length < 2) return [];
 
   const q = normalize(query);
@@ -477,7 +477,7 @@ export function searchDrugs(query: string, limit = 20): DCIDrug[] {
 /**
  * Get all unique drug categories present in the database.
  */
-export function getDrugCategories(): DCIDrugCategory[] {
+function getDrugCategories(): DCIDrugCategory[] {
   const categories = new Set<DCIDrugCategory>();
   for (const drug of DCI_DRUG_DATABASE) {
     categories.add(drug.category);
@@ -488,6 +488,6 @@ export function getDrugCategories(): DCIDrugCategory[] {
 /**
  * Filter drugs by category.
  */
-export function getDrugsByCategory(category: DCIDrugCategory): DCIDrug[] {
+function getDrugsByCategory(category: DCIDrugCategory): DCIDrug[] {
   return DCI_DRUG_DATABASE.filter((d) => d.category === category);
 }

--- a/src/lib/demo.ts
+++ b/src/lib/demo.ts
@@ -38,14 +38,14 @@ export const DEMO_USERS = {
 /**
  * Check if a clinic ID is the demo tenant.
  */
-export function isDemoClinic(clinicId: string | null | undefined): boolean {
+function isDemoClinic(clinicId: string | null | undefined): boolean {
   return clinicId === DEMO_CLINIC_ID;
 }
 
 /**
  * Check if a subdomain belongs to the demo tenant.
  */
-export function isDemoSubdomain(subdomain: string | null | undefined): boolean {
+function isDemoSubdomain(subdomain: string | null | undefined): boolean {
   return subdomain === DEMO_SUBDOMAIN;
 }
 
@@ -53,7 +53,7 @@ export function isDemoSubdomain(subdomain: string | null | undefined): boolean {
  * HTTP methods that are considered destructive (mutating).
  * In demo mode, these should be blocked or simulated.
  */
-export const DESTRUCTIVE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const DESTRUCTIVE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 /**
  * API paths that are allowed even in demo mode (e.g., auth, read-only endpoints).
@@ -71,7 +71,7 @@ export const DESTRUCTIVE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  * (which legitimately exercise these endpoints under the demo subdomain)
  * to fail before reaching the handler.
  */
-export const DEMO_ALLOWED_PATHS = new Set([
+const DEMO_ALLOWED_PATHS = new Set([
   "/api/auth",
   "/api/v1/register-clinic",
   "/api/webhooks",
@@ -113,7 +113,7 @@ export function shouldBlockDemoRequest(
  * This replaces the path/method allow-list approach with an explicit
  * opt-in per route handler.
  */
-export function demoSafe<T extends (...args: never[]) => unknown>(
+function demoSafe<T extends (...args: never[]) => unknown>(
   handler: T,
 ): T {
   // Tag the handler so middleware or withAuth can check it
@@ -124,7 +124,7 @@ export function demoSafe<T extends (...args: never[]) => unknown>(
 /**
  * Check if a handler has been marked as demo-safe via the demoSafe wrapper.
  */
-export function isDemoSafeHandler(handler: unknown): boolean {
+function isDemoSafeHandler(handler: unknown): boolean {
   return (
     typeof handler === "function" &&
     (handler as unknown as Record<string, unknown>).__demoSafe === true

--- a/src/lib/directory-constants.ts
+++ b/src/lib/directory-constants.ts
@@ -163,7 +163,7 @@ export function getSpecialtyBySlug(slug: string): DirectorySpecialty | undefined
  * Generate a doctor slug from their name.
  * e.g. "Dr. Ahmed El Fassi" → "dr-ahmed-el-fassi"
  */
-export function doctorNameToSlug(name: string): string {
+function doctorNameToSlug(name: string): string {
   return name
     .toLowerCase()
     .normalize("NFD")

--- a/src/lib/drug-interactions-db.ts
+++ b/src/lib/drug-interactions-db.ts
@@ -32,7 +32,7 @@ export interface DrugInteraction {
 
 // ── Interaction Database ──
 
-export const DRUG_INTERACTIONS: DrugInteraction[] = [
+const DRUG_INTERACTIONS: DrugInteraction[] = [
   // ── Anticoagulants / Antiplatelets ──
   {
     drugA: "warfarine",

--- a/src/lib/email-templates.ts
+++ b/src/lib/email-templates.ts
@@ -85,7 +85,7 @@ export function staffWelcomeEmail(params: {
 
 // ---------- Clinic created notification ----------
 
-export function clinicCreatedEmail(params: {
+function clinicCreatedEmail(params: {
   clinicName: string;
   adminName: string;
   adminEmail: string;
@@ -198,7 +198,7 @@ export function onboardingWelcomeEmail(params: {
 
 // ---------- Payment failure notification ----------
 
-export function paymentFailedEmail(params: {
+function paymentFailedEmail(params: {
   clinicName: string;
   recipientName: string;
   amount: number;

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -104,7 +104,7 @@ export type FeaturesConfig = Partial<Record<ClinicFeatureKey, boolean>>;
 /**
  * Default feature flags - used when no config is provided
  */
-export const DEFAULT_FEATURES: FeaturesConfig = {
+const DEFAULT_FEATURES: FeaturesConfig = {
   appointments: true,
   prescriptions: true,
   consultations: true,
@@ -115,7 +115,7 @@ export const DEFAULT_FEATURES: FeaturesConfig = {
 };
 
 /** Default features for veterinary clinics */
-export const VETERINARY_DEFAULT_FEATURES: FeaturesConfig = {
+const VETERINARY_DEFAULT_FEATURES: FeaturesConfig = {
   appointments: true,
   prescriptions: true,
   vaccination: true,
@@ -125,7 +125,7 @@ export const VETERINARY_DEFAULT_FEATURES: FeaturesConfig = {
 };
 
 /** Default features for restaurant businesses */
-export const RESTAURANT_DEFAULT_FEATURES: FeaturesConfig = {
+const RESTAURANT_DEFAULT_FEATURES: FeaturesConfig = {
   appointments: true,
   menu_management: true,
   table_management: true,
@@ -176,7 +176,7 @@ export async function isAIEnabled(): Promise<boolean> {
  * swallowed). The function still falls back to defaults for resilience, but
  * operators can monitor for "KV_FETCH_ERROR" in their dashboards.
  */
-export async function getKVFeatureFlags(): Promise<FeaturesConfig> {
+async function getKVFeatureFlags(): Promise<FeaturesConfig> {
   try {
     const kv = (globalThis as unknown as { FEATURE_FLAGS_KV?: CloudflareKV }).FEATURE_FLAGS_KV;
     if (!kv) {
@@ -201,7 +201,7 @@ export async function getKVFeatureFlags(): Promise<FeaturesConfig> {
  * Get feature flag override for a specific clinic
  * Returns clinic-specific override if exists, otherwise null
  */
-export async function getClinicFeatureOverride(
+async function getClinicFeatureOverride(
   clinicId: string,
 ): Promise<FeaturesConfig | null> {
   try {
@@ -232,7 +232,7 @@ export async function getClinicFeatureOverride(
  *
  * F-A90-05: Routes flag changes through logAuditEvent for compliance.
  */
-export async function setClinicFeatureOverride(
+async function setClinicFeatureOverride(
   clinicId: string,
   config: FeaturesConfig,
   actor?: string | null,
@@ -316,7 +316,7 @@ export async function setClinicFeatureOverride(
  * Sets a global override in KV that takes precedence over clinic-type defaults.
  * Setting a key to `false` disables the feature for ALL clinics immediately.
  */
-export async function setGlobalFeatureFlag(
+async function setGlobalFeatureFlag(
   key: ClinicFeatureKey,
   enabled: boolean,
   actor?: string | null,
@@ -396,7 +396,7 @@ export function isFeatureEnabled(
  *
  * This function supports runtime feature flag overrides via KV.
  */
-export async function isFeatureEnabledForClinic(
+async function isFeatureEnabledForClinic(
   clinicId: string,
   clinicTypeId: string | null,
   key: ClinicFeatureKey,
@@ -422,7 +422,7 @@ export async function isFeatureEnabledForClinic(
  * Fetch features config from database for a clinic type
  * Used as fallback when KV override doesn't exist
  */
-export async function getClinicTypeFeaturesFromDB(
+async function getClinicTypeFeaturesFromDB(
   clinicTypeId: string,
 ): Promise<FeaturesConfig | null> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -456,7 +456,7 @@ export async function getClinicTypeFeaturesFromDB(
  * Return only the subset of items whose `requiredFeature` is either
  * undefined (always shown) or enabled in the config.
  */
-export function filterByFeatures<T extends { requiredFeature?: ClinicFeatureKey }>(
+function filterByFeatures<T extends { requiredFeature?: ClinicFeatureKey }>(
   items: T[],
   config: FeaturesConfig | undefined | null,
 ): T[] {

--- a/src/lib/find-alternative-slots.ts
+++ b/src/lib/find-alternative-slots.ts
@@ -18,7 +18,7 @@ export interface AlternativeSlot {
   label: string;
 }
 
-export interface AffectedAppointment {
+interface AffectedAppointment {
   id: string;
   patientId: string;
   patientName: string;

--- a/src/lib/generate-subdomain.ts
+++ b/src/lib/generate-subdomain.ts
@@ -20,7 +20,7 @@
  * Normalise a string for use as a subdomain slug.
  * Pure function — no randomness, useful for testing.
  */
-export function slugify(input: string): string {
+function slugify(input: string): string {
   let slug = input
     // Decompose accented characters (é → e + combining accent) then strip accents
     .normalize("NFD")

--- a/src/lib/hooks/use-clinic-features.tsx
+++ b/src/lib/hooks/use-clinic-features.tsx
@@ -235,7 +235,7 @@ const ClinicFeaturesContext = createContext<ClinicFeaturesContextValue>({
  *
  * When neither is supplied, all features are enabled by default.
  */
-export function ClinicFeaturesProvider({
+function ClinicFeaturesProvider({
   children,
   initialConfig,
   clinicTypeKey,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -13,7 +13,7 @@ import fr from "../locales/fr.json";
 
 export type TranslationKey = keyof typeof fr;
 
-export const translations = {
+const translations = {
   fr,
   ar,
   en
@@ -108,7 +108,7 @@ const BCP47: Record<Locale, string> = {
  *   formatDate("fr", new Date("2026-05-01")) // "1 mai 2026"
  *   formatDate("ar", new Date("2026-05-01")) // "١ مايو ٢٠٢٦"
  */
-export function formatDate(
+function formatDate(
   locale: Locale,
   date: Date | string,
   options?: Intl.DateTimeFormatOptions,
@@ -131,7 +131,7 @@ export function formatDate(
  *   formatNumber("fr", 1234.5)  // "1 234,5"
  *   formatNumber("ar", 1234.5)  // "١٬٢٣٤٫٥"
  */
-export function formatNumber(locale: Locale, value: number, options?: Intl.NumberFormatOptions): string {
+function formatNumber(locale: Locale, value: number, options?: Intl.NumberFormatOptions): string {
   return new Intl.NumberFormat(BCP47[locale], options).format(value);
 }
 
@@ -144,7 +144,7 @@ export function formatNumber(locale: Locale, value: number, options?: Intl.Numbe
  *   formatCurrency("ar", 250)   // "٢٥٠٫٠٠ د.م."
  *   formatCurrency("en", 250)   // "MAD 250.00"
  */
-export function formatCurrency(
+function formatCurrency(
   locale: Locale,
   amount: number,
   currency = "MAD",
@@ -164,7 +164,7 @@ export function formatCurrency(
  *   formatRelativeTime("fr", -3, "hour")  // "il y a 3 heures"
  *   formatRelativeTime("ar", -1, "day")   // "أمس"
  */
-export function formatRelativeTime(
+function formatRelativeTime(
   locale: Locale,
   value: number,
   unit: Intl.RelativeTimeFormatUnit,

--- a/src/lib/mask.ts
+++ b/src/lib/mask.ts
@@ -31,7 +31,7 @@ export function maskPhone(value: string, level: MaskLevel = getMaskLevel()): str
 }
 
 /** Mask an email address. */
-export function maskEmail(value: string, level: MaskLevel = getMaskLevel()): string {
+function maskEmail(value: string, level: MaskLevel = getMaskLevel()): string {
   if (level === "none" || !value) return value;
   const [local, domain] = value.split("@");
   if (!domain) return value;

--- a/src/lib/mfa.ts
+++ b/src/lib/mfa.ts
@@ -126,7 +126,7 @@ export async function verifyMFAEnrollment(
  * Verify a TOTP code during login (MFA challenge step).
  * On success, redirects to the appropriate dashboard.
  */
-export async function verifyMFALogin(
+async function verifyMFALogin(
   factorId: string,
   code: string,
 ): Promise<MFAVerifyResult> {
@@ -159,7 +159,7 @@ export async function verifyMFALogin(
 /**
  * Unenroll (disable) a TOTP factor from the user's account.
  */
-export async function unenrollMFA(
+async function unenrollMFA(
   factorId: string,
 ): Promise<{ error: string | null }> {
   const supabase = await createClient();
@@ -198,7 +198,7 @@ export async function unenrollMFA(
  * Get the current user's MFA factors.
  * Returns verified TOTP factors if any exist.
  */
-export async function getMFAFactors(): Promise<{
+async function getMFAFactors(): Promise<{
   factors: Array<{ id: string; friendlyName: string | null; status: string }>;
   error: string | null;
 }> {
@@ -234,7 +234,7 @@ export async function getMFAFactors(): Promise<{
 /**
  * Check if the current user has MFA enabled (at least one verified TOTP factor).
  */
-export async function isMFAEnabled(): Promise<boolean> {
+async function isMFAEnabled(): Promise<boolean> {
   const { factors } = await getMFAFactors();
   return factors.some((f) => f.status === "verified");
 }
@@ -243,7 +243,7 @@ export async function isMFAEnabled(): Promise<boolean> {
  * Get the current MFA assurance level for the authenticated user.
  * Returns 'aal1' if only password was used, 'aal2' if MFA was verified.
  */
-export async function getMFAAssuranceLevel(): Promise<{
+async function getMFAAssuranceLevel(): Promise<{
   currentLevel: string | null;
   nextLevel: string | null;
   error: string | null;

--- a/src/lib/middleware/routes.ts
+++ b/src/lib/middleware/routes.ts
@@ -185,6 +185,6 @@ export function isProtectedRoute(pathname: string): boolean {
 /**
  * Get the dashboard path for a given role.
  */
-export function getDashboardPath(role: string): string {
+function getDashboardPath(role: string): string {
   return ROLE_DASHBOARD_MAP[role];
 }

--- a/src/lib/middleware/sanctioned-countries.ts
+++ b/src/lib/middleware/sanctioned-countries.ts
@@ -19,7 +19,7 @@ import { NextResponse } from "next/server";
  * Sources: US Treasury OFAC, EU Council Regulation, UN Security Council.
  * Review this list quarterly and after any new sanctions announcement.
  */
-export const SANCTIONED_COUNTRIES = new Set([
+const SANCTIONED_COUNTRIES = new Set([
   "CU", // Cuba
   "IR", // Iran
   "KP", // North Korea (DPRK)

--- a/src/lib/middleware/security-headers.ts
+++ b/src/lib/middleware/security-headers.ts
@@ -83,7 +83,7 @@ function getPlausibleHost(): string | null {
   }
 }
 
-export interface BuildCspOptions {
+interface BuildCspOptions {
   /**
    * When true, indicates the policy is intended for the Report-Only header.
    * The directives are identical either way; this flag is used by callers
@@ -110,7 +110,7 @@ export interface BuildCspOptions {
  * (no inline/eval), so production is fail-closed against XSS via injected
  * inline or third-party scripts. `'unsafe-eval'` remains dev-only.
  */
-export function buildCsp(nonce: string, _options?: BuildCspOptions): string {
+function buildCsp(nonce: string, _options?: BuildCspOptions): string {
   const isDev = process.env.NODE_ENV !== "production";
   const sbHost = getSupabaseHost();
   const plausibleHost = getPlausibleHost();
@@ -179,7 +179,7 @@ function isCspReportOnly(): boolean {
  * This stub remains temporarily for backward compatibility with any
  * call-sites that haven't been updated yet. It delegates to buildCsp.
  */
-export function buildLegacyCsp(nonce: string): string {
+function buildLegacyCsp(nonce: string): string {
   return buildCsp(nonce, { reportOnly: false });
 }
 

--- a/src/lib/morocco.ts
+++ b/src/lib/morocco.ts
@@ -17,7 +17,7 @@ const MOROCCO_COUNTRY_CODE = "+212";
  * Validates a Moroccan phone number.
  * Accepts formats: 0612345678, +212612345678, 212612345678, 06 12 34 56 78
  */
-export function isValidMoroccanPhone(phone: string): boolean {
+function isValidMoroccanPhone(phone: string): boolean {
   const cleaned = phone.replace(/[\s\-().]/g, "");
   // +212 format
   if (cleaned.startsWith("+212") || cleaned.startsWith("212")) {
@@ -35,7 +35,7 @@ export function isValidMoroccanPhone(phone: string): boolean {
  * Formats a phone number to international +212 format.
  * Input: "0612345678" → "+212 6 12 34 56 78"
  */
-export function formatMoroccanPhone(phone: string): string {
+function formatMoroccanPhone(phone: string): string {
   const cleaned = phone.replace(/[\s\-().]/g, "");
   let local: string;
 
@@ -70,7 +70,7 @@ export function phoneToWhatsApp(phone: string): string {
 /**
  * Returns the mobile prefix label for display.
  */
-export function getPhonePrefix(phone: string): string {
+function getPhonePrefix(phone: string): string {
   const cleaned = phone.replace(/[\s\-().]/g, "");
   if (cleaned.startsWith("06") || cleaned.includes("2126")) return "Maroc Telecom / Orange / inwi";
   if (cleaned.startsWith("07") || cleaned.includes("2127")) return "inwi / Orange";
@@ -81,10 +81,10 @@ export function getPhonePrefix(phone: string): string {
 // ---- TVA (Tax) Calculation ----
 
 /** Standard Moroccan TVA rate */
-export const TVA_RATE = 0.20;
+const TVA_RATE = 0.20;
 
 /** Reduced TVA rates */
-export const TVA_RATES = {
+const TVA_RATES = {
   standard: 0.20,    // 20% - default for services
   reduced_14: 0.14,  // 14% - transport, certain food
   reduced_10: 0.10,  // 10% - hospitality, certain goods
@@ -92,9 +92,9 @@ export const TVA_RATES = {
   exempt: 0,         // 0% - medical acts (some are exempt)
 } as const;
 
-export type TVARate = keyof typeof TVA_RATES;
+type TVARate = keyof typeof TVA_RATES;
 
-export interface TVABreakdown {
+interface TVABreakdown {
   /** Amount before tax */
   amountHT: number;
   /** TVA amount */
@@ -113,7 +113,7 @@ export interface TVABreakdown {
  * @param rate - TVA rate key (default: "standard" = 20%)
  * @param isAmountTTC - If true, amount is TTC (includes tax), calculate backwards
  */
-export function calculateTVA(
+function calculateTVA(
   amount: number,
   rate: TVARate = "standard",
   isAmountTTC = false,
@@ -139,7 +139,7 @@ export function calculateTVA(
  * @param amount - numeric amount
  * @param options - formatting options
  */
-export function formatMAD(
+function formatMAD(
   amount: number,
   options?: { locale?: string; showCurrency?: boolean; decimals?: number },
 ): string {
@@ -159,7 +159,7 @@ export function formatMAD(
  * Format amount in Moroccan Dirhams with centimes.
  * e.g. "1 500,00 DH" (formal) or "1500 MAD" (informal)
  */
-export function formatMADFormal(amount: number): string {
+function formatMADFormal(amount: number): string {
   return new Intl.NumberFormat("fr-MA", {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
@@ -168,9 +168,9 @@ export function formatMADFormal(amount: number): string {
 
 // ---- Insurance Types ----
 
-export type MoroccanInsuranceType = "cnss" | "cnops" | "amo" | "mutuelle" | "ramed" | "private" | "none";
+type MoroccanInsuranceType = "cnss" | "cnops" | "amo" | "mutuelle" | "ramed" | "private" | "none";
 
-export interface InsuranceProvider {
+interface InsuranceProvider {
   id: string;
   type: MoroccanInsuranceType;
   name: string;
@@ -180,7 +180,7 @@ export interface InsuranceProvider {
   description: string;
 }
 
-export const INSURANCE_PROVIDERS: InsuranceProvider[] = [
+const INSURANCE_PROVIDERS: InsuranceProvider[] = [
   {
     id: "cnss",
     type: "cnss",
@@ -273,13 +273,13 @@ export const INSURANCE_PROVIDERS: InsuranceProvider[] = [
   },
 ];
 
-export interface MutuelleInfo {
+interface MutuelleInfo {
   name: string;
   registrationNumber: string;
   coverageRate: number; // additional coverage on top of base insurance
 }
 
-export interface PatientInsurance {
+interface PatientInsurance {
   primaryInsurance: MoroccanInsuranceType;
   primaryInsuranceId: string;
   affiliationNumber: string;
@@ -291,7 +291,7 @@ export interface PatientInsurance {
  * Calculate the patient's out-of-pocket cost (reste à charge).
  * Takes into account primary insurance + optional mutuelle.
  */
-export function calculateResteACharge(
+function calculateResteACharge(
   totalAmount: number,
   insurance: PatientInsurance,
 ): {
@@ -329,7 +329,7 @@ export function calculateResteACharge(
 
 // ---- Payment Methods ----
 
-export type MoroccanPaymentMethod =
+type MoroccanPaymentMethod =
   | "cash"
   | "cmi"           // CMI card payment
   | "cashplus"      // CashPlus mobile money
@@ -340,7 +340,7 @@ export type MoroccanPaymentMethod =
   | "insurance"     // Direct insurance payment
   | "online";       // Online (generic)
 
-export interface PaymentMethodInfo {
+interface PaymentMethodInfo {
   id: MoroccanPaymentMethod;
   name: string;
   nameFr: string;
@@ -351,7 +351,7 @@ export interface PaymentMethodInfo {
   isOnline: boolean;
 }
 
-export const PAYMENT_METHODS: PaymentMethodInfo[] = [
+const PAYMENT_METHODS: PaymentMethodInfo[] = [
   {
     id: "cash",
     name: "Cash",
@@ -446,7 +446,7 @@ export const PAYMENT_METHODS: PaymentMethodInfo[] = [
 
 // ---- Ramadan Mode ----
 
-export interface RamadanConfig {
+interface RamadanConfig {
   enabled: boolean;
   startDate: string; // ISO date
   endDate: string;   // ISO date
@@ -457,7 +457,7 @@ export interface RamadanConfig {
  * Default Ramadan working hours for Moroccan clinics.
  * Typically 9:00-15:00 (shorter days, no lunch break).
  */
-export const DEFAULT_RAMADAN_HOURS: Record<number, { open: string; close: string; enabled: boolean }> = {
+const DEFAULT_RAMADAN_HOURS: Record<number, { open: string; close: string; enabled: boolean }> = {
   0: { open: "09:00", close: "15:00", enabled: false }, // Sunday
   1: { open: "09:00", close: "15:00", enabled: true },  // Monday
   2: { open: "09:00", close: "15:00", enabled: true },
@@ -470,7 +470,7 @@ export const DEFAULT_RAMADAN_HOURS: Record<number, { open: string; close: string
 /**
  * Check if a given date falls within Ramadan period.
  */
-export function isRamadanPeriod(date: Date, config: RamadanConfig): boolean {
+function isRamadanPeriod(date: Date, config: RamadanConfig): boolean {
   if (!config.enabled) return false;
   const d = date.toISOString().split("T")[0];
   return d >= config.startDate && d <= config.endDate;
@@ -480,7 +480,7 @@ export function isRamadanPeriod(date: Date, config: RamadanConfig): boolean {
  * Get the effective working hours for a given date.
  * Returns Ramadan hours if within Ramadan period, otherwise regular hours.
  */
-export function getEffectiveWorkingHours(
+function getEffectiveWorkingHours(
   date: Date,
   regularHours: Record<number, { open: string; close: string; enabled: boolean }>,
   ramadanConfig?: RamadanConfig,
@@ -494,7 +494,7 @@ export function getEffectiveWorkingHours(
 
 // ---- Installment Payments (Tqsit) ----
 
-export interface InstallmentPayment {
+interface InstallmentPayment {
   /** Payment number (1-based) */
   number: number;
   /** Amount for this payment */
@@ -505,7 +505,7 @@ export interface InstallmentPayment {
   status: "pending" | "paid" | "overdue";
 }
 
-export interface InstallmentPlan {
+interface InstallmentPlan {
   /** Total amount to be paid */
   totalAmount: number;
   /** Number of installments */
@@ -527,7 +527,7 @@ export interface InstallmentPlan {
  * @param numberOfPayments - Number of installments (2-12)
  * @param startDate - First payment date (defaults to today)
  */
-export function calculateInstallments(
+function calculateInstallments(
   totalAmount: number,
   numberOfPayments: number,
   startDate?: Date,
@@ -573,9 +573,9 @@ export const MOROCCAN_CITIES = [
 
 // ---- Garde / Astreinte Types ----
 
-export type GardeType = "garde" | "astreinte";
+type GardeType = "garde" | "astreinte";
 
-export interface GardeScheduleEntry {
+interface GardeScheduleEntry {
   id: string;
   doctorId: string;
   doctorName: string;
@@ -589,7 +589,7 @@ export interface GardeScheduleEntry {
 
 // ---- Multi-Cabinet ----
 
-export interface CabinetLocation {
+interface CabinetLocation {
   id: string;
   clinicId: string;
   name: string;

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -19,7 +19,7 @@ type ExtendedClient = SupabaseClient<Database>;
 
 // ── Types ──
 
-export interface QueuedNotification {
+interface QueuedNotification {
   id: string;
   clinic_id: string;
   channel: NotificationChannel;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -33,7 +33,7 @@ export type NotificationChannel = "whatsapp" | "in_app" | "email" | "sms";
 
 export type NotificationPriority = "low" | "normal" | "high" | "urgent";
 
-export type NotificationStatus = "pending" | "sent" | "delivered" | "failed" | "read";
+type NotificationStatus = "pending" | "sent" | "delivered" | "failed" | "read";
 
 // ---- Template Variable Types ----
 
@@ -93,7 +93,7 @@ export interface InAppNotification {
 
 // ---- WhatsApp Message ----
 
-export interface WhatsAppMessage {
+interface WhatsAppMessage {
   id: string;
   to: string;
   trigger: NotificationTrigger;
@@ -126,7 +126,7 @@ export interface NotificationLogEntry {
 
 // ---- User Notification Preferences ----
 
-export interface NotificationPreferences {
+interface NotificationPreferences {
   userId: string;
   channels: {
     whatsapp: boolean;
@@ -655,4 +655,4 @@ export async function dispatchNotification(
 
 // ---- Demo data has been moved to @/lib/__fixtures__/notifications.fixtures.ts ----
 // Re-export for backward compatibility.
-export { demoNotificationLog, demoInAppNotifications } from "@/lib/__fixtures__/notifications.fixtures";
+export { demoNotificationLog } from "@/lib/__fixtures__/notifications.fixtures";

--- a/src/lib/r2-cleanup.ts
+++ b/src/lib/r2-cleanup.ts
@@ -42,7 +42,7 @@ import { deleteFromR2, listR2Objects } from "@/lib/r2";
  * Matches the R2 lifecycle rule (`docs/r2-lifecycle.md`) so the cron
  * and the bucket policy agree on the same cutoff.
  */
-export const DEFAULT_ABANDONED_HOURS = 24;
+const DEFAULT_ABANDONED_HOURS = 24;
 
 /**
  * Default threshold for `emitOrphanRateAlert`. A reconciliation pass

--- a/src/lib/r2-encrypted.ts
+++ b/src/lib/r2-encrypted.ts
@@ -150,7 +150,7 @@ export async function downloadAndDecrypt(
  *
  * @param key  R2 object key (with or without `.enc` suffix)
  */
-export async function deleteEncrypted(key: string): Promise<void> {
+async function deleteEncrypted(key: string): Promise<void> {
   const encKey = key.endsWith(".enc") ? key : `${key}.enc`;
   return deleteFromR2(encKey);
 }

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -81,7 +81,7 @@ function getR2SigningSecret(): string {
  * @param expiresIn  URL validity in seconds (default: 3600 = 1 hour)
  * @returns Signed URL that validates against the secret
  */
-export function generateSignedR2Url(key: string, expiresIn = 3600): string {
+function generateSignedR2Url(key: string, expiresIn = 3600): string {
   const accountId = process.env.R2_ACCOUNT_ID;
   const bucketName = process.env.R2_BUCKET_NAME;
 
@@ -127,7 +127,7 @@ export function generateSignedR2Url(key: string, expiresIn = 3600): string {
  * @param signature  HMAC signature from URL
  * @returns true if the signature is valid and not expired
  */
-export function validateSignedR2Url(
+function validateSignedR2Url(
   bucket: string,
   key: string,
   expires: number,
@@ -414,7 +414,7 @@ export async function getPresignedUploadPost(
  * @param expiresIn  URL validity in seconds (default: 3600 = 1 hour)
  * @returns Pre-signed download URL, or null if R2 is not configured
  */
-export async function getPresignedDownloadUrl(
+async function getPresignedDownloadUrl(
   key: string,
   expiresIn = 3600,
 ): Promise<string | null> {
@@ -628,7 +628,7 @@ export function buildUploadKey(
 // ── Image Resizing Utilities ──
 
 /** Standard thumbnail widths for responsive images. */
-export const IMAGE_WIDTHS = [100, 300, 800] as const;
+const IMAGE_WIDTHS = [100, 300, 800] as const;
 
 /**
  * Build a Cloudflare Image Resizing URL for a given source image.
@@ -644,7 +644,7 @@ export const IMAGE_WIDTHS = [100, 300, 800] as const;
  *
  * @see https://developers.cloudflare.com/images/transform-images/transform-via-url/
  */
-export function getResizedImageUrl(
+function getResizedImageUrl(
   srcUrl: string,
   width: number,
   options: { quality?: number; fit?: "scale-down" | "contain" | "cover" | "crop" | "pad"; format?: "auto" | "webp" | "avif" } = {},

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -593,7 +593,7 @@ export const loginLimiter = createRateLimiter({
 });
 
 /** Auth endpoints catch-all: 10 req / 60s per IP (RL-01 defense-in-depth) */
-export const authLimiter = createRateLimiter({
+const authLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 10,
   failClosed: true,
@@ -645,33 +645,33 @@ export const passwordResetLimiter = createRateLimiter({
 
 /** Branding GET: 20 req / 60s per IP (public endpoint, prevents clinic enumeration)
  * R-22: Set failClosed: true for public clinic-enumeration surface */
-export const brandingLimiter = createRateLimiter({
+const brandingLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 20,
   failClosed: true,
 });
 
 /** General API mutations: 30 req / 60s per IP */
-export const apiMutationLimiter = createRateLimiter({
+const apiMutationLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 30,
 });
 
 /** File uploads: 10 req / 60s per IP */
-export const uploadLimiter = createRateLimiter({
+const uploadLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 10,
 });
 
 /** Onboarding (clinic creation): 5 req / 60s per IP — security-critical (registration). */
-export const onboardingLimiter = createRateLimiter({
+const onboardingLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 5,
   failClosed: true,
 });
 
 /** Chat endpoint: 15 req / 60s per IP (prevent AI API abuse) */
-export const chatLimiter = createRateLimiter({
+const chatLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 15,
   failClosed: true,
@@ -707,7 +707,7 @@ export const waitingListLimiter = createRateLimiter({
 });
 
 /** Email verification: 5 req / 60s per IP (prevent OTP/link abuse) */
-export const emailVerificationLimiter = createRateLimiter({
+const emailVerificationLimiter = createRateLimiter({
   windowMs: 60_000,
   max: 5,
 });

--- a/src/lib/subdomain-cache.ts
+++ b/src/lib/subdomain-cache.ts
@@ -42,7 +42,7 @@ export const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
  * Evict expired entries from the cache.
  * Called periodically to prevent stale entries from accumulating.
  */
-export function evictExpiredEntries(): void {
+function evictExpiredEntries(): void {
   const now = Date.now();
   for (const [key, value] of subdomainCache) {
     if (now - value.cachedAt > SUBDOMAIN_CACHE_TTL_MS) {
@@ -151,7 +151,7 @@ function getKV(): KVNamespace | null {
  * F-07: Try to read a subdomain entry from KV cache.
  * Returns null on miss or if KV is not available.
  */
-export async function getSubdomainFromKV(subdomain: string): Promise<CachedClinic | null> {
+async function getSubdomainFromKV(subdomain: string): Promise<CachedClinic | null> {
   const kv = getKV();
   if (!kv) return null;
   try {
@@ -164,7 +164,7 @@ export async function getSubdomainFromKV(subdomain: string): Promise<CachedClini
 /**
  * F-07: Write a subdomain entry to KV cache.
  */
-export async function setSubdomainInKV(subdomain: string, clinic: CachedClinic): Promise<void> {
+async function setSubdomainInKV(subdomain: string, clinic: CachedClinic): Promise<void> {
   const kv = getKV();
   if (!kv) return;
   try {
@@ -179,7 +179,7 @@ export async function setSubdomainInKV(subdomain: string, clinic: CachedClinic):
 /**
  * F-07: Delete a subdomain entry from KV cache.
  */
-export async function deleteSubdomainFromKV(subdomain: string): Promise<void> {
+async function deleteSubdomainFromKV(subdomain: string): Promise<void> {
   const kv = getKV();
   if (!kv) return;
   try {

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -14,7 +14,7 @@ import { logTenantContext } from "@/lib/tenant-context";
 // ---- Types ----
 
 export type SubscriptionPlan = "free" | "starter" | "professional" | "enterprise";
-export type SubscriptionStatus = "active" | "past_due" | "canceled" | "trialing" | "paused";
+type SubscriptionStatus = "active" | "past_due" | "canceled" | "trialing" | "paused";
 export type BillingInterval = "monthly" | "yearly";
 
 export interface PlanConfig {
@@ -52,7 +52,7 @@ export interface ClinicSubscription {
   nextPaymentAmount?: number;
 }
 
-export interface BillingEvent {
+interface BillingEvent {
   id: string;
   clinicId: string;
   type: "payment_succeeded" | "payment_failed" | "subscription_created" | "subscription_canceled" | "subscription_renewed" | "trial_ended" | "plan_changed";
@@ -198,7 +198,7 @@ export function calculateNextPeriod(
 /**
  * Check if a clinic has exceeded its plan limits.
  */
-export async function checkPlanLimits(
+async function checkPlanLimits(
   clinicId: string,
   plan: SubscriptionPlan,
 ): Promise<{ withinLimits: boolean; exceeded: string[] }> {

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -118,7 +118,7 @@ export interface CreateServiceInput {
   category?: string;
 }
 
-export interface CreateTimeSlotInput {
+interface CreateTimeSlotInput {
   doctor_id: string;
   clinic_id: string;
   day_of_week: number;
@@ -399,7 +399,7 @@ export async function createUser(input: CreateUserInput): Promise<UserRow> {
   return data as UserRow;
 }
 
-export async function fetchClinicUsers(clinicId: string): Promise<UserRow[]> {
+async function fetchClinicUsers(clinicId: string): Promise<UserRow[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("users")
@@ -431,7 +431,7 @@ export async function createService(input: CreateServiceInput): Promise<ServiceR
   return data as ServiceRow;
 }
 
-export async function fetchClinicServices(clinicId: string): Promise<ServiceRow[]> {
+async function fetchClinicServices(clinicId: string): Promise<ServiceRow[]> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("services")
@@ -444,7 +444,7 @@ export async function fetchClinicServices(clinicId: string): Promise<ServiceRow[
 
 // ---------- Time Slot CRUD ----------
 
-export async function createTimeSlot(input: CreateTimeSlotInput): Promise<TimeSlotRow> {
+async function createTimeSlot(input: CreateTimeSlotInput): Promise<TimeSlotRow> {
   const supabase = await rawClient();
   const { data, error } = await supabase
     .from("time_slots")
@@ -805,7 +805,7 @@ export async function fetchFeatureToggles(): Promise<FeatureToggleRow[]> {
 
 // ---------- Client Subscriptions ----------
 
-export interface ClientInvoice {
+interface ClientInvoice {
   id: string;
   date: string;
   amount: number;
@@ -814,7 +814,7 @@ export interface ClientInvoice {
 }
 
 export type SystemType = "doctor" | "dentist" | "pharmacy";
-export type TierSlug = "vitrine" | "cabinet" | "pro" | "premium" | "saas-monthly";
+type TierSlug = "vitrine" | "cabinet" | "pro" | "premium" | "saas-monthly";
 
 export interface ClientSubscription {
   id: string;

--- a/src/lib/template-presets.ts
+++ b/src/lib/template-presets.ts
@@ -589,6 +589,6 @@ export function getPresetsByVertical(vertical: VerticalId): TemplatePreset[] {
 }
 
 /** Get preset IDs for a given vertical (matches vertical.templatePresets arrays) */
-export function getPresetIdsForVertical(vertical: VerticalId): string[] {
+function getPresetIdsForVertical(vertical: VerticalId): string[] {
   return getPresetsByVertical(vertical).map((p) => p.id);
 }

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -23,10 +23,10 @@ export type HeaderVariant = "top-sticky" | "top-transparent" | "side-left" | "bo
 export type FooterVariant = "classic-3col" | "minimal" | "centered" | "hidden";
 
 /** Navigation style variant */
-export type NavStyle = "horizontal" | "vertical-side" | "hamburger-only" | "bottom-tabs" | "floating-dots";
+type NavStyle = "horizontal" | "vertical-side" | "hamburger-only" | "bottom-tabs" | "floating-dots";
 
 /** Hero section layout variant */
-export type HeroVariant = "split" | "centered" | "fullscreen-video" | "slider" | "parallax" | "none";
+type HeroVariant = "split" | "centered" | "fullscreen-video" | "slider" | "parallax" | "none";
 
 /** Product click behavior */
 export type ProductClickBehavior = "modal" | "landing-page" | "side-panel" | "new-tab";
@@ -66,7 +66,7 @@ export interface TemplateDefinition {
   productClickBehavior: ProductClickBehavior;
 }
 
-export const templates: Record<TemplateId, TemplateDefinition> = {
+const templates: Record<TemplateId, TemplateDefinition> = {
   modern: {
     id: "modern",
     name: "Modern",

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -60,7 +60,7 @@ export const bookingCancelSchema = z.object({
   reason: z.string().max(1000).optional(),
 });
 
-export const emergencySlotCreateSchema = z.object({
+const emergencySlotCreateSchema = z.object({
   action: z.literal("create"),
   doctorId: z.string().min(1),
   date: isoDate,
@@ -69,7 +69,7 @@ export const emergencySlotCreateSchema = z.object({
   reason: z.string().max(1000).optional(),
 });
 
-export const emergencySlotBookSchema = z.object({
+const emergencySlotBookSchema = z.object({
   action: z.literal("book"),
   slotId: z.string().min(1),
   patientId: z.string().min(1),
@@ -83,7 +83,7 @@ export const emergencySlotSchema = z.discriminatedUnion("action", [
   emergencySlotBookSchema,
 ]);
 
-export const recurringCreateSchema = z.object({
+const recurringCreateSchema = z.object({
   action: z.literal("create"),
   patientId: z.string().min(1),
   patientName: z.string().min(1).max(200),
@@ -98,7 +98,7 @@ export const recurringCreateSchema = z.object({
   hasInsurance: z.boolean().optional(),
 });
 
-export const recurringCancelSchema = z.object({
+const recurringCancelSchema = z.object({
   action: z.literal("cancel"),
   groupId: z.string().optional(),
   cancelAll: z.boolean().optional(),
@@ -222,7 +222,7 @@ export const cmiCallbackFieldsSchema = z.object({
   { message: "Unknown parameter in CMI callback — potential tampering" },
 );
 
-export type CmiCallbackFields = z.infer<typeof cmiCallbackFieldsSchema>;
+type CmiCallbackFields = z.infer<typeof cmiCallbackFieldsSchema>;
 
 export const cmiPaymentSchema = z.object({
   amount: z.number().positive().finite(),
@@ -434,7 +434,7 @@ export const aiPrescriptionRequestSchema = z.object({
   }).optional(),
 });
 
-export type AiPrescriptionRequest = z.infer<typeof aiPrescriptionRequestSchema>;
+type AiPrescriptionRequest = z.infer<typeof aiPrescriptionRequestSchema>;
 
 // ── Chat ────────────────────────────────────────────────────────────────
 
@@ -482,7 +482,7 @@ export const applyPresetSchema = z.object({
 
 // ── Upload ──────────────────────────────────────────────────────────────
 
-export const uploadPresignedSchema = z.object({
+const uploadPresignedSchema = z.object({
   filename: z.string().min(1).max(500),
   contentType: z.string().min(1).max(200),
   category: z.string().min(1).max(100),
@@ -509,7 +509,7 @@ export const consentSchema = z.object({
 
 // ── Clinic Features ─────────────────────────────────────────────────────
 
-export const clinicFeaturesQuerySchema = z.object({
+const clinicFeaturesQuerySchema = z.object({
   type_key: z.string().min(1).max(100),
 });
 
@@ -531,7 +531,7 @@ export const aiPatientSummaryRequestSchema = z.object({
   forceRefresh: z.boolean().optional().default(false),
 });
 
-export type AiPatientSummaryRequest = z.infer<typeof aiPatientSummaryRequestSchema>;
+type AiPatientSummaryRequest = z.infer<typeof aiPatientSummaryRequestSchema>;
 
 // ── AI Drug Interaction Checker ─────────────────────────────────────────
 
@@ -542,7 +542,7 @@ export const aiDrugCheckRequestSchema = z.object({
   useAiFallback: z.boolean().optional().default(true),
 });
 
-export type AiDrugCheckRequest = z.infer<typeof aiDrugCheckRequestSchema>;
+type AiDrugCheckRequest = z.infer<typeof aiDrugCheckRequestSchema>;
 
 export const aiDrugCheckOverrideSchema = z.object({
   patientId: z.string().min(1).optional(),
@@ -553,7 +553,7 @@ export const aiDrugCheckOverrideSchema = z.object({
   medications: z.array(z.string()).min(1),
 });
 
-export type AiDrugCheckOverride = z.infer<typeof aiDrugCheckOverrideSchema>;
+type AiDrugCheckOverride = z.infer<typeof aiDrugCheckOverrideSchema>;
 
 // ── Doctor Unavailability ────────────────────────────────────────────────
 
@@ -658,7 +658,7 @@ export const aiManagerRequestSchema = z.object({
   ).max(20).optional().default([]),
 });
 
-export type AiManagerRequest = z.infer<typeof aiManagerRequestSchema>;
+type AiManagerRequest = z.infer<typeof aiManagerRequestSchema>;
 
 // ── AI Auto-Suggest (Smart Prescription Suggestions) ────────────────────
 
@@ -675,7 +675,7 @@ export const aiAutoSuggestRequestSchema = z.object({
   }).optional(),
 });
 
-export type AiAutoSuggestRequest = z.infer<typeof aiAutoSuggestRequestSchema>;
+type AiAutoSuggestRequest = z.infer<typeof aiAutoSuggestRequestSchema>;
 
 // ── Pet Profiles (Veterinary) ────────────────────────────────────────────
 
@@ -709,14 +709,14 @@ export const petProfileUpdateSchema = z.object({
 
 // ── Menu Management (Restaurant) ────────────────────────────────────────
 
-export const menuCreateSchema = z.object({
+const menuCreateSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
   is_active: z.boolean().optional().default(true),
   sort_order: z.number().int().optional().default(0),
 });
 
-export const menuUpdateSchema = z.object({
+const menuUpdateSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1).max(200).optional(),
   description: z.string().max(2000).nullable().optional(),
@@ -724,7 +724,7 @@ export const menuUpdateSchema = z.object({
   sort_order: z.number().int().optional(),
 });
 
-export const menuItemCreateSchema = z.object({
+const menuItemCreateSchema = z.object({
   menu_id: z.string().min(1),
   category: z.string().min(1).max(200),
   name: z.string().min(1).max(200),
@@ -737,7 +737,7 @@ export const menuItemCreateSchema = z.object({
   sort_order: z.number().int().optional().default(0),
 });
 
-export const menuItemUpdateSchema = z.object({
+const menuItemUpdateSchema = z.object({
   id: z.string().min(1),
   category: z.string().min(1).max(200).optional(),
   name: z.string().min(1).max(200).optional(),
@@ -752,14 +752,14 @@ export const menuItemUpdateSchema = z.object({
 
 // ── Table Management (Restaurant) ───────────────────────────────────────
 
-export const restaurantTableCreateSchema = z.object({
+const restaurantTableCreateSchema = z.object({
   name: z.string().min(1).max(200),
   capacity: z.number().int().min(1).max(100),
   zone: z.string().max(200).optional(),
   is_active: z.boolean().optional().default(true),
 });
 
-export const restaurantTableUpdateSchema = z.object({
+const restaurantTableUpdateSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1).max(200).optional(),
   capacity: z.number().int().min(1).max(100).optional(),

--- a/src/lib/whatsapp-templates-darija.ts
+++ b/src/lib/whatsapp-templates-darija.ts
@@ -21,7 +21,7 @@ import type {
 
 // ---- Darija Template Definitions ----
 
-export interface DarijaTemplate {
+interface DarijaTemplate {
   id: string;
   trigger: NotificationTrigger;
   name: string;
@@ -45,7 +45,7 @@ export interface DarijaTemplate {
  * Moroccans actually communicate on WhatsApp — rather than using
  * formal Modern Standard Arabic.
  */
-export const darijaWhatsAppTemplates: DarijaTemplate[] = [
+const darijaWhatsAppTemplates: DarijaTemplate[] = [
   // 1. Appointment Confirmation
   {
     id: "darija_booking_confirmation",
@@ -252,7 +252,7 @@ export function toDarijaNotificationTemplates(): NotificationTemplate[] {
  * Look up a single Darija template by its notification trigger.
  * Returns `undefined` if no enabled template exists for that trigger.
  */
-export function getDarijaTemplate(
+function getDarijaTemplate(
   trigger: NotificationTrigger,
 ): DarijaTemplate | undefined {
   return darijaWhatsAppTemplates.find(

--- a/src/lib/whatsapp.ts
+++ b/src/lib/whatsapp.ts
@@ -20,7 +20,7 @@ import { toDarijaNotificationTemplates } from "./whatsapp-templates-darija";
  * - `ar`     – Arabic (same as default for now, can be extended)
  * - `darija` – Moroccan Arabic (uses Darija-specific templates)
  */
-export type PatientMessageLocale = "fr" | "ar" | "darija";
+type PatientMessageLocale = "fr" | "ar" | "darija";
 
 // ---- Types ----
 
@@ -66,9 +66,9 @@ interface WhatsAppSendResult {
   provider: WhatsAppProvider;
 }
 
-export type WhatsAppMessageStatus = "sent" | "delivered" | "read" | "failed";
+type WhatsAppMessageStatus = "sent" | "delivered" | "read" | "failed";
 
-export interface WhatsAppStatusUpdate {
+interface WhatsAppStatusUpdate {
   messageId: string;
   status: WhatsAppMessageStatus;
   timestamp: string;
@@ -315,7 +315,7 @@ export async function sendInteractiveMessage(
 /**
  * Send a WhatsApp template message using the configured provider.
  */
-export async function sendWhatsAppMessage(
+async function sendWhatsAppMessage(
   payload: WhatsAppMessagePayload,
 ): Promise<WhatsAppSendResult> {
   const config = getWhatsAppConfig();
@@ -359,7 +359,7 @@ export async function sendTextMessage(
  * Falls back to the default (French) templates when no locale-specific
  * set exists.
  */
-export function getTemplatesForLocale(
+function getTemplatesForLocale(
   locale: PatientMessageLocale = "fr",
 ): NotificationTemplate[] {
   switch (locale) {
@@ -382,7 +382,7 @@ export function getTemplatesForLocale(
  * (e.g. Darija) automatically. The explicit `templates` parameter still takes
  * precedence if supplied so existing call-sites are unaffected.
  */
-export async function sendNotificationWhatsApp(
+async function sendNotificationWhatsApp(
   trigger: NotificationTrigger,
   to: string,
   variables: TemplateVariables,


### PR DESCRIPTION
## Summary

Removes the `export` keyword from 162 functions, constants, and types across 46 files that are never imported outside their defining module. All symbols remain available for internal use.

**Scope includes:**
- UI components: badge, sheet, skeleton, footers, headers barrel exports
- Domain utils: morocco.ts (29), validations.ts (19), features.ts (10), i18n.ts (5)
- Infrastructure: rate-limit.ts (7), cloudflare-dns.ts (3), subdomain-cache.ts (4)
- AI: ai-disclaimer.ts (4), ai/config.ts (1)
- Security: mfa.ts (5), middleware/security-headers.ts (3)
- Misc utilities: demo.ts, blog.ts, templates.ts, etc.

**Intentionally skipped (API surface):**
- `src/lib/data/server.ts` — CRUD operations (intentional public API)
- `src/lib/data/client/*.ts` — client-side data access layer
- SEALED files per AGENTS.md

Verified: `tsc --noEmit` passes, all 814 tests pass (16 env-gated skips).

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Checklist

- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (814 passed, 16 skipped)