### PR TITLE
chore: add catch-all CODEOWNERS rule + verify SECURITY.md (F-9)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,9 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners (GitHub usernames or teams).
 
+# Default: repo owner reviews all PRs
+*                               @groupsmix
+
 # Security-critical: encryption, audit logging, authentication
 src/lib/encryption.ts           @groupsmix
 src/lib/audit-log.ts            @groupsmix


### PR DESCRIPTION
## Summary

Addresses **F-9 (P3)** from AUDIT_REPORT.md.

### CODEOWNERS

The file `.github/CODEOWNERS` already existed with path-specific rules for security-critical files. Added a catch-all `* @groupsmix` rule at the top so the repo owner is auto-requested as reviewer on all PRs. Existing path-specific rules are preserved.

### SECURITY.md

Already exists at repo root with `security@oltigo.com` as the vulnerability reporting contact, complete with response timeline and scope definition. No changes needed.

## Review & Testing Checklist for Human

- [ ] Verify GitHub shows the CODEOWNERS file as valid (Settings > Branches > Branch protection)
- [ ] On next PR, confirm @groupsmix is auto-requested as reviewer

### Notes
- The audit finding F-9 states these files are missing, but they were already present at the audited commit (d4db1c8). The only gap was the lack of a catch-all rule.