### PR TITLE
cleanup(C10): replace 3 TODO/FIXME comments with GitHub issue refs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,14 +59,10 @@ export const viewport: Viewport = {
  * SEO-01: Locale-aware metadata via i18n instead of hardcoded French.
  *
  * F-A89-01: The locale is defaulted to "fr" for now (same as the layout).
- * Per-tenant locale headers are not yet implemented. Arabic and English
- * users get a French shell until this is resolved. When per-tenant locale
- * headers are added (see TODO in RootLayout), this will automatically
- * pick up the correct language.
+ * Per-tenant locale headers are not yet implemented. See #628.
  */
 export async function generateMetadata(): Promise<Metadata> {
-  // Default locale — will be dynamically resolved once per-tenant locale
-  // headers are available (see TODO in RootLayout below).
+  // Default locale — see #628 for per-tenant locale support.
   const cookieStore = await import("next/headers").then(m => m.cookies());
   const preferredLocale = cookieStore.get("preferred-locale")?.value as Locale;
   const locale = preferredLocale || ("fr" as Locale);

--- a/src/lib/__tests__/integration/booking-flow.test.ts
+++ b/src/lib/__tests__/integration/booking-flow.test.ts
@@ -8,10 +8,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * handlers and invoke them with mocked Supabase clients so the full
  * authorisation → validation → mutation → notification path is covered.
  *
- * TODO (F-A89-03): Replace mock Supabase with Supabase local emulator when
- *       available for true end-to-end integration testing. Until then,
- *       this "integration" suite is unit-shaped (uses mocked Supabase
- *       client). Open audit finding.
+ * F-A89-03: This suite currently uses mocked Supabase clients. See #630
+ * for replacing with the Supabase local emulator.
  */
 
 // ── Mocks ─────────────────────────────────────────────────────────

--- a/src/lib/__tests__/integration/rls-real-postgres.test.ts
+++ b/src/lib/__tests__/integration/rls-real-postgres.test.ts
@@ -14,12 +14,12 @@
  * three env vars above. Tests are skipped when SUPABASE_LOCAL is not set,
  * or when any of the URL/anon/service-key env vars are missing.
  *
- * AUDIT F-03 / F-A89-04: Implemented real RLS assertions (previously only
- * TODO stubs). The SKIP gate has been inverted (audit finding #3) so that
- * the suite runs by default when the Supabase local env vars are present
- * (which CI provides via the `supabase start` step). Tests are only
- * skipped when SKIP_RLS=true is explicitly set or the env vars are absent.
+ * AUDIT F-03 / F-A89-04: Real RLS assertions implemented. The SKIP gate
+ * is inverted so the suite runs by default when Supabase local env vars
+ * are present (CI provides via `supabase start`). Tests are only skipped
+ * when SKIP_RLS=true is explicitly set or the env vars are absent.
  * The schema infrastructure tests always run regardless of SKIP.
+ * See #629 for remaining RLS coverage work.
  *
  * NOTE: We deliberately do NOT hardcode the well-known Supabase local
  * demo JWTs as fallbacks. Even though they are public dev keys, gitleaks


### PR DESCRIPTION
## Summary

Converts 3 in-code TODO/FIXME comments to tracked GitHub issues and replaces the comments with issue references (FR-009 from baseline report).

### Changes

| File | Line(s) | TODO | Issue |
|---|---|---|---|
| `src/app/layout.tsx` | 64, 69 | Per-tenant locale headers not implemented | #628 |
| `src/lib/__tests__/integration/rls-real-postgres.test.ts` | 18 | RLS tests were previously TODO stubs | #629 |
| `src/lib/__tests__/integration/booking-flow.test.ts` | 11 | Replace mock Supabase with local emulator | #630 |

### Verification
- `tsc --noEmit` passes cleanly
- Comments replaced with concise issue references — no TODOs remain in these locations

## Review & Testing Checklist for Human

- [ ] Verify the 3 GitHub issues have appropriate descriptions and labels

### Notes
- Part of cleanup wave 6 (final wave) from the baseline report.
- 3 files changed, net -6 lines.