### PR TITLE
chore: §5.1 add DB type drift detection guardrail

### DIFF
--- a/scripts/check-db-types-drift.sh
+++ b/scripts/check-db-types-drift.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# §5.1 — CI guardrail: detect DB type drift.
+#
+# Compares the committed database.ts against freshly generated types.
+# Exits non-zero when the files differ.
+#
+# Usage:
+#   SUPABASE_ACCESS_TOKEN=<token> ./scripts/check-db-types-drift.sh
+#
+# In CI, set SUPABASE_PROJECT_ID to override the default.
+set -euo pipefail
+
+PROJECT_ID="${SUPABASE_PROJECT_ID:-xxxlygxysprrghqojvvz}"
+TYPES_FILE="src/lib/types/database.ts"
+TMP_REGEN="/tmp/db-types-regen.ts"
+
+if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ]; then
+  echo "⚠️  SUPABASE_ACCESS_TOKEN not set — skipping DB type drift check."
+  exit 0
+fi
+
+echo "Regenerating types from project ${PROJECT_ID}…"
+npx supabase gen types typescript --project-id "$PROJECT_ID" > "$TMP_REGEN" 2>/dev/null
+
+if diff -q "$TYPES_FILE" "$TMP_REGEN" > /dev/null 2>&1; then
+  echo "✅ DB types are up to date."
+else
+  echo "::warning::DB types have drifted from the live schema."
+  echo "Run: SUPABASE_ACCESS_TOKEN=\$TOKEN npx supabase gen types typescript --project-id $PROJECT_ID > $TYPES_FILE"
+  # Non-blocking warning for now — change to exit 1 once the full regeneration is done.
+  exit 0
+fi


### PR DESCRIPTION
## Summary
Adds `scripts/check-db-types-drift.sh` per audit §5.1 — a CI-ready script that detects when `database.ts` drifts from the live Supabase schema.

Currently emits a **warning** (non-blocking) because the full type regeneration requires production migrations for `ai_usage` and `clinic_api_keys.expires_at/scopes`. Once those land, change `exit 0` to `exit 1` to make it blocking.

### §3.2 `as any` status
The 3 `as any` casts (`api-auth.ts:62`, `chat/route.ts:88,186`) are **legitimately needed** until the corresponding DB migrations run on production:
- `ai_usage` table: migration `00083` exists but not applied to production
- `clinic_api_keys.expires_at/scopes`: columns not in production schema

Once production is migrated → regenerate types → remove `as any` casts.

## Review & Testing Checklist for Human
- [ ] Run `SUPABASE_ACCESS_TOKEN=$TOKEN ./scripts/check-db-types-drift.sh`
- [ ] Apply pending migrations to production when ready