### PR TITLE
fix(security): HIGH-1 + HIGH-2 — fix RLS policies + CMI replay protection

### DIFF
--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiInternalError } from "@/lib/api-response";
 import { verifyCmiCallback } from "@/lib/cmi";
 import { logger } from "@/lib/logger";
-import { createClient } from "@/lib/supabase-server";
+import { createAdminClient, createClient } from "@/lib/supabase-server";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { cmiCallbackFieldsSchema } from "@/lib/validations";
@@ -140,6 +140,50 @@ export async function POST(request: NextRequest) {
 
     if (!callbackData) {
       return apiError("Invalid callback");
+    }
+
+    // HIGH-2: Replay protection — insert into cmi_callbacks_seen before
+    // any state mutation.  Uses admin client because tenant context is not
+    // yet established at this point and the table's RLS requires clinic_id.
+    // ON CONFLICT (clinic_id, transaction_id) rejects duplicates.
+    if (callbackData.transactionId) {
+      const adminClient = createAdminClient("webhook");
+      // Look up the payment first to get clinic_id for the dedup row.
+      const { data: dedupPayment } = await adminClient
+        .from("payments")
+        .select("clinic_id")
+        .eq("gateway_session_id", callbackData.orderId)
+        .single();
+
+      if (dedupPayment?.clinic_id) {
+        const { error: dedupErr } = await adminClient
+          .from("cmi_callbacks_seen" as never)
+          .insert({
+            clinic_id: dedupPayment.clinic_id,
+            transaction_id: callbackData.transactionId,
+          } as never);
+
+        if (dedupErr) {
+          // 23505 = unique_violation → duplicate callback, ACK but do nothing
+          if (dedupErr.code === "23505") {
+            logger.info("CMI callback replay detected — ignoring duplicate", {
+              context: "payments/cmi/callback",
+              transactionId: callbackData.transactionId,
+              clinicId: dedupPayment.clinic_id,
+            });
+            return new NextResponse("ACTION=POSTAUTH", {
+              status: 200,
+              headers: { "Content-Type": "text/plain" },
+            });
+          }
+          // Other DB errors — log but continue (fail-open for payment processing)
+          logger.error("CMI dedup insert failed", {
+            context: "payments/cmi/callback",
+            error: dedupErr,
+            transactionId: callbackData.transactionId,
+          });
+        }
+      }
     }
 
     const supabase = await createClient();

--- a/supabase/migrations/00091_fix_rls_ai_usage_cmi_callbacks.sql
+++ b/supabase/migrations/00091_fix_rls_ai_usage_cmi_callbacks.sql
@@ -1,0 +1,48 @@
+-- HIGH-1: Fix RLS policies on ai_usage and cmi_callbacks_seen.
+--
+-- Migrations 00083 and 00084 incorrectly referenced the non-existent
+-- session variable 'app.clinic_id'.  The codebase consistently uses
+-- 'app.current_clinic_id' (set by set_tenant_context()) and the
+-- per-request header read by get_request_clinic_id().  Using the wrong
+-- variable name caused the USING clause to always evaluate to NULL,
+-- silently rejecting every row under RLS.
+--
+-- Effects before this fix:
+--   - AI cost-cap SELECT returns NULL → cap never triggers → unbounded LLM spend.
+--   - ai_usage UPSERT fails silently → no usage tracking.
+--   - cmi_callbacks_seen INSERT fails under RLS → replay protection is dead code.
+--
+-- This migration replaces both policies to use get_request_clinic_id()
+-- (which checks the x-clinic-id header first, then falls back to the
+-- app.current_clinic_id session variable) and adds WITH CHECK clauses
+-- so INSERT/UPDATE are also properly constrained.
+
+-- ── ai_usage ────────────────────────────────────────────────────────
+
+DROP POLICY IF EXISTS ai_usage_tenant_isolation ON ai_usage;
+
+CREATE POLICY ai_usage_tenant_isolation ON ai_usage
+  FOR ALL
+  USING (
+    clinic_id = get_user_clinic_id()
+    OR clinic_id = get_request_clinic_id()
+  )
+  WITH CHECK (
+    clinic_id = get_user_clinic_id()
+    OR clinic_id = get_request_clinic_id()
+  );
+
+-- ── cmi_callbacks_seen ──────────────────────────────────────────────
+
+DROP POLICY IF EXISTS cmi_callbacks_tenant_isolation ON cmi_callbacks_seen;
+
+CREATE POLICY cmi_callbacks_tenant_isolation ON cmi_callbacks_seen
+  FOR ALL
+  USING (
+    clinic_id = get_user_clinic_id()
+    OR clinic_id = get_request_clinic_id()
+  )
+  WITH CHECK (
+    clinic_id = get_user_clinic_id()
+    OR clinic_id = get_request_clinic_id()
+  );


### PR DESCRIPTION
## Summary

P0 fixes from 2026-05-27 audit.

### HIGH-1
Migrations 00083/00084 used non-existent app.clinic_id session variable in RLS policies. Migration 00091 replaces with get_user_clinic_id() / get_request_clinic_id() + adds WITH CHECK.

### HIGH-2
CMI callback handler now inserts into cmi_callbacks_seen before state mutation. ON CONFLICT rejects replays.

## Changes
- supabase/migrations/00091_fix_rls_ai_usage_cmi_callbacks.sql
- src/app/api/payments/cmi/callback/route.ts