### PR TITLE
fix(audit): ETAP3 quick-wins — CI gates, cron Sentry, dedup purge, sanctions BY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,19 @@ jobs:
             exit 1
           fi
 
+      # H-02: Reject migrations that use the broken `app.clinic_id` session
+      # variable pattern instead of the canonical `get_request_clinic_id()`
+      # or `get_user_clinic_id()` helpers. Two migrations (00083, 00084)
+      # shipped this bug silently — this gate prevents recurrence.
+      - name: Guard RLS migration pattern
+        run: |
+          HITS=$(grep -rl "current_setting('app\.clinic_id'" supabase/migrations/ 2>/dev/null || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::Broken RLS pattern 'app.clinic_id' found in migrations (use get_request_clinic_id() or get_user_clinic_id()):"
+            echo "$HITS"
+            exit 1
+          fi
+
       # CI-01: Check for pending DB migrations. Fails if migration files
       # have been added but the migration-check workflow hasn't verified them.
       - name: Migration file check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,10 @@ jobs:
       # shipped this bug silently — this gate prevents recurrence.
       - name: Guard RLS migration pattern
         run: |
-          HITS=$(grep -rl "current_setting('app\.clinic_id'" supabase/migrations/ 2>/dev/null || true)
+          # Exclude legacy migrations 00083/00084 that already shipped with
+          # the broken pattern and cannot be retroactively changed.
+          HITS=$(grep -rl "current_setting('app\.clinic_id'" supabase/migrations/ 2>/dev/null \
+            | grep -v -E '00083_|00084_' || true)
           if [ -n "$HITS" ]; then
             echo "::error::Broken RLS pattern 'app.clinic_id' found in migrations (use get_request_clinic_id() or get_user_clinic_id()):"
             echo "$HITS"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,15 +93,18 @@ jobs:
           echo "SUPABASE_LOCAL_ANON_KEY=$(supabase status --output json | jq -r '.ANON_KEY')" >> "$GITHUB_ENV"
           echo "SUPABASE_LOCAL_SERVICE_ROLE_KEY=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY')" >> "$GITHUB_ENV"
 
-      # MEDIUM-8: Regenerate DB types from local Supabase and verify they
-      # match committed types. Fails if migrations added tables/columns
-      # without regenerating types (catches `as any` / `as never` drift).
+      # MEDIUM-8 / H-10: Regenerate DB types from local Supabase and verify
+      # they match committed types. Fails the build if migrations added
+      # tables/columns without regenerating types (catches `as any` drift).
+      # Promoted from warning to error per ETAP3 audit H-10.
       - name: Verify database types are up-to-date
         run: |
           npx supabase gen types typescript --local > src/lib/types/database.gen.ts 2>/dev/null || true
           if [ -f src/lib/types/database.gen.ts ]; then
             if ! diff -q src/lib/types/database.ts src/lib/types/database.gen.ts > /dev/null 2>&1; then
-              echo "::warning::Database types are stale — run 'npx supabase gen types typescript --local > src/lib/types/database.ts' to update"
+              echo "::error::Database types are stale — run 'npx supabase gen types typescript --local > src/lib/types/database.ts' to update"
+              diff src/lib/types/database.ts src/lib/types/database.gen.ts || true
+              exit 1
             fi
           fi
 

--- a/src/app/api/cron/dedup-purge/route.ts
+++ b/src/app/api/cron/dedup-purge/route.ts
@@ -1,0 +1,66 @@
+/**
+ * M-03/M-04: TTL purge cron for dedup tables.
+ *
+ * Deletes rows older than 90 days from:
+ * - `processed_stripe_events` (migration 00092)
+ * - `cmi_callbacks_seen` (migration 00084/00091)
+ *
+ * These tables grow unbounded without purging. The 90-day window is
+ * generous — Stripe webhook replay is at most 30 days, and CMI
+ * callbacks are one-shot. Keeping 90 days aids forensics.
+ *
+ * Schedule: daily at 04:00 UTC (between gdpr-purge and stripe-reconcile).
+ * Protected by CRON_SECRET via Authorization: Bearer header.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import { createAdminClient } from "@/lib/supabase-server";
+
+const RETENTION_DAYS = 90;
+
+export async function GET(request: NextRequest) {
+  const authError = verifyCronSecret(request);
+  if (authError) return authError;
+
+  const admin = createAdminClient("cron");
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const results: Record<string, number> = {};
+
+  // Purge processed_stripe_events
+  const { count: stripeCount, error: stripeErr } = await admin
+    .from("processed_stripe_events")
+    .delete({ count: "exact" })
+    .lt("processed_at", cutoff);
+
+  if (stripeErr) {
+    logger.error("dedup-purge: failed to purge processed_stripe_events", {
+      context: "cron/dedup-purge",
+      error: stripeErr.message,
+    });
+  }
+  results.processed_stripe_events = stripeCount ?? 0;
+
+  // Purge cmi_callbacks_seen
+  const { count: cmiCount, error: cmiErr } = await admin
+    .from("cmi_callbacks_seen")
+    .delete({ count: "exact" })
+    .lt("seen_at", cutoff);
+
+  if (cmiErr) {
+    logger.error("dedup-purge: failed to purge cmi_callbacks_seen", {
+      context: "cron/dedup-purge",
+      error: cmiErr.message,
+    });
+  }
+  results.cmi_callbacks_seen = cmiCount ?? 0;
+
+  const total = results.processed_stripe_events + results.cmi_callbacks_seen;
+  logger.info(`dedup-purge: purged ${total} rows older than ${RETENTION_DAYS} days`, {
+    context: "cron/dedup-purge",
+    ...results,
+  });
+
+  return NextResponse.json({ ok: true, purged: results, cutoff, retentionDays: RETENTION_DAYS });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -185,9 +185,17 @@ export function register() {
       enforceEnvValidation();
     })
     .catch((err) => {
+      // M-26: Capture to Sentry before crashing so the failure is visible
+      // in the dashboard, not buried in Workers Logs / console output.
+      console.error("[FATAL] Environment validation failed:", err);
+      if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+        Sentry.captureException(
+          err instanceof Error ? err : new Error(`Environment validation failed: ${err}`),
+          { tags: { component: "instrumentation", phase: "env-validation" }, level: "fatal" },
+        );
+      }
       // Re-throw to ensure the Worker/server process crashes on missing
       // required env vars instead of silently serving traffic.
-      console.error("[FATAL] Environment validation failed:", err);
       throw err;
     });
 

--- a/src/lib/__tests__/cron-schedule-sync.test.ts
+++ b/src/lib/__tests__/cron-schedule-sync.test.ts
@@ -1,0 +1,65 @@
+/**
+ * H-07: Verify that worker-cron-handler.ts CRON_ROUTES and wrangler.toml
+ * [triggers].crons declare the exact same set of cron expressions.
+ *
+ * Drift between these two lists causes silent cron failures: Cloudflare
+ * fires the cron, the handler logs "Unknown cron expression", and no
+ * Sentry alert fires.
+ */
+
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, it, expect } from "vitest";
+
+function parseWranglerCrons(): string[] {
+  const content = readFileSync(resolve(__dirname, "../../../wrangler.toml"), "utf-8");
+  const cronsMatch = content.match(/\[triggers\]\s*\ncrons\s*=\s*\[([\s\S]*?)\]/);
+  if (!cronsMatch) throw new Error("Could not find [triggers].crons in wrangler.toml");
+  const lines = cronsMatch[1].split("\n");
+  return lines
+    .map((line) => {
+      const match = line.match(/"([^"]+)"/);
+      return match ? match[1] : null;
+    })
+    .filter((v): v is string => v !== null)
+    .sort();
+}
+
+function getHandlerCrons(): string[] {
+  // Dynamic import won't work because the file imports .open-next/worker.js.
+  // Instead, read the file and extract the CRON_ROUTES keys via regex.
+  const content = readFileSync(resolve(__dirname, "../../../worker-cron-handler.ts"), "utf-8");
+  const routesMatch = content.match(/(?:export\s+)?const\s+CRON_ROUTES[\s\S]*?=\s*\{([\s\S]*?)\};/);
+  if (!routesMatch) throw new Error("Could not find CRON_ROUTES in worker-cron-handler.ts");
+  const keys: string[] = [];
+  const keyRegex = /"([^"]+)":\s*\[/g;
+  let m;
+  while ((m = keyRegex.exec(routesMatch[1])) !== null) {
+    keys.push(m[1]);
+  }
+  return keys.sort();
+}
+
+describe("Cron schedule synchronization", () => {
+  it("wrangler.toml crons match CRON_ROUTES keys exactly", () => {
+    const wranglerCrons = parseWranglerCrons();
+    const handlerCrons = getHandlerCrons();
+
+    expect(wranglerCrons).toEqual(handlerCrons);
+  });
+
+  it("every CRON_ROUTES entry maps to at least one route", () => {
+    const content = readFileSync(resolve(__dirname, "../../../worker-cron-handler.ts"), "utf-8");
+    const routesMatch = content.match(
+      /(?:export\s+)?const\s+CRON_ROUTES[\s\S]*?=\s*\{([\s\S]*?)\};/,
+    );
+    if (!routesMatch) throw new Error("Could not find CRON_ROUTES");
+
+    const entryRegex = /"[^"]+"\s*:\s*\[([^\]]+)\]/g;
+    let m;
+    while ((m = entryRegex.exec(routesMatch[1])) !== null) {
+      const routes = m[1].match(/"\/api\/cron\/[^"]+"/g);
+      expect(routes?.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/middleware/sanctioned-countries.ts
+++ b/src/lib/middleware/sanctioned-countries.ts
@@ -20,11 +20,12 @@ import { NextResponse } from "next/server";
  * Review this list quarterly and after any new sanctions announcement.
  */
 const SANCTIONED_COUNTRIES = new Set([
+  "BY", // Belarus (EU comprehensive sanctions since 2022)
   "CU", // Cuba
   "IR", // Iran
   "KP", // North Korea (DPRK)
-  "SY", // Syria
   "RU", // Russia (comprehensive since 2022)
+  "SY", // Syria
 ]);
 
 /**

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -81,6 +81,17 @@ export function extractClientIp(request: NextRequest): string {
             context: "rate-limit",
           },
         );
+        // M-15: Surface XFF fallback to Sentry as a breadcrumb so ops
+        // can track frequency without grepping Workers Logs.
+        import("@sentry/nextjs")
+          .then((Sentry) =>
+            Sentry.addBreadcrumb({
+              category: "rate-limit",
+              message: "XFF fallback: CF-Connecting-IP absent",
+              level: "warning",
+            }),
+          )
+          .catch(() => {});
       }
       return first;
     }

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -14,6 +14,7 @@
  *                        /api/cron/rebooking-reminders (rebooking prompts)
  *   - daily 02:00    →  /api/cron/billing       (subscription renewals)
  *   - daily 03:00    →  /api/cron/gdpr-purge    (GDPR patient data purge)
+ *   - daily 04:00    →  /api/cron/dedup-purge   (M-03/M-04 TTL purge)
  *   - daily 05:00    →  /api/cron/stripe-reconcile (BL-002 payment drift)
  *
  * @see https://opennext.js.org/cloudflare/howtos/custom-worker
@@ -29,15 +30,68 @@ import { default as handler } from "./.open-next/worker.js";
  *
  * Some schedules fan out to multiple routes (e.g. the hourly trigger fires
  * r2-cleanup, feedback, and rebooking-reminders in parallel).
+ *
+ * Exported for testing (H-07 cross-check with wrangler.toml).
  */
-const CRON_ROUTES: Record<string, string[]> = {
+export const CRON_ROUTES: Record<string, string[]> = {
   "*/15 * * * *": ["/api/cron/notifications", "/api/cron/audit-log-flush"],
   "*/30 * * * *": ["/api/cron/reminders"],
   "0 * * * *": ["/api/cron/r2-cleanup", "/api/cron/feedback", "/api/cron/rebooking-reminders"],
   "0 2 * * *": ["/api/cron/billing"],
   "0 3 * * *": ["/api/cron/gdpr-purge"],
+  "0 4 * * *": ["/api/cron/dedup-purge"],
   "0 5 * * *": ["/api/cron/stripe-reconcile"],
 };
+
+/**
+ * H-08: Report cron errors to the Sentry tunnel endpoint so they surface
+ * in the project dashboard. The route handlers already use @sentry/nextjs
+ * for in-request errors, but scheduled() failures (unknown cron, missing
+ * secrets, fetch-level errors) were previously console.error-only.
+ *
+ * We POST a minimal Sentry envelope to the DSN tunnel. If the DSN is
+ * unavailable, the error is still logged to Workers Logs via console.error.
+ */
+async function reportCronError(
+  env: Record<string, string>,
+  message: string,
+  extra: Record<string, unknown> = {},
+): Promise<void> {
+  console.error(`[Cron] ${message}`, extra);
+
+  const dsn = env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return;
+
+  try {
+    const dsnUrl = new URL(dsn);
+    const projectId = dsnUrl.pathname.replace("/", "");
+    const sentryHost = dsnUrl.hostname;
+    const publicKey = dsnUrl.username;
+
+    const eventId = crypto.randomUUID().replace(/-/g, "");
+    const envelope =
+      `{"event_id":"${eventId}","dsn":"${dsn}"}\n` +
+      `{"type":"event"}\n` +
+      JSON.stringify({
+        event_id: eventId,
+        timestamp: Date.now() / 1000,
+        platform: "javascript",
+        level: "error",
+        logger: "worker-cron-handler",
+        message: { formatted: message },
+        tags: { component: "cron-handler", ...extra },
+        environment: env.NODE_ENV || "production",
+      });
+
+    await fetch(`https://${sentryHost}/api/${projectId}/envelope/?sentry_key=${publicKey}`, {
+      method: "POST",
+      body: envelope,
+      headers: { "Content-Type": "application/x-sentry-envelope" },
+    });
+  } catch {
+    // Sentry reporting is best-effort; error already logged to console
+  }
+}
 
 export default {
   fetch: handler.fetch,
@@ -50,26 +104,29 @@ export default {
     const routes = CRON_ROUTES[controller.cron] ?? null;
 
     if (!routes) {
-      console.error(`[Cron] Unknown cron expression: ${controller.cron}`);
+      void reportCronError(env, `Unknown cron expression: ${controller.cron}`, {
+        cron: controller.cron,
+      });
       return;
     }
 
     const cronSecret = env.CRON_SECRET;
     if (!cronSecret) {
-      console.error(
-        `[Cron] CRON_SECRET is not set — skipping ${controller.cron} to prevent unauthenticated requests`,
+      void reportCronError(
+        env,
+        `CRON_SECRET is not set — skipping ${controller.cron} to prevent unauthenticated requests`,
+        { cron: controller.cron },
       );
       return;
     }
 
-    // B-03 / A43.5: Build requests to the Next.js API routes via the same
-    // Worker fetch handler.  CRON_SELF_BASE_URL (or ROOT_DOMAIN) must be set
-    // per-environment so staging crons never accidentally hit production.
     const cronBaseUrl =
       env.CRON_SELF_BASE_URL || (env.ROOT_DOMAIN ? `https://${env.ROOT_DOMAIN}` : null);
     if (!cronBaseUrl) {
-      console.error(
-        `[Cron] Neither CRON_SELF_BASE_URL nor ROOT_DOMAIN is set — refusing to fire ${controller.cron} to avoid cross-environment request`,
+      void reportCronError(
+        env,
+        `Neither CRON_SELF_BASE_URL nor ROOT_DOMAIN is set — refusing to fire ${controller.cron}`,
+        { cron: controller.cron },
       );
       return;
     }
@@ -86,11 +143,27 @@ export default {
         handler
           .fetch(request, env, ctx)
           .then(async (res: Response) => {
-            const body = await res.text();
-            console.log(`[Cron] ${route} responded ${res.status}: ${body}`);
+            // L-08: Redact response body — may contain operational data
+            // (row counts from gdpr-purge, billing details, etc.)
+            if (res.ok) {
+              console.log(`[Cron] ${route} responded ${res.status}`);
+            } else {
+              const body = await res.text();
+              const truncated = body.length > 200 ? body.slice(0, 200) + "…" : body;
+              console.error(`[Cron] ${route} responded ${res.status}: ${truncated}`);
+              void reportCronError(env, `${route} responded ${res.status}`, {
+                cron: controller.cron,
+                route,
+                status: String(res.status),
+              });
+            }
           })
           .catch((err: unknown) => {
             console.error(`[Cron] ${route} failed:`, err);
+            void reportCronError(env, `${route} fetch failed: ${err}`, {
+              cron: controller.cron,
+              route,
+            });
           }),
       );
     }

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -83,10 +83,12 @@ async function reportCronError(
         environment: env.NODE_ENV || "production",
       });
 
+    const headers = new Headers();
+    headers.set("Content-Type", "application/x-sentry-envelope");
     await fetch(`https://${sentryHost}/api/${projectId}/envelope/?sentry_key=${publicKey}`, {
       method: "POST",
       body: envelope,
-      headers: { "Content-Type": "application/x-sentry-envelope" },
+      headers,
     });
   } catch {
     // Sentry reporting is best-effort; error already logged to console

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -126,6 +126,7 @@ crons = [
   "0 * * * *",    # hourly — R2 cleanup + feedback + rebooking reminders
   "0 2 * * *",    # 02:00 UTC daily — subscription billing
   "0 3 * * *",    # 03:00 UTC daily — GDPR patient data purge
+  "0 4 * * *",    # 04:00 UTC daily — M-03/M-04 dedup table TTL purge
   "0 5 * * *",    # 05:00 UTC daily — BL-002 Stripe payment reconciliation
 ]
 


### PR DESCRIPTION
## Summary

Implements 10 quick-win findings from the ETAP3 audit (2026-05-28):

| Finding | Fix |
|---------|-----|
| **H-02** | CI grep gate rejects broken `app.clinic_id` RLS pattern in migrations |
| **H-07** | Unit test cross-checks `CRON_ROUTES` vs `wrangler.toml [triggers]` |
| **H-08** | Wire Sentry error reporting into `worker-cron-handler.ts scheduled()` |
| **H-10** | Promote DB-type-freshness CI step from `::warning` to `exit 1` |
| **L-08** | Redact cron response body logging (operational data leak) |
| **M-03/M-04** | Add `/api/cron/dedup-purge` route + wrangler trigger (90-day TTL) |
| **M-13** | Add BY (Belarus) to `SANCTIONED_COUNTRIES` |
| **M-15** | Add Sentry breadcrumb for XFF fallback in `extractClientIp()` |
| **M-26** | Capture env validation failures to Sentry before crash |
| **L-04** | Already present (`dangerouslyAllowSVG: false`) — no-op |

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Infrastructure / CI

## Security Impact

- [x] This PR changes tenant isolation or multi-tenant scoping

## Testing

- [x] Unit tests added/updated (cron-schedule-sync.test.ts)
- [x] Manual testing performed
- [x] 820 tests pass, 0 errors

## Checklist

- [x] `npm run lint` passes (0 errors, 4120 warnings baseline)
- [x] `npm run typecheck` passes
- [x] Coverage thresholds met