### PR TITLE
ci(F-009/F-054): add dedicated RLS integration test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,46 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: "semgrep"
+  # F-009 / F-054: Dedicated RLS integration test job that runs in parallel
+  # with `ci` — never skipped due to lint or build failures. This is the
+  # single highest-leverage quality investment: a malformed RLS policy in a
+  # future migration cannot merge without this job catching it.
+  rls:
+    runs-on: ubuntu-latest
+    name: RLS Integration Tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
+        with:
+          version: latest
+
+      - name: Boot local Supabase
+        run: |
+          supabase init --force
+          supabase start
+          echo "SUPABASE_LOCAL_URL=$(supabase status --output json | jq -r '.API_URL')" >> "$GITHUB_ENV"
+          echo "SUPABASE_LOCAL_ANON_KEY=$(supabase status --output json | jq -r '.ANON_KEY')" >> "$GITHUB_ENV"
+          echo "SUPABASE_LOCAL_SERVICE_ROLE_KEY=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY')" >> "$GITHUB_ENV"
+
+      - name: Run RLS integration tests
+        run: npx vitest run src/lib/__tests__/integration/rls-real-postgres.test.ts
+        env:
+          SUPABASE_LOCAL_URL: ${{ env.SUPABASE_LOCAL_URL }}
+          SUPABASE_LOCAL_ANON_KEY: ${{ env.SUPABASE_LOCAL_ANON_KEY }}
+          SUPABASE_LOCAL_SERVICE_KEY: ${{ env.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
+
   e2e:
     runs-on: ubuntu-latest
     needs: ci


### PR DESCRIPTION
## Summary

Adds a dedicated `rls` CI job that runs the RLS integration tests against a real Postgres engine **in parallel** with the `ci` and `security` jobs (no `needs:` dependency).

This addresses audit findings F-009 and F-054: the most security-critical layer of the multi-tenant model (RLS policies) previously only had automated verification inside the `e2e` job, which depends on `ci` passing. Any lint/build failure caused the RLS tests to be silently skipped.

The new job:
1. Boots a local Supabase instance (applies all 85 migrations)
2. Exports local URL, anon key, and service role key
3. Runs `rls-real-postgres.test.ts` — 20+ assertions verifying cross-tenant isolation

## Review & Testing Checklist for Human

- [ ] Verify the `RLS Integration Tests` job appears as a separate check on the PR
- [ ] Confirm all RLS tests pass (not skipped) in the new job
- [ ] Verify the `e2e` job still has its RLS test step (redundant but harmless defense-in-depth)

### Notes
- The existing RLS test step inside the `e2e` job is intentionally kept for defense-in-depth.
- Uses the same SHA-pinned actions as other jobs (checkout v6, setup-node v6, supabase-cli v2.1.1).
- 1 file changed (+40 lines in ci.yml).