### PR TITLE
fix: add static assets config to wrangler.toml — fixes unstyled landing page

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,6 +32,14 @@ routes = [
   { pattern = "*.oltigo.com/*", zone_name = "oltigo.com" },
 ]
 
+# ── Static Assets ─────────────────────────────────────────────────────
+# Serves _next/static/*, favicon, images, etc. from the Cloudflare edge.
+# Without this, CSS/JS assets return 404 because the Worker doesn't have
+# access to the build output's static files.
+[assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
+
 # ── KV Namespaces ─────────────────────────────────────────────────────
 # Rate-limiting counters (shared across all edge locations).
 # INF-002: Rate limiter MUST use KV in production to prevent per-isolate
@@ -66,6 +74,9 @@ RATE_LIMIT_BACKEND = "supabase"
 # from silently leaking into production. Deploy with: wrangler deploy --env production
 [env.production]
 name = "webs-alots"
+[env.production.assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
 [env.production.vars]
 NODE_ENV = "production"
 RATE_LIMIT_BACKEND = "supabase"
@@ -77,6 +88,9 @@ bucket_name = "webs-alots-uploads"
 # ── Staging Environment ───────────────────────────────────────────────
 [env.staging]
 name = "webs-alots-staging"
+[env.staging.assets]
+directory = ".open-next/assets"
+binding = "ASSETS"
 [env.staging.vars]
 NODE_ENV = "production"
 RATE_LIMIT_BACKEND = "supabase"


### PR DESCRIPTION
## Summary

The landing page displays unstyled because CSS/JS static assets return **HTTP 404** from production. Root cause: `wrangler.toml` had no `[assets]` section, so Cloudflare Workers never uploaded or served the static files from `.open-next/assets/`.

Adds `[assets]` with `directory = ".open-next/assets"` and `binding = "ASSETS"` to the top-level config and both production/staging environment blocks.

**Before:** `/_next/static/chunks/*.css` → 404 (Worker handles request, no static files available)
**After:** `/_next/static/chunks/*.css` → 200 (Cloudflare edge serves static assets directly)

Verified with `wrangler deploy --dry-run`:
```
✨ Read 306 files from the assets directory .open-next/assets
env.ASSETS                                       Assets
```

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations