### PR TITLE
fix: add concurrency group to deploy workflow (prevents parallel deploy stampedes)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,13 @@ on:
       - staging
   workflow_dispatch:
 
+# Serialize deploys per branch — rapid-fire merges to main must not
+# stampede 18 parallel `supabase link` + `wrangler deploy` runs. Only
+# the latest push matters; cancel stale runs to save CI minutes.
+concurrency:
+  group: deploy-${{ github.ref_name }}
+  cancel-in-progress: true
+
 # Least-privilege permissions — deploy only needs to read repo contents
 permissions:
   contents: read


### PR DESCRIPTION
Adds a concurrency group to deploy.yml to serialize deploys per branch. When 18 PRs were merged to main in rapid succession, 18 parallel deploy runs triggered simultaneously, each trying to run supabase link concurrently, causing Invalid project ref format errors.

The fix uses cancel-in-progress: true so only the latest push deploys.