### PR TITLE
ci(F-028, F-060): add recharts import guard + docs generation verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,12 @@ jobs:
             exit 1
           fi
 
+      # F-060: Verify typedoc generation succeeds. Catches broken JSDoc,
+      # missing re-exports, and TypeScript errors in doc comments before
+      # they reach main.
+      - name: Verify docs generate
+        run: npm run docs:generate
+
   security:
     name: Security Scans (Audit P2 #26)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,19 @@ jobs:
             echo "Ensure these migrations have been reviewed and tested."
           fi
 
+      # F-028: Prevent recharts (~200 kB gzipped) from leaking into
+      # non-admin bundles. Recharts should only be imported from admin
+      # and super-admin components.
+      - name: Guard recharts imports
+        run: |
+          HITS=$(grep -rn 'from "recharts"' src/app/ src/components/ --include='*.ts' --include='*.tsx' \
+            | grep -v '/admin/' | grep -v '/super-admin/' | grep -v '/analytics/' || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::recharts imported outside admin routes (inflates shared bundle):"
+            echo "$HITS"
+            exit 1
+          fi
+
   security:
     name: Security Scans (Audit P2 #26)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

**F-028:** Adds a CI grep guard that prevents `recharts` (~200 kB gzipped) from being imported outside `/admin/`, `/super-admin/`, or `/analytics/` routes. Currently recharts is correctly limited to admin components; this guard prevents accidental leakage into public bundles.

**F-060:** Adds `npm run docs:generate` (typedoc) to the CI job, catching broken JSDoc comments and doc generation failures before they reach main. Since `docs/api/` is gitignored, this validates successful generation rather than checking for drift.

## Review & Testing Checklist for Human

- [ ] Verify both new CI steps appear and pass in the PR checks
- [ ] Confirm recharts guard correctly excludes admin/analytics paths

### Notes
- 2 commits, +19 lines in ci.yml only.