### PR TITLE
feat(security): R-25 Knip CI job + R-15 booking token rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,29 @@ jobs:
         with:
           sarif_file: semgrep.sarif
           category: "semgrep"
+  # R-25: Run Knip to detect unused exports, files, and dependencies.
+  # Non-blocking (continue-on-error) because the current codebase has known
+  # findings — the goal is visibility, not gating.
+  knip:
+    runs-on: ubuntu-latest
+    name: Knip (dead code detection)
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run Knip
+        run: npx knip --no-exit-code
+
   # F-009 / F-054: Dedicated RLS integration test job that runs in parallel
   # with `ci` — never skipped due to lint or build failures. This is the
   # single highest-leverage quality investment: a malformed RLS policy in a

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -75,6 +75,35 @@ interface BookingTokenResult {
  *
  * Returns the verified phone so callers can enforce phone binding.
  */
+/**
+ * R-15: Verify an HMAC signature against one or more secrets.
+ * Returns true for the first matching secret (constant-time per attempt).
+ */
+async function verifyHmac(
+  secret: string,
+  payload: string,
+  signature: string,
+): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  const expectedSig = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  if (expectedSig.length !== signature.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < expectedSig.length; i++) {
+    mismatch |= expectedSig.charCodeAt(i) ^ signature.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
 async function verifyBookingToken(token: string): Promise<BookingTokenResult> {
   const secret = process.env.BOOKING_TOKEN_SECRET;
   if (!secret) {
@@ -86,9 +115,6 @@ async function verifyBookingToken(token: string): Promise<BookingTokenResult> {
   }
 
   // A6-13: token is now `clinicId:phone:expiry:signature` (4 parts).
-  // Tokens issued under the previous 3-part format become invalid the
-  // moment this code ships; given the 15-minute TTL the impact is a
-  // single retry of the verify step for users mid-flow at deploy time.
   const parts = token.split(":");
   if (parts.length !== 4) return { valid: false };
 
@@ -97,28 +123,23 @@ async function verifyBookingToken(token: string): Promise<BookingTokenResult> {
   const expiry = parseInt(expiryStr, 10);
   if (isNaN(expiry) || Date.now() > expiry) return { valid: false };
 
-  // Verify HMAC signature over the full payload (clinicId included).
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const data = encoder.encode(`${clinicId}:${phone}:${expiryStr}`);
-  const sig = await crypto.subtle.sign("HMAC", key, data);
-  const expectedSig = Array.from(new Uint8Array(sig))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  const payload = `${clinicId}:${phone}:${expiryStr}`;
 
-  // Constant-time comparison
-  if (expectedSig.length !== signature.length) return { valid: false };
-  let mismatch = 0;
-  for (let i = 0; i < expectedSig.length; i++) {
-    mismatch |= expectedSig.charCodeAt(i) ^ signature.charCodeAt(i);
+  // Try the current secret first.
+  if (await verifyHmac(secret, payload, signature)) {
+    return { valid: true, phone, clinicId };
   }
-  return mismatch === 0 ? { valid: true, phone, clinicId } : { valid: false };
+
+  // R-15: During key rotation, try the old secret. Set
+  // BOOKING_TOKEN_SECRET_OLD to the previous key, then remove it after
+  // the overlap window (>= token TTL, typically 15 min) has passed.
+  const oldSecret = process.env.BOOKING_TOKEN_SECRET_OLD;
+  if (oldSecret && await verifyHmac(oldSecret, payload, signature)) {
+    logger.info("Booking token verified with OLD secret — rotation in progress", { context: "booking" });
+    return { valid: true, phone, clinicId };
+  }
+
+  return { valid: false };
 }
 
 /** Inferred from the Zod schema — single source of truth. */

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -32,6 +32,9 @@ const ENV_RULES: EnvRule[] = [
 
   // ── Auth / Security ────────────────────────────────────────────────
   { name: "BOOKING_TOKEN_SECRET", required: process.env.NODE_ENV === "production", description: "HMAC secret for booking verification tokens (required in production)", group: "auth" },
+  // R-15: Set to the previous BOOKING_TOKEN_SECRET during key rotation.
+  // Remove after the overlap window (>= booking token TTL, 15 min).
+  { name: "BOOKING_TOKEN_SECRET_OLD", required: false, description: "Previous HMAC secret — set during rotation, remove after overlap window", group: "auth" },
 
   // ── Phone Auth (Twilio SMS OTP) ──────────────────────────────────────
   // These are NOT required at startup. They are only needed when


### PR DESCRIPTION
## Summary

**R-25**: Non-blocking Knip CI job for dead code detection. `continue-on-error: true` so it reports without gating.

**R-15**: `BOOKING_TOKEN_SECRET_OLD` rotation support. `verifyBookingToken` tries the current secret first, falls back to the old secret during rotation. Extracted `verifyHmac` helper. Added env.ts registration.

## Review & Testing Checklist for Human
- [ ] Verify Knip CI job runs and produces output without blocking the pipeline
- [ ] Test booking token verification works with both new and old secrets

### Notes
- Set BOOKING_TOKEN_SECRET_OLD to the previous key during rotation, remove after 15+ min overlap window.