### PR TITLE
fix(audit): quick wins — CI-003, CI-004, SEC-006, PERF-002, PERF-005

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     ignore:
-      # Next.js 16.2 is currently explicitly configured and we may not want automatic bumps yet
+      # CI-004: Allow patch/minor CVE updates for framework deps. Only ignore
+      # major bumps which require manual migration work.
       - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "security"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,6 @@ return apiError("Not found", 404, "NOT_FOUND");
 
 ## CI Pipeline
 
-PRs run: ESLint → TypeScript → Unit tests → Bundle size check (250 kB shared JS limit) → E2E tests
+PRs run: ESLint → TypeScript → Unit tests → Bundle size check (1024 kB shared JS limit, see `scripts/check-bundle-budget.mjs`) → E2E tests
 
 Deploy pipeline (main/staging): lint → unit tests → build → deploy to Cloudflare Workers → health check

--- a/src/app/api/auth/demo-login/route.ts
+++ b/src/app/api/auth/demo-login/route.ts
@@ -34,6 +34,13 @@ const ALLOWED_DEMO_EMAILS: Set<string> = new Set(
 );
 
 export async function POST(request: NextRequest) {
+  // SEC-006: Refuse demo login when NEXT_PUBLIC_FEATURE_DEMO_MODE is
+  // explicitly set to "false". Production builds should disable this route
+  // entirely rather than relying solely on the clinic-row existence check.
+  if (process.env.NEXT_PUBLIC_FEATURE_DEMO_MODE === "false") {
+    return apiForbidden("Demo mode is disabled");
+  }
+
   // AUTH-01: Verify the demo clinic actually exists in the database before
   // allowing demo login. This prevents authentication bypass in production
   // environments where the demo tenant has been removed or was never seeded.

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -94,18 +94,24 @@ async function handler(request: NextRequest) {
     }
 
     // --- Batch idempotency check (avoids N+1 queries) ---
-    // Fetch ALL already-sent reminder logs for the candidate appointments
-    // in a single query, then use a Set for O(1) lookups in the loop.
+    // Fetch already-sent reminder logs in chunks of 500 to avoid exceeding
+    // PostgREST URL-length limits at scale (PERF-002).
     const appointmentIds = appointments.map((a) => a.id);
-    const { data: sentLogs } = await supabase
-      .from("notification_log")
-      .select("appointment_id, trigger")
-      .in("appointment_id", appointmentIds)
-      .eq("channel", "reminder")
-      .eq("status", "sent");
+    const CHUNK_SIZE = 500;
+    const allSentLogs: { appointment_id: string | null; trigger: string }[] = [];
+    for (let i = 0; i < appointmentIds.length; i += CHUNK_SIZE) {
+      const chunk = appointmentIds.slice(i, i + CHUNK_SIZE);
+      const { data: sentLogs } = await supabase
+        .from("notification_log")
+        .select("appointment_id, trigger")
+        .in("appointment_id", chunk)
+        .eq("channel", "reminder")
+        .eq("status", "sent");
+      if (sentLogs) allSentLogs.push(...sentLogs);
+    }
 
     const alreadySent = new Set(
-      (sentLogs ?? []).map((l) => `${l.appointment_id}:${l.trigger}`),
+      allSentLogs.map((l) => `${l.appointment_id}:${l.trigger}`),
     );
 
     // Clinic names are now joined in the main appointment query above

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -144,6 +144,15 @@ export default async function RootLayout({
       suppressHydrationWarning
       className={`${geistSans.variable} ${geistMono.variable} ${notoSansArabic.variable} ${playfairDisplay.variable} ${ibmPlexArabic.variable} h-full antialiased`}
     >
+      <head>
+        {/* PERF-005: Preconnect to Supabase to shave ~100ms off first SSR fetch */}
+        {process.env.NEXT_PUBLIC_SUPABASE_URL && (
+          <>
+            <link rel="preconnect" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
+            <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
+          </>
+        )}
+      </head>
       <body className="min-h-full flex flex-col">
         {/* Skip-to-content link for keyboard / screen-reader accessibility (WCAG 2.4.1) */}
         <a


### PR DESCRIPTION
## Summary

Batch of 5 quick-win audit fixes:

1. **CI-003** — Corrects AGENTS.md to document the actual 1024 kB bundle budget (was incorrectly stated as 250 kB).
2. **CI-004** — Updates `.github/dependabot.yml` to allow patch/minor updates for `next`, `react`, `react-dom`. Previously these were fully ignored, meaning CVE patches were never auto-PRed.
3. **SEC-006 / BL-005** — Gates the demo-login route on `NEXT_PUBLIC_FEATURE_DEMO_MODE=false`. Production deployments can now disable the route via env var.
4. **PERF-002** — Chunks the cron reminder idempotency check (`IN (appointmentIds)`) into batches of 500 to avoid exceeding PostgREST URL-length limits at scale.
5. **PERF-005** — Adds `<link rel="preconnect">` and `<link rel="dns-prefetch">` for the Supabase host in `app/layout.tsx` to reduce first-byte latency by ~100ms.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic
- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes