### PR TITLE
fix(security): R-12 CSRF exact-path + R-10 Semgrep tenant-scoping rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Run Semgrep
         run: |
           python3 -m pip install --upgrade semgrep
-          semgrep --config p/javascript --sarif --output semgrep.sarif .
+          semgrep --config p/javascript --config .semgrep/ --sarif --output semgrep.sarif .
 
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -1,0 +1,36 @@
+rules:
+  # R-10: Flag supabase .from() queries that do not chain .eq("clinic_id", ...)
+  #
+  # Every tenant-scoped database query MUST include .eq("clinic_id", clinicId)
+  # to enforce application-level tenant isolation (AGENTS.md rule #1). RLS is
+  # defense-in-depth — application-level scoping is required even with RLS.
+  #
+  # False positives:
+  #   - Queries in cron jobs that intentionally iterate over all clinics
+  #   - Admin client queries (createAdminClient) used for cross-tenant ops
+  #   - Auth/registration flows before a clinic_id exists
+  #
+  # These should use a `// semgrep-ignore: tenant-scoping` comment.
+  - id: tenant-scoping
+    patterns:
+      - pattern: |
+          $CLIENT.from($TABLE).$METHOD(...)
+      - pattern-not: |
+          $CLIENT.from($TABLE).$METHOD(...).eq("clinic_id", ...)
+      - pattern-not: |
+          $CLIENT.from($TABLE).$METHOD(...).eq('clinic_id', ...)
+      - metavariable-regex:
+          metavariable: $METHOD
+          regex: ^(select|insert|update|delete|upsert)$
+    message: >
+      Supabase query on `$TABLE` missing `.eq("clinic_id", ...)` — every
+      tenant-scoped query must filter by clinic_id for application-level
+      isolation (see AGENTS.md).
+    severity: WARNING
+    languages: [typescript, javascript]
+    metadata:
+      category: security
+      technology:
+        - supabase
+      references:
+        - https://github.com/groupsmix/webs-alots/blob/main/AGENTS.md

--- a/src/lib/middleware/csrf.ts
+++ b/src/lib/middleware/csrf.ts
@@ -22,23 +22,39 @@ const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  * Adding a new exempt route without a corresponding signature/token check
  * creates an unauthenticated, CSRF-unprotected mutation endpoint.
  */
-const CSRF_EXEMPT_PREFIXES = [
-  "/api/webhooks",          // WhatsApp: X-Hub-Signature-256 HMAC
-  "/api/payments/webhook",  // Stripe: stripe-signature HMAC
+/**
+ * R-12: CSRF-exempt routes listed as exact paths, not prefixes.
+ *
+ * Prefix-based exemption is structurally risky — if someone adds
+ * `/api/webhooks/foo/route.ts` without HMAC verification, it inherits
+ * CSRF-exemption automatically. Exact matching forces each new route
+ * to be explicitly exempted and reviewed.
+ *
+ * Cron routes use a prefix because they share the CRON_SECRET Bearer
+ * token auth mechanism uniformly (CSRF-01), and new cron routes are
+ * forced through the `verifyCronSecret` helper by convention.
+ */
+const CSRF_EXEMPT_EXACT = new Set([
+  "/api/webhooks",              // WhatsApp: X-Hub-Signature-256 HMAC
+  "/api/payments/webhook",      // Stripe: stripe-signature HMAC
   "/api/payments/cmi/callback", // CMI: HMAC hash field verification
-  // CSRF-01: All cron endpoints are authenticated via CRON_SECRET bearer token
-  // and may be triggered by external schedulers (Cloudflare Cron Triggers).
-  "/api/cron/",             // Cron: CRON_SECRET Bearer token
   // CSP-RPT: Browsers send Content-Security-Policy violation reports as POST
   // requests with a `report-uri` or `report-to` directive. The Origin header
   // may not match the site URL (some browsers use `null` or omit it entirely),
   // so the endpoint must be CSRF-exempt. The payload is a fixed JSON schema
   // that the handler validates — no state mutation occurs.
   "/api/csp-report",
-];
+]);
+
+/**
+ * CSRF-01: All cron endpoints are authenticated via CRON_SECRET bearer token
+ * and may be triggered by external schedulers (Cloudflare Cron Triggers).
+ * Kept as a prefix because the auth mechanism is uniform.
+ */
+const CSRF_EXEMPT_CRON_PREFIX = "/api/cron/";
 
 function isCsrfExempt(pathname: string): boolean {
-  return CSRF_EXEMPT_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+  return CSRF_EXEMPT_EXACT.has(pathname) || pathname.startsWith(CSRF_EXEMPT_CRON_PREFIX);
 }
 
 /**

--- a/src/lib/middleware/csrf.ts
+++ b/src/lib/middleware/csrf.ts
@@ -54,7 +54,11 @@ const CSRF_EXEMPT_EXACT = new Set([
 const CSRF_EXEMPT_CRON_PREFIX = "/api/cron/";
 
 function isCsrfExempt(pathname: string): boolean {
-  return CSRF_EXEMPT_EXACT.has(pathname) || pathname.startsWith(CSRF_EXEMPT_CRON_PREFIX);
+  // Normalize trailing slash (trailingSlash: true in next.config.ts)
+  const normalized = pathname.endsWith("/") && pathname.length > 1
+    ? pathname.slice(0, -1)
+    : pathname;
+  return CSRF_EXEMPT_EXACT.has(normalized) || pathname.startsWith(CSRF_EXEMPT_CRON_PREFIX);
 }
 
 /**


### PR DESCRIPTION
## Summary

**R-12**: CSRF exemption changed from prefix-based to exact-path matching via `Set`. Webhook routes are now matched exactly — prevents accidental CSRF exemption of new sub-routes that lack their own auth. Cron routes remain prefix-based (uniform CRON_SECRET auth).

**R-10**: New `.semgrep/tenant-scoping.yml` rule flags Supabase `.from()` queries that miss `.eq("clinic_id", ...)` chaining. Wired into existing CI Semgrep job.

## Review & Testing Checklist for Human
- [ ] R-12: Verify webhook/payment/CSP routes still pass CSRF checks (paths must match exactly now)
- [ ] R-10: Review Semgrep findings — expect false positives on cron/admin/auth code paths

### Notes
- Semgrep rule is WARNING severity, not blocking. Review SARIF output and suppress legitimate exemptions with `// semgrep-ignore: tenant-scoping` comments.