### PR TITLE
ci: add workflow_dispatch trigger to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - staging
+  workflow_dispatch:
 
 # Least-privilege permissions — deploy only needs to read repo contents
 permissions:


### PR DESCRIPTION
Allows manual re-deploys from the GitHub Actions UI. Also triggers a deploy to verify Supabase migration secrets are working.