### PR TITLE
feat(security): R-01 createAdminClient requires purpose parameter

### DIFF
--- a/src/app/api/ai/whatsapp-receptionist/route.ts
+++ b/src/app/api/ai/whatsapp-receptionist/route.ts
@@ -118,7 +118,7 @@ async function fetchClinicContext(
   clinicId: string,
 ): Promise<ClinicContext | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("whatsapp_receptionist");
 
     const [clinicRes, servicesRes, doctorsRes] = await Promise.all([
       supabase
@@ -170,7 +170,7 @@ async function findClinicByPhoneNumberId(
   phoneNumberId: string,
 ): Promise<string | null> {
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("whatsapp_receptionist");
     // The WhatsApp phone number ID is stored in the clinic's metadata
     // as metadata->whatsapp_phone_number_id. We query all clinics and
     // filter in-app since Supabase JSONB containment is more reliable.
@@ -314,7 +314,7 @@ async function handleIncomingMessage(
   await sendTextMessage(from, aiReply);
 
   // F-AI-08: Audit log AI invocation
-  const adminClient = createAdminClient();
+  const adminClient = createAdminClient("whatsapp_receptionist");
   void logAuditEvent({
     supabase: adminClient,
     action: "ai_whatsapp_receptionist_invocation",
@@ -326,7 +326,7 @@ async function handleIncomingMessage(
 
   // Log the interaction for analytics
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("whatsapp_receptionist");
     await supabase.from("activity_logs").insert({
       action: "whatsapp_receptionist.message",
       type: "admin",

--- a/src/app/api/auth/demo-login/route.ts
+++ b/src/app/api/auth/demo-login/route.ts
@@ -135,7 +135,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("auth_admin");
 
     // Ensure the demo auth user exists (idempotent)
     // We query the public "users" table by email to find the auth_id.

--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -123,7 +123,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Use admin client — webhook requests bypass user auth
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("webhook");
 
     switch (event.type) {
       case "checkout.session.completed": {

--- a/src/app/api/cron/billing/route.ts
+++ b/src/app/api/cron/billing/route.ts
@@ -22,7 +22,7 @@ async function handler(request: NextRequest) {
   const authError = verifyCronSecret(request);
   if (authError) return authError;
 
-  const supabase = createAdminClient();
+  const supabase = createAdminClient("cron");
 
   // Fetch all active subscriptions that may need renewal
   const today = new Date().toISOString().split("T")[0];

--- a/src/app/api/cron/feedback/route.ts
+++ b/src/app/api/cron/feedback/route.ts
@@ -21,7 +21,7 @@ async function handler(request: NextRequest) {
   if (authError) return authError;
 
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("cron");
 
     // Audit 7.1: Short-circuit if there are no active clinics to save DB compute
     const { count } = await supabase.from("clinics").select("*", { count: "exact", head: true }).eq("status", "active");

--- a/src/app/api/cron/gdpr-purge/route.ts
+++ b/src/app/api/cron/gdpr-purge/route.ts
@@ -32,7 +32,7 @@ async function handler(request: NextRequest) {
   if (authError) return authError;
 
   try {
-    const supabase = createAdminClient() as UntypedClient;
+    const supabase = createAdminClient("cron") as UntypedClient;
     const thirtyDaysAgo = new Date(
       Date.now() - 30 * 24 * 60 * 60 * 1000,
     ).toISOString();

--- a/src/app/api/cron/r2-cleanup/route.ts
+++ b/src/app/api/cron/r2-cleanup/route.ts
@@ -45,7 +45,7 @@ async function handler(request: NextRequest) {
     // Cron has no tenant subdomain context — use the admin client to
     // enumerate clinics, then re-scope every per-clinic operation via
     // the library primitives that take an explicit `clinicId`.
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("cron");
 
     const { data: clinics, error: clinicsError } = await supabase
       .from("clinics")

--- a/src/app/api/cron/rebooking-reminders/route.ts
+++ b/src/app/api/cron/rebooking-reminders/route.ts
@@ -22,7 +22,7 @@ async function handler(request: NextRequest) {
   if (authError) return authError;
 
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("cron");
 
     // Audit 7.1: Short-circuit if there are no active clinics to save DB compute
     const { count } = await supabase.from("clinics").select("*", { count: "exact", head: true }).eq("status", "active");

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -8,7 +8,7 @@ import { substituteVariables, defaultNotificationTemplates } from "@/lib/notific
 import { withSentryCron } from "@/lib/sentry-cron";
 // B-02: Cron jobs run without user session cookies, so the cookie-based
 // `createClient()` would execute queries as anon under RLS, returning 0
-// rows and silently skipping all reminders. Use `createAdminClient()`
+// rows and silently skipping all reminders. Use `createAdminClient("cron")`
 // (service-role) which bypasses RLS, then iterate per-clinic.
 import { createAdminClient } from "@/lib/supabase-server";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
@@ -33,7 +33,7 @@ async function handler(request: NextRequest) {
   if (authError) return authError;
 
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("cron");
     // Quick check to see if there are any active clinics to avoid unnecessary DB queries
     const { count: activeClinicsCount } = await supabase
       .from("clinics")

--- a/src/app/api/cron/stripe-reconcile/route.ts
+++ b/src/app/api/cron/stripe-reconcile/route.ts
@@ -43,7 +43,7 @@ async function handler(request: NextRequest) {
   }
 
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("cron");
     const sevenDaysAgo = Math.floor(Date.now() / 1000) - 7 * 24 * 60 * 60;
 
     // Fetch completed Stripe Checkout Sessions from the last 7 days.

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -96,7 +96,7 @@ export const POST = withAuthValidation(impersonateSchema, async (body, request, 
     // server-side invalidation, audit queries, and concurrent session limits.
     let sessionId: string | null = null;
     try {
-      const adminClient = createAdminClient();
+      const adminClient = createAdminClient("impersonate");
       const expiresAt = new Date(Date.now() + sessionMaxAge * 1000).toISOString();
 
       // Look up the user's profile ID for the actor_id FK
@@ -107,7 +107,7 @@ export const POST = withAuthValidation(impersonateSchema, async (body, request, 
         .single();
 
       if (profile) {
-        const untypedClient = createUntypedAdminClient();
+        const untypedClient = createUntypedAdminClient("impersonate");
         const { data: session, error: sessionError } = await untypedClient
           .from("impersonation_sessions")
           .insert({
@@ -187,7 +187,7 @@ export const GET = withAuth(async () => {
   let reason: string | null = null;
   if (sessionId) {
     try {
-      const untypedClient = createUntypedAdminClient();
+      const untypedClient = createUntypedAdminClient("impersonate");
       const { data: session } = await untypedClient
         .from("impersonation_sessions")
         .select("reason, ended_at, expires_at")
@@ -217,7 +217,7 @@ export const DELETE = withAuth(async (_request, { supabase, user }) => {
     // AUDIT FINDING #6: Mark the server-side session as ended
     if (sessionId) {
       try {
-        const untypedClient = createUntypedAdminClient();
+        const untypedClient = createUntypedAdminClient("impersonate");
         await untypedClient
           .from("impersonation_sessions")
           .update({ ended_at: new Date().toISOString(), ended_reason: "manual" })

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -344,7 +344,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("register_clinic");
 
     // 1. Check if email is already registered.
     // Querying our own "users" table is O(1) and safe for admin.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -228,7 +228,7 @@ export function register() {
 
     import("@/lib/supabase-server").then(({ createAdminClient }) => {
       try {
-        const supabase = createAdminClient();
+        const supabase = createAdminClient("instrumentation");
         supabase
           .from("users")
           .select("id")

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -1,7 +1,7 @@
 /**
  * Audit logging utility for healthcare compliance.
  *
- * F-09: Uses createAdminClient() with explicit clinic_id so RLS cannot
+ * F-09: Uses createAdminClient("audit_log") with explicit clinic_id so RLS cannot
  * drop writes. On insert failure, raises a Sentry alert with compliance
  * tags and writes a structured log line for DLQ-style recovery.
  */
@@ -56,7 +56,7 @@ export async function logAuditEvent({
     let client: SupabaseClient<Database> = supabase;
     try {
       const { createAdminClient } = await import("@/lib/supabase-server");
-      client = createAdminClient();
+      client = createAdminClient("audit_log");
     } catch {
       // Service role key unavailable (dev/build) — fall back to caller's client
       if (!supabase) {
@@ -120,7 +120,7 @@ export async function logAuditEvent({
     // queue into activity_logs periodically.
     try {
       const { createUntypedAdminClient } = await import("@/lib/supabase-server");
-      const retryClient = createUntypedAdminClient();
+      const retryClient = createUntypedAdminClient("audit_log");
       await retryClient
         .from("pending_audit_logs")
         .insert({

--- a/src/lib/data/directory.ts
+++ b/src/lib/data/directory.ts
@@ -159,7 +159,7 @@ async function fetchDirectoryDoctors(): Promise<DirectoryDoctor[]> {
     // inside a "use cache" directive in Next.js 15+. We must use the admin client or a 
     // standalone client that doesn't read cookies, since the directory is public anyway.
     const { createAdminClient } = await import("@/lib/supabase-server");
-    const supabase = createAdminClient();
+    const supabase = createAdminClient("directory");
 
     // Fetch all doctors from active clinics
     const { data: doctors, error: doctorsError } = await supabase

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -285,7 +285,7 @@ export async function setClinicFeatureOverride(
     try {
       const { createAdminClient } = await import("@/lib/supabase-server");
       const { logAuditEvent } = await import("@/lib/audit-log");
-      const supabase = createAdminClient();
+      const supabase = createAdminClient("features");
       await logAuditEvent({
         supabase,
         action: "feature_flag.updated",
@@ -348,7 +348,7 @@ export async function setGlobalFeatureFlag(
     try {
       const { createAdminClient } = await import("@/lib/supabase-server");
       const { logAuditEvent } = await import("@/lib/audit-log");
-      const supabase = createAdminClient();
+      const supabase = createAdminClient("features");
       await logAuditEvent({
         supabase,
         action: "feature_flag.global_updated",

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -93,7 +93,7 @@ export async function enqueueNotification(
 ): Promise<string | null> {
   try {
     const { createAdminClient } = await import("@/lib/supabase-server");
-    const supabase = createAdminClient() as ExtendedClient;
+    const supabase = createAdminClient("notification") as ExtendedClient;
 
     const { data, error } = await supabase
       .from("notification_queue")
@@ -148,7 +148,7 @@ export async function processNotificationQueue(): Promise<ProcessResult> {
 
   try {
     const { createAdminClient } = await import("@/lib/supabase-server");
-    const supabase = createAdminClient() as ExtendedClient;
+    const supabase = createAdminClient("notification") as ExtendedClient;
 
     // Fetch pending items ready for processing
     const { data: items, error: fetchError } = await supabase

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -111,6 +111,24 @@ export async function createTenantClient(clinicId: string) {
 }
 
 /**
+ * R-01: Every call site must declare its purpose so auditors can
+ * verify each admin-client usage is intentional and appropriately scoped.
+ */
+export type AdminPurpose =
+  | "auth_admin"
+  | "cron"
+  | "audit_log"
+  | "notification"
+  | "webhook"
+  | "super_admin"
+  | "register_clinic"
+  | "impersonate"
+  | "features"
+  | "directory"
+  | "instrumentation"
+  | "whatsapp_receptionist";
+
+/**
  * Create a Supabase admin client using the service role key.
  *
  * This client bypasses RLS and can perform admin operations such as
@@ -120,9 +138,14 @@ export async function createTenantClient(clinicId: string) {
  * onboarding staff accounts, audit log writes). Never expose this client
  * to the browser.
  *
+ * R-01: Requires `purpose` so each usage is auditable. Optionally accepts
+ * `clinicId` for structured logging (does NOT set tenant context — use
+ * createTenantClient for that).
+ *
  * @throws Error if SUPABASE_SERVICE_ROLE_KEY is not configured
  */
-export function createAdminClient() {
+export function createAdminClient(purpose: AdminPurpose, clinicId?: string) {
+  logger.debug("Admin client created", { context: "supabase-server", purpose, clinicId });
   return createSupabaseClient<Database>(
     requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
     requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
@@ -137,7 +160,8 @@ export function createAdminClient() {
  * (e.g. impersonation_sessions, pending_audit_logs). Once the types are
  * regenerated, callers should migrate to createAdminClient() for type safety.
  */
-export function createUntypedAdminClient() {
+export function createUntypedAdminClient(purpose: AdminPurpose, clinicId?: string) {
+  logger.debug("Untyped admin client created", { context: "supabase-server", purpose, clinicId });
   return createSupabaseClient(
     requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
     requireEnv("SUPABASE_SERVICE_ROLE_KEY"),

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -29,10 +29,10 @@ import type {
  * This function returns a cookie-based Supabase client whose queries
  * run under the authenticated user's session. It does NOT bypass RLS
  * by itself. However, some callers (e.g. `createUser`) also use
- * `createAdminClient()` which creates a service-role client that
+ * `createAdminClient("super_admin")` which creates a service-role client that
  * **does bypass all Row Level Security policies**.
  *
- * Any function in this file that uses `createAdminClient()` must:
+ * Any function in this file that uses `createAdminClient("super_admin")` must:
  *   1. Validate all inputs before passing them to the admin client.
  *   2. Be restricted to super_admin callers (enforced by `requireRole`).
  *   3. Log the operation for audit purposes (see `activity_logs` table).
@@ -252,7 +252,7 @@ export async function createUser(input: CreateUserInput): Promise<UserRow> {
   // Attempt to create a Supabase Auth account if email is provided
   if (input.email && process.env.SUPABASE_SERVICE_ROLE_KEY) {
     try {
-      const admin = createAdminClient();
+      const admin = createAdminClient("super_admin");
       // Audit P1 #12: Generate a secure random one-time password for new staff
       // so we don't rely on a shared static STAFF_DEFAULT_PASSWORD constant.
       const secureOneTimePassword = crypto.randomUUID() + crypto.randomUUID().slice(0, 8);
@@ -368,7 +368,7 @@ export async function createUser(input: CreateUserInput): Promise<UserRow> {
   if (input.email) {
     try {
       const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
-      const admin = createAdminClient();
+      const admin = createAdminClient("super_admin");
       const { data: resetLink } = await admin.auth.admin.generateLink({
         type: "recovery",
         email: input.email,


### PR DESCRIPTION
## Summary

**R-01 (P0)**: `createAdminClient()` and `createUntypedAdminClient()` now require an `AdminPurpose` literal type as the first parameter. Every call site must declare its purpose (e.g. `"cron"`, `"webhook"`, `"super_admin"`) which is logged for audit trail.

- Added `AdminPurpose` type union with 12 literals
- Updated all 28 call sites across 18 files
- TypeScript enforces that new call sites provide a valid purpose

## Review & Testing Checklist for Human
- [ ] Verify no call sites were missed (TypeScript catches this at compile time)
- [ ] Review purpose assignments match actual usage
- [ ] Confirm Sentry/logging picks up the purpose field in structured logs

### Notes
- 19 files changed, 58 insertions, 34 deletions. Purely additive — no behavioral change.