### PR TITLE
refactor: §3.5 extract subdomain-resolution + mfa-enforcement from middleware

### DIFF
--- a/src/lib/middleware/mfa-enforcement.ts
+++ b/src/lib/middleware/mfa-enforcement.ts
@@ -1,0 +1,51 @@
+/**
+ * §3.5 — MFA enforcement logic for privileged roles.
+ *
+ * Extracted from middleware.ts to keep the orchestrator under ~300 lines.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { secureRedirect } from "@/lib/middleware/security-headers";
+
+/**
+ * Enforce MFA requirements based on role.
+ *
+ * - `super_admin`: MUST have MFA enrolled AND verified (AAL2).
+ * - `doctor` / `clinic_admin`: redirect to verify if factors enrolled but session is AAL1.
+ *
+ * Returns a redirect Response if MFA is required, or `null` if the user passes.
+ */
+export async function enforceMfa(
+  supabase: SupabaseClient,
+  role: string,
+  pathname: string,
+  requestUrl: string,
+): Promise<Response | null> {
+  if (role === "super_admin") {
+    const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+    if (aalData?.currentLevel !== "aal2") {
+      if (aalData?.nextLevel === "aal2") {
+        return secureRedirect(new URL("/login?mfa=required", requestUrl));
+      }
+      if (!pathname.startsWith("/setup-2fa")) {
+        return secureRedirect(new URL("/setup-2fa?required=super_admin", requestUrl));
+      }
+    }
+    return null;
+  }
+
+  if (role === "doctor") {
+    const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+    if (aalData?.currentLevel === "aal1" && aalData?.nextLevel === "aal2") {
+      return secureRedirect(new URL("/login?mfa=required", requestUrl));
+    }
+  }
+
+  if (role === "clinic_admin" && pathname.startsWith("/admin")) {
+    const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+    if (aalData?.currentLevel === "aal1" && aalData?.nextLevel === "aal2") {
+      return secureRedirect(new URL("/login?mfa=required", requestUrl));
+    }
+  }
+
+  return null;
+}

--- a/src/lib/middleware/subdomain-resolution.ts
+++ b/src/lib/middleware/subdomain-resolution.ts
@@ -1,0 +1,85 @@
+/**
+ * §3.5 — Subdomain → clinic resolution with in-memory cache.
+ *
+ * Extracted from middleware.ts to keep the orchestrator under ~300 lines.
+ */
+import { createServerClient } from "@supabase/ssr";
+import {
+  subdomainCache,
+  SUBDOMAIN_CACHE_TTL_MS,
+  setSubdomainCache,
+  negativeSubdomainCache,
+  NEGATIVE_CACHE_TTL_MS,
+  setNegativeSubdomainCache,
+} from "@/lib/subdomain-cache";
+
+export interface CachedClinic {
+  id: string;
+  name: string;
+  subdomain: string;
+  type: string;
+  tier: string;
+  patient_message_locale?: string;
+  cachedAt: number;
+}
+
+/**
+ * Resolve a subdomain to a clinic record, using an in-memory cache
+ * with TTL and negative-cache to avoid redundant Supabase queries.
+ *
+ * Returns `undefined` if the subdomain is unknown or invalid.
+ */
+export async function resolveSubdomainClinic(
+  subdomain: string,
+  supabaseUrl: string,
+  supabaseAnonKey: string,
+): Promise<CachedClinic | undefined> {
+  const cached = subdomainCache.get(subdomain);
+  const negativeCached = negativeSubdomainCache.get(subdomain);
+
+  if (cached && Date.now() - cached.cachedAt < SUBDOMAIN_CACHE_TTL_MS) {
+    return cached;
+  }
+
+  if (negativeCached && Date.now() - negativeCached.cachedAt < NEGATIVE_CACHE_TTL_MS) {
+    return undefined;
+  }
+
+  // Use a separate anon-only Supabase client (no user session cookies)
+  // for subdomain resolution. The RLS policy on `clinics` allows
+  // unauthenticated reads (auth.uid() IS NULL) for active clinics,
+  // but blocks authenticated users whose clinic_id doesn't match.
+  const anonSupabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return [];
+      },
+      setAll() {
+        /* no-op */
+      },
+    },
+  });
+
+  // S-07 (migration 00068): anon callers read from the narrower
+  // `public_clinic_directory` view instead of `clinics` directly.
+  const { data } = await anonSupabase
+    .from("public_clinic_directory")
+    .select("id, name, type, tier, subdomain, patient_message_locale")
+    .eq("subdomain", subdomain)
+    .single();
+
+  if (data) {
+    const clinic: CachedClinic = {
+      ...data,
+      subdomain: data.subdomain ?? subdomain,
+      cachedAt: Date.now(),
+    };
+    setSubdomainCache(subdomain, clinic);
+    return clinic;
+  }
+
+  // Evict stale entry if the subdomain was previously valid
+  subdomainCache.delete(subdomain);
+  setNegativeSubdomainCache(subdomain);
+  return undefined;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,10 +33,10 @@ import {
   secureRedirect,
   applyAllSecurityHeaders,
 } from "@/lib/middleware/security-headers";
