### PR TITLE
fix(F-003, F-042): remove Cache-Control override + use env var for alternates URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,18 +33,6 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Next.js uses content-hashed filenames for static chunks, so they
-        // are effectively immutable. Use a long max-age + immutable to avoid
-        // unnecessary revalidation on repeat visits (PERF-08).
-        source: "/_next/static/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, immutable",
-          },
-        ],
-      },
-      {
         // Default: prevent caching of API responses (authentication, patient
         // data, mutations, etc.).  Individual routes that serve truly public
         // data can override this with their own Cache-Control header.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -70,6 +70,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const cookieStore = await import("next/headers").then(m => m.cookies());
   const preferredLocale = cookieStore.get("preferred-locale")?.value as Locale;
   const locale = preferredLocale || ("fr" as Locale);
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
 
   return {
     manifest: "/manifest.webmanifest",
@@ -103,8 +104,8 @@ export async function generateMetadata(): Promise<Metadata> {
     authors: [{ name: "Oltigo" }],
     alternates: {
       languages: {
-        "fr": "https://oltigo.com",
-        "ar": "https://oltigo.com?lang=ar",
+        "fr": siteUrl,
+        "ar": `${siteUrl}?lang=ar`,
       },
     },
     openGraph: {


### PR DESCRIPTION
## Summary

**F-003:** Remove the explicit `/_next/static/:path*` Cache-Control header from `next.config.ts`. Next.js manages this header itself for content-hashed filenames. Removing it eliminates the build warning: `Custom Cache-Control headers detected for /_next/static/:path*`. This was one of only two warnings in the clean build output.

**F-042:** Replace hardcoded `https://oltigo.com` in root layout `alternates.languages` with `process.env.NEXT_PUBLIC_SITE_URL` so staging and clinic subdomain deployments emit correct alternate URLs for SEO instead of always pointing at production.

## Review & Testing Checklist for Human

- [ ] Run `npm run build` and verify the Cache-Control warning is gone (zero warnings expected now)
- [ ] Check that `/_next/static/` assets still get immutable caching in production (Next.js handles this natively)

### Notes
- 2 files changed, net -11 lines.