### PR TITLE
refactor(F-001): migrate middleware.ts → proxy.ts per Next.js 16 convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Every database operation **must** be scoped to a `clinic_id`. Failing to do so c
 
 1. **Always filter by `clinic_id`** — Every `.from("table").select()`, `.insert()`, `.update()`, `.delete()` must include `.eq("clinic_id", clinicId)`.
 2. **Use `requireTenant()` or `requireTenantWithConfig()`** — Never hardcode or trust client-supplied clinic IDs.
-3. **Middleware strips tenant headers** — The middleware (`src/middleware.ts`) removes any incoming `x-clinic-id` headers and re-derives tenant context from the subdomain. Never trust client-supplied tenant headers.
+3. **Proxy strips tenant headers** — The proxy (`src/proxy.ts`) removes any incoming `x-clinic-id` headers and re-derives tenant context from the subdomain. Never trust client-supplied tenant headers.
 4. **RLS is defense-in-depth** — Application-level scoping is required even though database RLS policies exist. Both layers must agree.
 5. **Webhooks must resolve tenant** — In webhook handlers (WhatsApp, Stripe), resolve the `clinic_id` from the webhook payload (e.g., WABA phone number ID, Stripe metadata). If resolution fails, skip processing — never query across tenants.
 6. **Cron jobs iterate per-clinic** — Scheduled tasks must iterate over clinics and scope each operation to the current clinic's ID.
@@ -34,7 +34,7 @@ Every database operation **must** be scoped to a `clinic_id`. Failing to do so c
 - `src/lib/tenant.ts` — `requireTenant()`, `requireTenantWithConfig()`, `getTenant()`
 - `src/lib/tenant-context.ts` — `setTenantContext()`, `logTenantContext()`
 - `src/lib/assert-tenant.ts` — `assertClinicId()` runtime UUID validation
-- `src/middleware.ts` — Subdomain routing, tenant header injection, CSRF checks
+- `src/proxy.ts` — Subdomain routing, tenant header injection, CSRF checks
 
 ## Test Conventions
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For local development, subdomains work automatically via `*.localhost` (e.g., `d
 
 **How it works:**
 
-- `middleware.ts` extracts the subdomain and queries the `clinics` table
+- `proxy.ts` extracts the subdomain and queries the `clinics` table
 - Resolved clinic info is passed via `x-tenant-*` headers
 - Server Components use `getTenant()` from `src/lib/tenant.ts`
 - Client Components use `useTenant()` from `src/components/tenant-provider.tsx`

--- a/knip.json
+++ b/knip.json
@@ -10,7 +10,7 @@
     "src/app/**/default.tsx",
     "src/app/**/template.tsx",
     "src/app/global-error.tsx",
-    "src/middleware.ts",
+    "src/proxy.ts",
     "src/instrumentation.ts",
     "sentry.*.config.ts",
     "scripts/**/*.{ts,mjs}",

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const withAnalyzer = withBundleAnalyzer({
 });
 
 // Security headers (X-Frame-Options, HSTS, X-Content-Type-Options, CSP, etc.)
-// are applied exclusively in middleware.ts to avoid duplication and ensure
+// are applied exclusively in proxy.ts to avoid duplication and ensure
 // consistency. See @/lib/middleware/security-headers for the implementation.
 
 const nextConfig: NextConfig = {
@@ -105,7 +105,7 @@ const nextConfig: NextConfig = {
   },
 
   async redirects() {
-    // WWW → non-www redirect is handled in middleware.ts so it works
+    // WWW → non-www redirect is handled in proxy.ts so it works
     // on Cloudflare Workers (next.config redirects are not supported
     // by OpenNext on Workers). This block is kept for any future
     // non-host-based redirects.

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -54,7 +54,7 @@ import { withAuth } from "@/lib/with-auth";
  * 2 MB is too small for real clinical workflows: PDFs, scanned scripts,
  * lab reports, and radiology images routinely exceed it. We size each
  * category to its real-world payload, capped at MAX_UPLOAD_BYTES so the
- * middleware-level body limit (`MAX_BODY_BYTES` in `src/middleware.ts`)
+ * proxy-level body limit (`MAX_BODY_BYTES` in `src/proxy.ts`)
  * is the global ceiling.
  *
  * Keys are normalized via `normalizeCategory()` so callers may use

--- a/src/lib/middleware/__tests__/csrf-options-header-strip.test.ts
+++ b/src/lib/middleware/__tests__/csrf-options-header-strip.test.ts
@@ -21,11 +21,11 @@ import { TENANT_HEADERS } from "@/lib/tenant";
 //
 // Since the middleware function itself depends on heavy imports
 // (Supabase, etc.), we test the header-stripping invariant in isolation
-// by replicating the exact logic from middleware.ts.
+// by replicating the exact logic from proxy.ts.
 
 describe("Tenant header stripping — method-independent (mutation gaps)", () => {
   /**
-   * Replicate the exact header-stripping logic from middleware.ts (lines 140-146).
+   * Replicate the exact header-stripping logic from proxy.ts (lines 140-146).
    * This is the code under test — if it were mutated to skip certain methods,
    * these tests would catch it.
    */

--- a/src/lib/middleware/__tests__/security-headers.test.ts
+++ b/src/lib/middleware/__tests__/security-headers.test.ts
@@ -8,7 +8,7 @@
  * header's presence (e.g. `headers.has("Content-Security-Policy")`)
  * would see the blank header instead of either no header or the actual
  * policy. The middleware-side request-header forwarding has the same
- * guard for the same reason — see `src/middleware.ts:115`.
+ * guard for the same reason — see `src/proxy.ts:115`.
  */
 import { NextResponse } from "next/server";
 import { describe, it, expect } from "vitest";

--- a/src/lib/middleware/routes.ts
+++ b/src/lib/middleware/routes.ts
@@ -59,7 +59,7 @@ export const LIGHTWEIGHT_API_PATHS = new Set([
  * AUDIT-LB2: Every role that has a PROTECTED_PREFIXES entry MUST appear
  * here. If a role is missing, the middleware check fails open and the
  * user bypasses route scoping. Unknown roles are denied in middleware
- * (see fail-closed block in middleware.ts).
+ * (see fail-closed block in proxy.ts).
  */
 export const ROLE_ROUTE_MAP: Record<string, string> = {
   super_admin: "/super-admin",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,11 @@
 /**
- * Next.js Middleware
+ * Next.js Proxy (formerly Middleware)
  *
- * Refactored from a monolithic 557-line file into composable modules:
+ * Migrated from middleware.ts to proxy.ts per the Next.js 16 convention
+ * rename (F-001). Semantics are identical; only the file name and the
+ * exported function name changed.
+ *
+ * Composable modules:
  *   - @/lib/middleware/security-headers — CSP, HSTS, nonce generation
  *   - @/lib/middleware/csrf             — Origin-based CSRF validation
  *   - @/lib/middleware/rate-limiting    — Per-IP rate limiting for API routes
@@ -69,7 +73,7 @@ function setTenantHeaders(
 const MAX_BODY_BYTES = 25 * 1024 * 1024;
 
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   // AUDIT-25: Record middleware start time for CPU telemetry.
   // Cloudflare Workers CPU budget is set to 50ms in wrangler.toml (Paid plan).
   // This timing helps identify when middleware complexity approaches that


### PR DESCRIPTION
## Summary

Migrates `src/middleware.ts` → `src/proxy.ts` and renames the exported function from `middleware` to `proxy` per the Next.js 16 deprecation notice.

This is the **highest priority non-functional change** from the audit report (F-001). The entire security chain — CSP nonce injection, CSRF validation, rate limiting, subdomain→tenant resolution, seed-user guard, MFA AAL2 enforcement, tenant header stripping — lives in this file.

**Changes:**
- `src/middleware.ts` → `src/proxy.ts` (git rename, 98% similarity)
- Exported function: `middleware()` → `proxy()`
- Updated `knip.json` entry point
- Updated comment references in `AGENTS.md`, `README.md`, `next.config.ts`, `routes.ts`, test files, `upload/route.ts`

**Build verified:** The middleware deprecation warning is gone.

## Review & Testing Checklist for Human

- [ ] Run `npm run build` and verify no middleware deprecation warning appears
- [ ] Run `npm run test:e2e` — especially `csp-headers.spec.ts`, `tenant-isolation.spec.ts`, `rbac.spec.ts`
- [ ] Verify CSP nonce propagates correctly
- [ ] Test subdomain tenant resolution (e.g., `demo.localhost:3000`)

### Notes
- The `@/lib/middleware/` directory is unchanged — only the root-level file convention was renamed.
- No behavioral changes — purely a rename.