### PR TITLE
feat(theme): app-wide editorial typography (Inter + JetBrains Mono)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -58,6 +58,13 @@
  * with the green accent held constant (see design direction rule 4).
  */
 :root {
+  /* Editorial type: Inter (UI/body) + JetBrains Mono (metadata/labels),
+     loaded via next/font in layout.tsx. Arabic falls back to IBM Plex Arabic. */
+  --font-sans:
+    var(--font-inter), var(--font-ibm-plex-arabic), ui-sans-serif, system-ui, -apple-system,
+    sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, "Cascadia Code", monospace;
+
   --background: var(--bone); /* #f4f1ea */
   --foreground: var(--ink); /* #0b0f0e */
   --card: #faf8f2; /* paper, one tier above bone */
@@ -219,7 +226,7 @@
 
 /* Arabic typography — use Noto Sans Arabic when in RTL mode (Issue 62) */
 [dir="rtl"] {
-  font-family: var(--font-noto-arabic), var(--font-geist-sans), sans-serif;
+  font-family: var(--font-noto-arabic), var(--font-ibm-plex-arabic), var(--font-inter), sans-serif;
   font-feature-settings:
     "liga" 1,
     "calt" 1;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import {
-  Geist,
-  Geist_Mono,
+  Inter,
+  JetBrains_Mono,
   IBM_Plex_Sans_Arabic,
   Noto_Sans_Arabic,
   Playfair_Display,
@@ -18,14 +18,15 @@ import { ToastProvider } from "@/components/ui/toast";
 import { getDirection, t, type Locale, type TranslationKey } from "@/lib/i18n";
 import { getTenant } from "@/lib/tenant";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+// Editorial typography: Inter for UI/body, JetBrains Mono for metadata/labels.
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
   display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
   display: "swap",
 });
@@ -144,7 +145,7 @@ export default async function RootLayout({
       lang={locale}
       dir={dir}
       suppressHydrationWarning
-      className={`${geistSans.variable} ${geistMono.variable} ${notoSansArabic.variable} ${playfairDisplay.variable} ${ibmPlexArabic.variable} h-full antialiased`}
+      className={`${inter.variable} ${jetbrainsMono.variable} ${notoSansArabic.variable} ${playfairDisplay.variable} ${ibmPlexArabic.variable} h-full antialiased`}
     >
       <head>
         {/* PERF-005: Preconnect to Supabase to shave ~100ms off first SSR fetch */}


### PR DESCRIPTION
## Summary

Second half of the design-system foundation: switches the app-wide typeface to the editorial pairing **Inter** (UI/body) + **JetBrains Mono** (metadata/labels), replacing Geist.

- `src/app/layout.tsx`: load `Inter` and `JetBrains_Mono` via `next/font/google` (self-hosted, `display: swap`), exposing `--font-inter` / `--font-jetbrains-mono`.
- `src/app/globals.css`: point the `--font-sans` / `--font-mono` theme tokens at the new variables, so every `font-sans` / `font-mono` consumer (all app surfaces) picks up the editorial type. Arabic RTL still uses Noto / IBM Plex Sans Arabic fallbacks.

This unifies the app typography with the marketing/editorial landing (which already uses Inter + JetBrains Mono), completing the shared foundation alongside the palette PR.

**Stacked on** `devin/1779995170-editorial-app-theme` (the palette PR, #705). Base is set to that branch so this PR's diff is just the typography change; retarget to `main` once #705 merges.

Verified locally:
- `tsc --noEmit` clean; dev server compiles; `/login` renders in Inter with the editorial palette intact.
- Only font wiring changed — no logic/structural changes; tests and lint warning count unaffected.

## Review & Testing Checklist for Human

- [ ] Confirm Inter renders across light/dark and a few dashboards; check for any layout shift from the metric change (Geist → Inter).
- [ ] Verify Arabic (RTL) pages still render with the Arabic font fallback, not Inter.
- [ ] Confirm mono labels/metadata (tables, badges, code) now use JetBrains Mono.
- [ ] Check the font network payload is acceptable (two self-hosted Google fonts added; JS bundle budget is unaffected since fonts aren't JS).

### Notes
- Tenant-configurable site fonts (the "Geist" default in branding data) are intentionally left untouched — those are per-clinic storefront options, separate from the app chrome typeface.
