### PR TITLE
fix(security): HIGH-4 RLS test assertion + MEDIUM-1 consent tenant guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
           echo "SUPABASE_LOCAL_SERVICE_ROLE_KEY=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY')" >> "$GITHUB_ENV"
 
       - name: Run RLS integration tests
-        run: npx vitest run src/lib/__tests__/integration/rls-real-postgres.test.ts
+        run: npx vitest run src/lib/__tests__/integration/rls-real-postgres.test.ts --reporter=json --outputFile=rls-results.json 2>&1 || true
         env:
           SUPABASE_LOCAL_URL: ${{ env.SUPABASE_LOCAL_URL }}
           SUPABASE_LOCAL_ANON_KEY: ${{ env.SUPABASE_LOCAL_ANON_KEY }}
@@ -350,6 +350,30 @@ jobs:
         env:
           SUPABASE_LOCAL_URL: ${{ env.SUPABASE_LOCAL_URL }}
           SUPABASE_LOCAL_SERVICE_KEY: ${{ env.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
+
+      # HIGH-4: Positive assertion — fail CI if the RLS suite was silently skipped.
+      # The JSON reporter counts skipped vs passed tests. If ALL tests were skipped,
+      # the env vars are likely missing and we should fail loudly rather than
+      # green-lighting a PR with zero RLS coverage.
+      - name: Assert RLS tests actually ran
+        run: |
+          if [ ! -f rls-results.json ]; then
+            echo "::error::RLS test results file not found — vitest may have crashed"
+            exit 1
+          fi
+          PASSED=$(node -e "const r=require('./rls-results.json'); console.log(r.numPassedTests || 0)")
+          FAILED=$(node -e "const r=require('./rls-results.json'); console.log(r.numFailedTests || 0)")
+          TOTAL=$((PASSED + FAILED))
+          echo "RLS tests: $PASSED passed, $FAILED failed, $TOTAL total"
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "::error::RLS integration suite ran 0 tests — env vars may be missing"
+            exit 1
+          fi
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED RLS test(s) failed"
+            exit 1
+          fi
+          echo "✓ $PASSED RLS tests passed"
 
   e2e:
     runs-on: ubuntu-latest

--- a/src/app/api/consent/route.ts
+++ b/src/app/api/consent/route.ts
@@ -12,11 +12,11 @@
  */
 
 import { NextRequest } from "next/server";
-import { apiSuccess, apiRateLimited } from "@/lib/api-response";
+import { apiError, apiSuccess, apiRateLimited } from "@/lib/api-response";
 import { withValidation } from "@/lib/api-validate";
 import { logger } from "@/lib/logger";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
-import { createClient, createTenantClient } from "@/lib/supabase-server";
+import { createTenantClient } from "@/lib/supabase-server";
 import { getTenant } from "@/lib/tenant";
 import { consentSchema } from "@/lib/validations";
 
@@ -35,14 +35,14 @@ export const POST = withValidation(consentSchema, async (data, request: NextRequ
 
   const { consentType, granted } = data;
 
-  // AUDIT F-02: Use the standard Supabase client factories so the tenant
-  // context header (x-clinic-id) is set, keeping consent records properly
-  // scoped by RLS policies. If a tenant subdomain is resolved, use the
-  // tenant-scoped client; otherwise fall back to the plain server client
-  // (e.g. consent recorded on the root domain before any clinic context).
-  const supabase = tenant?.clinicId
-    ? await createTenantClient(tenant.clinicId)
-    : await createClient();
+  // MEDIUM-1: Require tenant context — never fall back to a non-tenant
+  // client for a write that creates a tenant-scoped row. Consent without
+  // a resolved clinic context (e.g. root-domain hit, broken subdomain
+  // cache) is rejected with 400 to maintain defense-in-depth.
+  if (!tenant?.clinicId) {
+    return apiError("Tenant context required for consent logging", 400, "TENANT_REQUIRED");
+  }
+  const supabase = await createTenantClient(tenant.clinicId);
 
   // User may or may not be authenticated (cookie consent can happen pre-login)
   const {


### PR DESCRIPTION
## Summary

### HIGH-4: RLS test positive assertion in CI
Added Assert RLS tests actually ran step that reads vitest JSON output and fails if 0 tests ran or any failed. Prevents silent skipping.

### MEDIUM-1: Consent route requires tenant
Removed fallback to non-tenant client. Returns 400 TENANT_REQUIRED if no clinic context.

## Changes
- .github/workflows/ci.yml (RLS assertion step)
- src/app/api/consent/route.ts (tenant guard)