### PR TITLE
fix(security): LOW — Slack URL validation + PHI Cache-Control + Semgrep packs (S0-02-04, A53-02, A9-03)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22.13"
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -285,7 +285,7 @@ jobs:
       - name: Run Semgrep
         run: |
           python3 -m pip install --upgrade semgrep
-          semgrep --config p/javascript --config .semgrep/ --sarif --output semgrep.sarif .
+          semgrep --config p/javascript --config p/owasp-top-ten --config p/secrets --config .semgrep/ --sarif --output semgrep.sarif .
 
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -38,7 +38,12 @@ const registerLimiter = createRateLimiter({ windowMs: 60 * 60 * 1000, max: 2, fa
 // ---------------------------------------------------------------------------
 // Slack webhook for registration alerts (R-12 fix)
 // ---------------------------------------------------------------------------
-const SLACK_WEBHOOK_URL = process.env.SLACK_REGISTRATION_ALERTS_WEBHOOK_URL;
+// S0-02-04: Validate Slack webhook URL to prevent SSRF via operator mis-paste.
+const _rawSlackUrl = process.env.SLACK_REGISTRATION_ALERTS_WEBHOOK_URL;
+const SLACK_WEBHOOK_URL =
+  _rawSlackUrl && /^https:\/\/hooks\.slack\.com\/services\//.test(_rawSlackUrl)
+    ? _rawSlackUrl
+    : undefined;
 
 /**
  * Send an alert to Slack when a new clinic registers.
@@ -170,44 +175,42 @@ async function verifyDnsTxtRecord(hostname: string, token: string): Promise<bool
 // bytes before length checks, so attackers cannot register two visually
 // identical clinics using composed-vs-decomposed Unicode and cannot smuggle
 // `\u0000` past downstream consumers.
-const registerClinicSchema = z.object({
-  clinic_name: z
-    .string()
-    .transform(normalizeText)
-    .pipe(z.string().min(2, "Le nom de la clinique est requis").max(200)),
-  doctor_name: z
-    .string()
-    .transform(normalizeText)
-    .pipe(z.string().min(2, "Le nom du docteur est requis").max(200)),
-  email: z.string().email("Email invalide").max(254),
-  phone: z.string().min(8, "Numéro de téléphone invalide").max(30),
-  specialty: z
-    .string()
-    .transform(normalizeText)
-    .pipe(z.string().min(1, "La spécialité est requise").max(200)),
-  city: z
-    .string()
-    .transform(normalizeText)
-    .pipe(z.string().max(200))
-    .optional(),
-  // F-28: Cloudflare Turnstile token for bot protection
-  turnstile_token: z.string().min(1, "Turnstile verification required").optional(),
-  // R-12: Identity verification
-  // Option 1: DNS TXT record verification.
-  // The token is NOT supplied by the client — the server derives it from
-  // (email, website_domain) so attackers cannot self-verify by supplying
-  // their own token alongside their own domain. Clients must first call
-  // POST /api/v1/register-clinic/verification-token to fetch the token,
-  // then publish it as a TXT record before calling this endpoint.
-  // Accepts either a full URL (`https://myclinic.ma`) or a bare hostname
-  // (`myclinic.ma`); both are normalized via normalizeDomain() before use,
-  // and the verification-token endpoint accepts the same shapes so the
-  // value the user supplies to both endpoints is identical.
-  website_domain: z.string().min(1, "Domain is required").max(255).optional(),
-  // Option 2: Phone OTP from pre-listed registry
-  phone_otp: z.string().optional(),
-  phone_otp_id: z.string().optional(),
-}).strict();
+const registerClinicSchema = z
+  .object({
+    clinic_name: z
+      .string()
+      .transform(normalizeText)
+      .pipe(z.string().min(2, "Le nom de la clinique est requis").max(200)),
+    doctor_name: z
+      .string()
+      .transform(normalizeText)
+      .pipe(z.string().min(2, "Le nom du docteur est requis").max(200)),
+    email: z.string().email("Email invalide").max(254),
+    phone: z.string().min(8, "Numéro de téléphone invalide").max(30),
+    specialty: z
+      .string()
+      .transform(normalizeText)
+      .pipe(z.string().min(1, "La spécialité est requise").max(200)),
+    city: z.string().transform(normalizeText).pipe(z.string().max(200)).optional(),
+    // F-28: Cloudflare Turnstile token for bot protection
+    turnstile_token: z.string().min(1, "Turnstile verification required").optional(),
+    // R-12: Identity verification
+    // Option 1: DNS TXT record verification.
+    // The token is NOT supplied by the client — the server derives it from
+    // (email, website_domain) so attackers cannot self-verify by supplying
+    // their own token alongside their own domain. Clients must first call
+    // POST /api/v1/register-clinic/verification-token to fetch the token,
+    // then publish it as a TXT record before calling this endpoint.
+    // Accepts either a full URL (`https://myclinic.ma`) or a bare hostname
+    // (`myclinic.ma`); both are normalized via normalizeDomain() before use,
+    // and the verification-token endpoint accepts the same shapes so the
+    // value the user supplies to both endpoints is identical.
+    website_domain: z.string().min(1, "Domain is required").max(255).optional(),
+    // Option 2: Phone OTP from pre-listed registry
+    phone_otp: z.string().optional(),
+    phone_otp_id: z.string().optional(),
+  })
+  .strict();
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -223,7 +226,10 @@ export async function POST(request: NextRequest) {
   // Rate limiting (IP-based)
   const clientIp = extractClientIp(request);
   if (!(await registerLimiter.check(`register_${clientIp}`))) {
-    logger.warn("Public registration rate-limit exceeded", { context: "register-clinic", ip: clientIp });
+    logger.warn("Public registration rate-limit exceeded", {
+      context: "register-clinic",
+      ip: clientIp,
+    });
     return apiError("Too many registration attempts. Please try again later.", 429);
   }
 
@@ -296,8 +302,8 @@ export async function POST(request: NextRequest) {
   else {
     return apiError(
       "Identity verification is required. Please provide one of:\n" +
-      "- DNS TXT record on your website domain (set website_domain — token is issued via /api/v1/register-clinic/verification-token)\n" +
-      "- Phone OTP from pre-listed registry (coming soon)",
+        "- DNS TXT record on your website domain (set website_domain — token is issued via /api/v1/register-clinic/verification-token)\n" +
+        "- Phone OTP from pre-listed registry (coming soon)",
       400,
       "VERIFICATION_REQUIRED",
     );
@@ -310,19 +316,16 @@ export async function POST(request: NextRequest) {
       return apiError("Turnstile verification is required", 400);
     }
     try {
-      const verifyRes = await fetch(
-        "https://challenges.cloudflare.com/turnstile/v0/siteverify",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: new URLSearchParams({
-            secret: turnstileSecret,
-            response: data.turnstile_token,
-            remoteip: clientIp,
-          }),
-          signal: AbortSignal.timeout(5_000),
-        },
-      );
+      const verifyRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          secret: turnstileSecret,
+          response: data.turnstile_token,
+          remoteip: clientIp,
+        }),
+        signal: AbortSignal.timeout(5_000),
+      });
       const verifyData = (await verifyRes.json()) as { success: boolean };
       if (!verifyData.success) {
         logger.warn("Turnstile verification failed", {
@@ -408,7 +411,7 @@ export async function POST(request: NextRequest) {
         p_city: string | null;
         p_specialty: string;
         p_auth_id: string;
-      }
+      },
     ) => ReturnType<typeof supabase.rpc>;
 
     const { data: clinicId, error: rpcError } = await rpc("register_new_clinic", {
@@ -437,7 +440,7 @@ export async function POST(request: NextRequest) {
       user_metadata: {
         full_name: data.doctor_name,
         clinic_id: clinicId,
-      }
+      },
     });
 
     // MEDIUM-10: Self-service clinics require manual review before activation.

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -29,8 +29,8 @@ import type { Database } from "@/lib/types/database";
 // Lightweight in-memory sliding window per authenticated user ID.
 // Supplements the per-IP middleware limits to catch authenticated abuse.
 const USER_RATE_WINDOW_MS = 60_000; // 1 minute
-const USER_RATE_MAX = 100;          // max requests per window per user
-const USER_RATE_MAX_KEYS = 10_000;  // prevent unbounded memory growth
+const USER_RATE_MAX = 100; // max requests per window per user
+const USER_RATE_MAX_KEYS = 10_000; // prevent unbounded memory growth
 
 interface UserRateEntry {
   count: number;
@@ -91,10 +91,7 @@ export interface AuthContext {
   profile: { id: string; role: UserRole; clinic_id: string | null };
 }
 
-type AuthenticatedHandler = (
-  request: NextRequest,
-  auth: AuthContext,
-) => Promise<NextResponse>;
+type AuthenticatedHandler = (request: NextRequest, auth: AuthContext) => Promise<NextResponse>;
 
 /**
  * Options for the `withAuth` / `withAuthAnyRole` wrappers.
@@ -140,10 +137,7 @@ export function withAuth(
       } = await supabase.auth.getUser();
 
       if (!user) {
-        return NextResponse.json(
-          { error: "Not authenticated" },
-          { status: 401 },
-        );
+        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
       }
 
       // Check for signed profile headers from middleware to avoid double-querying (Audit P1 #8).
@@ -164,10 +158,13 @@ export function withAuth(
         : null;
 
       if (!profile && request.headers.get(PROFILE_HEADER_NAMES.sig)) {
-        logger.warn("Profile headers present but signature could not be verified — falling back to DB", {
-          context: "with-auth",
-          userId: user.id,
-        });
+        logger.warn(
+          "Profile headers present but signature could not be verified — falling back to DB",
+          {
+            context: "with-auth",
+            userId: user.id,
+          },
+        );
       }
 
       if (!profile) {
@@ -181,10 +178,7 @@ export function withAuth(
       }
 
       if (!profile) {
-        return NextResponse.json(
-          { error: "User profile not found" },
-          { status: 404 },
-        );
+        return NextResponse.json({ error: "User profile not found" }, { status: 404 });
       }
 
       // If specific roles are required, enforce them.
@@ -209,10 +203,7 @@ export function withAuth(
               subdomainClinicId: tenant.clinicId,
               userId: profile.id,
             });
-            return NextResponse.json(
-              { error: "Forbidden — tenant mismatch" },
-              { status: 403 },
-            );
+            return NextResponse.json({ error: "Forbidden — tenant mismatch" }, { status: 403 });
           }
         } catch (tenantErr) {
           logger.warn("Could not resolve tenant for assertion", {
@@ -241,10 +232,7 @@ export function withAuth(
             error: tenantErr,
           });
           if (!failOpen) {
-            return NextResponse.json(
-              { error: "Tenant context unavailable" },
-              { status: 503 },
-            );
+            return NextResponse.json({ error: "Tenant context unavailable" }, { status: 503 });
           }
         }
       }
@@ -272,10 +260,12 @@ export function withAuth(
       // can be downsampled to reduce volume.
       if (request.method === "GET") {
         const pathname = request.nextUrl.pathname;
-        const isPhiEndpoint = /^\/(api\/)?(patient|appointments|booking|prescriptions|consultations|medical|lab)/.test(pathname);
-        const shouldLog = process.env.NODE_ENV !== "production"
-          || isPhiEndpoint
-          || Math.random() < 0.01;
+        const isPhiEndpoint =
+          /^\/(api\/)?(patient|appointments|booking|prescriptions|consultations|medical|lab)/.test(
+            pathname,
+          );
+        const shouldLog =
+          process.env.NODE_ENV !== "production" || isPhiEndpoint || Math.random() < 0.01;
         if (shouldLog) {
           logger.info(`API Read Access: ${request.method} ${pathname}`, {
             context: "audit-read",
@@ -288,17 +278,23 @@ export function withAuth(
         }
       }
 
-      return handler(request, {
+      const response = await handler(request, {
         supabase,
         user,
-        profile: { id: profile.id, role: profile.role as UserRole, clinic_id: profile.clinic_id ?? null },
+        profile: {
+          id: profile.id,
+          role: profile.role as UserRole,
+          clinic_id: profile.clinic_id ?? null,
+        },
       });
+      // A53-02: Prevent Cloudflare / browser from caching PHI responses.
+      if (!response.headers.has("Cache-Control")) {
+        response.headers.set("Cache-Control", "private, no-store");
+      }
+      return response;
     } catch (err) {
       logger.error("Authentication failed", { context: "with-auth", error: err });
-      return NextResponse.json(
-        { error: "Authentication failed" },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Authentication failed" }, { status: 500 });
     }
   };
 }
@@ -310,10 +306,7 @@ export function withAuth(
  * Usage:
  *   export const POST = withAuthAnyRole(handler);
  */
-export function withAuthAnyRole(
-  handler: AuthenticatedHandler,
-  options: WithAuthOptions = {},
-) {
+export function withAuthAnyRole(handler: AuthenticatedHandler, options: WithAuthOptions = {}) {
   const failOpen = options.failOpen === true;
   // Pass an empty array to withAuth, then check that the user is authenticated
   // without enforcing any specific role. This is a "deny-by-default with
@@ -327,10 +320,7 @@ export function withAuthAnyRole(
       } = await supabase.auth.getUser();
 
       if (!user) {
-        return NextResponse.json(
-          { error: "Not authenticated" },
-          { status: 401 },
-        );
+        return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
       }
 
       // Check for signed profile headers from middleware
@@ -352,10 +342,13 @@ export function withAuthAnyRole(
       // with bad signatures still leave a trail. Routes migrated from
       // withAuth(handler, null) to withAuthAnyRole would otherwise lose this.
       if (!profile && request.headers.get(PROFILE_HEADER_NAMES.sig)) {
-        logger.warn("Profile headers present but signature could not be verified — falling back to DB", {
-          context: "with-auth-any-role",
-          userId: user.id,
-        });
+        logger.warn(
+          "Profile headers present but signature could not be verified — falling back to DB",
+          {
+            context: "with-auth-any-role",
+            userId: user.id,
+          },
+        );
       }
 
       if (!profile) {
@@ -368,10 +361,7 @@ export function withAuthAnyRole(
       }
 
       if (!profile) {
-        return NextResponse.json(
-          { error: "User profile not found" },
-          { status: 404 },
-        );
+        return NextResponse.json({ error: "User profile not found" }, { status: 404 });
       }
 
       // F-08: Assert the user's clinic_id matches the subdomain-resolved tenant
@@ -388,10 +378,7 @@ export function withAuthAnyRole(
               subdomainClinicId: tenant.clinicId,
               userId: profile.id,
             });
-            return NextResponse.json(
-              { error: "Forbidden — tenant mismatch" },
-              { status: 403 },
-            );
+            return NextResponse.json({ error: "Forbidden — tenant mismatch" }, { status: 403 });
           }
         } catch (tenantErr) {
           logger.warn("Could not resolve tenant for assertion", {
@@ -413,10 +400,7 @@ export function withAuthAnyRole(
             error: tenantErr,
           });
           if (!failOpen) {
-            return NextResponse.json(
-              { error: "Tenant context unavailable" },
-              { status: 503 },
-            );
+            return NextResponse.json({ error: "Tenant context unavailable" }, { status: 503 });
           }
         }
       }
@@ -426,17 +410,26 @@ export function withAuthAnyRole(
         role: profile.role,
       });
 
-      return handler(request, {
+      const response = await handler(request, {
         supabase,
         user,
-        profile: { id: profile.id, role: profile.role as UserRole, clinic_id: profile.clinic_id ?? null },
+        profile: {
+          id: profile.id,
+          role: profile.role as UserRole,
+          clinic_id: profile.clinic_id ?? null,
+        },
       });
+      // A53-02: Prevent Cloudflare / browser from caching PHI responses.
+      if (!response.headers.has("Cache-Control")) {
+        response.headers.set("Cache-Control", "private, no-store");
+      }
+      return response;
     } catch (err) {
-      logger.error("Authentication failed in withAuthAnyRole", { context: "with-auth", error: err });
-      return NextResponse.json(
-        { error: "Authentication failed" },
-        { status: 500 },
-      );
+      logger.error("Authentication failed in withAuthAnyRole", {
+        context: "with-auth",
+        error: err,
+      });
+      return NextResponse.json({ error: "Authentication failed" }, { status: 500 });
     }
   };
 }


### PR DESCRIPTION
## Summary

- **S0-02-04**: Validate `SLACK_REGISTRATION_ALERTS_WEBHOOK_URL` matches `^https://hooks.slack.com/services/` to prevent SSRF via operator mis-paste.
- **A53-02**: Add `Cache-Control: private, no-store` to all authenticated responses via `withAuth`/`withAuthAnyRole`.
- **A9-03**: Add `p/owasp-top-ten` and `p/secrets` Semgrep rule packs to CI.

## Review & Testing Checklist for Human

- [ ] Verify Slack alerts still fire for valid webhook URLs
- [ ] Check authenticated API responses now include `Cache-Control: private, no-store`
- [ ] Monitor Semgrep CI for any new findings from additional rule packs