### PR TITLE
fix: resolve dashboard branding 400, data unwrapping, misplaced breadcrumbs, and notifications demo data

### DIFF
--- a/src/app/(admin)/admin/billing/page.tsx
+++ b/src/app/(admin)/admin/billing/page.tsx
@@ -99,6 +99,7 @@ export default function ClientBillingPage() {
 
   return (
     <div>
+      <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Billing" }]} />
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
         <div>
           <h1 className="text-2xl font-bold">Facturation & Abonnement</h1>
@@ -314,7 +315,6 @@ export default function ClientBillingPage() {
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4 py-4">
-                <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Billing" }]} />
                 <div className="flex items-center justify-between rounded-lg border p-4">
                   <div>
                     <p className="text-sm text-muted-foreground">Plan actuel</p>

--- a/src/app/(admin)/admin/branding/page.tsx
+++ b/src/app/(admin)/admin/branding/page.tsx
@@ -91,20 +91,23 @@ export default function BrandingPage() {
           if (!r.ok) throw new Error(`Failed to load branding (${r.status})`);
           return r.json();
         })
-        .then((data) => ({
-          name: data.name ?? "",
-          tagline: data.tagline ?? "",
-          phone: data.phone ?? "",
-          address: data.address ?? "",
-          logo_url: data.logo_url ?? null,
-          favicon_url: data.favicon_url ?? null,
-          cover_photo_url: data.cover_photo_url ?? null,
-          primary_color: data.primary_color ?? "#1E4DA1",
-          secondary_color: data.secondary_color ?? "#0F6E56",
-          heading_font: data.heading_font ?? "Geist",
-          body_font: data.body_font ?? "Geist",
-          hero_image_url: data.hero_image_url ?? null,
-        })),
+        .then((json) => {
+          const data = json.data ?? json;
+          return {
+            name: data.name ?? "",
+            tagline: data.tagline ?? "",
+            phone: data.phone ?? "",
+            address: data.address ?? "",
+            logo_url: data.logo_url ?? null,
+            favicon_url: data.favicon_url ?? null,
+            cover_photo_url: data.cover_photo_url ?? null,
+            primary_color: data.primary_color ?? "#1E4DA1",
+            secondary_color: data.secondary_color ?? "#0F6E56",
+            heading_font: data.heading_font ?? "Geist",
+            body_font: data.body_font ?? "Geist",
+            hero_image_url: data.hero_image_url ?? null,
+          };
+        }),
     DEFAULT_BRANDING,
   );
   const [branding, setBranding] = useState<BrandingState>(DEFAULT_BRANDING);
@@ -180,7 +183,8 @@ export default function BrandingPage() {
         return;
       }
 
-      const { url } = await res.json();
+      const json = await res.json();
+      const { url } = json.data ?? json;
       const urlField =
         field === "logo"
           ? "logo_url"

--- a/src/app/(admin)/admin/custom-fields/page.tsx
+++ b/src/app/(admin)/admin/custom-fields/page.tsx
@@ -97,7 +97,8 @@ export default function CustomFieldsAdminPage() {
         url += `&entity_type=${encodeURIComponent(selectedEntity)}`;
       }
       const res = await fetch(url);
-      const data = await res.json();
+      const json = await res.json();
+      const data = json.data ?? json;
       setDefinitions(data.definitions ?? []);
     } catch (err) {
       logger.warn("Failed to load custom field definitions", { context: "custom-fields", error: err });

--- a/src/app/(admin)/admin/notifications/page.tsx
+++ b/src/app/(admin)/admin/notifications/page.tsx
@@ -13,7 +13,7 @@ import {
   Save,
   AlertTriangle,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -27,11 +27,12 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { PageLoader } from "@/components/ui/page-loader";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { getCurrentUser } from "@/lib/data/client";
 import {
-  demoNotificationLog,
   defaultNotificationTemplates,
   triggerMetadata,
   substituteVariables,
@@ -39,8 +40,8 @@ import {
   type NotificationTemplate,
   type NotificationTrigger,
 } from "@/lib/notifications";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber, formatDisplayDate } from "@/lib/utils";
+import { createClient } from "@/lib/supabase-client";
+import { formatDisplayDate } from "@/lib/utils";
 
 // ---- Status & Channel Badges ----
 
@@ -59,10 +60,41 @@ const channelConfig: Record<string, { color: string; label: string }> = {
   sms: { color: "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200", label: "SMS" },
 };
 
+interface NotificationLogRaw {
+  id: string;
+  trigger: string;
+  channel: string;
+  recipient_name: string | null;
+  body: string | null;
+  status: string;
+  error_message: string | null;
+  created_at: string;
+}
+
+function mapNotificationLog(raw: NotificationLogRaw): NotificationLogEntry {
+  const body = raw.body ?? "";
+  return {
+    id: raw.id,
+    trigger: raw.trigger as NotificationLogEntry["trigger"],
+    channel: raw.channel as NotificationLogEntry["channel"],
+    recipientId: "",
+    recipientName: raw.recipient_name ?? "Unknown",
+    recipientRole: "patient",
+    title: triggerMetadata[raw.trigger as NotificationTrigger]?.label ?? raw.trigger,
+    body,
+    status: raw.status as NotificationLogEntry["status"],
+    priority: "normal",
+    createdAt: raw.created_at,
+    error: raw.error_message ?? undefined,
+  };
+}
+
 export default function AdminNotificationsPage() {
   const [locale] = useLocale();
 
-  const [logs] = useState<NotificationLogEntry[]>(demoNotificationLog);
+  const [logs, setLogs] = useState<NotificationLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
   const [templates, setTemplates] = useState<NotificationTemplate[]>(defaultNotificationTemplates);
   const [search, setSearch] = useState("");
   const [filterChannel, setFilterChannel] = useState<string>("all");
@@ -71,12 +103,45 @@ export default function AdminNotificationsPage() {
   const [previewTemplate, setPreviewTemplate] = useState<NotificationTemplate | null>(null);
   const [savedFeedback, setSavedFeedback] = useState<string | null>(null);
 
+  useEffect(() => {
+    const controller = new AbortController();
+    async function loadLogs() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) { setLoading(false); return; }
+
+      const supabase = createClient();
+      const { data, error: dbError } = await supabase
+        .from("notification_log")
+        .select("id, trigger, channel, recipient_name, body, status, error_message, created_at")
+        .eq("clinic_id", user.clinic_id)
+        .order("created_at", { ascending: false })
+        .limit(200);
+
+      if (controller.signal.aborted) return;
+      if (dbError) {
+        setError(new Error(dbError.message));
+        setLoading(false);
+        return;
+      }
+      setLogs((data ?? []).map((row) => mapNotificationLog(row as NotificationLogRaw)));
+      setLoading(false);
+    }
+    loadLogs().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => { controller.abort(); };
+  }, []);
+
   // ---- Notification Log Filtering ----
   const filteredLogs = logs.filter((log) => {
     const matchSearch =
       log.recipientName.toLowerCase().includes(search.toLowerCase()) ||
       log.title.toLowerCase().includes(search.toLowerCase()) ||
-      log.body.toLowerCase().includes(search.toLowerCase());
+      (log.body ?? "").toLowerCase().includes(search.toLowerCase());
     const matchChannel = filterChannel === "all" || log.channel === filterChannel;
     const matchStatus = filterStatus === "all" || log.status === filterStatus;
     return matchSearch && matchChannel && matchStatus;
@@ -120,6 +185,19 @@ export default function AdminNotificationsPage() {
     review_stars: "5",
     review_comment: "Excellent service!",
   };
+
+  if (loading) {
+    return <PageLoader message="Loading notifications..." />;
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load notifications.</p>
+        <p className="text-sm text-muted-foreground mt-2">{error.message}</p>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/app/(admin)/admin/patients/page.tsx
+++ b/src/app/(admin)/admin/patients/page.tsx
@@ -97,6 +97,7 @@ export default function AdminPatientDatabasePage() {
 
   return (
     <div>
+      <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Patients" }]} />
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold">Patient Database</h1>
@@ -126,7 +127,6 @@ export default function AdminPatientDatabasePage() {
             <Card key={patient.id}>
               <CardContent className="pt-4 pb-4">
                 <div className="flex items-start gap-3">
-                  <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Patients" }]} />
                   <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
                     <User className="h-5 w-5 text-primary" />
                   </div>

--- a/src/app/(admin)/admin/sections/page.tsx
+++ b/src/app/(admin)/admin/sections/page.tsx
@@ -29,7 +29,10 @@ export default function SectionsPage() {
           if (!r.ok) throw new Error(`Failed to load sections (${r.status})`);
           return r.json();
         })
-        .then((data) => mergeSectionVisibility(data.section_visibility)),
+        .then((json) => {
+          const data = json.data ?? json;
+          return mergeSectionVisibility(data.section_visibility);
+        }),
     defaultSectionVisibility,
   );
   const [visibility, setVisibility] =
@@ -100,6 +103,7 @@ export default function SectionsPage() {
 
   return (
     <div>
+      <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Sections" }]} />
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold">Section Control</h1>
@@ -138,7 +142,6 @@ export default function SectionsPage() {
                     !isOn && !isAlwaysOn ? "opacity-50" : ""
                   }`}
                 >
-                  <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Sections" }]} />
                   <div className="space-y-0.5">
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-medium">

--- a/src/app/(admin)/admin/templates/page.tsx
+++ b/src/app/(admin)/admin/templates/page.tsx
@@ -53,7 +53,10 @@ export default function TemplatesPage() {
           if (!r.ok) throw new Error(`Failed to load templates (${r.status})`);
           return r.json();
         })
-        .then((data) => (data.template_id ?? "modern") as TemplateId),
+        .then((json) => {
+          const data = json.data ?? json;
+          return (data.template_id ?? "modern") as TemplateId;
+        }),
     "modern" as TemplateId,
   );
   const [selected, setSelected] = useState<TemplateId>("modern");

--- a/src/app/(admin)/admin/working-hours/page.tsx
+++ b/src/app/(admin)/admin/working-hours/page.tsx
@@ -97,6 +97,7 @@ export default function WorkingHoursPage() {
 
   return (
     <div>
+      <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Working Hours" }]} />
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Working Hours</h1>
         <Button onClick={handleSave}>
@@ -132,7 +133,6 @@ export default function WorkingHoursPage() {
                 const daySchedule = currentSchedule.days[i];
                 return (
                   <div key={i} className="flex items-center gap-4 p-3 border rounded-lg">
-                    <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Working Hours" }]} />
                     <div className="w-28">
                       <span className="text-sm font-medium">{day}</span>
                     </div>

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -67,7 +67,23 @@ export async function GET() {
     const tenant = await getTenant();
 
     if (!tenant?.clinicId) {
-      return apiError("No clinic context. This endpoint requires a clinic subdomain.");
+      return apiSuccess({
+        name: "Clinic",
+        logo_url: null,
+        favicon_url: null,
+        primary_color: "#1E4DA1",
+        secondary_color: "#0F6E56",
+        heading_font: "Geist",
+        body_font: "Geist",
+        hero_image_url: null,
+        tagline: null,
+        cover_photo_url: null,
+        template_id: "modern",
+        section_visibility: {},
+        website_config: null,
+        phone: null,
+        address: null,
+      });
     }
 
     const clinicId = tenant.clinicId;


### PR DESCRIPTION
## Summary

Fixes multiple broken dashboard features:

1. **Branding 400 error** — `/api/branding` GET returned a hard 400 when no tenant context (no subdomain). Now returns sensible defaults, matching the existing fallback for missing clinic rows.

2. **`{ok, data}` envelope unwrapping** — All admin pages calling `/api/branding` (branding, templates, sections) read `data.name` instead of `data.data.name`. The API wraps responses in `{ok: true, data: {...}}` but client code didn't unwrap it. Also fixed in branding upload handler and custom-fields page.

3. **Misplaced Breadcrumb components** — In 4 pages (patients, sections, working-hours, billing), the `<Breadcrumb>` was rendered inside `.map()` loops or dialogs. Moved to page top.

4. **Notifications page hardcoded demo data** — Replaced `demoNotificationLog` fixture with a real Supabase query against `notification_log` (clinic_id scoped, RLS enforced). Added loading/error states.

## Review & Testing Checklist for Human

- [ ] **Branding page** — Visit `/admin/branding` on a clinic subdomain. Verify clinic name, colors, logo load correctly (not empty). Try uploading a logo.
- [ ] **Templates page** — Visit `/admin/templates`. Verify the current template is selected (not always modern).
- [ ] **Sections page** — Visit `/admin/sections`. Verify toggle states reflect DB values. Breadcrumb appears once at top.
- [ ] **Notifications page** — Visit `/admin/notifications`. Verify log tab shows real data or empty state.
- [ ] **Patients page** — Visit `/admin/patients`. Breadcrumb appears once at top, not in each card.

### Notes
- Pre-existing `i18next/no-literal-string` warnings in touched files also exist on `main`.
- No new lint errors or type errors (verified with `npm run lint` and `npm run typecheck`).