### PR TITLE
refactor(webhooks): unify body-size limiting (AUD-011, TASK-011)

### DIFF
--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -7,6 +7,7 @@ import { createAdminClient } from "@/lib/supabase-server";
 import type { Json } from "@/lib/types/database";
 import { subscriptionWebhookEventSchema } from "@/lib/validations";
 import type { SubscriptionWebhookEvent } from "@/lib/validations";
+import { readWebhookBody } from "@/lib/webhook-body";
 
 /**
  * Q-01: Stripe API timeout. If Stripe is degraded, an unbounded fetch here
@@ -89,7 +90,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const rawBody = await request.text();
+    // AUD-011: Use shared streaming body reader with 1 MB cap (consistent with payments/webhook).
+    const rawBody = await readWebhookBody(request);
+    if (rawBody === null) {
+      return apiError("Payload too large", 413);
+    }
     const signature = request.headers.get("stripe-signature");
 
     // Verify webhook signature — webhook secret MUST be configured

--- a/src/app/api/payments/webhook/route.ts
+++ b/src/app/api/payments/webhook/route.ts
@@ -8,6 +8,7 @@ import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 import { APPOINTMENT_STATUS, PAYMENT_STATUS } from "@/lib/types/database";
 import { stripeWebhookEventSchema } from "@/lib/validations";
 import type { StripeWebhookEvent } from "@/lib/validations";
+import { readWebhookBody } from "@/lib/webhook-body";
 
 /**
  * POST /api/payments/webhook
@@ -26,40 +27,6 @@ import type { StripeWebhookEvent } from "@/lib/validations";
 /** AUDIT FINDING #24: Max webhook payload size (1 MB). */
 const MAX_WEBHOOK_BYTES = 1 * 1024 * 1024;
 
-/**
- * S0-11-05: Streaming body reader that enforces a hard byte cap regardless
- * of whether Content-Length is present (chunked TE bypass).
- * Pattern identical to readBodyWithLimit in CMI callback route.
- */
-async function readBodyWithLimit(request: NextRequest, maxBytes: number): Promise<string | null> {
-  const reader = request.body?.getReader();
-  if (!reader) return "";
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      try {
-        await reader.cancel();
-      } catch {
-        /* best effort */
-      }
-      return null;
-    }
-    chunks.push(value);
-  }
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(out);
-}
-
 export async function POST(request: NextRequest) {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
@@ -70,7 +37,7 @@ export async function POST(request: NextRequest) {
 
   try {
     // S0-11-05: Stream-based body cap replaces Content-Length-only check.
-    const rawBody = await readBodyWithLimit(request, MAX_WEBHOOK_BYTES);
+    const rawBody = await readWebhookBody(request, MAX_WEBHOOK_BYTES);
     if (rawBody === null) {
       return apiError("Payload too large", 413);
     }

--- a/src/lib/__tests__/webhook-body.test.ts
+++ b/src/lib/__tests__/webhook-body.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { readWebhookBody } from "@/lib/webhook-body";
+
+function createMockRequest(body: string): Request {
+  return new Request("https://example.com/webhook", {
+    method: "POST",
+    body,
+  });
+}
+
+describe("readWebhookBody", () => {
+  it("returns decoded string for a body under the limit", async () => {
+    const payload = JSON.stringify({ type: "checkout.session.completed" });
+    const result = await readWebhookBody(createMockRequest(payload));
+    expect(result).toBe(payload);
+  });
+
+  it("returns null when body exceeds the limit", async () => {
+    const oversized = "x".repeat(2 * 1024 * 1024);
+    const result = await readWebhookBody(createMockRequest(oversized), 1024 * 1024);
+    expect(result).toBeNull();
+  });
+
+  it("returns empty string for a request with no body", async () => {
+    const req = new Request("https://example.com/webhook", { method: "POST" });
+    const result = await readWebhookBody(req);
+    expect(result).toBe("");
+  });
+
+  it("respects a custom maxBytes parameter", async () => {
+    const payload = "a".repeat(500);
+    const result = await readWebhookBody(createMockRequest(payload), 100);
+    expect(result).toBeNull();
+  });
+
+  it("returns body exactly at the limit", async () => {
+    const payload = "b".repeat(100);
+    const result = await readWebhookBody(createMockRequest(payload), 100);
+    expect(result).toBe(payload);
+  });
+});

--- a/src/lib/webhook-body.ts
+++ b/src/lib/webhook-body.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared streaming body reader for webhook handlers.
+ *
+ * Enforces a hard byte cap regardless of whether Content-Length is present
+ * (chunked transfer encoding bypass). Returns the decoded UTF-8 string or
+ * `null` when the body exceeds the limit.
+ *
+ * Extracted from `src/app/api/payments/webhook/route.ts` (AUD-011, TASK-011).
+ */
+
+/** Default cap: 1 MB — generous for any Stripe/WhatsApp payload. */
+const DEFAULT_MAX_BYTES = 1 * 1024 * 1024;
+
+export async function readWebhookBody(
+  request: Request,
+  maxBytes: number = DEFAULT_MAX_BYTES,
+): Promise<string | null> {
+  const reader = request.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        /* best effort */
+      }
+      return null;
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(out);
+}


### PR DESCRIPTION
## Summary

Extracts `readWebhookBody()` into `src/lib/webhook-body.ts` — a shared streaming body reader with a 1 MB default cap.

- **billing/webhook** previously used raw `request.text()` with no size limit. Now uses `readWebhookBody()` with 1 MB cap + returns 413 on overflow.
- **payments/webhook** had an inline `readBodyWithLimit()` doing the same thing. Deleted the inline copy, replaced with the shared import.

Both Stripe webhook routes now use identical body-reading behavior.

**Source:** AUD-011 (inconsistent body-size limiting between webhook handlers), TASK-011 from EXECUTION_PLAN.

## Review & Testing Checklist for Human

- [ ] **Billing webhook body cap**: POST a >1 MB payload to `/api/billing/webhook` in staging — should return 413 (previously would accept any size up to Cloudflare edge limit)
- [ ] **Payments webhook unchanged**: Verify existing Stripe payment flow still works end-to-end (signature verification + body reading path unchanged)
- [ ] Existing webhook tests still pass

### Notes
- CMI callback route (`payments/cmi/callback`) was NOT modified — it returns `Uint8Array` (not string) for HMAC verification, so it has a different contract
- WhatsApp webhook was NOT modified — different body structure
- 5 new unit tests cover: normal body, oversized body, empty body, custom cap, body exactly at limit