### PR TITLE
fix(bl): Stripe reconciliation cron (BL-002) + GDPR erasure email (BL-003)

### DIFF
--- a/src/app/api/cron/gdpr-purge/route.ts
+++ b/src/app/api/cron/gdpr-purge/route.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { NextRequest } from "next/server";
 import { apiSuccess, apiInternalError } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
+import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
 import { deleteFromR2, isR2Configured } from "@/lib/r2";
 import { withSentryCron } from "@/lib/sentry-cron";
@@ -39,7 +40,7 @@ async function handler(request: NextRequest) {
     // Find users whose deletion grace period has expired
     const { data: usersToDelete, error: queryError } = await supabase
       .from("users")
-      .select("id, name, clinic_id")
+      .select("id, name, email, clinic_id")
       .not("deletion_requested_at", "is", null)
       .lte("deletion_requested_at", thirtyDaysAgo)
       .limit(50); // Process in batches to avoid timeouts
@@ -189,6 +190,34 @@ async function handler(request: NextRequest) {
             error: "Failed to delete user record",
           });
           continue;
+        }
+
+        // BL-003: Send erasure confirmation email to the user's last-known
+        // address. GDPR Art. 17 & Moroccan Law 09-08 require user-visible
+        // confirmation that data has been deleted. Best-effort: failure to
+        // send does not roll back the purge.
+        if (user.email) {
+          try {
+            await sendEmail({
+              to: user.email,
+              subject: "Confirmation de suppression de vos données — Oltigo",
+              html: [
+                "<p>Bonjour,</p>",
+                "<p>Conformément à votre demande et aux dispositions de la Loi 09-08, ",
+                "nous vous confirmons que l'ensemble de vos données personnelles a été ",
+                "définitivement supprimé de nos systèmes.</p>",
+                "<p>Si vous n'êtes pas à l'origine de cette demande, veuillez contacter ",
+                "notre support immédiatement.</p>",
+                "<p>Cordialement,<br/>L'équipe Oltigo</p>",
+              ].join(""),
+            });
+          } catch (emailErr) {
+            logger.warn("Failed to send GDPR erasure confirmation email", {
+              context: "cron/gdpr-purge",
+              userId: user.id,
+              error: emailErr,
+            });
+          }
         }
 
         logger.info("GDPR purge completed for user", {

--- a/src/app/api/cron/stripe-reconcile/route.ts
+++ b/src/app/api/cron/stripe-reconcile/route.ts
@@ -1,0 +1,146 @@
+/**
+ * GET /api/cron/stripe-reconcile
+ *
+ * BL-002: Daily Stripe payment reconciliation.
+ *
+ * Compares completed Stripe Checkout Sessions (last 7 days) against the
+ * local `payments` table. Any session not matched by `reference` is logged
+ * as drift. This catches missed webhooks (Stripe retries for ≤3 days, so
+ * 7-day window provides overlap).
+ *
+ * Drift items are logged at `error` level so Sentry captures them, and
+ * they appear in the JSON response for operator dashboards.
+ */
+
+import { NextRequest } from "next/server";
+import { apiSuccess, apiInternalError, apiError } from "@/lib/api-response";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import { withSentryCron } from "@/lib/sentry-cron";
+import { createAdminClient } from "@/lib/supabase-server";
+
+interface StripeSession {
+  id: string;
+  payment_status: string;
+  metadata: Record<string, string>;
+  amount_total: number | null;
+  created: number;
+}
+
+interface StripeListResponse {
+  data: StripeSession[];
+  has_more: boolean;
+  url: string;
+}
+
+async function handler(request: NextRequest) {
+  const authError = verifyCronSecret(request);
+  if (authError) return authError;
+
+  const stripeKey = process.env.STRIPE_SECRET_KEY;
+  if (!stripeKey) {
+    return apiError("STRIPE_SECRET_KEY not configured", 503);
+  }
+
+  try {
+    const supabase = createAdminClient();
+    const sevenDaysAgo = Math.floor(Date.now() / 1000) - 7 * 24 * 60 * 60;
+
+    // Fetch completed Stripe Checkout Sessions from the last 7 days.
+    // Paginate in case there are many sessions.
+    const allSessions: StripeSession[] = [];
+    let hasMore = true;
+    let startingAfter: string | undefined;
+
+    while (hasMore) {
+      const params = new URLSearchParams({
+        "created[gte]": sevenDaysAgo.toString(),
+        limit: "100",
+        status: "complete",
+      });
+      if (startingAfter) params.set("starting_after", startingAfter);
+
+      const res = await fetch(
+        `https://api.stripe.com/v1/checkout/sessions?${params.toString()}`,
+        {
+          headers: {
+            Authorization: `Bearer ${stripeKey}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        },
+      );
+
+      if (!res.ok) {
+        logger.error("Stripe API error during reconciliation", {
+          context: "cron/stripe-reconcile",
+          status: res.status,
+        });
+        return apiInternalError("Stripe API returned an error");
+      }
+
+      const body = (await res.json()) as StripeListResponse;
+      allSessions.push(...body.data);
+      hasMore = body.has_more;
+      if (body.data.length > 0) {
+        startingAfter = body.data[body.data.length - 1].id;
+      }
+    }
+
+    if (allSessions.length === 0) {
+      return apiSuccess({
+        message: "No Stripe sessions in the last 7 days",
+        checked: 0,
+        drift: 0,
+      });
+    }
+
+    // Fetch all local payment references for comparison
+    const sessionIds = allSessions.map((s) => s.id);
+    const { data: localPayments } = await supabase
+      .from("payments")
+      .select("reference")
+      .in("reference", sessionIds);
+
+    const localRefs = new Set(
+      (localPayments ?? []).map((p) => p.reference).filter(Boolean),
+    );
+
+    // Find drift: Stripe says paid, local DB has no record
+    const driftSessions = allSessions.filter(
+      (s) => s.payment_status === "paid" && !localRefs.has(s.id),
+    );
+
+    for (const drift of driftSessions) {
+      logger.error("Stripe payment drift detected — session not in payments table", {
+        context: "cron/stripe-reconcile",
+        stripeSessionId: drift.id,
+        amountTotal: drift.amount_total,
+        clinicId: drift.metadata?.clinic_id ?? "unknown",
+        created: new Date(drift.created * 1000).toISOString(),
+      });
+    }
+
+    if (driftSessions.length > 0) {
+      logger.warn(`Stripe reconciliation found ${driftSessions.length} unmatched sessions`, {
+        context: "cron/stripe-reconcile",
+        total: allSessions.length,
+        drift: driftSessions.length,
+      });
+    }
+
+    return apiSuccess({
+      message: `Reconciliation complete: ${allSessions.length} checked, ${driftSessions.length} drift`,
+      checked: allSessions.length,
+      drift: driftSessions.length,
+      driftSessionIds: driftSessions.map((s) => s.id),
+    });
+  } catch (err) {
+    logger.error("Stripe reconciliation cron failed", {
+      context: "cron/stripe-reconcile",
+      error: err,
+    });
+    return apiInternalError("Failed to reconcile Stripe payments");
+  }
+}
+
+export const GET = withSentryCron("stripe-reconcile-daily", "0 5 * * *", handler);

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -13,6 +13,7 @@
  *                        /api/cron/rebooking-reminders (rebooking prompts)
  *   - daily 02:00    →  /api/cron/billing       (subscription renewals)
  *   - daily 03:00    →  /api/cron/gdpr-purge    (GDPR patient data purge)
+ *   - daily 05:00    →  /api/cron/stripe-reconcile (BL-002 payment drift)
  *
  * @see https://opennext.js.org/cloudflare/howtos/custom-worker
  */
@@ -34,6 +35,7 @@ const CRON_ROUTES: Record<string, string[]> = {
   "0 * * * *":    ["/api/cron/r2-cleanup", "/api/cron/feedback", "/api/cron/rebooking-reminders"],
   "0 2 * * *":    ["/api/cron/billing"],
   "0 3 * * *":    ["/api/cron/gdpr-purge"],
+  "0 5 * * *":    ["/api/cron/stripe-reconcile"],
 };
 
 export default {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -86,6 +86,7 @@ crons = [
   "0 * * * *",    # hourly — R2 cleanup + feedback + rebooking reminders
   "0 2 * * *",    # 02:00 UTC daily — subscription billing
   "0 3 * * *",    # 03:00 UTC daily — GDPR patient data purge
+  "0 5 * * *",    # 05:00 UTC daily — BL-002 Stripe payment reconciliation
 ]
 
 # ── Build ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

1. **BL-002** — New daily Stripe reconciliation cron (`/api/cron/stripe-reconcile`, 05:00 UTC). Lists completed Stripe Checkout Sessions from the last 7 days and compares against the `payments` table. Any session marked as paid in Stripe but missing from the local DB is logged at `error` level (Sentry will capture these). Prevents the "patient pays but app shows unpaid" scenario when webhooks are missed.

2. **BL-003** — GDPR purge cron now sends a confirmation email to the user's last-known email address after successful data deletion. Required by GDPR Art. 17 and Moroccan Law 09-08 for user-visible erasure confirmation. Email failure is best-effort and does not block the purge.

3. Registered the new cron in both `wrangler.toml` and `worker-cron-handler.ts` (CI guard script `check-cron-mapping.ts` will verify the mapping).

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Infrastructure / CI

## Security Impact

- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes