### PR TITLE
fix(booking): harden input validation + cap HMAC signature length (IV-01, IV-02, IV-03, FP-24)

### DIFF
--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -30,6 +30,10 @@ import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
 // For the anonymous booking flow we use the booking_find_or_create_patient RPC instead
 // (SECURITY DEFINER function that bypasses users-table RLS).
 
+// IV-01: Strip Unicode bidi override characters that can spoof display direction.
+const BIDI_CONTROLS = /[\u202A-\u202E\u2066-\u2069\u200E\u200F]/g;
+const stripBidi = (s: string) => s.replace(BIDI_CONTROLS, "");
+
 const bookingRequestSchema = z.object({
   specialtyId: z.string().min(1),
   doctorId: z.string().min(1),
@@ -40,14 +44,18 @@ const bookingRequestSchema = z.object({
   isFirstVisit: z.boolean(),
   hasInsurance: z.boolean(),
   patient: z.object({
-    name: z.string().min(2).max(200),
+    name: z.string().min(2).max(200).transform(stripBidi),
     phone: z
       .string()
       .min(8)
       .max(30)
       .regex(/^\+?[0-9 ()\-]{8,30}$/, "Invalid phone number format"),
-    email: z.string().email().optional(),
-    reason: z.string().max(1000).optional(),
+    email: z.string().email().max(254).optional(),
+    reason: z
+      .string()
+      .max(1000)
+      .optional()
+      .transform((v) => (v ? stripBidi(v) : v)),
   }),
   slotDuration: z.number().int().positive(),
   bufferTime: z.number().int().min(0),
@@ -91,6 +99,10 @@ interface BookingTokenResult {
  * Returns true for the first matching secret (constant-time per attempt).
  */
 async function verifyHmac(secret: string, payload: string, signature: string): Promise<boolean> {
+  // FP-24: Cap attacker-controlled signature length to avoid CPU amplification.
+  // SHA-256 HMAC produces 64 hex chars; reject anything longer.
+  if (signature.length > 128) return false;
+
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     "raw",
@@ -103,15 +115,13 @@ async function verifyHmac(secret: string, payload: string, signature: string): P
   const expectedSig = Array.from(new Uint8Array(sig))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
-  // A6-05: Compare via constant-time loop without length precheck.
-  // Both are 64-char hex strings, but skipping the length guard avoids
-  // leaking length info if the format ever changes.
-  const maxLen = Math.max(expectedSig.length, signature.length);
-  let mismatch = expectedSig.length ^ signature.length;
-  for (let i = 0; i < maxLen; i++) {
-    mismatch |= (expectedSig.charCodeAt(i) || 0) ^ (signature.charCodeAt(i) || 0);
+  // A6-05: Constant-time comparison.
+  if (expectedSig.length !== signature.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expectedSig.length; i++) {
+    diff |= expectedSig.charCodeAt(i) ^ signature.charCodeAt(i);
   }
-  return mismatch === 0;
+  return diff === 0;
 }
 
 async function verifyBookingToken(token: string): Promise<BookingTokenResult> {
@@ -275,7 +285,7 @@ export const POST = withValidation(bookingRequestSchema, async (body, request: N
   // AUDIT-04: Bind the verified phone from the token to the submitted
   // patient phone. Prevents a user from verifying one phone number and
   // then booking under a different one.
-  const normalizePhone = (p: string) => p.replace(/[\s\-()]/g, "");
+  const normalizePhone = (p: string) => p.replace(/[^\d]/g, "");
   if (normalizePhone(tokenResult.phone!) !== normalizePhone(body.patient.phone)) {
     return apiForbidden("Booking token does not match the submitted patient phone number");
   }


### PR DESCRIPTION
## Summary

Input validation hardening for the booking route, addressing 5 Season 0 audit findings:

- **IV-01**: Strip Unicode bidi override characters (U+202A–U+202E, U+2066–U+2069, U+200E–U+200F) from patient `name` and `reason` fields via Zod `.transform()`. Prevents display-direction spoofing in staff UI.
- **IV-02**: Normalize phone comparison to digits-only (`/[^\d]/g`) instead of just stripping spaces/hyphens/parens. The OTP token may embed `212600000000` while the booking submits `+212600000000` — both now compare as `212600000000`.
- **IV-03**: Cap email field at 254 chars per RFC 5321 (`.max(254)`).
- **FP-24/FP-25**: Cap attacker-supplied signature length at 128 chars in `verifyHmac()`. Previously, the comparison loop ran `Math.max(expectedSig.length, signature.length)` iterations — a 1 MB signature would burn ~1M iterations. Now rejects oversized signatures immediately and uses length-checked constant-time comparison.

## Review & Testing Checklist for Human

- [ ] Verify bidi stripping: `name` and `reason` fields use `.transform(stripBidi)` — test with `Ahmed\u202EFraud` to confirm the bidi char is stripped
- [ ] Verify phone normalization: `normalizePhone` now strips ALL non-digit chars (including `+`). Test that `+212600000000` matches `212600000000` in token verification
- [ ] Verify email max: `.email().max(254)` rejects >254 char emails
- [ ] Verify signature cap: `verifyHmac` returns false for signatures >128 chars without entering the HMAC loop
- [ ] Run `npm run test` to confirm no regressions

### Notes

Source: Season 0 audit IV-01, IV-02, IV-03, FP-24, FP-25.