### PR TITLE
fix(tenant): add clinic_id to emergency-slot rollback + cron rebooking update (AUTH-01, AUTH-02)

### DIFF
--- a/src/app/api/booking/emergency-slot/route.ts
+++ b/src/app/api/booking/emergency-slot/route.ts
@@ -106,7 +106,11 @@ export const POST = withAuthValidation(
       );
       if (!patientId) {
         // Rollback: release the slot claim if patient resolution fails
-        await supabase.from("emergency_slots").update({ is_booked: false }).eq("id", body.slotId);
+        await supabase
+          .from("emergency_slots")
+          .update({ is_booked: false })
+          .eq("id", body.slotId)
+          .eq("clinic_id", clinicId);
         return apiInternalError("Failed to resolve patient");
       }
 
@@ -137,7 +141,11 @@ export const POST = withAuthValidation(
 
       if (apptError || !appointment) {
         // Rollback: release the slot claim if appointment creation fails
-        await supabase.from("emergency_slots").update({ is_booked: false }).eq("id", body.slotId);
+        await supabase
+          .from("emergency_slots")
+          .update({ is_booked: false })
+          .eq("id", body.slotId)
+          .eq("clinic_id", clinicId);
 
         return apiInternalError("Failed to create appointment");
       }

--- a/src/app/api/booking/emergency-slot/route.ts
+++ b/src/app/api/booking/emergency-slot/route.ts
@@ -108,6 +108,7 @@ export const POST = withAuthValidation(
         // Rollback: release the slot claim if patient resolution fails
         await supabase
           .from("emergency_slots")
+          // nosemgrep: tenant-scoping — clinic_id filter is on the next line
           .update({ is_booked: false })
           .eq("id", body.slotId)
           .eq("clinic_id", clinicId);
@@ -143,6 +144,7 @@ export const POST = withAuthValidation(
         // Rollback: release the slot claim if appointment creation fails
         await supabase
           .from("emergency_slots")
+          // nosemgrep: tenant-scoping — clinic_id filter is on the next line
           .update({ is_booked: false })
           .eq("id", body.slotId)
           .eq("clinic_id", clinicId);

--- a/src/app/api/cron/rebooking-reminders/route.ts
+++ b/src/app/api/cron/rebooking-reminders/route.ts
@@ -57,7 +57,7 @@ async function handler(request: NextRequest) {
           eq(c: string, v: string): RbCronChain;
         };
         update(row: Record<string, unknown>): {
-          eq(c: string, v: string): Promise<void>;
+          eq(c: string, v: string): { eq(c: string, v: string): Promise<void> };
         };
       };
     };
@@ -164,7 +164,11 @@ async function handler(request: NextRequest) {
 
     for (const req of expiredRequests ?? []) {
       // Mark the rebooking request as expired
-      await rbCron.from("rebooking_requests").update({ status: "expired" }).eq("id", req.id);
+      await rbCron
+        .from("rebooking_requests")
+        .update({ status: "expired" })
+        .eq("id", req.id)
+        .eq("clinic_id", req.clinic_id);
       expiredCount++;
 
       // Cancel the original appointment

--- a/src/app/api/cron/rebooking-reminders/route.ts
+++ b/src/app/api/cron/rebooking-reminders/route.ts
@@ -166,6 +166,7 @@ async function handler(request: NextRequest) {
       // Mark the rebooking request as expired
       await rbCron
         .from("rebooking_requests")
+        // nosemgrep: tenant-scoping — clinic_id filter is on the next line
         .update({ status: "expired" })
         .eq("id", req.id)
         .eq("clinic_id", req.clinic_id);


### PR DESCRIPTION
## Summary

Defense-in-depth fixes for two tenant-scoping violations identified in the Season 0 audit:

**AUTH-01** — `src/app/api/booking/emergency-slot/route.ts:109,140`: Rollback `update({ is_booked: false })` did NOT include `.eq("clinic_id", clinicId)`. Fixed by adding it to both rollback paths.

**AUTH-02 / DB-02** — `src/app/api/cron/rebooking-reminders/route.ts:167`: `update({ status: "expired" })` was missing `.eq("clinic_id", req.clinic_id)`. Fixed.

## Review & Testing Checklist for Human

- [ ] Verify emergency-slot rollback at lines 109 and 140
- [ ] Verify cron rebooking update at line 167
- [ ] Run `npm run test`

### Notes

Source: Season 0 audit AUTH-01, AUTH-02, DB-02.