### PR TITLE
fix(webhook): wire WhatsApp message dedup into handler (F-1)

### DIFF
--- a/src/app/api/__tests__/webhooks-dedup.test.ts
+++ b/src/app/api/__tests__/webhooks-dedup.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for WhatsApp webhook idempotency guard (R-16).
+ *
+ * Verifies that duplicate WhatsApp message deliveries are skipped
+ * using the processed_whatsapp_messages table, same insert-on-conflict
+ * pattern as processed_stripe_events in billing/webhook/route.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { hmacSha256Hex } from "@/lib/crypto-utils";
+
+// ── Spy targets ───────────────────────────────────────────────────────
+
+let dedupInsertSpy: ReturnType<typeof vi.fn>;
+
+/**
+ * Build a deeply-chainable Supabase mock that supports:
+ *   .from(t).select(...).eq(...).eq(...).eq(...).order(...).limit(...).maybeSingle()
+ *   .from(t).select(...).eq(...).single()
+ *   .from(t).select(...).eq(...).in(...).order(...).limit(...).single()
+ *   .from(t).update(...).eq(...).eq(...)
+ *   .from(t).insert(...)
+ */
+function chainableMock(leafData: unknown = null) {
+  const self: Record<string, ReturnType<typeof vi.fn>> = {};
+  const terminalReturn = { data: leafData, error: null };
+  self.select = vi.fn(() => self);
+  self.eq = vi.fn(() => self);
+  self.in = vi.fn(() => self);
+  self.order = vi.fn(() => self);
+  self.limit = vi.fn(() => self);
+  self.single = vi.fn(() => terminalReturn);
+  self.maybeSingle = vi.fn(() => terminalReturn);
+  self.update = vi.fn(() => self);
+  self.insert = vi.fn(() => ({ error: null }));
+  return self;
+}
+
+function mockAdminClient() {
+  dedupInsertSpy = vi.fn(() => ({ error: null }));
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "processed_whatsapp_messages") {
+        return { insert: dedupInsertSpy };
+      }
+      // notification_log updates for status webhooks
+      const chain = chainableMock();
+      return chain;
+    }),
+  };
+}
+
+function mockAnonClient() {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === "clinics") {
+        return chainableMock({ id: "clinic-uuid-1", name: "Test Clinic" });
+      }
+      // users, appointments, etc. — return null data (no patient found)
+      return chainableMock(null);
+    }),
+  };
+}
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: vi.fn(() => mockAnonClient()),
+  createAdminClient: vi.fn(() => mockAdminClient()),
+}));
+
+vi.mock("@/lib/tenant-context", () => ({
+  setTenantContext: vi.fn(),
+  logTenantContext: vi.fn(),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  dispatchNotification: vi.fn(() => []),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const TEST_APP_SECRET = "test-meta-app-secret-dedup";
+
+async function signBody(rawBody: string): Promise<string> {
+  const hex = await hmacSha256Hex(TEST_APP_SECRET, rawBody);
+  return `sha256=${hex}`;
+}
+
+function buildWebhookBodyWithMessage(messageId: string, from = "+212661000000") {
+  return JSON.stringify({
+    object: "whatsapp_business_account",
+    entry: [
+      {
+        id: "waba-123",
+        changes: [
+          {
+            field: "messages",
+            value: {
+              messaging_product: "whatsapp",
+              metadata: {
+                phone_number_id: "pn-clinic-1",
+                display_phone_number: "+212522000000",
+              },
+              messages: [
+                {
+                  id: messageId,
+                  from,
+                  type: "text",
+                  text: { body: "CONFIRM" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("Webhook POST — WhatsApp message idempotency (R-16)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("META_APP_SECRET", TEST_APP_SECRET);
+    vi.stubEnv("WHATSAPP_VERIFY_TOKEN", "test-verify-token");
+  });
+
+  it("inserts message_id into processed_whatsapp_messages on first delivery", async () => {
+    const { POST } = await import("@/app/api/webhooks/route");
+    const rawBody = buildWebhookBodyWithMessage("wamid.HBgLFirst001");
+    const sig = await signBody(rawBody);
+    const request = new Request("http://localhost/api/webhooks", {
+      method: "POST",
+      body: rawBody,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": sig,
+      },
+    });
+
+    const response = await POST(request as never);
+    expect(response.status).toBe(200);
+
+    expect(dedupInsertSpy).toHaveBeenCalledWith({
+      message_id: "wamid.HBgLFirst001",
+      clinic_id: "clinic-uuid-1",
+    });
+  });
+
+  it("skips processing when message_id is a duplicate (23505 conflict)", async () => {
+    dedupInsertSpy = vi.fn(() => ({
+      error: { code: "23505", message: "duplicate key value violates unique constraint" },
+    }));
+
+    const { createAdminClient } = await import("@/lib/supabase-server");
+    vi.mocked(createAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "processed_whatsapp_messages") {
+          return { insert: dedupInsertSpy } as never;
+        }
+        return chainableMock() as never;
+      }),
+    } as never);
+
+    const { POST } = await import("@/app/api/webhooks/route");
+    const rawBody = buildWebhookBodyWithMessage("wamid.HBgLDuplicate001");
+    const sig = await signBody(rawBody);
+    const request = new Request("http://localhost/api/webhooks", {
+      method: "POST",
+      body: rawBody,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": sig,
+      },
+    });
+
+    const response = await POST(request as never);
+    expect(response.status).toBe(200);
+
+    expect(dedupInsertSpy).toHaveBeenCalledWith({
+      message_id: "wamid.HBgLDuplicate001",
+      clinic_id: "clinic-uuid-1",
+    });
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.info).toHaveBeenCalledWith(
+      "WhatsApp webhook replay detected — ignoring duplicate",
+      expect.objectContaining({
+        context: "webhooks/whatsapp",
+        messageId: "wamid.HBgLDuplicate001",
+      }),
+    );
+  });
+
+  it("continues processing when dedup insert fails with non-conflict error", async () => {
+    dedupInsertSpy = vi.fn(() => ({
+      error: { code: "PGRST301", message: "connection pool exhausted" },
+    }));
+
+    const { createAdminClient } = await import("@/lib/supabase-server");
+    vi.mocked(createAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "processed_whatsapp_messages") {
+          return { insert: dedupInsertSpy } as never;
+        }
+        return chainableMock() as never;
+      }),
+    } as never);
+
+    const { POST } = await import("@/app/api/webhooks/route");
+    const rawBody = buildWebhookBodyWithMessage("wamid.HBgLTransient001");
+    const sig = await signBody(rawBody);
+    const request = new Request("http://localhost/api/webhooks", {
+      method: "POST",
+      body: rawBody,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": sig,
+      },
+    });
+
+    const response = await POST(request as never);
+    expect(response.status).toBe(200);
+
+    const { logger } = await import("@/lib/logger");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "WhatsApp message dedup insert failed",
+      expect.objectContaining({
+        context: "webhooks/whatsapp",
+        messageId: "wamid.HBgLTransient001",
+      }),
+    );
+  });
+});

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -23,6 +23,7 @@ interface WaInteractive {
 }
 
 interface WaMessage {
+  id?: string;
   from?: string;
   type?: string;
   text?: WaTextMessage;
@@ -87,7 +88,9 @@ async function verifyWebhookSignature(
  * Extracts the message text and sender phone from a WhatsApp webhook payload.
  * Supports both regular text messages and interactive button replies.
  */
-function extractMessageInfo(entry: WaEntry): { text: string; senderPhone: string } | null {
+function extractMessageInfo(
+  entry: WaEntry,
+): { text: string; senderPhone: string; messageId: string } | null {
   const changes = entry.changes;
   if (!changes) return null;
   for (const change of changes) {
@@ -99,19 +102,22 @@ function extractMessageInfo(entry: WaEntry): { text: string; senderPhone: string
       const from = msg.from;
       if (!from) continue;
 
+      const messageId = msg.id;
+      if (!messageId) continue;
+
       // Handle interactive button replies (quick replies from reminders)
       const interactive = msg.interactive;
       if (interactive?.type === "button_reply") {
         const buttonReply = interactive.button_reply;
         if (buttonReply && typeof buttonReply.id === "string") {
-          return { text: buttonReply.id, senderPhone: from };
+          return { text: buttonReply.id, senderPhone: from, messageId };
         }
       }
 
       // Handle regular text messages
       const text = msg.text;
       if (text && typeof text.body === "string") {
-        return { text: text.body, senderPhone: from };
+        return { text: text.body, senderPhone: from, messageId };
       }
     }
   }
@@ -282,6 +288,41 @@ export async function POST(request: NextRequest) {
       logTenantContext(clinicId, "webhooks/whatsapp", {
         senderPhone: msgInfo.senderPhone,
       });
+
+      // R-16: Insert-on-conflict idempotency guard — same pattern as
+      // processed_stripe_events in billing/webhook/route.ts.
+      // If the message was already processed, skip it to prevent duplicate
+      // appointments, notifications, and audit-log entries on Meta retries.
+      const { error: dedupErr } = await (
+        admin as never as {
+          from(t: string): {
+            insert(
+              r: Record<string, unknown>,
+            ): Promise<{ error: { code?: string; message: string } | null }>;
+          };
+        }
+      )
+        .from("processed_whatsapp_messages")
+        .insert({
+          message_id: msgInfo.messageId,
+          clinic_id: clinicId,
+        });
+
+      if (dedupErr) {
+        if (dedupErr.code === "23505") {
+          logger.info("WhatsApp webhook replay detected — ignoring duplicate", {
+            context: "webhooks/whatsapp",
+            messageId: msgInfo.messageId,
+            clinicId,
+          });
+          continue;
+        }
+        logger.warn("WhatsApp message dedup insert failed", {
+          context: "webhooks/whatsapp",
+          messageId: msgInfo.messageId,
+          error: dedupErr.message,
+        });
+      }
 
       // Patient lookup is now always scoped to the resolved clinic.
       // C-05: Use .maybeSingle() instead of .single() to avoid crashing


### PR DESCRIPTION
## Summary

Fixes **F-1 (P1)** from AUDIT_REPORT.md: the `processed_whatsapp_messages` table (migration 00094) was created and purged by cron but **never inserted into or checked** by the webhook handler. WhatsApp replay protection was non-functional.

Wires the same insert-on-conflict dedup pattern used by `processed_stripe_events` in `billing/webhook/route.ts:142-150`.

### Changes

- **`src/app/api/webhooks/route.ts`**:
  - Add `id` field to `WaMessage` interface (Meta always sends a `wamid.*` message ID)
  - `extractMessageInfo()` now returns `messageId` alongside `text` and `senderPhone`
  - After clinic resolution + tenant context, insert `(message_id, clinic_id)` into `processed_whatsapp_messages` via admin client
  - On `23505` (unique violation): log info + `continue` (skip duplicate)
  - On other insert errors: log warning + continue processing (fail-open to not drop messages on transient DB errors)

- **`src/app/api/__tests__/webhooks-dedup.test.ts`** (new):
  - Tests first delivery inserts dedup row
  - Tests duplicate delivery (23505) is skipped with info log
  - Tests transient DB error is warned but processing continues

## Review & Testing Checklist for Human

- [ ] Deploy to staging, send a WhatsApp message to a test clinic, verify `processed_whatsapp_messages` gets a row
- [ ] Replay the same webhook payload (e.g., via Meta test webhook tool) — second delivery should be skipped (check logs for replay detection message)
- [ ] Verify existing WhatsApp flows (CONFIRM, CANCEL, RESCHEDULE) still work end-to-end

### Notes
- No new dependencies added
- Existing webhook tests (webhooks.test.ts, webhooks-mutation.test.ts) still pass
- Uses admin client for the dedup insert (webhooks have no user session, same as notification_log updates)