### PR TITLE
fix: export normalizePhiCategory from encryption.ts (hotfix)

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -239,7 +239,7 @@ export async function decryptBuffer(
  * `x_rays` had a 25 MB limit but bypassed encryption because the PHI set
  * only listed `x-rays` / `xrays`.
  */
-function normalizePhiCategory(category: string): string {
+export function normalizePhiCategory(category: string): string {
   return category.trim().toLowerCase().replace(/-/g, "_");
 }
 


### PR DESCRIPTION
## Summary

**HOTFIX:** `normalizePhiCategory` was imported by `upload/route.ts` (R-11 fix in PR #639) but was not exported after PR #627 un-exported it. This breaks TypeScript compilation and Cloudflare Workers build on main and all open PR branches.

## Changes
- Add `export` keyword to `normalizePhiCategory()` in `src/lib/encryption.ts`

## Impact
- Fixes broken main build
- Unblocks all 6 open audit PRs (#640, #641, #643, #644, #645, #646)