### PR TITLE
chore: §5.5 add Prettier + .editorconfig + lint-staged wiring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+.next/
+node_modules/
+.open-next/
+coverage/
+dist/
+supabase/migrations/
+src/lib/types/database.ts
+pnpm-lock.yaml
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "jsdom": "^29.1.0",
         "knip": "^6.14.2",
         "lint-staged": "^16.4.0",
+        "prettier": "^3.8.3",
         "swagger-ui-react": "5.32.6",
         "tailwindcss": "^4",
         "tsx": "^4.22.3",
@@ -18849,6 +18850,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "deploy": "npm run build:cf && wrangler deploy",
     "docs:generate": "typedoc",
     "analyze": "ANALYZE=true next build",
-    "prepare": "husky"
+    "prepare": "husky",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1037.0",
@@ -70,6 +72,7 @@
     "jsdom": "^29.1.0",
     "knip": "^6.14.2",
     "lint-staged": "^16.4.0",
+    "prettier": "^3.8.3",
     "swagger-ui-react": "5.32.6",
     "tailwindcss": "^4",
     "tsx": "^4.22.3",
@@ -80,7 +83,11 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs}": [
-      "eslint --fix --max-warnings=0"
+      "eslint --fix --max-warnings=0",
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml,css}": [
+      "prettier --write"
     ]
   },
   "overrides": {


### PR DESCRIPTION
## Summary
Adds code formatting infrastructure per audit §5.5:

- `.prettierrc` — 2-space indent, double quotes, trailing commas, 100 col width (matches existing style)
- `.editorconfig` — UTF-8, LF, trim trailing whitespace
- `.prettierignore` — excludes build artifacts, migrations, generated types
- `npm run format` / `npm run format:check` scripts
- `lint-staged` updated: prettier --write runs alongside eslint --fix on staged files

No files were reformatted in this PR — only tooling setup. First run of `npm run format` can be done in a follow-up.

## Review & Testing Checklist for Human
- [ ] Run `npm run format:check` to see current drift
- [ ] Verify lint-staged hook runs on commit (stage a .ts file, commit)

### Notes
The lint-staged config adds prettier for json/md/yml/yaml/css files too.