### PR TITLE
fix: skip supabase link/push when no new migrations in commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,48 +177,60 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Preflight — check migration secrets
+      - name: Preflight — check migration secrets & changes
         id: preflight
-        # Check if Supabase CLI secrets are configured. If not, skip
-        # migrations with a warning — this allows deploy to proceed
-        # for initial setup before a Supabase project is linked.
-        # However, if new migration files were added in this push,
-        # fail hard to prevent deploying without running migrations.
+        # Check two things:
+        # 1. Are Supabase CLI secrets configured?
+        # 2. Are there new migration files in this push?
+        #
+        # If secrets are missing AND new migrations exist → fail hard.
+        # If secrets are present but no new migrations → skip (no-op).
+        # If secrets are present AND new migrations → run migrations.
         run: |
+          # Check for new migration files
+          NEW_MIGRATIONS=$(git diff --name-only HEAD~1 -- 'supabase/migrations/' 2>/dev/null || echo "")
+          if [ -n "$NEW_MIGRATIONS" ]; then
+            echo "New migration files detected:"
+            echo "$NEW_MIGRATIONS"
+            echo "has_migrations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No new migration files in this push."
+            echo "has_migrations=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Check secrets
           missing=0
           for v in SUPABASE_ACCESS_TOKEN SUPABASE_DB_PASSWORD SUPABASE_PROJECT_REF; do
             if [ -z "${!v:-}" ]; then
-              echo "::warning::Secret '$v' is not set — migrations will be skipped."
+              echo "::warning::Secret '$v' is not set."
               missing=1
             fi
           done
           if [ "$missing" -eq 1 ]; then
-            NEW_MIGRATIONS=$(git diff --name-only HEAD~1 -- 'supabase/migrations/' 2>/dev/null || echo "")
             if [ -n "$NEW_MIGRATIONS" ]; then
-              echo "::error::New migration files detected but migration secrets are missing:"
-              echo "$NEW_MIGRATIONS"
+              echo "::error::New migration files detected but migration secrets are missing."
               echo "::error::Blocking deploy — configure SUPABASE_ACCESS_TOKEN, SUPABASE_DB_PASSWORD, and SUPABASE_PROJECT_REF."
               exit 1
             fi
-            echo "::warning::Supabase migration secrets not configured. Skipping migrations."
+            echo "::warning::Supabase secrets not configured. Skipping migrations."
             echo "secrets_ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "secrets_ok=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Supabase CLI
-        if: steps.preflight.outputs.secrets_ok == 'true'
+        if: steps.preflight.outputs.secrets_ok == 'true' && steps.preflight.outputs.has_migrations == 'true'
         # F-19: Pin to SHA for supply-chain hardening
         uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
         with:
           version: latest
 
       - name: Link to Supabase project
-        if: steps.preflight.outputs.secrets_ok == 'true'
+        if: steps.preflight.outputs.secrets_ok == 'true' && steps.preflight.outputs.has_migrations == 'true'
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
 
       - name: Dry-run — show pending migrations
-        if: steps.preflight.outputs.secrets_ok == 'true'
+        if: steps.preflight.outputs.secrets_ok == 'true' && steps.preflight.outputs.has_migrations == 'true'
         # `db push --dry-run --include-all` prints the SQL the CLI
         # would execute without applying it, so an operator can
         # inspect the diff in the job log before the real push runs.
@@ -227,7 +239,7 @@ jobs:
         run: supabase db push --include-all --dry-run
 
       - name: Apply migrations (blocking)
-        if: steps.preflight.outputs.secrets_ok == 'true'
+        if: steps.preflight.outputs.secrets_ok == 'true' && steps.preflight.outputs.has_migrations == 'true'
         # Real push. Keep --include-all so repair-only / out-of-order
         # migrations are applied in their declared order. Failure
         # here blocks the downstream deploy job.


### PR DESCRIPTION
## Problem

The `supabase link` step was failing in the migrate job, blocking ALL deploys even when there are no migration files to apply. This prevented the hydration/CSP fix (PR #619) from deploying.

## Fix

Added `has_migrations` output to preflight step. Supabase CLI install, link, dry-run, and push are now gated on `has_migrations == true` in addition to `secrets_ok == true`. When a commit has no changes in `supabase/migrations/`, the entire Supabase CLI flow is skipped and the job succeeds.

## Type of change
- [x] Bug fix (CI/CD)

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A