### PR TITLE
feat(theme): editorial design-system foundation (palette + typography) app-wide

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,73 +48,84 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+/*
+ * App-wide theme — Oltigo editorial-institutional.
+ *
+ * These shadcn tokens drive every dashboard, auth, and tenant surface built
+ * on the UI primitives. They are mapped onto the editorial design tokens in
+ * tokens.css (--ink / --bone / --oltigo-green / --rule) so the whole product
+ * shares one palette. Light mode = ink-on-bone; dark mode swaps ink<->bone
+ * with the green accent held constant (see design direction rule 4).
+ */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.45 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: var(--bone); /* #f4f1ea */
+  --foreground: var(--ink); /* #0b0f0e */
+  --card: #faf8f2; /* paper, one tier above bone */
+  --card-foreground: var(--ink);
+  --popover: #faf8f2;
+  --popover-foreground: var(--ink);
+  --primary: var(--oltigo-green); /* #005a3b */
+  --primary-foreground: var(--bone);
+  --secondary: #eae6db; /* deeper bone */
+  --secondary-foreground: var(--ink);
+  --muted: #eae6db;
+  --muted-foreground: rgba(11, 15, 14, 0.66);
+  --accent: #e3e9e4; /* faint green-tinted neutral (hover) */
+  --accent-foreground: var(--ink);
+  --destructive: var(--signal-red); /* #b42318 */
+  --border: var(--rule); /* ink @12% */
+  --input: var(--rule);
+  --ring: var(--oltigo-green);
+  /* Charts: editorial sequence — green, ink tiers, status amber. */
+  --chart-1: var(--oltigo-green);
+  --chart-2: rgba(11, 15, 14, 0.72);
+  --chart-3: var(--signal-amber);
+  --chart-4: rgba(11, 15, 14, 0.4);
+  --chart-5: #3f6f5a;
+  --radius: 0.5rem;
+  --sidebar: #efebe1; /* distinct from bone canvas */
+  --sidebar-foreground: var(--ink);
+  --sidebar-primary: var(--oltigo-green);
+  --sidebar-primary-foreground: var(--bone);
+  --sidebar-accent: #e3e9e4;
+  --sidebar-accent-foreground: var(--ink);
+  --sidebar-border: var(--rule);
+  --sidebar-ring: var(--oltigo-green);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.75 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Ink<->bone swap; green accent held constant. */
+  --background: var(--ink); /* #0b0f0e */
+  --foreground: var(--bone); /* #f4f1ea */
+  --card: #121615; /* one tier above ink */
+  --card-foreground: var(--bone);
+  --popover: #121615;
+  --popover-foreground: var(--bone);
+  --primary: #2f8f63; /* lifted green for legibility on ink */
+  --primary-foreground: #06110c;
+  --secondary: #1b211f;
+  --secondary-foreground: var(--bone);
+  --muted: #1b211f;
+  --muted-foreground: rgba(244, 241, 234, 0.64);
+  --accent: #1b211f;
+  --accent-foreground: var(--bone);
+  --destructive: #e5615a;
+  --border: rgba(244, 241, 234, 0.14);
+  --input: rgba(244, 241, 234, 0.16);
+  --ring: #2f8f63;
+  --chart-1: #2f8f63;
+  --chart-2: rgba(244, 241, 234, 0.7);
+  --chart-3: var(--signal-amber);
+  --chart-4: rgba(244, 241, 234, 0.4);
+  --chart-5: #5fae8a;
+  --sidebar: #0e1312;
+  --sidebar-foreground: var(--bone);
+  --sidebar-primary: #2f8f63;
+  --sidebar-primary-foreground: #06110c;
+  --sidebar-accent: #1b211f;
+  --sidebar-accent-foreground: var(--bone);
+  --sidebar-border: rgba(244, 241, 234, 0.14);
+  --sidebar-ring: #2f8f63;
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -58,6 +58,13 @@
  * with the green accent held constant (see design direction rule 4).
  */
 :root {
+  /* Editorial type: Inter (UI/body) + JetBrains Mono (metadata/labels),
+     loaded via next/font in layout.tsx. Arabic falls back to IBM Plex Arabic. */
+  --font-sans:
+    var(--font-inter), var(--font-ibm-plex-arabic), ui-sans-serif, system-ui, -apple-system,
+    sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, "Cascadia Code", monospace;
+
   --background: var(--bone); /* #f4f1ea */
   --foreground: var(--ink); /* #0b0f0e */
   --card: #faf8f2; /* paper, one tier above bone */
@@ -219,7 +226,7 @@
 
 /* Arabic typography — use Noto Sans Arabic when in RTL mode (Issue 62) */
 [dir="rtl"] {
-  font-family: var(--font-noto-arabic), var(--font-geist-sans), sans-serif;
+  font-family: var(--font-noto-arabic), var(--font-ibm-plex-arabic), var(--font-inter), sans-serif;
   font-feature-settings:
     "liga" 1,
     "calt" 1;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import {
-  Geist,
-  Geist_Mono,
+  Inter,
+  JetBrains_Mono,
   IBM_Plex_Sans_Arabic,
   Noto_Sans_Arabic,
   Playfair_Display,
@@ -18,14 +18,15 @@ import { ToastProvider } from "@/components/ui/toast";
 import { getDirection, t, type Locale, type TranslationKey } from "@/lib/i18n";
 import { getTenant } from "@/lib/tenant";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+// Editorial typography: Inter for UI/body, JetBrains Mono for metadata/labels.
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
   display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
   display: "swap",
 });
@@ -144,7 +145,7 @@ export default async function RootLayout({
       lang={locale}
       dir={dir}
       suppressHydrationWarning
-      className={`${geistSans.variable} ${geistMono.variable} ${notoSansArabic.variable} ${playfairDisplay.variable} ${ibmPlexArabic.variable} h-full antialiased`}
+      className={`${inter.variable} ${jetbrainsMono.variable} ${notoSansArabic.variable} ${playfairDisplay.variable} ${ibmPlexArabic.variable} h-full antialiased`}
     >
       <head>
         {/* PERF-005: Preconnect to Supabase to shave ~100ms off first SSR fetch */}


### PR DESCRIPTION
## Summary

The **design-system foundation** for rolling Oltigo's editorial-institutional language across the whole product. Both halves are centralized so all ~190 app screens (every dashboard, auth page, tenant surface built on the UI primitives) adopt the look at once — no per-page edits.

**1. Palette** — rewrites the light (`:root`) and dark (`.dark`) shadcn theme tokens in `globals.css`, mapping them onto the editorial tokens in `tokens.css`:
- `--background` → bone, `--foreground` → ink, `--primary` → oltigo-green, `--border`/`--input` → hairline (`--rule`), `--ring` → green.
- Cards/popovers use a paper tier above bone; secondary/muted use a deeper bone; accent is a faint green-tinted hover neutral.
- Chart palette → editorial sequence (green, ink tiers, status amber). `--radius` tightened 0.625rem → 0.5rem.
- Dark mode swaps ink ↔ bone with the green accent held constant (design rule 4); green lifted to `#2f8f63` for legibility on ink.

**2. Typography** — switches the app typeface to **Inter** (UI/body) + **JetBrains Mono** (metadata/labels), replacing Geist:
- `layout.tsx` loads both via `next/font/google`; `globals.css` wires them into `--font-sans` / `--font-mono`.
- Arabic RTL keeps Noto / IBM Plex Sans Arabic fallbacks.

The marketing/editorial landing is unaffected (it consumes `--ink`/`--bone` and Inter directly); this just brings the app chrome in line with it.

Verified locally:
- `tsc --noEmit` clean; dev server compiles; `/login` and `/about` render in the editorial palette + Inter (light & dark).
- Only theme token *values* + font wiring changed — no Tailwind/structural/logic changes, so tests and lint warning count are unaffected.

## Review & Testing Checklist for Human

- [ ] Click through representative surfaces in **light and dark** (a dashboard, a data table, a form, the sidebar) — confirm contrast/legibility and that nothing is unreadable.
- [ ] Look for components hardcoding colors (`bg-white`, `text-gray-*`, `bg-blue-*`) that won't pick up the theme and may clash with bone — flag for follow-up.
- [ ] Verify Arabic (RTL) pages render with the Arabic font fallback, not Inter, and recharts charts read clearly with the new palette.
- [ ] Confirm tenant storefronts that inject brand colors via CSS vars still look correct, and focus/selected states use the green ring.

### Notes
- This is the "design-system-first" base: a single source of truth so subsequent per-area PRs only refine layout/typography, not re-color each page.
- Tenant-configurable site fonts (the "Geist" default in branding data) are intentionally left untouched — those are per-clinic storefront options, separate from the app chrome typeface.
