### PR TITLE
refactor(stripe): extract verifyStripeSignature into shared module (F-4)

### DIFF
--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { apiError, apiSuccess, apiInternalError } from "@/lib/api-response";
 import { getPlanByPriceId, type PlanSlug } from "@/lib/config/subscription-plans";
-import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
+import { verifyStripeSignature } from "@/lib/stripe-signature";
 import { createAdminClient } from "@/lib/supabase-server";
 import type { Json } from "@/lib/types/database";
 import { subscriptionWebhookEventSchema } from "@/lib/validations";
@@ -374,41 +374,5 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     logger.warn("Failed to process billing webhook", { context: "billing/webhook", error: err });
     return apiInternalError("Failed to process webhook");
-  }
-}
-
-/**
- * Verify Stripe webhook signature using HMAC-SHA256.
- * Implements Stripe's signature verification without requiring the Stripe SDK.
- */
-async function verifyStripeSignature(
-  payload: string,
-  signatureHeader: string,
-  secret: string,
-): Promise<boolean> {
-  try {
-    const parts = signatureHeader.split(",");
-    let timestamp = "";
-    let signature = "";
-
-    for (const part of parts) {
-      const [key, value] = part.split("=");
-      if (key === "t") timestamp = value;
-      if (key === "v1") signature = value;
-    }
-
-    if (!timestamp || !signature) return false;
-
-    // Check timestamp tolerance (5 minutes)
-    const now = Math.floor(Date.now() / 1000);
-    if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
-
-    const signedPayload = `${timestamp}.${payload}`;
-    const expectedSignature = await hmacSha256Hex(secret, signedPayload);
-
-    return timingSafeEqual(expectedSignature, signature);
-  } catch (err) {
-    logger.warn("Signature verification failed", { context: "billing/webhook", error: err });
-    return false;
   }
 }

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { apiError, apiSuccess, apiInternalError } from "@/lib/api-response";
 import { assertClinicId } from "@/lib/assert-tenant";
-import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
+import { verifyStripeSignature } from "@/lib/stripe-signature";
 import { createClient } from "@/lib/supabase-server";
 import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
@@ -262,41 +262,5 @@ export async function POST(request: NextRequest) {
     // F-A93-03: Webhook processing failure is an error, not a warning
     logger.error("Stripe webhook processing failed", { context: "payments/webhook", error: err });
     return apiInternalError("Failed to process webhook");
-  }
-}
-
-/**
- * Verify Stripe webhook signature using HMAC-SHA256.
- * Implements Stripe's signature verification without requiring the Stripe SDK.
- */
-async function verifyStripeSignature(
-  payload: string,
-  signatureHeader: string,
-  secret: string,
-): Promise<boolean> {
-  try {
-    const parts = signatureHeader.split(",");
-    let timestamp = "";
-    let signature = "";
-
-    for (const part of parts) {
-      const [key, value] = part.split("=");
-      if (key === "t") timestamp = value;
-      if (key === "v1") signature = value;
-    }
-
-    if (!timestamp || !signature) return false;
-
-    // Check timestamp tolerance (5 minutes)
-    const now = Math.floor(Date.now() / 1000);
-    if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
-
-    const signedPayload = `${timestamp}.${payload}`;
-    const expectedSignature = await hmacSha256Hex(secret, signedPayload);
-
-    return timingSafeEqual(expectedSignature, signature);
-  } catch (err) {
-    logger.warn("Failed to process Stripe webhook", { context: "payments/webhook", error: err });
-    return false;
   }
 }

--- a/src/lib/stripe-signature.ts
+++ b/src/lib/stripe-signature.ts
@@ -1,0 +1,43 @@
+import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
+import { logger } from "@/lib/logger";
+
+/**
+ * Verify Stripe webhook signature using HMAC-SHA256.
+ * Implements Stripe's signature verification without requiring the Stripe SDK.
+ *
+ * Shared by payments/webhook and billing/webhook routes.
+ */
+export async function verifyStripeSignature(
+  payload: string,
+  signatureHeader: string,
+  secret: string,
+): Promise<boolean> {
+  try {
+    const parts = signatureHeader.split(",");
+    let timestamp = "";
+    let signature = "";
+
+    for (const part of parts) {
+      const [key, value] = part.split("=");
+      if (key === "t") timestamp = value;
+      if (key === "v1") signature = value;
+    }
+
+    if (!timestamp || !signature) return false;
+
+    // Check timestamp tolerance (5 minutes)
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
+
+    const signedPayload = `${timestamp}.${payload}`;
+    const expectedSignature = await hmacSha256Hex(secret, signedPayload);
+
+    return timingSafeEqual(expectedSignature, signature);
+  } catch (err) {
+    logger.warn("Stripe signature verification failed", {
+      context: "stripe-signature",
+      error: err,
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes **F-4 (P2)** from AUDIT_REPORT.md: `verifyStripeSignature` was duplicated byte-for-byte in two route files, creating a maintenance hazard where bug fixes or hardening must be applied in two places.

### Changes

- **`src/lib/stripe-signature.ts`** (new): Single shared implementation of `verifyStripeSignature()` — same HMAC-SHA256 logic, 5-minute timestamp tolerance, `timingSafeEqual` comparison.
- **`src/app/api/payments/webhook/route.ts`**: Removed local `verifyStripeSignature` + `hmacSha256Hex`/`timingSafeEqual` imports. Now imports from `@/lib/stripe-signature`.
- **`src/app/api/billing/webhook/route.ts`**: Same — removed local copy, imports shared version.

### Verification

- `npm run typecheck` passes
- All existing Stripe webhook tests pass (20 tests across 3 test files)
- No behavioral change — byte-identical logic, just moved to shared module

## Review & Testing Checklist for Human

- [ ] Verify Stripe payment webhook still processes `checkout.session.completed` events in staging
- [ ] Verify Stripe billing webhook still processes `invoice.paid` / `customer.subscription.deleted` events

### Notes
- Pure refactor — no behavioral change
- The shared module uses a generic `stripe-signature` context label for the catch-block logger call instead of route-specific labels