### PR TITLE
fix(security): MEDIUM — CSP report rate limit + per-clinic rate cap + Stripe streaming body (S0-11-02, A39-04, S0-11-05)

### DIFF
--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -26,6 +26,40 @@ import type { StripeWebhookEvent } from "@/lib/validations";
 /** AUDIT FINDING #24: Max webhook payload size (1 MB). */
 const MAX_WEBHOOK_BYTES = 1 * 1024 * 1024;
 
+/**
+ * S0-11-05: Streaming body reader that enforces a hard byte cap regardless
+ * of whether Content-Length is present (chunked TE bypass).
+ * Pattern identical to readBodyWithLimit in CMI callback route.
+ */
+async function readBodyWithLimit(request: NextRequest, maxBytes: number): Promise<string | null> {
+  const reader = request.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        /* best effort */
+      }
+      return null;
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(out);
+}
+
 export async function POST(request: NextRequest) {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -34,14 +68,12 @@ export async function POST(request: NextRequest) {
     return apiError("Stripe not configured", 503);
   }
 
-  // AUDIT FINDING #24: Reject oversized webhook payloads before parsing.
-  const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
-  if (contentLength > MAX_WEBHOOK_BYTES) {
-    return apiError("Payload too large", 413);
-  }
-
   try {
-    const rawBody = await request.text();
+    // S0-11-05: Stream-based body cap replaces Content-Length-only check.
+    const rawBody = await readBodyWithLimit(request, MAX_WEBHOOK_BYTES);
+    if (rawBody === null) {
+      return apiError("Payload too large", 413);
+    }
     const signature = request.headers.get("stripe-signature");
 
     // Verify webhook signature — webhook secret MUST be configured
@@ -97,7 +129,7 @@ export async function POST(request: NextRequest) {
             break;
           }
           logTenantContext(clinicId, "payments/webhook:checkout.completed");
-          
+
           // Audit 3.8 Fix: Webhook Deduplication / Replay Protection
           // We check if this exact Stripe event ID has already been processed to
           // prevent duplicate processing in case of Stripe retries.
@@ -108,7 +140,9 @@ export async function POST(request: NextRequest) {
             .maybeSingle();
 
           if (existingPayment) {
-            logger.info(`Stripe webhook event already processed: ${session.id}`, { context: "payments/webhook" });
+            logger.info(`Stripe webhook event already processed: ${session.id}`, {
+              context: "payments/webhook",
+            });
             break; // Skip processing since it's already handled
           }
 
@@ -122,13 +156,16 @@ export async function POST(request: NextRequest) {
               .eq("id", appointmentId)
               .maybeSingle();
             if (appt && appt.clinic_id !== clinicId) {
-              logger.error("Stripe webhook: appointment.clinic_id does not match metadata.clinic_id", {
-                context: "payments/webhook",
-                appointmentClinicId: appt.clinic_id,
-                metadataClinicId: clinicId,
-                appointmentId,
-                sessionId: session.id,
-              });
+              logger.error(
+                "Stripe webhook: appointment.clinic_id does not match metadata.clinic_id",
+                {
+                  context: "payments/webhook",
+                  appointmentClinicId: appt.clinic_id,
+                  metadataClinicId: clinicId,
+                  appointmentId,
+                  sessionId: session.id,
+                },
+              );
               return apiError("Appointment does not belong to the specified clinic", 422);
             }
           }
@@ -138,11 +175,11 @@ export async function POST(request: NextRequest) {
               clinic_id: clinicId,
               patient_id: patientId,
               appointment_id: appointmentId || null,
-                  amount: Math.round(session.amount_total || 0) / 100, // A29-01: integer-safe centimes→MAD
-                  method: "online",
-                  status: PAYMENT_STATUS.COMPLETED,
-                  reference: session.id,
-                  payment_type: "full",
+              amount: Math.round(session.amount_total || 0) / 100, // A29-01: integer-safe centimes→MAD
+              method: "online",
+              status: PAYMENT_STATUS.COMPLETED,
+              reference: session.id,
+              payment_type: "full",
             },
             { onConflict: "reference" },
           );
@@ -194,7 +231,9 @@ export async function POST(request: NextRequest) {
             .maybeSingle();
 
           if (existingFailed) {
-            logger.info(`Stripe failed payment event already processed: ${intent.id}`, { context: "payments/webhook" });
+            logger.info(`Stripe failed payment event already processed: ${intent.id}`, {
+              context: "payments/webhook",
+            });
             break;
           }
 
@@ -227,7 +266,7 @@ export async function POST(request: NextRequest) {
       }
 
       default:
-        // Unhandled event type — acknowledged without processing
+      // Unhandled event type — acknowledged without processing
     }
 
     return apiSuccess({ received: true });

--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -1,5 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { rateLimitRules, extractClientIp, globalPageLimiter } from "@/lib/rate-limit";
+import {
+  rateLimitRules,
+  extractClientIp,
+  globalPageLimiter,
+  perClinicLimiter,
+} from "@/lib/rate-limit";
 import type { CspHeaderValues } from "./security-headers";
 
 /**
@@ -62,7 +67,10 @@ export async function applyRateLimit(
         rateLimitInfo: { limit: rule.max, remaining: 0, reset },
       };
     }
-  } else if (!pathname.startsWith("/_next/") && !pathname.match(/\.(ico|png|jpg|jpeg|svg|css|js|woff2?|ttf|eot)$/i)) {
+  } else if (
+    !pathname.startsWith("/_next/") &&
+    !pathname.match(/\.(ico|png|jpg|jpeg|svg|css|js|woff2?|ttf|eot)$/i)
+  ) {
     // A36.4: Apply a dedicated global rate limiter for non-API paths (HTML
     // pages, etc.) to prevent subdomain-enumeration DDoS attacks.
     // Previously this depended on a lookup against the /api/ catch-all rule
@@ -73,6 +81,28 @@ export async function applyRateLimit(
       const response = withSecurityHeaders(
         NextResponse.json(
           { error: "Too many requests. Please try again later.", code: "RATE_LIMIT_EXCEEDED" },
+          { status: 429 },
+        ),
+        csp,
+      );
+      response.headers.set("Retry-After", "60");
+      return { response };
+    }
+  }
+
+  // A39-04: Per-clinic global rate cap. Keyed by subdomain (tenant) so a
+  // single clinic cannot accumulate unlimited API traffic across sessions.
+  // Uses hostname as the clinic key since clinic_id isn't resolved yet at
+  // the rate-limiting stage.
+  if (pathname.startsWith("/api/") && hostname) {
+    const clinicAllowed = await perClinicLimiter.check(`clinic:${hostname}`);
+    if (!clinicAllowed) {
+      const response = withSecurityHeaders(
+        NextResponse.json(
+          {
+            error: "Clinic rate limit exceeded. Please try again later.",
+            code: "CLINIC_RATE_LIMIT_EXCEEDED",
+          },
           { status: 429 },
         ),
         csp,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -75,9 +75,12 @@ export function extractClientIp(request: NextRequest): string {
     const first = xff.split(",")[0]?.trim();
     if (first && isPlausibleIp(first)) {
       if (isProduction) {
-        logger.warn("Rate limiter fell back to X-Forwarded-For (CF-Connecting-IP absent in production)", {
-          context: "rate-limit",
-        });
+        logger.warn(
+          "Rate limiter fell back to X-Forwarded-For (CF-Connecting-IP absent in production)",
+          {
+            context: "rate-limit",
+          },
+        );
       }
       return first;
     }
@@ -197,7 +200,7 @@ function recordFailure(state: CircuitBreakerState, options: RateLimiterOptions):
       state.fallback = createMemoryRateLimiter(options);
     }
     logger.warn(
-      `Rate limiter circuit breaker tripped after ${state.consecutiveFailures} failures — ${state.failClosed ? 'failing closed' : 'falling back to in-memory limiter'}`,
+      `Rate limiter circuit breaker tripped after ${state.consecutiveFailures} failures — ${state.failClosed ? "failing closed" : "falling back to in-memory limiter"}`,
       { context: "rate-limit" },
     );
   }
@@ -270,13 +273,12 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
         // If the RPC doesn't exist, fall back to the non-atomic approach
         // with a single upsert that's still better than separate SELECT+UPDATE.
         const resetAt = now + windowMs;
-        const { data: rpcResult, error: rpcError } = await supabase
-          .rpc("rate_limit_increment", {
-            p_key: key,
-            p_window_start: windowStart,
-            p_reset_at: resetAt,
-            p_now: new Date(now).toISOString(),
-          });
+        const { data: rpcResult, error: rpcError } = await supabase.rpc("rate_limit_increment", {
+          p_key: key,
+          p_window_start: windowStart,
+          p_reset_at: resetAt,
+          p_now: new Date(now).toISOString(),
+        });
 
         if (!rpcError && rpcResult != null) {
           // RPC succeeded — rpcResult is the new count
@@ -288,7 +290,10 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
         // This is still susceptible to a narrow race window but is
         // better than the original SELECT → UPDATE pattern.
         if (rpcError) {
-          logger.warn("Rate limiter RPC unavailable, falling back to upsert", { context: "rate-limit", error: rpcError });
+          logger.warn("Rate limiter RPC unavailable, falling back to upsert", {
+            context: "rate-limit",
+            error: rpcError,
+          });
         }
 
         const { data, error } = await supabase
@@ -318,7 +323,10 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
             );
 
           if (upsertError) {
-            logger.error("Rate limiter upsert failed", { context: "rate-limit", error: upsertError });
+            logger.error("Rate limiter upsert failed", {
+              context: "rate-limit",
+              error: upsertError,
+            });
             recordFailure(circuitBreaker, options);
             reportRateLimitBackendError("upsert", upsertError);
             if (circuitBreaker.failClosed) return false;
@@ -401,7 +409,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
   // endpoints (public reads) should explicitly set failClosed: false.
   const { windowMs, max, failClosed = true } = options;
   const circuitBreaker = createCircuitBreaker(failClosed);
-  
+
   // KV-backed limiters have a configured grace period before they fail-closed
   const getKvGraceMs = () => {
     const raw = process.env.RATE_LIMIT_KV_GRACE_MS;
@@ -422,7 +430,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
           logger.error("Rate limiter KV grace period expired, failing closed", {
             context: "rate-limit",
             key,
-            elapsedMs: elapsed
+            elapsedMs: elapsed,
           });
           return false; // Fail closed after grace period
         }
@@ -440,7 +448,9 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
 
         if (!kv) {
           // KV binding not available, fall back to memory
-          logger.warn("Rate limiter KV binding not available, falling back to in-memory", { context: "rate-limit" });
+          logger.warn("Rate limiter KV binding not available, falling back to in-memory", {
+            context: "rate-limit",
+          });
           recordFailure(circuitBreaker, options);
           if (circuitBreaker.failClosed) return false;
           const elapsed = Date.now() - (circuitBreaker.lastFailure || 0);
@@ -523,7 +533,7 @@ function createMemoryRateLimiter(options: RateLimiterOptions): RateLimiter {
         if (process.env.NODE_ENV !== "test") {
           logger.warn(
             "In-memory rate limiter active — counters are not shared across isolates and will reset on cold starts. " +
-            "Configure RATE_LIMIT_BACKEND=kv or RATE_LIMIT_BACKEND=supabase for production use.",
+              "Configure RATE_LIMIT_BACKEND=kv or RATE_LIMIT_BACKEND=supabase for production use.",
             { context: "rate-limit" },
           );
         }
@@ -568,9 +578,9 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
   if (process.env.NODE_ENV !== "test") {
     logger.warn(
       "Rate limiter falling back to in-memory backend. " +
-      "This is unsuitable for production serverless deployments — " +
-      "counters reset on cold starts and are not shared across isolates. " +
-      "Set RATE_LIMIT_BACKEND=kv or configure NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.",
+        "This is unsuitable for production serverless deployments — " +
+        "counters reset on cold starts and are not shared across isolates. " +
+        "Set RATE_LIMIT_BACKEND=kv or configure NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.",
       { context: "rate-limit" },
     );
   }
@@ -752,6 +762,25 @@ export const globalPageLimiter = createRateLimiter({
   max: 120,
 });
 
+/**
+ * S0-11-02: CSP report endpoint — 60 req / 60s per IP.
+ * Matches the route-local limiter for defense-in-depth via middleware.
+ */
+export const cspReportLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 60,
+});
+
+/**
+ * A39-04: Per-clinic global rate cap — 10 000 req / 60s per clinic_id.
+ * Prevents a malicious clinic admin from accumulating API calls across
+ * multiple authenticated sessions. Keyed by clinic_id, not IP.
+ */
+export const perClinicLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 10_000,
+});
+
 export interface RateLimitRule {
   /** URL prefix to match */
   prefix: string;
@@ -776,18 +805,50 @@ export const rateLimitRules: RateLimitRule[] = [
   // RL-01: Public check-in kiosk endpoints
   { prefix: "/api/checkin", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
   // RL-01: Password reset — strict limit to prevent email spam
-  { prefix: "/api/patient/delete-account", limiter: passwordResetLimiter, windowMs: 60_000, max: 3 },
-  { prefix: "/api/booking/waiting-list", limiter: waitingListLimiter, windowMs: 60 * 60_000, max: 3 },
+  {
+    prefix: "/api/patient/delete-account",
+    limiter: passwordResetLimiter,
+    windowMs: 60_000,
+    max: 3,
+  },
+  {
+    prefix: "/api/booking/waiting-list",
+    limiter: waitingListLimiter,
+    windowMs: 60 * 60_000,
+    max: 3,
+  },
   { prefix: "/api/book", limiter: bookingLimiter, windowMs: 60_000, max: 10 },
   { prefix: "/api/verify-email", limiter: emailVerificationLimiter, windowMs: 60_000, max: 5 },
   { prefix: "/api/upload", limiter: uploadLimiter, windowMs: 60_000, max: 10 },
   { prefix: "/api/onboarding", limiter: onboardingLimiter, windowMs: 60_000, max: 5 },
-  { prefix: "/api/v1/ai/patient-summary", limiter: aiPatientSummaryLimiter, windowMs: 24 * 60 * 60_000, max: 30 },
-  { prefix: "/api/v1/ai/drug-check", limiter: aiDrugCheckLimiter, windowMs: 24 * 60 * 60_000, max: 100 },
-  { prefix: "/api/v1/ai/prescription", limiter: aiPrescriptionLimiter, windowMs: 24 * 60 * 60_000, max: 50 },
+  {
+    prefix: "/api/v1/ai/patient-summary",
+    limiter: aiPatientSummaryLimiter,
+    windowMs: 24 * 60 * 60_000,
+    max: 30,
+  },
+  {
+    prefix: "/api/v1/ai/drug-check",
+    limiter: aiDrugCheckLimiter,
+    windowMs: 24 * 60 * 60_000,
+    max: 100,
+  },
+  {
+    prefix: "/api/v1/ai/prescription",
+    limiter: aiPrescriptionLimiter,
+    windowMs: 24 * 60 * 60_000,
+    max: 50,
+  },
   { prefix: "/api/ai/manager", limiter: aiManagerLimiter, windowMs: 24 * 60 * 60_000, max: 30 },
-  { prefix: "/api/ai/auto-suggest", limiter: aiAutoSuggestLimiter, windowMs: 24 * 60 * 60_000, max: 100 },
+  {
+    prefix: "/api/ai/auto-suggest",
+    limiter: aiAutoSuggestLimiter,
+    windowMs: 24 * 60 * 60_000,
+    max: 100,
+  },
   { prefix: "/api/chat", limiter: chatLimiter, windowMs: 60_000, max: 15 },
+  // S0-11-02: CSP report — defense-in-depth alongside route-local limiter
+  { prefix: "/api/csp-report", limiter: cspReportLimiter, windowMs: 60_000, max: 60 },
   { prefix: "/api/webhooks", limiter: webhookLimiter, windowMs: 60_000, max: 100 },
   { prefix: "/api/branding", limiter: brandingLimiter, windowMs: 60_000, max: 20 },
   { prefix: "/api/notifications", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },


### PR DESCRIPTION
## Summary

- **S0-11-02**: Add `cspReportLimiter` (60 req/60s per IP) to middleware `rateLimitRules` — defense-in-depth alongside route-local limiter.
- **A39-04**: Add `perClinicLimiter` (10k req/60s per subdomain) — prevents malicious clinic admin from accumulating unlimited API traffic.
- **S0-11-05**: Replace Content-Length-only body cap in Stripe webhook with streaming `readBodyWithLimit` (same pattern as CMI callback). Prevents chunked TE bypass.

## Review & Testing Checklist for Human

- [ ] Verify Stripe webhook still processes payments correctly
- [ ] Test CSP report endpoint still returns 204 under normal usage
- [ ] Monitor per-clinic rate limit to ensure 10k/min threshold is appropriate for largest clinic

### Notes
- CSP report has both route-local and middleware rate limiters for defense-in-depth
- Per-clinic limiter uses hostname as key since clinic_id is not resolved at rate-limit stage