### PR TITLE
feat(editorial): editorial design system for legal/document pages

### DIFF
--- a/src/app/(public)/accessibility/page.tsx
+++ b/src/app/(public)/accessibility/page.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable i18next/no-literal-string -- Static legal/compliance page with French content */
 import type { Metadata } from "next";
+import { LegalDoc, type LegalDocSection } from "@/components/editorial/legal-doc";
 
 export const metadata: Metadata = {
   title: "Déclaration d'accessibilité",
@@ -20,40 +21,43 @@ export const metadata: Metadata = {
  * contact information for reporting barriers.
  */
 export default function AccessibilityPage() {
-  return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="mx-auto max-w-3xl prose prose-gray">
-        <h1 className="text-3xl font-bold mb-8">Déclaration d&apos;accessibilité</h1>
-
-        <p className="text-muted-foreground mb-6">Dernière mise à jour : mai 2026</p>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Engagement</h2>
-          <p className="text-muted-foreground mb-4">
-            Oltigo Health s&apos;engage à rendre sa plateforme accessible à toutes les personnes, y
-            compris celles en situation de handicap. Nous travaillons continuellement à améliorer
-            l&apos;expérience utilisateur et à appliquer les normes d&apos;accessibilité
-            pertinentes.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Norme de référence</h2>
-          <p className="text-muted-foreground mb-4">
-            Cette déclaration s&apos;appuie sur les{" "}
-            <strong>Web Content Accessibility Guidelines (WCAG) 2.2, niveau AA</strong>, publiées
-            par le W3C. Ces directives sont la référence internationale pour l&apos;accessibilité
-            des contenus web.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">État de conformité</h2>
-          <p className="text-muted-foreground mb-4">
+  const sections: LegalDocSection[] = [
+    {
+      id: "engagement",
+      number: "01",
+      title: "Engagement",
+      children: (
+        <p>
+          Oltigo Health s&apos;engage à rendre sa plateforme accessible à toutes les personnes, y
+          compris celles en situation de handicap. Nous travaillons continuellement à améliorer
+          l&apos;expérience utilisateur et à appliquer les normes d&apos;accessibilité pertinentes.
+        </p>
+      ),
+    },
+    {
+      id: "norme",
+      number: "02",
+      title: "Norme de référence",
+      children: (
+        <p>
+          Cette déclaration s&apos;appuie sur les{" "}
+          <strong>Web Content Accessibility Guidelines (WCAG) 2.2, niveau AA</strong>, publiées par
+          le W3C. Ces directives sont la référence internationale pour l&apos;accessibilité des
+          contenus web.
+        </p>
+      ),
+    },
+    {
+      id: "conformite",
+      number: "03",
+      title: "État de conformité",
+      children: (
+        <>
+          <p>
             La plateforme Oltigo Health est en <strong>conformité partielle</strong> avec les WCAG
             2.2 niveau AA. Les points suivants sont assurés :
           </p>
-          <ul className="list-disc pl-6 text-muted-foreground mb-4 space-y-2">
+          <ul>
             <li>
               <strong>Navigation au clavier</strong> : toutes les fonctionnalités principales sont
               accessibles sans souris.
@@ -79,14 +83,17 @@ export default function AccessibilityPage() {
               tailles d&apos;écran et niveaux de zoom jusqu&apos;à 200%.
             </li>
           </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Limitations connues</h2>
-          <p className="text-muted-foreground mb-4">
-            Malgré nos efforts, certains contenus peuvent ne pas être pleinement accessibles :
-          </p>
-          <ul className="list-disc pl-6 text-muted-foreground mb-4 space-y-2">
+        </>
+      ),
+    },
+    {
+      id: "limitations",
+      number: "04",
+      title: "Limitations connues",
+      children: (
+        <>
+          <p>Malgré nos efforts, certains contenus peuvent ne pas être pleinement accessibles :</p>
+          <ul>
             <li>
               Certains composants de calendrier/planification peuvent ne pas être entièrement
               navigables au clavier.
@@ -100,24 +107,30 @@ export default function AccessibilityPage() {
               testés avec des lecteurs d&apos;écran.
             </li>
           </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Technologies utilisées</h2>
-          <ul className="list-disc pl-6 text-muted-foreground mb-4 space-y-1">
-            <li>HTML5</li>
-            <li>CSS3 / Tailwind CSS</li>
-            <li>JavaScript / TypeScript (React 19, Next.js 16)</li>
-            <li>WAI-ARIA pour les composants interactifs</li>
-          </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Méthode d&apos;évaluation</h2>
-          <p className="text-muted-foreground mb-4">
-            L&apos;accessibilité d&apos;Oltigo Health est évaluée par :
-          </p>
-          <ul className="list-disc pl-6 text-muted-foreground mb-4 space-y-2">
+        </>
+      ),
+    },
+    {
+      id: "technologies",
+      number: "05",
+      title: "Technologies utilisées",
+      children: (
+        <ul>
+          <li>HTML5</li>
+          <li>CSS3 / Tailwind CSS</li>
+          <li>JavaScript / TypeScript (React 19, Next.js 16)</li>
+          <li>WAI-ARIA pour les composants interactifs</li>
+        </ul>
+      ),
+    },
+    {
+      id: "methode",
+      number: "06",
+      title: "Méthode d'évaluation",
+      children: (
+        <>
+          <p>L&apos;accessibilité d&apos;Oltigo Health est évaluée par :</p>
+          <ul>
             <li>
               Tests automatisés avec <code>jest-axe</code> intégrés à la suite de tests CI/CD.
             </li>
@@ -126,45 +139,52 @@ export default function AccessibilityPage() {
             </li>
             <li>Test avec le lecteur d&apos;écran NVDA (Windows) et VoiceOver (macOS/iOS).</li>
           </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Retour d&apos;information et contact</h2>
-          <p className="text-muted-foreground mb-4">
+        </>
+      ),
+    },
+    {
+      id: "contact",
+      number: "07",
+      title: "Retour d'information et contact",
+      children: (
+        <>
+          <p>
             Si vous rencontrez un obstacle d&apos;accessibilité sur notre plateforme, nous vous
             invitons à nous contacter :
           </p>
-          <ul className="list-disc pl-6 text-muted-foreground mb-4 space-y-2">
+          <ul>
             <li>
               <strong>Email</strong> :{" "}
-              <a href="mailto:accessibilite@oltigo.com" className="text-primary underline">
-                accessibilite@oltigo.com
-              </a>
+              <a href="mailto:accessibilite@oltigo.com">accessibilite@oltigo.com</a>
             </li>
             <li>
-              <strong>Formulaire de contact</strong> :{" "}
-              <a href="/contact" className="text-primary underline">
-                oltigo.com/contact
-              </a>
+              <strong>Formulaire de contact</strong> : <a href="/contact">oltigo.com/contact</a>
             </li>
           </ul>
-          <p className="text-muted-foreground mb-4">
+          <p>
             Nous nous engageons à répondre à tout signalement dans un délai de 15 jours ouvrables et
             à proposer une solution alternative si le contenu ne peut pas être rendu accessible
             immédiatement.
           </p>
-        </section>
+        </>
+      ),
+    },
+    {
+      id: "recours",
+      number: "08",
+      title: "Voies de recours",
+      children: (
+        <p>
+          Si, après nous avoir contactés, vous estimez que votre signalement n&apos;a pas été traité
+          de manière satisfaisante, vous pouvez saisir le Médiateur du Royaume du Maroc ou
+          l&apos;autorité compétente en matière d&apos;accessibilité numérique dans votre pays de
+          résidence.
+        </p>
+      ),
+    },
+  ];
 
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">Voies de recours</h2>
-          <p className="text-muted-foreground mb-4">
-            Si, après nous avoir contactés, vous estimez que votre signalement n&apos;a pas été
-            traité de manière satisfaisante, vous pouvez saisir le Médiateur du Royaume du Maroc ou
-            l&apos;autorité compétente en matière d&apos;accessibilité numérique dans votre pays de
-            résidence.
-          </p>
-        </section>
-      </div>
-    </div>
+  return (
+    <LegalDoc title="Déclaration d'accessibilité" lastUpdated="MAI 2026" sections={sections} />
   );
 }

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { LegalDoc, type LegalDocSection } from "@/components/editorial/legal-doc";
 
 export const metadata: Metadata = {
   title: "Politique de Confidentialité",
@@ -11,30 +12,29 @@ export const metadata: Metadata = {
 };
 
 export default function PrivacyPage() {
-  return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="mx-auto max-w-3xl prose prose-gray">
-        <h1 className="text-3xl font-bold mb-8">Politique de Confidentialité</h1>
-
-        <p className="text-muted-foreground mb-6">Dernière mise à jour : mars 2026</p>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">1. Introduction</h2>
-          <p className="text-muted-foreground mb-4">
-            La présente politique de confidentialité décrit comment Oltigo (&quot;nous&quot;,
-            &quot;notre&quot;, &quot;la plateforme&quot;) collecte, utilise et protège vos données
-            personnelles conformément au Règlement Général sur la Protection des Données (RGPD) et à
-            la loi marocaine n° 09-08 relative à la protection des personnes physiques à
-            l&apos;égard du traitement des données à caractère personnel.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">2. Données Collectées</h2>
-          <p className="text-muted-foreground mb-4">
-            Dans le cadre de nos services, nous pouvons collecter les données suivantes :
-          </p>
-          <ul className="list-disc pl-6 text-muted-foreground space-y-2 mb-4">
+  const sections: LegalDocSection[] = [
+    {
+      id: "introduction",
+      number: "01",
+      title: "Introduction",
+      children: (
+        <p>
+          La présente politique de confidentialité décrit comment Oltigo (&quot;nous&quot;,
+          &quot;notre&quot;, &quot;la plateforme&quot;) collecte, utilise et protège vos données
+          personnelles conformément au Règlement Général sur la Protection des Données (RGPD) et à
+          la loi marocaine n° 09-08 relative à la protection des personnes physiques à l&apos;égard
+          du traitement des données à caractère personnel.
+        </p>
+      ),
+    },
+    {
+      id: "donnees-collectees",
+      number: "02",
+      title: "Données Collectées",
+      children: (
+        <>
+          <p>Dans le cadre de nos services, nous pouvons collecter les données suivantes :</p>
+          <ul>
             <li>
               <strong>Données d&apos;identification :</strong> nom, prénom, adresse e-mail, numéro
               de téléphone.
@@ -51,55 +51,70 @@ export default function PrivacyPage() {
               <strong>Données de rendez-vous :</strong> dates, heures, praticiens consultés.
             </li>
           </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">3. Finalités du Traitement</h2>
-          <p className="text-muted-foreground mb-4">
-            Vos données sont traitées pour les finalités suivantes :
-          </p>
-          <ul className="list-disc pl-6 text-muted-foreground space-y-2 mb-4">
+        </>
+      ),
+    },
+    {
+      id: "finalites",
+      number: "03",
+      title: "Finalités du Traitement",
+      children: (
+        <>
+          <p>Vos données sont traitées pour les finalités suivantes :</p>
+          <ul>
             <li>Gestion des rendez-vous et du suivi médical.</li>
             <li>Communication avec les patients (rappels, confirmations).</li>
             <li>Amélioration de nos services et de l&apos;expérience utilisateur.</li>
             <li>Respect des obligations légales et réglementaires.</li>
           </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">4. Protection des Données</h2>
-          <p className="text-muted-foreground mb-4">
-            Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour
-            protéger vos données personnelles contre tout accès non autorisé, modification,
-            divulgation ou destruction. Les données de santé font l&apos;objet de mesures de
-            protection renforcées.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">5. Partage des Données</h2>
-          <p className="text-muted-foreground mb-4">
-            Vos données personnelles ne sont partagées qu&apos;avec les praticiens et le personnel
-            médical impliqués dans votre prise en charge. Nous ne vendons ni ne louons vos données à
-            des tiers.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">6. Conservation des Données</h2>
-          <p className="text-muted-foreground mb-4">
-            Vos données sont conservées pendant la durée nécessaire aux finalités pour lesquelles
-            elles ont été collectées, et conformément aux délais de conservation prévus par la
-            réglementation en vigueur.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">7. Vos Droits</h2>
-          <p className="text-muted-foreground mb-4">
-            Conformément à la réglementation applicable, vous disposez des droits suivants :
-          </p>
-          <ul className="list-disc pl-6 text-muted-foreground space-y-2 mb-4">
+        </>
+      ),
+    },
+    {
+      id: "protection",
+      number: "04",
+      title: "Protection des Données",
+      children: (
+        <p>
+          Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour
+          protéger vos données personnelles contre tout accès non autorisé, modification,
+          divulgation ou destruction. Les données de santé font l&apos;objet de mesures de
+          protection renforcées.
+        </p>
+      ),
+    },
+    {
+      id: "partage",
+      number: "05",
+      title: "Partage des Données",
+      children: (
+        <p>
+          Vos données personnelles ne sont partagées qu&apos;avec les praticiens et le personnel
+          médical impliqués dans votre prise en charge. Nous ne vendons ni ne louons vos données à
+          des tiers.
+        </p>
+      ),
+    },
+    {
+      id: "conservation",
+      number: "06",
+      title: "Conservation des Données",
+      children: (
+        <p>
+          Vos données sont conservées pendant la durée nécessaire aux finalités pour lesquelles
+          elles ont été collectées, et conformément aux délais de conservation prévus par la
+          réglementation en vigueur.
+        </p>
+      ),
+    },
+    {
+      id: "vos-droits",
+      number: "07",
+      title: "Vos Droits",
+      children: (
+        <>
+          <p>Conformément à la réglementation applicable, vous disposez des droits suivants :</p>
+          <ul>
             <li>
               <strong>Droit d&apos;accès :</strong> obtenir une copie de vos données personnelles.
             </li>
@@ -118,23 +133,24 @@ export default function PrivacyPage() {
               structuré.
             </li>
           </ul>
-          <p className="text-muted-foreground mb-4">
-            Pour exercer ces droits, veuillez nous contacter via notre page de contact.
-          </p>
-        </section>
+          <p>Pour exercer ces droits, veuillez nous contacter via notre page de contact.</p>
+        </>
+      ),
+    },
+    {
+      id: "contact",
+      number: "08",
+      title: "Contact",
+      children: (
+        <p>
+          Pour toute question relative à cette politique de confidentialité ou à la protection de
+          vos données, vous pouvez nous contacter via notre <a href="/contact">page de contact</a>.
+        </p>
+      ),
+    },
+  ];
 
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">8. Contact</h2>
-          <p className="text-muted-foreground mb-4">
-            Pour toute question relative à cette politique de confidentialité ou à la protection de
-            vos données, vous pouvez nous contacter via notre{" "}
-            <a href="/contact" className="text-primary hover:underline">
-              page de contact
-            </a>
-            .
-          </p>
-        </section>
-      </div>
-    </div>
+  return (
+    <LegalDoc title="Politique de Confidentialité" lastUpdated="MARS 2026" sections={sections} />
   );
 }

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { LegalDoc, type LegalDocSection } from "@/components/editorial/legal-doc";
 
 export const metadata: Metadata = {
   title: "Conditions Générales d'Utilisation",
@@ -11,55 +12,59 @@ export const metadata: Metadata = {
 };
 
 export default function TermsPage() {
-  return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="mx-auto max-w-3xl prose prose-gray">
-        <h1 className="text-3xl font-bold mb-8">Conditions Générales d&apos;Utilisation</h1>
-
-        <p className="text-muted-foreground mb-6">Dernière mise à jour : mars 2026</p>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">1. Objet</h2>
-          <p className="text-muted-foreground mb-4">
+  const sections: LegalDocSection[] = [
+    {
+      id: "objet",
+      number: "01",
+      title: "Objet",
+      children: (
+        <>
+          <p>
             Les présentes conditions générales d&apos;utilisation (CGU) régissent l&apos;accès et
             l&apos;utilisation de la plateforme Oltigo (&quot;la Plateforme&quot;), un service SaaS
             de gestion de cabinets médicaux, dentaires et pharmacies au Maroc.
           </p>
-          <p className="text-muted-foreground mb-4">
+          <p>
             En accédant à la Plateforme, vous acceptez les présentes CGU dans leur intégralité. Si
             vous n&apos;acceptez pas ces conditions, veuillez ne pas utiliser la Plateforme.
           </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">2. Définitions</h2>
-          <ul className="list-disc pl-6 text-muted-foreground space-y-2 mb-4">
-            <li>
-              <strong>Utilisateur :</strong> toute personne accédant à la Plateforme, qu&apos;il
-              s&apos;agisse d&apos;un professionnel de santé (médecin, dentiste, pharmacien) ou
-              d&apos;un patient.
-            </li>
-            <li>
-              <strong>Client :</strong> le professionnel de santé ou l&apos;établissement
-              souscrivant à un abonnement.
-            </li>
-            <li>
-              <strong>Patient :</strong> toute personne utilisant la Plateforme pour prendre
-              rendez-vous ou consulter ses informations médicales.
-            </li>
-            <li>
-              <strong>Tenant :</strong> l&apos;espace dédié à un cabinet ou établissement de santé
-              sur la Plateforme.
-            </li>
-          </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">3. Services</h2>
-          <p className="text-muted-foreground mb-4">
-            La Plateforme propose les services suivants :
-          </p>
-          <ul className="list-disc pl-6 text-muted-foreground space-y-2 mb-4">
+        </>
+      ),
+    },
+    {
+      id: "definitions",
+      number: "02",
+      title: "Définitions",
+      children: (
+        <ul>
+          <li>
+            <strong>Utilisateur :</strong> toute personne accédant à la Plateforme, qu&apos;il
+            s&apos;agisse d&apos;un professionnel de santé (médecin, dentiste, pharmacien) ou
+            d&apos;un patient.
+          </li>
+          <li>
+            <strong>Client :</strong> le professionnel de santé ou l&apos;établissement souscrivant
+            à un abonnement.
+          </li>
+          <li>
+            <strong>Patient :</strong> toute personne utilisant la Plateforme pour prendre
+            rendez-vous ou consulter ses informations médicales.
+          </li>
+          <li>
+            <strong>Tenant :</strong> l&apos;espace dédié à un cabinet ou établissement de santé sur
+            la Plateforme.
+          </li>
+        </ul>
+      ),
+    },
+    {
+      id: "services",
+      number: "03",
+      title: "Services",
+      children: (
+        <>
+          <p>La Plateforme propose les services suivants :</p>
+          <ul>
             <li>Gestion des rendez-vous en ligne.</li>
             <li>Gestion des dossiers patients.</li>
             <li>Site web professionnel pour le cabinet.</li>
@@ -67,102 +72,130 @@ export default function TermsPage() {
             <li>Facturation et comptabilité.</li>
             <li>Ordonnances et prescriptions électroniques.</li>
           </ul>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">4. Inscription et Compte</h2>
-          <p className="text-muted-foreground mb-4">
-            L&apos;inscription nécessite la fourniture d&apos;informations exactes et à jour. Chaque
-            utilisateur est responsable de la confidentialité de ses identifiants de connexion.
-            Toute activité réalisée sous votre compte est de votre responsabilité.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">5. Protection des Données</h2>
-          <p className="text-muted-foreground mb-4">
+        </>
+      ),
+    },
+    {
+      id: "inscription",
+      number: "04",
+      title: "Inscription et Compte",
+      children: (
+        <p>
+          L&apos;inscription nécessite la fourniture d&apos;informations exactes et à jour. Chaque
+          utilisateur est responsable de la confidentialité de ses identifiants de connexion. Toute
+          activité réalisée sous votre compte est de votre responsabilité.
+        </p>
+      ),
+    },
+    {
+      id: "protection-donnees",
+      number: "05",
+      title: "Protection des Données",
+      children: (
+        <>
+          <p>
             La collecte et le traitement des données personnelles sont régis par notre{" "}
-            <a href="/privacy" className="text-primary hover:underline">
-              Politique de Confidentialité
-            </a>
-            , conformément au Règlement Général sur la Protection des Données (RGPD) et à la loi
-            marocaine n° 09-08 relative à la protection des données à caractère personnel.
+            <a href="/privacy">Politique de Confidentialité</a>, conformément au Règlement Général
+            sur la Protection des Données (RGPD) et à la loi marocaine n° 09-08 relative à la
+            protection des données à caractère personnel.
           </p>
-          <p className="text-muted-foreground mb-4">
+          <p>
             Les données de santé sont considérées comme des données sensibles et font l&apos;objet
             de mesures de protection renforcées, conformément aux exigences de la CNDP (Commission
             Nationale de contrôle de la protection des Données à caractère Personnel).
           </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">6. Responsabilités</h2>
-          <h3 className="text-lg font-medium mb-2">6.1 Responsabilité de l&apos;utilisateur</h3>
-          <p className="text-muted-foreground mb-4">
+        </>
+      ),
+    },
+    {
+      id: "responsabilites",
+      number: "06",
+      title: "Responsabilités",
+      children: (
+        <>
+          <h3>6.1 Responsabilité de l&apos;utilisateur</h3>
+          <p>
             L&apos;utilisateur s&apos;engage à utiliser la Plateforme conformément aux lois en
             vigueur et aux présentes CGU. Il est interdit d&apos;utiliser la Plateforme à des fins
             illicites ou portant atteinte aux droits de tiers.
           </p>
-          <h3 className="text-lg font-medium mb-2">6.2 Responsabilité d&apos;Oltigo</h3>
-          <p className="text-muted-foreground mb-4">
+          <h3>6.2 Responsabilité d&apos;Oltigo</h3>
+          <p>
             Oltigo s&apos;engage à fournir un service fiable et sécurisé. La Plateforme est fournie
             &quot;en l&apos;état&quot; et Oltigo ne garantit pas une disponibilité ininterrompue.
             Oltigo ne saurait être tenu responsable des décisions médicales prises sur la base des
             informations affichées sur la Plateforme.
           </p>
-        </section>
+        </>
+      ),
+    },
+    {
+      id: "propriete-intellectuelle",
+      number: "07",
+      title: "Propriété Intellectuelle",
+      children: (
+        <p>
+          L&apos;ensemble des éléments de la Plateforme (textes, images, logos, code source) est
+          protégé par le droit de la propriété intellectuelle. Toute reproduction ou utilisation non
+          autorisée est strictement interdite.
+        </p>
+      ),
+    },
+    {
+      id: "abonnements",
+      number: "08",
+      title: "Abonnements et Paiements",
+      children: (
+        <p>
+          Les tarifs des abonnements sont indiqués sur la page <a href="/pricing">Tarifs</a>. Les
+          paiements sont effectués via les moyens de paiement acceptés (CMI, virement bancaire). Les
+          abonnements sont renouvelés automatiquement sauf résiliation préalable.
+        </p>
+      ),
+    },
+    {
+      id: "resiliation",
+      number: "09",
+      title: "Résiliation",
+      children: (
+        <p>
+          L&apos;utilisateur peut résilier son compte à tout moment depuis les paramètres de son
+          compte. Conformément au RGPD, une suppression complète des données sera effectuée dans un
+          délai de 30 jours suivant la demande, sous réserve des obligations légales de
+          conservation.
+        </p>
+      ),
+    },
+    {
+      id: "droit-applicable",
+      number: "10",
+      title: "Droit Applicable",
+      children: (
+        <p>
+          Les présentes CGU sont soumises au droit marocain. Tout litige relatif à
+          l&apos;interprétation ou à l&apos;exécution des présentes sera soumis aux tribunaux
+          compétents de Casablanca, Maroc.
+        </p>
+      ),
+    },
+    {
+      id: "contact",
+      number: "11",
+      title: "Contact",
+      children: (
+        <p>
+          Pour toute question relative aux présentes CGU, vous pouvez nous contacter via notre{" "}
+          <a href="/contact">page de contact</a>.
+        </p>
+      ),
+    },
+  ];
 
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">7. Propriété Intellectuelle</h2>
-          <p className="text-muted-foreground mb-4">
-            L&apos;ensemble des éléments de la Plateforme (textes, images, logos, code source) est
-            protégé par le droit de la propriété intellectuelle. Toute reproduction ou utilisation
-            non autorisée est strictement interdite.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">8. Abonnements et Paiements</h2>
-          <p className="text-muted-foreground mb-4">
-            Les tarifs des abonnements sont indiqués sur la page{" "}
-            <a href="/pricing" className="text-primary hover:underline">
-              Tarifs
-            </a>
-            . Les paiements sont effectués via les moyens de paiement acceptés (CMI, virement
-            bancaire). Les abonnements sont renouvelés automatiquement sauf résiliation préalable.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">9. Résiliation</h2>
-          <p className="text-muted-foreground mb-4">
-            L&apos;utilisateur peut résilier son compte à tout moment depuis les paramètres de son
-            compte. Conformément au RGPD, une suppression complète des données sera effectuée dans
-            un délai de 30 jours suivant la demande, sous réserve des obligations légales de
-            conservation.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">10. Droit Applicable</h2>
-          <p className="text-muted-foreground mb-4">
-            Les présentes CGU sont soumises au droit marocain. Tout litige relatif à
-            l&apos;interprétation ou à l&apos;exécution des présentes sera soumis aux tribunaux
-            compétents de Casablanca, Maroc.
-          </p>
-        </section>
-
-        <section className="mb-8">
-          <h2 className="text-xl font-semibold mb-4">11. Contact</h2>
-          <p className="text-muted-foreground mb-4">
-            Pour toute question relative aux présentes CGU, vous pouvez nous contacter via notre{" "}
-            <a href="/contact" className="text-primary hover:underline">
-              page de contact
-            </a>
-            .
-          </p>
-        </section>
-      </div>
-    </div>
+  return (
+    <LegalDoc
+      title="Conditions Générales d'Utilisation"
+      lastUpdated="MARS 2026"
+      sections={sections}
+    />
   );
 }

--- a/src/components/editorial/legal-doc.tsx
+++ b/src/components/editorial/legal-doc.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Editorial-institutional legal/document layout.
+ *
+ * Shared chrome for static document pages (privacy, terms, accessibility).
+ * Design direction: Stripe-docs measure + Linear typographic restraint +
+ * Bloomberg-terminal mono metadata. See docs design tokens in tokens.css:
+ * --ink / --bone / --oltigo-green / --rule plus --font-*-landing.
+ *
+ * Renders a ~58% reading measure with a sticky, scroll-spied table of
+ * contents in the left gutter on desktop. Mono section numbers, hairline
+ * dividers, no shadows.
+ */
+
+export interface LegalDocSection {
+  /** Stable anchor id (also the scroll target). */
+  id: string;
+  /** Mono section number, e.g. "01". */
+  number: string;
+  /** Section heading. */
+  title: string;
+  /** Section body. */
+  children: React.ReactNode;
+}
+
+export function LegalDoc({
+  title,
+  lastUpdated,
+  sections,
+}: {
+  title: string;
+  lastUpdated: string;
+  sections: LegalDocSection[];
+}) {
+  const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? "");
+
+  useEffect(() => {
+    const headings = sections
+      .map((s) => document.getElementById(s.id))
+      .filter((el): el is HTMLElement => el !== null);
+
+    if (headings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]?.target.id) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: "-96px 0px -70% 0px", threshold: 0 },
+    );
+
+    headings.forEach((h) => observer.observe(h));
+    return () => observer.disconnect();
+  }, [sections]);
+
+  return (
+    <div
+      style={{
+        backgroundColor: "var(--bone)",
+        color: "var(--ink)",
+        fontFamily: "var(--font-sans-landing)",
+      }}
+    >
+      <div
+        className="mx-auto w-full"
+        style={{
+          maxWidth: "var(--container-max)",
+          paddingInline: "var(--gutter-desktop)",
+          paddingBlock: "var(--space-9)",
+        }}
+      >
+        {/* Mono eyebrow */}
+        <div
+          style={{
+            fontFamily: "var(--font-mono-landing)",
+            fontSize: "var(--text-mono)",
+            lineHeight: "var(--lh-mono)",
+            letterSpacing: "var(--ls-mono)",
+            textTransform: "uppercase",
+            color: "var(--ink-60)",
+          }}
+        >
+          OLTIGO · DOCUMENT · MISE À JOUR {lastUpdated}
+        </div>
+
+        <div style={{ height: "var(--space-4)" }} />
+
+        {/* Title */}
+        <h1
+          style={{
+            fontFamily: "var(--font-sans-landing)",
+            fontSize: "clamp(2rem, 4vw, var(--text-h1))",
+            lineHeight: "var(--lh-h1)",
+            letterSpacing: "var(--ls-h1)",
+            fontWeight: 500,
+            color: "var(--ink)",
+            maxWidth: "75%",
+          }}
+        >
+          {title}
+        </h1>
+
+        <div style={{ height: "var(--space-7)" }} />
+        <hr style={{ border: "none", borderTop: "1px solid var(--rule)", margin: 0 }} />
+        <div style={{ height: "var(--space-7)" }} />
+
+        <div
+          className="grid gap-12 lg:grid-cols-[220px_minmax(0,1fr)]"
+          style={{ alignItems: "start" }}
+        >
+          {/* Sticky TOC (desktop only) */}
+          <nav
+            aria-label="Sommaire"
+            className="hidden lg:block"
+            style={{ position: "sticky", top: "var(--space-8)" }}
+          >
+            <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+              {sections.map((s) => {
+                const active = s.id === activeId;
+                return (
+                  <li key={s.id} style={{ marginBottom: "var(--space-2)" }}>
+                    <a
+                      href={`#${s.id}`}
+                      style={{
+                        display: "flex",
+                        gap: 8,
+                        fontFamily: "var(--font-mono-landing)",
+                        fontSize: "var(--text-mono)",
+                        letterSpacing: "var(--ls-mono)",
+                        textTransform: "uppercase",
+                        color: active ? "var(--oltigo-green)" : "var(--ink-60)",
+                        textDecoration: "none",
+                        paddingInlineStart: 10,
+                        borderInlineStart: `2px solid ${active ? "var(--oltigo-green)" : "var(--rule)"}`,
+                        lineHeight: 1.4,
+                        transition: "color var(--duration) var(--easing)",
+                      }}
+                    >
+                      <span>{s.number}</span>
+                      <span>{s.title}</span>
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+
+          {/* Document body */}
+          <div style={{ maxWidth: "68ch" }}>
+            {sections.map((s, i) => (
+              <section key={s.id} id={s.id} style={{ scrollMarginTop: "var(--space-8)" }}>
+                {i > 0 && (
+                  <>
+                    <div style={{ height: "var(--space-7)" }} />
+                    <hr style={{ border: "none", borderTop: "1px solid var(--rule)", margin: 0 }} />
+                    <div style={{ height: "var(--space-7)" }} />
+                  </>
+                )}
+                <div
+                  style={{
+                    fontFamily: "var(--font-mono-landing)",
+                    fontSize: "var(--text-mono)",
+                    letterSpacing: "var(--ls-mono)",
+                    textTransform: "uppercase",
+                    color: "var(--ink-60)",
+                    marginBottom: "var(--space-2)",
+                  }}
+                >
+                  {s.number}
+                </div>
+                <h2
+                  style={{
+                    fontFamily: "var(--font-sans-landing)",
+                    fontSize: "var(--text-h3)",
+                    lineHeight: "var(--lh-h3)",
+                    letterSpacing: "var(--ls-h3)",
+                    fontWeight: 500,
+                    color: "var(--ink)",
+                    marginBottom: "var(--space-4)",
+                  }}
+                >
+                  {s.title}
+                </h2>
+                <div className="legal-doc-body">{s.children}</div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <style>{`
+        .legal-doc-body {
+          font-family: var(--font-sans-landing);
+          font-size: var(--text-body);
+          line-height: var(--lh-body);
+          color: var(--ink-80);
+        }
+        .legal-doc-body p { margin: 0 0 var(--space-4) 0; }
+        .legal-doc-body p:last-child { margin-bottom: 0; }
+        .legal-doc-body h3 {
+          font-family: var(--font-sans-landing);
+          font-size: var(--text-body-lg);
+          line-height: var(--lh-body-lg);
+          font-weight: 500;
+          color: var(--ink);
+          margin: var(--space-5) 0 var(--space-3) 0;
+        }
+        .legal-doc-body ul {
+          margin: 0 0 var(--space-4) 0;
+          padding-inline-start: 0;
+          list-style: none;
+        }
+        .legal-doc-body li {
+          position: relative;
+          padding-inline-start: 20px;
+          margin-bottom: var(--space-2);
+        }
+        .legal-doc-body li::before {
+          content: "";
+          position: absolute;
+          inset-inline-start: 0;
+          top: 11px;
+          width: 6px;
+          height: 1px;
+          background: var(--oltigo-green);
+        }
+        .legal-doc-body strong { color: var(--ink); font-weight: 600; }
+        .legal-doc-body code {
+          font-family: var(--font-mono-landing);
+          font-size: 0.85em;
+          background: var(--rule);
+          padding: 1px 5px;
+          border-radius: 4px;
+          color: var(--ink);
+        }
+        .legal-doc-body a {
+          color: var(--oltigo-green);
+          text-decoration: underline;
+          text-underline-offset: 3px;
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

First slice of rolling the Oltigo editorial-institutional design language across the app's pages. This PR establishes a reusable document layout and applies it to the three static legal/compliance pages.

- Adds `src/components/editorial/legal-doc.tsx` — a shared `LegalDoc` layout component:
  - Bone canvas + ink type using the existing design tokens (`--ink`, `--bone`, `--oltigo-green`, `--rule`, `--font-*-landing`).
  - Mono metadata eyebrow, large Inter title, hairline section dividers, mono section numbers, green-dash bullet lists.
  - Sticky, scroll-spied table of contents in the left gutter on desktop (IntersectionObserver), collapses on mobile.
- Migrates `privacy`, `terms`, and `accessibility` pages onto `LegalDoc`. **All legal text is preserved verbatim** — only structure/presentation changed (sections are now passed as data with stable anchor ids).

Verified locally:
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors; total warnings reduced 4119 → 4097 (under the CI ceiling).
- Rendered all three routes on the dev server; TOC scroll-spy and anchors work.

This is intentionally a small, low-risk first batch (static pages, no tenant data, no DB) to lock the foundation. Subsequent PRs roll the system through the other page groups.

## Review & Testing Checklist for Human

- [ ] Visit `/privacy`, `/terms`, `/accessibility` and confirm the full legal text matches the previous versions (no wording dropped or altered).
- [ ] Check the pages on a clinic subdomain (tenant context) as well as the root domain — confirm the new bone/ink styling reads acceptably against tenant branding wrappers.
- [ ] Verify the sticky TOC scroll-spy and in-page anchor links on desktop, and that the layout collapses cleanly on mobile.
- [ ] Confirm `prefers-reduced-motion` / RTL (Arabic) rendering is acceptable for these pages.

### Notes
- `LegalDoc` is a client component because the TOC uses IntersectionObserver; section bodies are passed as JSX from the server page components.
- The bone/ink palette is applied directly (not via tenant brand vars) so legal pages are consistently Oltigo-branded — flag if you'd prefer them to inherit tenant branding instead.