+import { resolveSubdomainClinic, type CachedClinic } from "@/lib/middleware/subdomain-resolution";
 import { signProfileHeader, PROFILE_HEADER_NAMES } from "@/lib/profile-header-hmac";
 import { isSeedUserBlocked } from "@/lib/seed-guard";
 import { extractSubdomain } from "@/lib/subdomain";
-import { resolveSubdomainClinic, type CachedClinic } from "@/lib/middleware/subdomain-resolution";
 import { TENANT_HEADERS } from "@/lib/tenant";
 
 /**

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,15 @@
 /**
  * Next.js Middleware
  *
- * Refactored from a monolithic 557-line file into composable modules:
- *   - @/lib/middleware/security-headers — CSP, HSTS, nonce generation
- *   - @/lib/middleware/csrf             — Origin-based CSRF validation
- *   - @/lib/middleware/rate-limiting    — Per-IP rate limiting for API routes
- *   - @/lib/middleware/routes           — Route classification helpers
+ * Composable modules:
+ *   - @/lib/middleware/security-headers      — CSP, HSTS, nonce generation
+ *   - @/lib/middleware/csrf                  — Origin-based CSRF validation
+ *   - @/lib/middleware/rate-limiting         — Per-IP rate limiting for API routes
+ *   - @/lib/middleware/routes                — Route classification helpers
+ *   - @/lib/middleware/subdomain-resolution  — Subdomain → clinic cache + DB lookup
+ *   - @/lib/middleware/mfa-enforcement       — MFA gating per role
  *
- * This file orchestrates the modules and handles Supabase auth + subdomain resolution.
+ * This file orchestrates the modules and handles Supabase auth.
  */
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
@@ -15,6 +17,7 @@ import { DEMO_SUBDOMAIN, shouldBlockDemoRequest } from "@/lib/demo";
 import { generateTraceId, TRACE_ID_HEADER } from "@/lib/logger";
 import { validateCsrf } from "@/lib/middleware/csrf";
 import { checkGeoRestriction } from "@/lib/middleware/geo-restriction";
+import { enforceMfa } from "@/lib/middleware/mfa-enforcement";
 import { applyRateLimit } from "@/lib/middleware/rate-limiting";
 import {
   isPublicRoute,
@@ -33,21 +36,8 @@ import {
 import { signProfileHeader, PROFILE_HEADER_NAMES } from "@/lib/profile-header-hmac";
 import { isSeedUserBlocked } from "@/lib/seed-guard";
 import { extractSubdomain } from "@/lib/subdomain";
-import { subdomainCache, SUBDOMAIN_CACHE_TTL_MS, setSubdomainCache, negativeSubdomainCache, NEGATIVE_CACHE_TTL_MS, setNegativeSubdomainCache } from "@/lib/subdomain-cache";
+import { resolveSubdomainClinic, type CachedClinic } from "@/lib/middleware/subdomain-resolution";
 import { TENANT_HEADERS } from "@/lib/tenant";
-
-// ── Subdomain → clinic resolution cache ──────────────────────────
-// Cache is now shared via @/lib/subdomain-cache so API routes can
-// invalidate entries when a clinic's subdomain changes.
-interface CachedClinic {
-  id: string;
-  name: string;
-  subdomain: string;
-  type: string;
-  tier: string;
-  patient_message_locale?: string;
-  cachedAt: number;
-}
 
 /**
  * Set tenant headers on a response so downstream Server Components
@@ -287,58 +277,10 @@ export async function middleware(request: NextRequest) {
     }
   );
 
-  // --- Resolve clinic from subdomain (with in-memory cache) ---
-  // Track resolved clinic so tenant headers can be re-applied if setAll
-  // recreates supabaseResponse during token refresh.
+  // --- Resolve clinic from subdomain (delegated to composable module) ---
   let resolvedClinic: CachedClinic | undefined;
   if (subdomain) {
-    let clinic: CachedClinic | undefined;
-    const cached = subdomainCache.get(subdomain);
-    const negativeCached = negativeSubdomainCache.get(subdomain);
-
-    if (cached && Date.now() - cached.cachedAt < SUBDOMAIN_CACHE_TTL_MS) {
-      clinic = cached;
-    } else if (negativeCached && Date.now() - negativeCached.cachedAt < NEGATIVE_CACHE_TTL_MS) {
-      // Subdomain is known to be invalid — bypass Supabase entirely
-      clinic = undefined;
-    } else {
-      // Use a separate anon-only Supabase client (no user session cookies)
-      // for subdomain resolution. The RLS policy on `clinics` allows
-      // unauthenticated reads (auth.uid() IS NULL) for active clinics,
-      // but blocks authenticated users whose clinic_id doesn't match.
-      // By omitting cookies, the query always runs as unauthenticated,
-      // ensuring subdomain resolution works for all users.
-      const anonSupabase = createServerClient(
-        supabaseUrl,
-        supabaseAnonKey,
-        {
-          cookies: {
-            getAll() { return []; },
-            setAll() { /* no-op */ },
-          },
-        }
-      );
-
-      // S-07 (migration 00068): anon callers can no longer SELECT from
-      // `clinics` directly. They read from the narrower
-      // `public_clinic_directory` view instead, which exposes only the
-      // columns needed for tenant header population.
-      const { data } = await anonSupabase
-        .from("public_clinic_directory")
-        .select("id, name, type, tier, subdomain, patient_message_locale")
-        .eq("subdomain", subdomain)
-        .single();
-
-      if (data) {
-        clinic = { ...data, subdomain: data.subdomain ?? subdomain, cachedAt: Date.now() };
-        setSubdomainCache(subdomain, clinic);
-      } else {
-        // Evict stale entry if the subdomain was previously valid
-        subdomainCache.delete(subdomain);
-        // Add to negative cache to prevent Supabase queries on random subdomains
-        setNegativeSubdomainCache(subdomain);
-      }
-    }
+    const clinic = await resolveSubdomainClinic(subdomain, supabaseUrl, supabaseAnonKey);
 
     if (!clinic) {
       // A146-F2: Unknown subdomain — return a hard 404 with X-Robots-Tag
@@ -523,41 +465,10 @@ export async function middleware(request: NextRequest) {
       return secureRedirect(new URL("/login?error=unauthorized_role", request.url));
     }
 
-    // Super admin: MUST have MFA enrolled AND verified (AAL2).
-    // MEDIUM-5: A super_admin compromise = total platform compromise.
-    // If no factors are enrolled, redirect to setup; if enrolled but not
-    // verified this session, redirect to verify.
-    if (profile.role === "super_admin") {
-      const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aalData?.currentLevel !== "aal2") {
-        if (aalData?.nextLevel === "aal2") {
-          return secureRedirect(new URL("/login?mfa=required", request.url));
-        }
-        // No factors enrolled — redirect to setup (allow the setup page itself)
-        if (!pathname.startsWith("/setup-2fa")) {
-          return secureRedirect(new URL("/setup-2fa?required=super_admin", request.url));
-        }
-      }
-      return supabaseResponse;
-    }
-
-    // Doctor: complete MFA if configured (existing behavior, not mandatory)
-    if (profile.role === "doctor") {
-      const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aalData?.currentLevel === "aal1" && aalData?.nextLevel === "aal2") {
-        return secureRedirect(new URL("/login?mfa=required", request.url));
-      }
-    }
-
-    // Enforce 2FA for clinic_admin role: if admin has MFA factors but
-    // current session is only AAL1, redirect to the 2FA setup/verify page.
-    // This ensures admins cannot access admin routes without completing MFA.
-    if (profile.role === "clinic_admin" && pathname.startsWith("/admin")) {
-      const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aalData?.currentLevel === "aal1" && aalData?.nextLevel === "aal2") {
-        return secureRedirect(new URL("/login?mfa=required", request.url));
-      }
-    }
+    // MFA enforcement (delegated to composable module)
+    const mfaRedirect = await enforceMfa(supabase, profile.role, pathname, request.url);
+    if (mfaRedirect) return mfaRedirect;
+    if (profile.role === "super_admin") return supabaseResponse;
 
     // Check if user is accessing their allowed routes
     if (!pathname.startsWith(allowedPrefix)) {


### PR DESCRIPTION
## Summary
Addresses audit §3.5 — split middleware.ts from 595 → 506 lines by extracting two composable modules:

### New modules
- **`src/lib/middleware/subdomain-resolution.ts`** — Cache + DB lookup for subdomain → clinic resolution. Uses the existing `subdomainCache` / `negativeSubdomainCache` from `@/lib/subdomain-cache`.
- **`src/lib/middleware/mfa-enforcement.ts`** — MFA gating logic for `super_admin` (mandatory AAL2), `doctor`, and `clinic_admin` roles.

### What changed
- `middleware.ts` now imports and delegates to these modules instead of inlining the logic.
- No behavioral changes — same control flow, same cache behavior, same MFA rules.

### Verification
- `npx tsc --noEmit` — 0 errors
- `npx vitest run` — 817/817 tests pass
- All existing E2E tests should pass unchanged

## Review & Testing Checklist for Human
- [ ] Verify middleware behavior is unchanged
- [ ] Confirm subdomain resolution still works
- [ ] Confirm MFA enforcement still works