### PR TITLE
fix(security): P0 infrastructure + webhook hardening (INF-001/002/003, SEC-001, API-002)

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,11 +1,10 @@
 name: Automated Database Backups
 
 on:
-  # Schedule disabled — no backups exist in R2 yet and the required
-  # secrets (SUPABASE_DB_URL, BACKUP_GPG_KEY, R2_*) are not fully
-  # configured. Re-enable the cron once backup infrastructure is live.
-  # schedule:
-  #   - cron: "0 2 * * *"
+  # INF-001: Re-enabled daily backup schedule. The job self-checks for
+  # required secrets and fails-closed if any are missing.
+  schedule:
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       backup_type:

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,10 +1,9 @@
 name: Monthly Database Restore Drill
 
 on:
-  # Schedule disabled — depends on backup.yml producing encrypted
-  # backups in R2 first. Re-enable once backups are running.
-  # schedule:
-  #   - cron: '0 4 1 * *'
+  # INF-001: Re-enabled monthly restore drill. Validates backup integrity.
+  schedule:
+    - cron: '0 4 1 * *'
   workflow_dispatch:
 
 # Least-privilege permissions

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -103,6 +103,27 @@ export async function POST(request: NextRequest) {
             break; // Skip processing since it's already handled
           }
 
+          // API-002 / SEC-014: Verify that the appointment actually belongs
+          // to the clinic specified in metadata. A forged or replayed webhook
+          // with a mismatched clinic_id must not attribute payments incorrectly.
+          if (appointmentId) {
+            const { data: appt } = await supabase
+              .from("appointments")
+              .select("clinic_id")
+              .eq("id", appointmentId)
+              .maybeSingle();
+            if (appt && appt.clinic_id !== clinicId) {
+              logger.error("Stripe webhook: appointment.clinic_id does not match metadata.clinic_id", {
+                context: "payments/webhook",
+                appointmentClinicId: appt.clinic_id,
+                metadataClinicId: clinicId,
+                appointmentId,
+                sessionId: session.id,
+              });
+              return apiError("Appointment does not belong to the specified clinic", 422);
+            }
+          }
+
           await supabase.from("payments").upsert(
             {
               clinic_id: clinicId,

--- a/src/lib/dns-verification.ts
+++ b/src/lib/dns-verification.ts
@@ -22,20 +22,18 @@ import { createHmac } from "crypto";
 const TOKEN_PREFIX = "oltigo";
 
 /**
- * Returns the secret used to sign DNS verification tokens, or `null` if no
- * secret is configured. Callers MUST treat `null` as "verification is not
- * available" and refuse to issue tokens or pass DNS verification — never
- * substitute a literal fallback (which would let attackers compute tokens).
+ * Returns the dedicated DNS verification secret, or `null` if not configured.
  *
- * Prefers a dedicated `DNS_VERIFICATION_SECRET` so a leak does not compromise
- * other HMAC keys, and falls back to `BOOKING_TOKEN_SECRET` for deployments
- * that have not provisioned the dedicated key yet.
+ * SEC-001: The BOOKING_TOKEN_SECRET fallback has been removed. NIST SP 800-57
+ * §5.2 requires distinct keys per HMAC purpose. A leaked DNS verification
+ * token must not be replayable as a booking token (or vice versa).
+ *
+ * If `DNS_VERIFICATION_SECRET` is unset, callers MUST treat the return as
+ * "verification is not available" and refuse to issue tokens.
  */
 function getDnsVerificationSecret(): string | null {
   const dedicated = process.env.DNS_VERIFICATION_SECRET;
   if (dedicated && dedicated.length > 0) return dedicated;
-  const fallback = process.env.BOOKING_TOKEN_SECRET;
-  if (fallback && fallback.length > 0) return fallback;
   return null;
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -34,19 +34,22 @@ routes = [
 
 # ── KV Namespaces ─────────────────────────────────────────────────────
 # Rate-limiting counters (shared across all edge locations).
-# Currently production uses RATE_LIMIT_BACKEND=supabase, so the KV binding
-# is not required for deploy. Uncomment and set the real namespace ID when
-# migrating to KV-backed rate limiting:
+# INF-002: Rate limiter MUST use KV in production to prevent per-isolate
+# counter fragmentation. Provision with:
 #
-#   wrangler kv namespace create RATE_LIMIT_KV
-#   # Copy the returned ID below
+#   wrangler kv:namespace create RATE_LIMIT_KV
+#   wrangler kv:namespace create RATE_LIMIT_KV --preview
+#   # Paste the returned IDs below, then set RATE_LIMIT_BACKEND=kv in [vars]
 #
 # [[kv_namespaces]]
 # binding = "RATE_LIMIT_KV"
-# id = "<paste-real-kv-namespace-id-here>"
+# id = "<paste-production-kv-namespace-id>"
+# preview_id = "<paste-preview-kv-namespace-id>"
 
 # ── R2 Buckets ────────────────────────────────────────────────────────
 # AUDIT-LB3: IaC — PHI file storage (encrypted uploads).
+# INF-003: Production bucket is declared at the top level. Staging overrides
+# below to prevent cross-environment PHI contamination.
 [[r2_buckets]]
 binding = "UPLOADS_BUCKET"
 bucket_name = "webs-alots-uploads"
@@ -64,6 +67,12 @@ name = "webs-alots-staging"
 [env.staging.vars]
 NODE_ENV = "production"
 RATE_LIMIT_BACKEND = "supabase"
+
+# INF-003: Staging uses a separate R2 bucket to prevent cross-environment
+# PHI contamination. Create with: wrangler r2 bucket create webs-alots-uploads-staging
+[[env.staging.r2_buckets]]
+binding = "UPLOADS_BUCKET"
+bucket_name = "webs-alots-uploads-staging"
 
 # ── Limits ────────────────────────────────────────────────────────────
 [limits]


### PR DESCRIPTION
## Summary

Addresses 5 P0/Critical findings from the full-stack audit report:

1. **INF-001** — Re-enables daily automated backup schedule (`backup.yml`) and monthly restore drill (`restore-test.yml`). Both were disabled pending secret provisioning. The jobs already fail-closed when secrets are missing.
2. **INF-002** — Updates KV provisioning instructions with correct `wrangler kv:namespace create` commands and `preview_id` slot.
3. **INF-003** — Adds `[[env.staging.r2_buckets]]` override so staging deploys use a separate R2 bucket (`webs-alots-uploads-staging`), preventing cross-environment PHI contamination.
4. **SEC-001** — Removes the `BOOKING_TOKEN_SECRET` fallback in `dns-verification.ts`. Per NIST SP 800-57 §5.2, each HMAC purpose must use a distinct key.
5. **API-002 / SEC-014** — Adds appointment ownership assertion in the Stripe webhook handler: verifies `appointment.clinic_id === metadata.clinic_id`. Rejects with 422 on mismatch.

### Operator action required after merge

- **INF-001**: Provision backup secrets as GitHub Actions secrets. Run one manual backup to seed R2.
- **INF-002**: Run `wrangler kv:namespace create RATE_LIMIT_KV` and paste IDs into `wrangler.toml`.
- **INF-003**: Run `wrangler r2 bucket create webs-alots-uploads-staging`.
- **SEC-001**: Provision `DNS_VERIFICATION_SECRET` via `wrangler secret put`.

## Type of change

- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact

- [x] This PR modifies encryption, audit logging, or PII handling
- [x] This PR changes tenant isolation or multi-tenant scoping

## Migration Safety

- [x] N/A — no migrations

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes