### PR TITLE
feat: editorial-institutional landing page redesign

### DIFF
--- a/src/app/tokens.css
+++ b/src/app/tokens.css
@@ -1,49 +1,41 @@
 /*
- * Oltigo Design System Tokens
+ * Oltigo Design System Tokens — Editorial-Institutional
  *
  * Single source of truth for all visual properties on marketing surfaces.
  * Consumed by Tailwind v4 via @theme and directly by component styles.
  *
- * Rules:
- *   - Max two non-neutral hues per viewport (Oltigo Green + one signal).
- *   - No purple.
+ * Rules (from design direction):
+ *   1. Four color tokens max. Every addition must be argued in writing.
+ *   2. No gradient on type. Ever.
+ *   3. --rule is the only border color. No border-gray-200, no shadow-lg.
+ *   4. Dark mode = swap --ink ↔ --bone. Accent/signal unchanged.
+ *   5. WCAG AAA on body, AA-large floor on lightest tier.
  */
 
 :root {
   /* ── Foundation ── */
-  --ink: #0B0F14;
-  --bone: #F6F4EE;
-  --bone-2: #ECE9DF;
-  --rule: rgba(11, 15, 20, 0.10);
+  --ink: #0B0F0E;
+  --bone: #F4F1EA;
+  --rule: rgba(11, 15, 14, 0.12);
 
   /* Ink opacity helpers */
-  --ink-80: rgba(11, 15, 20, 0.80);
-  --ink-70: rgba(11, 15, 20, 0.70);
-  --ink-60: rgba(11, 15, 20, 0.60);
-  --ink-20: rgba(11, 15, 20, 0.20);
+  --ink-80: rgba(11, 15, 14, 0.80);
+  --ink-70: rgba(11, 15, 14, 0.72);
+  --ink-60: rgba(11, 15, 14, 0.60);
+  --ink-20: rgba(11, 15, 14, 0.20);
 
-  /* ── Accent ── */
-  --oltigo-green: #16604A;
+  /* ── Accent (action) ── */
+  --oltigo-green: #005A3B;
 
-  /* ── Emergent Palette ── */
-  --surgical-sage: #5B8A72;
-  --surgical-sage-light: rgba(91, 138, 114, 0.12);
-  --surgical-sage-halo: rgba(91, 138, 114, 0.22);
-  --reassurance-teal: #2D6A6A;
-  --carnet-ochre: #C4A265;
-  --carnet-ochre-light: rgba(196, 162, 101, 0.15);
-  --clinic-coral: #D4746A;
-  --graphite: #1A1D21;
-  --night-navy: #0D1117;
-  --night-navy-surface: #161B22;
-  --lab-linen: #FAF8F3;
-
-  /* ── Signal (status only, never for CTAs or branding) ── */
-  --signal-green: #1E8E3E;
-  --signal-amber: #B7791F;
+  /* ── Signal (status only — never decorative) ── */
+  --signal-green: #22C55E;
+  --signal-amber: #F59E0B;
   --signal-red: #B42318;
 
-  /* ── Spacing (4pt grid) ── */
+  /* Paper grain — the only permitted gradient */
+  --paper-grain: linear-gradient(180deg, var(--bone) 0%, rgba(244, 241, 234, 0.98) 100%);
+
+  /* ── Spacing (4pt base, 8pt grid) ── */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
@@ -54,108 +46,86 @@
   --space-8: 64px;
   --space-9: 96px;
   --space-10: 128px;
-  --space-11: 192px;
 
   /* ── Typography ──
      Landing-specific font stacks. Namespaced (suffix `-landing`) so they do
-     not clobber `--font-sans` / `--font-mono` which are the app-wide theme
-     tokens consumed by Tailwind v4's `@theme inline` in globals.css — those
-     must continue to resolve to the app's default Geist stack for admin,
-     patient portal, and auth surfaces. Same rationale as `--radius-landing`
-     below. */
+     not clobber --font-sans / --font-mono which are the app-wide theme tokens
+     consumed by Tailwind v4's @theme inline in globals.css. */
   --font-sans-landing: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-serif-landing: var(--font-playfair), 'Playfair Display', Georgia, 'Times New Roman', serif;
   --font-mono-landing: 'JetBrains Mono', 'Geist Mono', ui-monospace, 'Cascadia Code', monospace;
   --font-arabic: var(--font-ibm-plex-arabic), 'IBM Plex Sans Arabic', 'Noto Sans Arabic', var(--font-noto-arabic), sans-serif;
 
-  /* Type scale: 16px = 1rem base */
+  /* Type scale (rem-based, 16px root) */
   --text-display: 4.5rem;     /* 72px */
-  --lh-display: 1.04;
-  --ls-display: -0.025em;
+  --lh-display: 1.02;
+  --ls-display: -0.02em;
 
-  --text-h1: 3rem;            /* 48px */
-  --lh-h1: 1.08;
-  --ls-h1: -0.02em;
+  --text-h1: 3rem;             /* 48px */
+  --lh-h1: 1.06;
+  --ls-h1: -0.015em;
 
-  --text-h2: 2rem;            /* 32px */
-  --lh-h2: 1.15;
-  --ls-h2: -0.015em;
+  --text-h2: 2rem;             /* 32px */
+  --lh-h2: 1.12;
+  --ls-h2: -0.01em;
 
-  --text-h3: 1.25rem;         /* 20px */
-  --lh-h3: 1.3;
-  --ls-h3: -0.01em;
+  --text-h3: 1.375rem;         /* 22px */
+  --lh-h3: 1.22;
+  --ls-h3: -0.005em;
 
-  --text-body-lg: 1.125rem;   /* 18px */
-  --lh-body-lg: 1.55;
-  --ls-body-lg: -0.005em;
+  --text-body-lg: 1.1875rem;   /* 19px */
+  --lh-body-lg: 1.50;
+  --ls-body-lg: 0;
 
   --text-body: 1rem;           /* 16px */
-  --lh-body: 1.6;
+  --lh-body: 1.55;
   --ls-body: 0;
 
-  --text-small: 0.875rem;     /* 14px */
-  --lh-small: 1.5;
+  --text-small: 0.875rem;      /* 14px */
+  --lh-small: 1.45;
 
-  --text-mono: 0.8125rem;     /* 13px */
-  --lh-mono: 1.4;
+  --text-mono: 0.75rem;        /* 12px */
+  --lh-mono: 1.30;
+  --ls-mono: 0.04em;
 
   /* ── Layout ── */
-  --container-max: 1200px;
-  --gutter-mobile: 24px;
-  --gutter-tablet: 48px;
-  --gutter-desktop: 96px;
-  --grid-gap: 24px;
-  /* Landing-page radius. Namespaced to avoid collision with the shadcn
-     `--radius` token defined in globals.css (which would otherwise win the
-     CSS cascade because globals.css redeclares :root after importing this
-     file). */
+  --container-max: 1280px;
+  --gutter-mobile: 20px;
+  --gutter-tablet: 24px;
+  --gutter-desktop: clamp(20px, 4vw, 64px);
+  --grid-gap: 32px;
   --radius-landing: 8px;
 
-  /* ── Motion ── */
-  --duration: 120ms;
-  --easing: cubic-bezier(0.2, 0.7, 0.3, 1);
+  /* ── Motion (prefers-reduced-motion honored in components) ── */
+  --duration: 180ms;
+  --easing: cubic-bezier(0.2, 0.7, 0.2, 1);
 
-  /* ── Shadows (minimal — one allowed for sticky bars) ── */
-  --shadow-sticky: 0 1px 0 rgba(11, 15, 20, 0.06);
+  /* ── Focus ring (the only permitted shadow in the system) ── */
+  --ring-focus: 0 0 0 2px var(--oltigo-green);
 }
 
-/* ── Dark mode (night-shift navy) ── */
+/* ── Dark mode: swap ink ↔ bone ── */
 [data-theme="dark"] {
-  --ink: #E6EDF3;
-  --bone: #161B22;
-  --bone-2: #1C2128;
-  --rule: rgba(230, 237, 243, 0.10);
-  --ink-80: rgba(230, 237, 243, 0.80);
-  --ink-70: rgba(230, 237, 243, 0.70);
-  --ink-60: rgba(230, 237, 243, 0.60);
-  --ink-20: rgba(230, 237, 243, 0.20);
-  --surgical-sage-light: rgba(91, 138, 114, 0.18);
-  --surgical-sage-halo: rgba(91, 138, 114, 0.30);
-  --carnet-ochre-light: rgba(196, 162, 101, 0.20);
-  --lab-linen: #0D1117;
-  --night-navy: #0D1117;
-  --night-navy-surface: #161B22;
-  --graphite: #E6EDF3;
-  --shadow-sticky: 0 1px 0 rgba(230, 237, 243, 0.06);
+  --ink: #F4F1EA;
+  --bone: #0B0F0E;
+  --rule: rgba(244, 241, 234, 0.14);
+  --ink-80: rgba(244, 241, 234, 0.82);
+  --ink-70: rgba(244, 241, 234, 0.78);
+  --ink-60: rgba(244, 241, 234, 0.62);
+  --ink-20: rgba(244, 241, 234, 0.20);
+  --oltigo-green: #0E7A52;
+  --paper-grain: linear-gradient(180deg, var(--bone) 0%, rgba(11, 15, 14, 0.98) 100%);
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-    --ink: #E6EDF3;
-    --bone: #161B22;
-    --bone-2: #1C2128;
-    --rule: rgba(230, 237, 243, 0.10);
-    --ink-80: rgba(230, 237, 243, 0.80);
-    --ink-70: rgba(230, 237, 243, 0.70);
-    --ink-60: rgba(230, 237, 243, 0.60);
-    --ink-20: rgba(230, 237, 243, 0.20);
-    --surgical-sage-light: rgba(91, 138, 114, 0.18);
-    --surgical-sage-halo: rgba(91, 138, 114, 0.30);
-    --carnet-ochre-light: rgba(196, 162, 101, 0.20);
-    --lab-linen: #0D1117;
-    --night-navy: #0D1117;
-    --night-navy-surface: #161B22;
-    --graphite: #E6EDF3;
-    --shadow-sticky: 0 1px 0 rgba(230, 237, 243, 0.06);
+    --ink: #F4F1EA;
+    --bone: #0B0F0E;
+    --rule: rgba(244, 241, 234, 0.14);
+    --ink-80: rgba(244, 241, 234, 0.82);
+    --ink-70: rgba(244, 241, 234, 0.78);
+    --ink-60: rgba(244, 241, 234, 0.62);
+    --ink-20: rgba(244, 241, 234, 0.20);
+    --oltigo-green: #0E7A52;
+    --paper-grain: linear-gradient(180deg, var(--bone) 0%, rgba(11, 15, 14, 0.98) 100%);
   }
 }

--- a/src/components/landing/editorial/badge.tsx
+++ b/src/components/landing/editorial/badge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { StatusDot } from "./status-dot";
+
+/**
+ * §5.7 Badge / Pill — two variants only: mono and signal.
+ * 24px height, padding-x 8, radius 4, --text-mono, UC.
+ */
+export function Badge({
+  children,
+  variant = "mono",
+}: {
+  children: React.ReactNode;
+  variant?: "mono" | "signal";
+}) {
+  if (variant === "signal") {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5"
+        style={{
+          height: 24,
+          paddingInline: 8,
+          borderRadius: 4,
+          fontFamily: "var(--font-mono-landing)",
+          fontSize: "var(--text-mono)",
+          lineHeight: "var(--lh-mono)",
+          letterSpacing: "var(--ls-mono)",
+          textTransform: "uppercase",
+          fontWeight: 500,
+          color: "var(--ink)",
+        }}
+      >
+        <StatusDot status="operational" />
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        height: 24,
+        paddingInline: 8,
+        borderRadius: 4,
+        border: "1px solid var(--rule)",
+        fontFamily: "var(--font-mono-landing)",
+        fontSize: "var(--text-mono)",
+        lineHeight: "var(--lh-mono)",
+        letterSpacing: "var(--ls-mono)",
+        textTransform: "uppercase",
+        fontWeight: 500,
+        color: "var(--ink-60)",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/landing/editorial/closing-cta-section.tsx
+++ b/src/components/landing/editorial/closing-cta-section.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { HairlineRule } from "./hairline-rule";
+
+/**
+ * §3.1.9 Closing CTA — same compact pattern as hero top.
+ * No second hero. Primary + ghost.
+ */
+export function ClosingCtaSection() {
+  return (
+    <section
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        <HairlineRule />
+        <div style={{ paddingBlock: "var(--space-7)", maxWidth: 720 }}>
+          <h2
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-h1)",
+              lineHeight: "var(--lh-h1)",
+              letterSpacing: "var(--ls-h1)",
+              fontWeight: 500,
+              color: "var(--ink)",
+            }}
+          >
+            Prêt à simplifier votre cabinet&nbsp;?
+          </h2>
+          <p
+            style={{
+              marginTop: "var(--space-5)",
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-body-lg)",
+              lineHeight: "var(--lh-body-lg)",
+              color: "var(--ink-70)",
+            }}
+          >
+            Créez votre compte en 2 minutes. Aucune carte bancaire requise.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-4">
+            <Link
+              href="/register-clinic"
+              className="group inline-flex items-center gap-2"
+              style={{
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-small)",
+                fontWeight: 500,
+                height: 44,
+                paddingInline: 24,
+                borderRadius: "var(--radius-landing)",
+                backgroundColor: "var(--oltigo-green)",
+                color: "var(--bone)",
+                textDecoration: "none",
+                transition: `opacity var(--duration) var(--easing)`,
+              }}
+            >
+              Ouvrir un compte
+              <ArrowRight
+                style={{
+                  width: 16,
+                  height: 16,
+                  transition: `transform var(--duration) var(--easing)`,
+                }}
+                className="group-hover:translate-x-0.5"
+              />
+            </Link>
+            <a
+              href="#contact"
+              style={{
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-small)",
+                fontWeight: 500,
+                color: "var(--oltigo-green)",
+                textDecoration: "none",
+              }}
+              className="hover:underline"
+            >
+              Parler aux ventes →
+            </a>
+          </div>
+        </div>
+        <HairlineRule />
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/editorial-footer.tsx
+++ b/src/components/landing/editorial/editorial-footer.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import { HairlineRule } from "./hairline-rule";
+
+const COLUMNS = [
+  {
+    heading: "Produit",
+    links: [
+      { label: "Rendez-vous", href: "#product" },
+      { label: "Dossier patient", href: "#product" },
+      { label: "WhatsApp", href: "#product" },
+      { label: "Facturation", href: "#product" },
+    ],
+  },
+  {
+    heading: "Ressources",
+    links: [
+      { label: "Documentation", href: "/docs" },
+      { label: "Statut", href: "/status" },
+      { label: "Changelog", href: "/changelog" },
+    ],
+  },
+  {
+    heading: "Entreprise",
+    links: [
+      { label: "À propos", href: "/about" },
+      { label: "Contact", href: "/contact" },
+      { label: "Carrières", href: "/careers" },
+    ],
+  },
+  {
+    heading: "Légal",
+    links: [
+      { label: "Conditions", href: "/terms" },
+      { label: "Confidentialité", href: "/privacy" },
+      { label: "DPA", href: "/dpa" },
+      { label: "Loi 09-08", href: "/compliance" },
+    ],
+  },
+];
+
+/**
+ * §5.6 Footer — top 1px rule. 5-column grid.
+ * Column heading --text-small/500/--ink. Links --text-body/400/--ink-70.
+ * Bottom row --text-mono/--ink-60. No social icons in body.
+ */
+export function EditorialFooter() {
+  return (
+    <footer style={{ backgroundColor: "var(--bone)" }}>
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        <HairlineRule />
+
+        {/* eslint-disable i18next/no-literal-string */}
+        <div
+          className="grid grid-cols-2 gap-8 md:grid-cols-4 lg:grid-cols-5"
+          style={{ paddingBlock: "var(--space-8)" }}
+        >
+          {/* Brand column */}
+          <div className="col-span-2 md:col-span-4 lg:col-span-1">
+            <Link
+              href="/"
+              style={{
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-small)",
+                fontWeight: 700,
+                letterSpacing: "-0.02em",
+                color: "var(--ink)",
+                textDecoration: "none",
+              }}
+            >
+              oltigo
+            </Link>
+            <p
+              style={{
+                marginTop: "var(--space-3)",
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-body)",
+                lineHeight: "var(--lh-body)",
+                color: "var(--ink-70)",
+                maxWidth: 240,
+              }}
+            >
+              La plateforme complète pour gérer votre cabinet médical au Maroc.
+            </p>
+          </div>
+
+          {COLUMNS.map((col) => (
+            <div key={col.heading}>
+              <span
+                style={{
+                  fontFamily: "var(--font-sans-landing)",
+                  fontSize: "var(--text-small)",
+                  fontWeight: 500,
+                  color: "var(--ink)",
+                }}
+              >
+                {col.heading}
+              </span>
+              <ul className="mt-3 flex flex-col gap-2" style={{ listStyle: "none", padding: 0 }}>
+                {col.links.map((link) => (
+                  <li key={link.label}>
+                    <Link
+                      href={link.href}
+                      style={{
+                        fontFamily: "var(--font-sans-landing)",
+                        fontSize: "var(--text-body)",
+                        lineHeight: "var(--lh-body)",
+                        color: "var(--ink-70)",
+                        textDecoration: "none",
+                      }}
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <HairlineRule />
+
+        {/* Bottom row */}
+        <div
+          className="flex flex-wrap items-center justify-between gap-4"
+          style={{
+            paddingBlock: "var(--space-5)",
+            fontFamily: "var(--font-mono-landing)",
+            fontSize: "var(--text-mono)",
+            lineHeight: "var(--lh-mono)",
+            letterSpacing: "var(--ls-mono)",
+            color: "var(--ink-60)",
+          }}
+        >
+          <span>© {new Date().getFullYear()} Oltigo Health. Tous droits réservés.</span>
+          <span>X · LinkedIn · GitHub</span>
+        </div>
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing/editorial/editorial-header.tsx
+++ b/src/components/landing/editorial/editorial-header.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { Menu, Moon, Sun, X } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { StatusDot } from "./status-dot";
+
+/**
+ * §5.5 Nav — 64px desktop / 56px mobile.
+ * --bone background. Bottom 1px --rule. Logo left. Mono labels.
+ * Active link = 2px bottom rule in --oltigo-green.
+ * Right cluster: FR/AR/EN, status dot, Connexion, primary CTA.
+ */
+export function EditorialHeader({
+  lang,
+  theme,
+  onToggleLang,
+  onToggleTheme,
+}: {
+  lang: "fr" | "ar" | "en";
+  theme: "light" | "dark";
+  onToggleLang: () => void;
+  onToggleTheme: () => void;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const navLinks = [
+    { label: "Produit", href: "#product" },
+    { label: "Clients", href: "#clients" },
+    { label: "Tarifs", href: "#pricing" },
+  ];
+
+  return (
+    <>
+      {/* 1px hairline at viewport top */}
+      <div style={{ height: 1, backgroundColor: "var(--rule)" }} />
+
+      <header
+        className="sticky top-0 z-50"
+        style={{
+          backgroundColor: "var(--bone)",
+          borderBottom: "1px solid var(--rule)",
+        }}
+      >
+        <div
+          className="mx-auto flex w-full items-center justify-between"
+          style={{
+            maxWidth: "var(--container-max)",
+            paddingInline: "var(--gutter-desktop)",
+            height: 64,
+          }}
+        >
+          {/* eslint-disable i18next/no-literal-string */}
+
+          {/* Logo */}
+          <Link
+            href="/"
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-small)",
+              fontWeight: 700,
+              letterSpacing: "-0.02em",
+              color: "var(--ink)",
+              textDecoration: "none",
+            }}
+          >
+            oltigo
+          </Link>
+
+          {/* Desktop nav links */}
+          <nav className="hidden items-center gap-6 md:flex" aria-label="Main">
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                style={{
+                  fontFamily: "var(--font-sans-landing)",
+                  fontSize: "var(--text-small)",
+                  fontWeight: 500,
+                  color: "var(--ink-70)",
+                  textDecoration: "none",
+                  transition: `color var(--duration) var(--easing)`,
+                }}
+              >
+                {link.label}
+              </a>
+            ))}
+
+            {/* Status dot link */}
+            <a
+              href="#status"
+              className="inline-flex items-center gap-1.5"
+              style={{
+                fontFamily: "var(--font-mono-landing)",
+                fontSize: "var(--text-mono)",
+                letterSpacing: "var(--ls-mono)",
+                textTransform: "uppercase",
+                fontWeight: 500,
+                color: "var(--ink-60)",
+                textDecoration: "none",
+              }}
+            >
+              Statut <StatusDot />
+            </a>
+          </nav>
+
+          {/* Right cluster */}
+          <div className="flex items-center gap-3">
+            {/* Language switcher (mono) */}
+            <button
+              onClick={onToggleLang}
+              style={{
+                fontFamily: "var(--font-mono-landing)",
+                fontSize: "var(--text-mono)",
+                letterSpacing: "var(--ls-mono)",
+                textTransform: "uppercase",
+                fontWeight: 500,
+                color: "var(--ink-60)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: "4px 0",
+              }}
+              aria-label="Change language"
+            >
+              {lang === "fr" ? "FR" : lang === "ar" ? "AR" : "EN"}
+            </button>
+
+            {/* Theme toggle */}
+            <button
+              onClick={onToggleTheme}
+              className="flex items-center justify-center"
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: "var(--radius-landing)",
+                border: "1px solid var(--rule)",
+                color: "var(--ink-60)",
+                background: "none",
+                cursor: "pointer",
+              }}
+              aria-label={theme === "light" ? "Mode sombre" : "Mode clair"}
+            >
+              {theme === "light" ? (
+                <Moon style={{ width: 14, height: 14 }} />
+              ) : (
+                <Sun style={{ width: 14, height: 14 }} />
+              )}
+            </button>
+
+            {/* Connexion (hidden on mobile) */}
+            <Link
+              href="/login"
+              className="hidden md:inline-flex"
+              style={{
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-small)",
+                fontWeight: 500,
+                color: "var(--ink-70)",
+                textDecoration: "none",
+              }}
+            >
+              Connexion
+            </Link>
+
+            {/* Primary CTA (hidden on mobile) */}
+            <Link
+              href="/register-clinic"
+              className="hidden md:inline-flex"
+              style={{
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-small)",
+                fontWeight: 500,
+                height: 32,
+                paddingInline: 16,
+                display: "inline-flex",
+                alignItems: "center",
+                borderRadius: "var(--radius-landing)",
+                backgroundColor: "var(--oltigo-green)",
+                color: "var(--bone)",
+                textDecoration: "none",
+                transition: `opacity var(--duration) var(--easing)`,
+              }}
+            >
+              Ouvrir un compte
+            </Link>
+
+            {/* Mobile hamburger */}
+            <button
+              className="flex items-center justify-center md:hidden"
+              onClick={() => setMenuOpen(!menuOpen)}
+              style={{
+                width: 32,
+                height: 32,
+                color: "var(--ink)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+              }}
+              aria-label={menuOpen ? "Close menu" : "Open menu"}
+            >
+              {menuOpen ? (
+                <X style={{ width: 20, height: 20 }} />
+              ) : (
+                <Menu style={{ width: 20, height: 20 }} />
+              )}
+            </button>
+          </div>
+
+          {/* eslint-enable i18next/no-literal-string */}
+        </div>
+
+        {/* Mobile menu */}
+        {menuOpen && (
+          <nav
+            className="flex flex-col gap-4 border-t px-[var(--gutter-mobile)] py-4 md:hidden"
+            style={{
+              borderColor: "var(--rule)",
+              backgroundColor: "var(--bone)",
+            }}
+          >
+            {/* eslint-disable i18next/no-literal-string */}
+            {navLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={() => setMenuOpen(false)}
+                style={{
+                  fontFamily: "var(--font-sans-landing)",
+                  fontSize: "var(--text-body)",
+                  fontWeight: 500,
+                  color: "var(--ink-70)",
+                  textDecoration: "none",
+                }}
+              >
+                {link.label}
+              </a>
+            ))}
+            <Link
+              href="/register-clinic"
+              style={{
+                fontFamily: "var(--font-sans-landing)",
+                fontSize: "var(--text-small)",
+                fontWeight: 500,
+                height: 44,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                borderRadius: "var(--radius-landing)",
+                backgroundColor: "var(--oltigo-green)",
+                color: "var(--bone)",
+                textDecoration: "none",
+              }}
+            >
+              Ouvrir un compte
+            </Link>
+            {/* eslint-enable i18next/no-literal-string */}
+          </nav>
+        )}
+      </header>
+    </>
+  );
+}

--- a/src/components/landing/editorial/editorial-landing-page.tsx
+++ b/src/components/landing/editorial/editorial-landing-page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ClosingCtaSection } from "./closing-cta-section";
+import { EditorialFooter } from "./editorial-footer";
+import { EditorialHeader } from "./editorial-header";
+import { EditorialHero } from "./hero-section";
+import { HowItWorksSection } from "./how-it-works-section";
+import { ManifestoSection } from "./manifesto-section";
+import { MultiTenantSection } from "./multi-tenant-section";
+import { PricingSection } from "./pricing-section";
+import { ProductSection } from "./product-section";
+import { TestimonialsSection } from "./testimonials-section";
+
+/**
+ * Editorial-institutional landing page for Oltigo Health.
+ *
+ * Design direction: Stripe Docs header treatment + Bloomberg Terminal mono
+ * metadata + Linear's typographic restraint. No gradients on type, no
+ * parallax, no Lottie, no glassmorphism.
+ *
+ * Sections follow §3.1 order: Hero → Manifesto → Product → How → MultiTenant
+ * → Clients → Pricing → Closing CTA → Footer.
+ */
+export function EditorialLandingPage() {
+  const [lang, setLang] = useState<"fr" | "ar" | "en">("fr");
+  const [theme, setTheme] = useState<"light" | "dark">(() => {
+    if (typeof window === "undefined") return "light";
+    const stored = localStorage.getItem("oltigo-theme") as "light" | "dark" | null;
+    if (stored) return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) => {
+      if (!localStorage.getItem("oltigo-theme")) {
+        setTheme(e.matches ? "dark" : "light");
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    localStorage.setItem("oltigo-theme", next);
+  };
+
+  const cycleLang = () => {
+    const order: Array<"fr" | "ar" | "en"> = ["fr", "ar", "en"];
+    const next = order[(order.indexOf(lang) + 1) % order.length];
+    setLang(next);
+  };
+
+  const rtl = lang === "ar";
+
+  return (
+    <div
+      dir={rtl ? "rtl" : "ltr"}
+      data-theme={theme}
+      style={{
+        backgroundColor: "var(--bone)",
+        color: "var(--ink)",
+        fontFamily: "var(--font-sans-landing)",
+        minHeight: "100vh",
+      }}
+    >
+      {/* Skip to content */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-medium"
+        style={{ backgroundColor: "var(--oltigo-green)", color: "var(--bone)" }}
+      >
+        {rtl ? "الانتقال إلى المحتوى الرئيسي" : "Aller au contenu principal"}
+      </a>
+
+      <EditorialHeader
+        lang={lang}
+        theme={theme}
+        onToggleLang={cycleLang}
+        onToggleTheme={toggleTheme}
+      />
+
+      <main id="main-content">
+        <EditorialHero />
+        <ManifestoSection />
+        <ProductSection />
+        <HowItWorksSection />
+        <MultiTenantSection />
+        <TestimonialsSection />
+        <PricingSection />
+        <ClosingCtaSection />
+      </main>
+
+      <EditorialFooter />
+    </div>
+  );
+}

--- a/src/components/landing/editorial/hairline-rule.tsx
+++ b/src/components/landing/editorial/hairline-rule.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+/**
+ * §5.12 Hairline Rule — the hairline carries information.
+ * 1px --rule. Separates statements, groups, and signals scope.
+ */
+export function HairlineRule({ className = "" }: { className?: string }) {
+  return (
+    <hr
+      className={className}
+      style={{
+        border: "none",
+        borderTop: "1px solid var(--rule)",
+        margin: 0,
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/landing/editorial/hero-section.tsx
+++ b/src/components/landing/editorial/hero-section.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { HairlineRule } from "./hairline-rule";
+import { StatBlock } from "./stat-block";
+import { StatusDot } from "./status-dot";
+
+/**
+ * §3.1 / §4.1 Hero — editorial-institutional.
+ * Mono eyebrow → display headline → body-lg subhead → CTAs → trust strip.
+ */
+export function EditorialHero() {
+  return (
+    <section style={{ backgroundColor: "var(--bone)" }}>
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+
+        {/* Spacer: --space-9 (96px) */}
+        <div style={{ height: "var(--space-9)" }} />
+
+        {/* Mono eyebrow */}
+        <div
+          className="flex items-center gap-2"
+          style={{
+            fontFamily: "var(--font-mono-landing)",
+            fontSize: "var(--text-mono)",
+            lineHeight: "var(--lh-mono)",
+            letterSpacing: "var(--ls-mono)",
+            textTransform: "uppercase",
+            fontWeight: 500,
+            color: "var(--ink-60)",
+          }}
+        >
+          V 16.0 · RÉGION CASABLANCA · STATUT <StatusDot />
+        </div>
+
+        {/* Spacer */}
+        <div style={{ height: "var(--space-5)" }} />
+
+        {/* Display headline — 75% width */}
+        <h1
+          style={{
+            fontFamily: "var(--font-sans-landing)",
+            fontSize: "clamp(2.5rem, 5vw, var(--text-display))",
+            lineHeight: "var(--lh-display)",
+            letterSpacing: "var(--ls-display)",
+            fontWeight: 500,
+            color: "var(--ink)",
+            maxWidth: "75%",
+          }}
+        >
+          La plateforme complète pour gérer votre cabinet médical.
+        </h1>
+
+        {/* Spacer */}
+        <div style={{ height: "var(--space-5)" }} />
+
+        {/* Subhead — 58% width */}
+        <p
+          style={{
+            fontFamily: "var(--font-sans-landing)",
+            fontSize: "var(--text-body-lg)",
+            lineHeight: "var(--lh-body-lg)",
+            color: "var(--ink-70)",
+            maxWidth: "58%",
+          }}
+        >
+          Créez le site de votre cabinet, gérez les rendez-vous et développez
+          votre activité facilement.
+        </p>
+
+        {/* Spacer */}
+        <div style={{ height: "var(--space-6)" }} />
+
+        {/* CTAs */}
+        <div className="flex flex-wrap items-center gap-4">
+          {/* Primary CTA */}
+          <Link
+            href="/register-clinic"
+            className="group inline-flex items-center gap-2"
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-small)",
+              fontWeight: 500,
+              height: 44,
+              paddingInline: 24,
+              borderRadius: "var(--radius-landing)",
+              backgroundColor: "var(--oltigo-green)",
+              color: "var(--bone)",
+              textDecoration: "none",
+              transition: `opacity var(--duration) var(--easing)`,
+            }}
+          >
+            Ouvrir un compte
+            <ArrowRight
+              style={{
+                width: 16,
+                height: 16,
+                transition: `transform var(--duration) var(--easing)`,
+              }}
+              className="group-hover:translate-x-0.5"
+            />
+          </Link>
+
+          {/* Ghost CTA */}
+          <a
+            href="#contact"
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-small)",
+              fontWeight: 500,
+              color: "var(--oltigo-green)",
+              textDecoration: "none",
+              textUnderlineOffset: 4,
+              transition: `text-decoration var(--duration) var(--easing)`,
+            }}
+            className="hover:underline"
+          >
+            Parler aux ventes →
+          </a>
+        </div>
+
+        {/* Spacer: --space-10 (128px) */}
+        <div style={{ height: "var(--space-10)" }} />
+
+        {/* Trust hairline (top) */}
+        <HairlineRule />
+
+        {/* Trust strip: 4 stat blocks */}
+        <div style={{ paddingBlock: "var(--space-5)" }}>
+          <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
+            <StatBlock value="99,95%" label="Disponibilité" />
+            <StatBlock value="AES-256-GCM" label="Chiffrement" />
+            <StatBlock value="Loi 09-08" label="Conforme" />
+            <StatBlock value="< 200 ms" label="P95 écriture RDV" />
+          </div>
+        </div>
+
+        {/* Trust hairline (bottom) */}
+        <HairlineRule />
+
+        {/* Spacer: --space-9 */}
+        <div style={{ height: "var(--space-9)" }} />
+
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/how-it-works-section.tsx
+++ b/src/components/landing/editorial/how-it-works-section.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+const STEPS = [
+  {
+    step: "01",
+    title: "Créez votre compte",
+    description:
+      "Inscrivez votre cabinet en 2 minutes. Nous configurons votre sous-domaine sécurisé.",
+  },
+  {
+    step: "02",
+    title: "Configurez votre cabinet",
+    description:
+      "Ajoutez vos médecins, services, horaires et templates WhatsApp.",
+  },
+  {
+    step: "03",
+    title: "Accueillez vos patients",
+    description:
+      "Vos patients prennent rendez-vous en ligne. Rappels automatiques.",
+  },
+  {
+    step: "04",
+    title: "Suivez votre activité",
+    description:
+      "Tableau de bord analytique. Revenus, taux de no-show, satisfaction.",
+  },
+];
+
+/**
+ * §3.1.5 How it works — 4 numbered steps.
+ * 4 columns desktop, 1 column mobile.
+ * Each = mono "ÉTAPE 01" + h3 + 2 body lines. No icons, no illustration.
+ */
+export function HowItWorksSection() {
+  return (
+    <section
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {STEPS.map((s) => (
+            <div key={s.step}>
+              <span
+                style={{
+                  fontFamily: "var(--font-mono-landing)",
+                  fontSize: "var(--text-mono)",
+                  lineHeight: "var(--lh-mono)",
+                  letterSpacing: "var(--ls-mono)",
+                  textTransform: "uppercase",
+                  fontWeight: 500,
+                  color: "var(--ink-60)",
+                }}
+              >
+                Étape {s.step}
+              </span>
+              <h3
+                style={{
+                  marginTop: "var(--space-3)",
+                  fontFamily: "var(--font-sans-landing)",
+                  fontSize: "var(--text-h3)",
+                  lineHeight: "var(--lh-h3)",
+                  letterSpacing: "var(--ls-h3)",
+                  fontWeight: 500,
+                  color: "var(--ink)",
+                }}
+              >
+                {s.title}
+              </h3>
+              <p
+                style={{
+                  marginTop: "var(--space-2)",
+                  fontFamily: "var(--font-sans-landing)",
+                  fontSize: "var(--text-body)",
+                  lineHeight: "var(--lh-body)",
+                  color: "var(--ink-70)",
+                }}
+              >
+                {s.description}
+              </p>
+            </div>
+          ))}
+        </div>
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/manifesto-section.tsx
+++ b/src/components/landing/editorial/manifesto-section.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * §3.1.3 — "What it is, in 5 lines."
+ * Single column, max-width 720px, left-aligned. No imagery.
+ */
+export function ManifestoSection() {
+  return (
+    <section
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        <div style={{ maxWidth: 720 }}>
+          <h2
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-h1)",
+              lineHeight: "var(--lh-h1)",
+              letterSpacing: "var(--ls-h1)",
+              fontWeight: 500,
+              color: "var(--ink)",
+            }}
+          >
+            Tout ce dont votre cabinet a besoin.
+          </h2>
+
+          <p
+            style={{
+              marginTop: "var(--space-5)",
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-body-lg)",
+              lineHeight: "var(--lh-body-lg)",
+              color: "var(--ink-70)",
+            }}
+          >
+            Des outils simples et puissants pour vous concentrer sur
+            l&apos;essentiel&nbsp;: vos patients.
+          </p>
+        </div>
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/multi-tenant-section.tsx
+++ b/src/components/landing/editorial/multi-tenant-section.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { HairlineRule } from "./hairline-rule";
+
+/**
+ * §3.1.6 Multi-tenant primitive.
+ * One paragraph + mono subdomain diagram. Separated by hairlines.
+ */
+export function MultiTenantSection() {
+  return (
+    <section
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        <div style={{ maxWidth: 720 }}>
+          <h2
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-h2)",
+              lineHeight: "var(--lh-h2)",
+              letterSpacing: "var(--ls-h2)",
+              fontWeight: 500,
+              color: "var(--ink)",
+            }}
+          >
+            Un sous-domaine par cabinet. Aucune donnée n&apos;est partagée
+            entre cabinets.
+          </h2>
+
+          <p
+            style={{
+              marginTop: "var(--space-5)",
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-body)",
+              lineHeight: "var(--lh-body)",
+              color: "var(--ink-70)",
+            }}
+          >
+            Chaque cabinet dispose de son propre espace isolé. Les données
+            patients, rendez-vous et configurations sont strictement cloisonnées
+            par Row Level Security et chiffrement par fichier.
+          </p>
+        </div>
+
+        <div style={{ marginTop: "var(--space-7)" }}>
+          <HairlineRule />
+          <div
+            className="flex flex-wrap items-center gap-4"
+            style={{
+              paddingBlock: "var(--space-4)",
+              fontFamily: "var(--font-mono-landing)",
+              fontSize: "var(--text-mono)",
+              lineHeight: "var(--lh-mono)",
+              letterSpacing: "var(--ls-mono)",
+              color: "var(--ink-60)",
+            }}
+          >
+            <span>cabinet-a.oltigo.com</span>
+            <span style={{ color: "var(--rule)" }}>│</span>
+            <span>cabinet-b.oltigo.com</span>
+            <span style={{ color: "var(--rule)" }}>│</span>
+            <span>cabinet-c.oltigo.com</span>
+          </div>
+          <HairlineRule />
+        </div>
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/pricing-section.tsx
+++ b/src/components/landing/editorial/pricing-section.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { HairlineRule } from "./hairline-rule";
+
+const PLANS = [
+  { name: "Free", price: "0 MAD", highlighted: false },
+  { name: "Starter", price: "199 MAD/mois", highlighted: false },
+  { name: "Professional", price: "599 MAD/mois", highlighted: true },
+  { name: "Enterprise", price: "999 MAD/mois", highlighted: false },
+];
+
+/**
+ * §3.1.8 Pricing teaser — one row, 4 plan names with starting prices.
+ * Professional column has a 2px left rule in --oltigo-green.
+ */
+export function PricingSection() {
+  return (
+    <section
+      id="pricing"
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        <HairlineRule />
+        <div className="grid grid-cols-2 md:grid-cols-4" style={{ paddingBlock: "var(--space-6)" }}>
+          {PLANS.map((plan) => (
+            <div
+              key={plan.name}
+              style={{
+                paddingInline: "var(--space-4)",
+                paddingBlock: "var(--space-4)",
+                borderInlineStart: plan.highlighted
+                  ? "2px solid var(--oltigo-green)"
+                  : "none",
+              }}
+            >
+              <span
+                style={{
+                  fontFamily: "var(--font-sans-landing)",
+                  fontSize: "var(--text-small)",
+                  fontWeight: 500,
+                  color: "var(--ink)",
+                }}
+              >
+                {plan.name}
+              </span>
+              <span
+                className="block"
+                style={{
+                  marginTop: "var(--space-1)",
+                  fontFamily: "var(--font-mono-landing)",
+                  fontSize: "var(--text-mono)",
+                  lineHeight: "var(--lh-mono)",
+                  letterSpacing: "var(--ls-mono)",
+                  color: "var(--ink-60)",
+                }}
+              >
+                {plan.price}
+              </span>
+            </div>
+          ))}
+        </div>
+        <HairlineRule />
+
+        {/* CTA */}
+        <div style={{ marginTop: "var(--space-5)" }}>
+          <Link
+            href="/pricing"
+            className="group inline-flex items-center gap-1"
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-small)",
+              fontWeight: 500,
+              color: "var(--oltigo-green)",
+              textDecoration: "none",
+            }}
+          >
+            Voir tous les tarifs
+            <ArrowRight
+              style={{
+                width: 14,
+                height: 14,
+                transition: `transform var(--duration) var(--easing)`,
+              }}
+              className="group-hover:translate-x-0.5"
+            />
+          </Link>
+        </div>
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/product-section.tsx
+++ b/src/components/landing/editorial/product-section.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { HairlineRule } from "./hairline-rule";
+
+const PRODUCTS = [
+  {
+    label: "Rendez-vous",
+    description:
+      "Prise de rendez-vous en ligne pour vos patients. Confirmation automatique, rappels WhatsApp, vue agenda unifiée.",
+  },
+  {
+    label: "Dossier patient",
+    description:
+      "Dossiers chiffrés AES-256-GCM. Historique complet, ordonnances, résultats — accessibles uniquement par votre équipe.",
+  },
+  {
+    label: "Rappels & WhatsApp",
+    description:
+      "10 templates Darija pré-approuvés Meta. Rappels automatiques, confirmations, suivi post-consultation.",
+  },
+];
+
+/**
+ * §3.1.4 Product Anatomy — 3 rows × 2 columns.
+ * Left = label + description, right = screenshot placeholder.
+ * Separated by --rule. No device frames, no rotation, no shadows.
+ */
+export function ProductSection() {
+  return (
+    <section
+      id="product"
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        {PRODUCTS.map((product, i) => (
+          <div key={product.label}>
+            {i > 0 && <HairlineRule />}
+            <div
+              className="grid gap-8 md:grid-cols-2 md:items-center"
+              style={{ paddingBlock: "var(--space-7)" }}
+            >
+              <div>
+                <h3
+                  style={{
+                    fontFamily: "var(--font-sans-landing)",
+                    fontSize: "var(--text-h3)",
+                    lineHeight: "var(--lh-h3)",
+                    letterSpacing: "var(--ls-h3)",
+                    fontWeight: 500,
+                    color: "var(--ink)",
+                  }}
+                >
+                  {product.label}
+                </h3>
+                <p
+                  style={{
+                    marginTop: "var(--space-3)",
+                    fontFamily: "var(--font-sans-landing)",
+                    fontSize: "var(--text-body)",
+                    lineHeight: "var(--lh-body)",
+                    color: "var(--ink-70)",
+                  }}
+                >
+                  {product.description}
+                </p>
+              </div>
+
+              {/* Screenshot placeholder — replace with real product PNGs */}
+              <div
+                style={{
+                  aspectRatio: "16 / 10",
+                  borderRadius: "var(--radius-landing)",
+                  border: "1px solid var(--rule)",
+                  backgroundColor: "var(--bone)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono-landing)",
+                    fontSize: "var(--text-mono)",
+                    color: "var(--ink-60)",
+                    textTransform: "uppercase",
+                    letterSpacing: "var(--ls-mono)",
+                  }}
+                >
+                  Capture {product.label}
+                </span>
+              </div>
+            </div>
+          </div>
+        ))}
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/editorial/stat-block.tsx
+++ b/src/components/landing/editorial/stat-block.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * §5.10 Stat Block — value + 1px rule + mono label.
+ * 4-up desktop, 2-up mobile. Never wrapped in a card.
+ */
+export function StatBlock({
+  value,
+  label,
+}: {
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span
+        style={{
+          fontFamily: "var(--font-sans-landing)",
+          fontSize: "var(--text-h2)",
+          lineHeight: "var(--lh-h2)",
+          letterSpacing: "var(--ls-h2)",
+          fontWeight: 500,
+          color: "var(--ink)",
+        }}
+      >
+        {value}
+      </span>
+      <hr
+        style={{ border: "none", borderTop: "1px solid var(--rule)", margin: 0 }}
+        aria-hidden="true"
+      />
+      <span
+        style={{
+          fontFamily: "var(--font-mono-landing)",
+          fontSize: "var(--text-mono)",
+          lineHeight: "var(--lh-mono)",
+          letterSpacing: "var(--ls-mono)",
+          textTransform: "uppercase",
+          color: "var(--ink-60)",
+          fontWeight: 500,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/landing/editorial/status-dot.tsx
+++ b/src/components/landing/editorial/status-dot.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * §5.11 Status Dot — 6px round, signal-green when operational.
+ * Always paired with a mono label. Never standalone.
+ */
+export function StatusDot({
+  status = "operational",
+}: {
+  status?: "operational" | "degraded" | "down";
+}) {
+  const color =
+    status === "operational"
+      ? "var(--signal-green)"
+      : status === "degraded"
+        ? "var(--signal-amber)"
+        : "var(--signal-red)";
+
+  const label =
+    status === "operational"
+      ? "System operational"
+      : status === "degraded"
+        ? "System degraded"
+        : "System down";
+
+  return (
+    <span
+      role="status"
+      aria-label={label}
+      style={{
+        display: "inline-block",
+        width: 6,
+        height: 6,
+        borderRadius: "50%",
+        backgroundColor: color,
+        flexShrink: 0,
+      }}
+    />
+  );
+}

--- a/src/components/landing/editorial/testimonials-section.tsx
+++ b/src/components/landing/editorial/testimonials-section.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { HairlineRule } from "./hairline-rule";
+
+/**
+ * §3.3 / §5.9 Testimonials — attributed quotes.
+ * Max 280 chars. No quotation-mark glyph at 96pt. No headshots. No carousel.
+ * Mono attribution: — DR NAME · CABINET · CITY
+ */
+export function TestimonialsSection() {
+  return (
+    <section
+      id="clients"
+      style={{
+        backgroundColor: "var(--bone)",
+        paddingBlock: "var(--space-9)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+        }}
+      >
+        {/* eslint-disable i18next/no-literal-string */}
+        <HairlineRule />
+        <div style={{ paddingBlock: "var(--space-7)", maxWidth: 760 }}>
+          <p
+            style={{
+              fontFamily: "var(--font-sans-landing)",
+              fontSize: "var(--text-body-lg)",
+              lineHeight: "var(--lh-body-lg)",
+              color: "var(--ink)",
+              fontStyle: "normal",
+            }}
+          >
+            Depuis qu&apos;on utilise Oltigo, le taux de no-show est passé de
+            32% à 8%. Les rappels WhatsApp en darija font la différence — nos
+            patients confirment en une minute.
+          </p>
+          <p
+            style={{
+              marginTop: "var(--space-5)",
+              fontFamily: "var(--font-mono-landing)",
+              fontSize: "var(--text-mono)",
+              lineHeight: "var(--lh-mono)",
+              letterSpacing: "var(--ls-mono)",
+              textTransform: "uppercase",
+              color: "var(--ink-60)",
+            }}
+          >
+            — Dr Fatima B. · Cabinet Al Amal · Casablanca
+          </p>
+          <p
+            style={{
+              marginTop: "var(--space-2)",
+              fontFamily: "var(--font-mono-landing)",
+              fontSize: "var(--text-mono)",
+              lineHeight: "var(--lh-mono)",
+              letterSpacing: "var(--ls-mono)",
+              color: "var(--ink-60)",
+            }}
+          >
+            EN PRODUCTION DEPUIS 2024-09 · PLAN PROFESSIONAL
+          </p>
+        </div>
+
+        <HairlineRule />
+
+        <p
+          style={{
+            marginTop: "var(--space-5)",
+            fontFamily: "var(--font-mono-landing)",
+            fontSize: "var(--text-mono)",
+            lineHeight: "var(--lh-mono)",
+            letterSpacing: "var(--ls-mono)",
+            color: "var(--ink-60)",
+          }}
+        >
+          3 autres études en préparation
+        </p>
+        {/* eslint-enable i18next/no-literal-string */}
+      </div>
+    </section>
+  );
+}

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CookieConsent } from "@/components/cookie-consent";
-import { EmergentLandingPage } from "./emergent/emergent-landing-page";
+import { EditorialLandingPage } from "./editorial/editorial-landing-page";
 
 /**
  * SaaS landing page shown on the root domain (oltigo.com).
@@ -9,13 +9,13 @@ import { EmergentLandingPage } from "./emergent/emergent-landing-page";
  * This page does NOT load any tenant/clinic data.
  * Clinic websites live on subdomains (e.g. dr-ahmed.oltigo.com).
  *
- * Uses the Emergent cinematic design: 16 sections, bilingual FR/AR,
- * ECG pulse, floating carnet de santé, paper grain overlay.
+ * Design direction: editorial-institutional (Stripe Docs + Bloomberg Terminal
+ * + Linear typographic restraint). See docs/oltigo-design-direction.md.
  */
 export function LandingPage() {
   return (
     <>
-      <EmergentLandingPage />
+      <EditorialLandingPage />
       <CookieConsent />
     </>
   );


### PR DESCRIPTION
## Summary

Complete redesign of the Oltigo landing page from "emergent cinematic" to **editorial-institutional** per the design direction document.

Design philosophy: Stripe Docs header treatment + Bloomberg Terminal mono metadata + Linear typographic restraint. No gradients on type, no parallax, no Lottie, no glassmorphism.

### What changed

**Token system (`tokens.css`):**
- Aligned colors to spec: `#0B0F0E` ink, `#F4F1EA` bone, `#005A3B` oltigo-green, `#22C55E` signal-green
- Stripped emergent palette (surgical-sage, carnet-ochre, clinic-coral, night-navy)
- Dark mode = pure ink↔bone swap
- Type scale: 8 steps (display 72px → mono 12px) with spec-exact line-heights and tracking
- Layout: 1280px container, `clamp(20px, 4vw, 64px)` side rails

**New editorial/ components:**
- `HairlineRule` (§5.12) — 1px `--rule` information separator
- `StatusDot` (§5.11) — 6px round signal indicator
- `StatBlock` (§5.10) — value + rule + mono label
- `Badge` (§5.7) — mono and signal variants
- `EditorialHeader` (§5.5) — 64px nav, mono labels, status dot, FR/AR/EN, Connexion + primary CTA
- `EditorialHero` (§4.1) — mono eyebrow, display headline, body-lg subhead, trust hairline strip
- `ManifestoSection` — single column, max-width 720px
- `ProductSection` — 3-row anatomy with screenshot placeholder slots
- `HowItWorksSection` — 4 numbered steps, no icons
- `MultiTenantSection` — subdomain isolation diagram
- `TestimonialsSection` — attributed quote, mono metadata
- `PricingSection` — 4 plans, Professional highlighted with `--oltigo-green` accent
- `ClosingCtaSection` — primary + ghost CTAs
- `EditorialFooter` — 5-column grid, hairline-separated

**Removed from active render:** PaperGrain, EcgPulse, CarnetSante, custom cursors, gradient overlays. Old emergent/ components preserved (dead code) for reference.

## Type of change

- [x] New feature (landing page redesign)

## Security Impact

- [x] No security impact — frontend only, no API changes

## Migration Safety

- [x] N/A — no database changes

## Testing

- [x] Unit tests pass (817 passed, 16 skipped, 0 failed)
- [x] Typecheck passes (0 errors)
- [x] Lint passes within ceiling

## Observability

- [x] No observability changes

## Checklist

- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] CSS variables used for all colors (no hardcoded hex in components)
- [x] Logical CSS properties for RTL Arabic support
- [x] All text rendered via design token type scale