### PR TITLE
docs(migrations): document numbering gaps (AUD-005, TASK-017)

### DIFF
--- a/supabase/migrations/CHANGELOG.md
+++ b/supabase/migrations/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Migration Numbering Gaps
+
+Source: AUD-005 (audit 2026-05-28).
+
+The following migration numbers are absent from the sequence. Each was
+reserved during development but never committed. They are documented here
+so future auditors do not flag them as missing or out-of-order.
+
+| Number | Status                       |
+| ------ | ---------------------------- |
+| 00003  | Reserved — never used        |
+| 00025  | Reserved — never used        |
+| 00044  | Reserved — never used        |
+| 00078  | Reserved — never used        |
+
+Going forward: keep sequential numbering. Do not renumber existing migrations.


### PR DESCRIPTION
## Summary

Adds `supabase/migrations/CHANGELOG.md` documenting the four migration numbering gaps (00003, 00025, 00044, 00078). Each was reserved during development but never committed.

**Source:** AUD-005, TASK-017 from EXECUTION_PLAN.

## Review & Testing Checklist for Human

- [ ] Confirm gap numbers are correct (run `ls supabase/migrations/ | awk -F_ "{print $1}" | sort -n` to verify)

### Notes
- Doc only — no migration files or code touched
- Existing migrations are NOT renumbered