### PR TITLE
docs(security): status page + CNDP registration + Supabase outage + PITR posture (S0-09-04, A247-02, A248-02, A74-02)

### DIFF
--- a/docs/compliance/cndp-registration.md
+++ b/docs/compliance/cndp-registration.md
@@ -1,0 +1,56 @@
+# CNDP Registration — Oltigo Health (A247-02)
+
+> **Audit finding:** A247-02 (Medium) — No documented CNDP registration ("déclaration / autorisation préalable") number visible in repo.
+
+## Status
+
+**Pending registration.** Oltigo Health processes personal health data (données à caractère personnel de santé) and must register with the CNDP under Moroccan Law 09-08 (Loi relative à la protection des personnes physiques à l'égard du traitement des données à caractère personnel).
+
+## Registration Type
+
+Healthcare platforms processing PHI require an **autorisation préalable** (prior authorization) under Article 12 of Law 09-08, not a simple déclaration, because:
+
+1. Data includes health information (Article 1, sensitive data)
+2. Processing involves automated decision-making (appointment scheduling, billing)
+3. Data may be transferred internationally (Supabase infrastructure in EU/US regions)
+
+## Registration Steps
+
+1. **Prepare the dossier:**
+   - Formulaire de demande d'autorisation (available at https://www.cndp.ma/)
+   - Description of data processing activities (see `docs/compliance/data-flow-map.md`)
+   - Data Protection Impact Assessment (see `docs/compliance/dpia.md`)
+   - Security measures documentation (see `docs/FULL_AUDIT_REPORT.md`)
+   - Data retention policy (see `docs/compliance/retention.md`)
+   - Data processing agreements with sub-processors (see `docs/compliance/dpa-template.md`)
+
+2. **Submit to CNDP:**
+   - Online: https://www.cndp.ma/
+   - Physical: Commission Nationale de Contrôle de la Protection des Données à Caractère Personnel, Rabat
+
+3. **Await receipt:**
+   - CNDP issues a registration receipt ("récépissé de dépôt") within 24 hours
+   - Final authorization is issued within 2 months (Article 15)
+
+## After Registration
+
+Once the CNDP registration number is received:
+
+1. Update this file with the registration number and date
+2. Display the registration number in the platform footer and privacy policy
+3. Add to `src/app/(public)/privacy/page.tsx`
+
+## Registration Number
+
+> **CNDP Registration #:** _Pending — submit dossier and update this field_
+>
+> **Date:** _Pending_
+>
+> **Expiry:** _N/A (no expiry for autorisations, but subject to periodic review)_
+
+## Related Documents
+
+- `docs/compliance/cndp.md` — CNDP compliance framework
+- `docs/compliance/dpia.md` — Data Protection Impact Assessment
+- `docs/compliance/data-flow-map.md` — Data flow mapping
+- `docs/compliance/retention.md` — Data retention policy

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -9,20 +9,20 @@
 
 ### 1.1 Severity Levels
 
-| Severity | Definition | Response Time | Examples |
-|----------|------------|---------------|----------|
-| **SEV-1** | Complete service outage or data loss | Immediate (< 5 min) | Database down, all APIs returning 5xx |
-| **SEV-2** | Major feature broken, > 50% users affected | < 15 min | Booking API down, authentication broken |
-| **SEV-3** | Minor feature degraded, < 50% users affected | < 1 hour | Slow responses, minor feature broken |
-| **SEV-4** | Minor issue, no user impact | < 4 hours | Logging errors, non-critical bugs |
+| Severity  | Definition                                   | Response Time       | Examples                                |
+| --------- | -------------------------------------------- | ------------------- | --------------------------------------- |
+| **SEV-1** | Complete service outage or data loss         | Immediate (< 5 min) | Database down, all APIs returning 5xx   |
+| **SEV-2** | Major feature broken, > 50% users affected   | < 15 min            | Booking API down, authentication broken |
+| **SEV-3** | Minor feature degraded, < 50% users affected | < 1 hour            | Slow responses, minor feature broken    |
+| **SEV-4** | Minor issue, no user impact                  | < 4 hours           | Logging errors, non-critical bugs       |
 
 ### 1.2 SLO Impact Classification
 
-| Impact | Condition | Severity Override |
-|--------|-----------|-------------------|
-| **Critical** | Availability SLO breached (> 4-9s downtime) | SEV-1 or SEV-2 |
-| **Major** | Latency SLO breached (p95 > target) | SEV-2 or SEV-3 |
-| **Minor** | Single error type accounting for < 1% errors | SEV-3 or SEV-4 |
+| Impact       | Condition                                    | Severity Override |
+| ------------ | -------------------------------------------- | ----------------- |
+| **Critical** | Availability SLO breached (> 4-9s downtime)  | SEV-1 or SEV-2    |
+| **Major**    | Latency SLO breached (p95 > target)          | SEV-2 or SEV-3    |
+| **Minor**    | Single error type accounting for < 1% errors | SEV-3 or SEV-4    |
 
 ---
 
@@ -31,11 +31,13 @@
 ### 2.1 Detection & Alerting
 
 Incidents are detected via:
+
 1. **Automated alerts** from Cloudflare, Sentry, or custom monitoring
 2. **User reports** via Slack `#support` or direct contact
 3. **On-call engineer observation**
 
 When an alert fires:
+
 1. Acknowledge the alert (prevents escalation)
 2. Join the incident Slack channel
 3. Begin assessment
@@ -43,12 +45,14 @@ When an alert fires:
 ### 2.2 Initial Assessment (First 5 Minutes)
 
 **For all incidents:**
+
 1. Identify affected services and scope
 2. Check current error rates vs. SLO baseline
 3. Verify monitoring dashboards are showing correct data
 4. Identify any recent deployments or config changes
 
 **SEV-1 specific:**
+
 1. Immediately page additional responders if needed
 2. Consider enabling maintenance mode to prevent data corruption
 3. Begin impact assessment: How many users affected?
@@ -56,25 +60,28 @@ When an alert fires:
 ### 2.3 Incident Commander Role
 
 For SEV-1 and SEV-2:
+
 - **IC (Incident Commander)**: Coordinates response, makes decisions, delegates
 - **Comms**: Communicates status to stakeholders
 - **Tech Lead**: Leads technical investigation and remediation
 
 For SEV-3 and SEV-4:
+
 - Single engineer can lead (may still designate IC for complex incidents)
 
 ### 2.4 Communication Cadence
 
-| Severity | Status Updates | Stakeholder Updates |
-|----------|---------------|---------------------|
-| SEV-1 | Every 15 minutes | Every 30 minutes |
-| SEV-2 | Every 30 minutes | Every 1 hour |
-| SEV-3 | Hourly | End of incident |
-| SEV-4 | End of incident | End of incident |
+| Severity | Status Updates   | Stakeholder Updates |
+| -------- | ---------------- | ------------------- |
+| SEV-1    | Every 15 minutes | Every 30 minutes    |
+| SEV-2    | Every 30 minutes | Every 1 hour        |
+| SEV-3    | Hourly           | End of incident     |
+| SEV-4    | End of incident  | End of incident     |
 
 ### 2.5 Resolution & Closure
 
 When service is restored:
+
 1. Verify metrics are back to normal (wait 5-10 minutes)
 2. Document root cause in incident channel
 3. Schedule post-mortem meeting (within 48 hours)
@@ -87,44 +94,96 @@ When service is restored:
 ### 3.1 Supabase Down
 
 **Symptoms:**
+
 - All API requests returning 500/503
 - Database connection errors in logs
 - Slow query times or timeouts
 
 **Assessment:**
+
 1. Check Supabase Status (status.supabase.com)
 2. Check Supabase Dashboard for active incidents
 3. Check database connection pool exhaustion
 
 **Mitigation:**
+
 1. Enable maintenance mode to prevent partial writes
 2. If connection pool exhausted: restart API workers to reset connections
 3. Monitor for automatic Supabase recovery
 4. If > 15 minutes, escalate to Supabase support
 
 **Recovery:**
+
 1. Wait for Supabase to restore service
 2. Verify RLS policies intact
 3. Run post-incident health check
 
+### 3.1.1 Supabase Region Outage — Vendor-Exit Playbook (A248-02)
+
+**Scenario:** Supabase's primary region (eu-central-1) is unavailable for >4 hours, or Supabase announces extended downtime.
+
+**Assessment:**
+
+1. Confirm scope: region outage vs global outage vs project-level issue
+2. Check Supabase status page (status.supabase.com) for ETA
+3. Evaluate if failover is warranted (>4h outage or no ETA)
+
+**Failover Options (in order of preference):**
+
+1. **Supabase read replica (if Pro plan PITR enabled):**
+   - Promote read replica to primary via Supabase Dashboard
+   - Update `SUPABASE_URL` and `SUPABASE_ANON_KEY` in Cloudflare Workers env
+   - Re-deploy via `wrangler deploy`
+   - Caveat: Read replica may have up to 1 minute of replication lag
+
+2. **Neon PostgreSQL (cold standby):**
+   - Restore from latest nightly R2 backup (see `docs/bcp.md`)
+   - Create Neon project, import backup
+   - Update connection strings in Workers env
+   - Caveat: RLS policies and auth.users must be manually verified
+
+3. **Self-hosted PostgreSQL:**
+   - Provision a Hetzner/OVH VPS in EU
+   - Restore from R2 backup
+   - Update connection strings
+   - Caveat: No Supabase Auth — must use JWT verification only
+
+**Recovery (after Supabase restores):**
+
+1. Compare data between failover and primary: identify any writes during outage
+2. Merge/reconcile conflicts manually
+3. Switch connection strings back to Supabase
+4. Re-deploy and verify RLS policies
+
+**RPO/RTO Posture (A74-02):**
+
+- **Current RPO:** 24 hours (nightly R2 backup)
+- **With Supabase Pro PITR:** ~1 minute (continuous WAL archiving)
+- **Target RTO:** 1 hour for read-only mode, 4 hours for full read-write failover
+- **Recommendation:** Enable Supabase Pro PITR to reduce RPO from 24h to ~1min
+
 ### 3.2 R2 Down
 
 **Symptoms:**
+
 - File upload failures (500 on upload API)
 - Missing images on clinic pages
 - Error logs showing R2/S3 errors
 
 **Assessment:**
+
 1. Check Cloudflare R2 status
 2. Verify R2 credentials are valid
 3. Check for R2 bucket policy issues
 
 **Mitigation:**
+
 1. If uploads failing: enable maintenance mode for file uploads
 2. If downloads failing: show placeholder images
 3. Check if issue is specific to one bucket or all
 
 **Recovery:**
+
 1. Wait for R2 to recover
 2. If credentials issue: rotate credentials
 3. Verify uploaded files are accessible
@@ -132,21 +191,25 @@ When service is restored:
 ### 3.3 Cloudflare Incident
 
 **Symptoms:**
+
 - All requests failing (DNS issues)
 - Intermittent 5xx errors
 - Slow response times globally
 
 **Assessment:**
+
 1. Check Cloudflare Status (cloudflare.status.com)
 2. Check for widespread issues vs. account-specific
 3. Verify DNS is resolving correctly
 
 **Mitigation:**
+
 1. If account-level: point directly to Supabase/S3 origins temporarily
 2. If global outage: wait for Cloudflare to restore
 3. Consider enabling "Under Attack" mode if DDoS suspected
 
 **Recovery:**
+
 1. Verify Cloudflare cache is repopulating
 2. Check for any residual issues
 3. Update status page
@@ -154,21 +217,25 @@ When service is restored:
 ### 3.4 Stripe Webhook Backlog
 
 **Symptoms:**
+
 - Stripe webhook delivery failures
 - Payment status not updating
 - Refund/ subscription issues
 
 **Assessment:**
+
 1. Check Stripe Dashboard for webhook failures
 2. Check application logs for Stripe errors
 3. Verify Stripe API is accessible
 
 **Mitigation:**
+
 1. Check for code issues causing webhook processing failures
 2. If processing is failing, fix the root cause
 3. Use Stripe dashboard to retry failed webhooks
 
 **Recovery:**
+
 1. Process backlog via Stripe dashboard "Retry" feature
 2. Verify payment status is correct in database
 3. Manually reconcile if needed
@@ -176,21 +243,25 @@ When service is restored:
 ### 3.5 KV Down
 
 **Symptoms:**
+
 - Rate limiting not working
 - Feature flags not updating
 - Inconsistent state across requests
 
 **Assessment:**
+
 1. Check Cloudflare KV status
 2. Verify KV binding is correct
 3. Check for quota exhaustion
 
 **Mitigation:**
+
 1. Fall back to Supabase-based rate limiting
 2. Use default feature flags (defined in code)
 3. Monitor for quota issues
 
 **Recovery:**
+
 1. Wait for KV to recover
 2. Verify rate limiting is working again
 3. Consider increasing KV quota if exhausted
@@ -198,21 +269,25 @@ When service is restored:
 ### 3.6 Meta API Outage (WhatsApp)
 
 **Symptoms:**
+
 - WhatsApp messages not sending
 - Meta API errors in logs
 - Message queue backup
 
 **Assessment:**
+
 1. Check Meta for Business status
 2. Check WhatsApp API status
 3. Verify API credentials are valid
 
 **Mitigation:**
+
 1. Switch to email as fallback notification
 2. Queue messages for later delivery
 3. Enable offline mode for notifications
 
 **Recovery:**
+
 1. Monitor Meta API recovery
 2. Process queued messages
 3. Verify message delivery
@@ -220,21 +295,25 @@ When service is restored:
 ### 3.7 OpenAI Outage
 
 **Symptoms:**
+
 - AI features not working
 - OpenAI API errors
 - Timeout errors from AI endpoints
 
 **Assessment:**
+
 1. Check OpenAI Status (status.openai.com)
 2. Verify API key is valid
 3. Check rate limit status
 
 **Mitigation:**
+
 1. Use fallback responses for non-critical AI features
 2. Disable AI features if critical path
 3. Display user-friendly error messages
 
 **Recovery:**
+
 1. Monitor OpenAI recovery
 2. Re-enable features gradually
 3. Process any queued requests
@@ -242,21 +321,25 @@ When service is restored:
 ### 3.8 Audit Log Gap Detected
 
 **Symptoms:**
+
 - Missing entries in audit_logs table
 - Gap in sequential IDs
 - Suspicious activity not logged
 
 **Assessment:**
+
 1. Identify time range of gap
 2. Check for errors in audit-log writing
 3. Verify database is not in degraded state
 
 **Mitigation:**
+
 1. Enable additional logging to capture details
 2. Identify affected records manually
 3. Preserve current state for investigation
 
 **Recovery:**
+
 1. Document gap and reason
 2. Implement fix to prevent future gaps
 3. If data integrity compromised, notify compliance team
@@ -286,29 +369,36 @@ For SEV-1 and SEV-2 incidents, conduct a post-mortem within 48 hours:
 **Affected Users:** X%
 
 ## Summary
+
 [Brief description of incident]
 
 ## Timeline
+
 - HH:MM - Event
 - HH:MM - Event
 
 ## Root Cause
+
 [What caused the incident]
 
 ## Impact
+
 - Users affected: X
 - Revenue impact: $X (if applicable)
 - SLO impact: X minutes over budget
 
 ## What Went Well
+
 - [List]
 
 ## What Could Be Improved
+
 - [List]
 
 ## Action Items
-| Item | Owner | Due Date |
-|------|-------|----------|
+
+| Item   | Owner    | Due Date   |
+| ------ | -------- | ---------- |
 | [Task] | [Person] | YYYY-MM-DD |
 ```
 
@@ -316,12 +406,12 @@ For SEV-1 and SEV-2 incidents, conduct a post-mortem within 48 hours:
 
 ## 5. Escalation Contacts
 
-| Service | Primary Contact | Escalation |
-|---------|-----------------|------------|
-| Supabase | Cloud support | enterprise@supabase.com |
-| Cloudflare | Enterprise support | cf-support@oltigo.com |
-| Stripe | merchant support | support@stripe.com |
-| Meta/WhatsApp | Business support | businesssupport@meta.com |
+| Service       | Primary Contact    | Escalation               |
+| ------------- | ------------------ | ------------------------ |
+| Supabase      | Cloud support      | enterprise@supabase.com  |
+| Cloudflare    | Enterprise support | cf-support@oltigo.com    |
+| Stripe        | merchant support   | support@stripe.com       |
+| Meta/WhatsApp | Business support   | businesssupport@meta.com |
 
 ---
 

--- a/docs/status-page.md
+++ b/docs/status-page.md
@@ -1,0 +1,54 @@
+# Status Page — Oltigo Health (S0-09-04)
+
+> **Audit finding:** S0-09-04 (Low) — No public-facing status page tracked in repo.
+
+## Proposed Architecture
+
+**Domain:** `status.oltigo.com`
+
+### Option A: Cloudflare-native (Recommended)
+
+Use **Cloudflare Pages** with a static status dashboard:
+
+1. Create a Cloudflare Pages project at `status.oltigo.com`
+2. Deploy a minimal static HTML/React app that polls health endpoints
+3. Integrate with Cloudflare Notifications for uptime monitoring
+
+### Option B: Third-party (Betteruptime / Instatus / Statuspage)
+
+Use a managed status page provider:
+
+- **Betteruptime** (free tier: 5 monitors, public status page)
+- **Instatus** (free tier: unlimited subscribers, custom domain)
+- **Atlassian Statuspage** (paid, industry standard)
+
+## Health Endpoints to Monitor
+
+| Endpoint                                      | Method | Expected | Description         |
+| --------------------------------------------- | ------ | -------- | ------------------- |
+| `https://oltigo.com/api/health`               | GET    | 200      | Application health  |
+| `https://oltigo.com/api/booking/availability` | GET    | 200      | Booking service     |
+| `https://oltigo.com`                          | GET    | 200      | Public landing page |
+
+## Incident Communication SLA
+
+| Severity               | Initial Update | Follow-up Cadence | Post-mortem     |
+| ---------------------- | -------------- | ----------------- | --------------- |
+| SEV-1 (Full outage)    | 5 min          | Every 15 min      | Within 48 hours |
+| SEV-2 (Partial outage) | 15 min         | Every 30 min      | Within 1 week   |
+| SEV-3 (Degraded)       | 30 min         | Every 1 hour      | Optional        |
+
+## Integration with IR Process
+
+1. When an incident is declared (see `docs/incident-response.md`), update the status page
+2. Post incident updates at the cadence above
+3. Mark resolved when recovery is confirmed
+4. Link post-mortem from the incident timeline
+
+## Action Items
+
+- [ ] Choose status page provider (Option A or B)
+- [ ] Configure `status.oltigo.com` DNS CNAME
+- [ ] Set up health check monitors
+- [ ] Add status page link to application footer
+- [ ] Document in `docs/incident-response.md` Section 2.4


### PR DESCRIPTION
## Summary

- **S0-09-04**: Add `docs/status-page.md` with architecture options, health endpoints, and incident communication SLA.
- **A247-02**: Add `docs/compliance/cndp-registration.md` with autorisation préalable steps and registration template.
- **A248-02**: Add §3.1.1 Supabase region outage vendor-exit playbook (3 failover tiers).
- **A74-02**: Document RPO/RTO posture and PITR recommendation.

## Operator Action Required

- Choose status page provider and configure `status.oltigo.com`
- Submit CNDP registration dossier and update `cndp-registration.md` with receipt
- Consider enabling Supabase Pro PITR to reduce RPO from 24h to ~1min