### PR TITLE
feat(brand): distinctive Oltigo wordmark + monogram across auth & all app shells

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { ArrowLeft, Heart, Mail, Check } from "lucide-react";
+import { ArrowLeft, Mail, Check } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { OltigoWordmark } from "@/components/brand/oltigo-mark";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
 import {
@@ -53,14 +54,12 @@ export default function ForgotPasswordPage() {
 
   return (
     <div className="w-full max-w-md mx-auto">
-      <div className="text-center mb-6">
-        <div className="flex items-center justify-center gap-2 mb-2">
-          <div className="h-10 w-10 rounded-xl bg-primary flex items-center justify-center">
-            <Heart className="h-5 w-5 text-primary-foreground" />
-          </div>
-        </div>
-        <h1 className="text-xl font-bold">{t(locale, "auth.portalTitle")}</h1>
-        <p className="text-sm text-muted-foreground">{t(locale, "forgot.resetSubtitle")}</p>
+      <div className="mb-8 text-center">
+        <OltigoWordmark size="lg" className="justify-center" />
+        <p className="mt-3 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-muted-foreground">
+          {t(locale, "auth.portalTitle")}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">{t(locale, "forgot.resetSubtitle")}</p>
       </div>
 
       <Card>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Phone, ShieldCheck, ArrowLeft, Heart, Mail, Lock, Key } from "lucide-react";
+import { Phone, ArrowLeft, Lock, Key } from "lucide-react";
 import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
+import { OltigoWordmark } from "@/components/brand/oltigo-mark";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
 import {
@@ -211,27 +212,16 @@ export default function LoginPage() {
 
   return (
     <div className="w-full max-w-md mx-auto">
-      <div className="text-center mb-6">
-        <div className="flex items-center justify-center gap-2 mb-2">
-          <div className="h-10 w-10 rounded-xl bg-primary flex items-center justify-center">
-            <Heart className="h-5 w-5 text-primary-foreground" />
-          </div>
-        </div>
-        <h1 className="text-xl font-bold">{t(locale, "auth.portalTitle")}</h1>
-        <p className="text-sm text-muted-foreground">{t(locale, "auth.loginSubtitle")}</p>
+      <div className="mb-8 text-center">
+        <OltigoWordmark size="lg" className="justify-center" />
+        <p className="mt-3 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-muted-foreground">
+          {t(locale, "auth.portalTitle")}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">{t(locale, "auth.loginSubtitle")}</p>
       </div>
 
       <Card>
-        <CardHeader className="text-center pb-4">
-          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-            {step === "otp" || step === "mfa" || step === "backup" ? (
-              <ShieldCheck className="h-6 w-6 text-primary" />
-            ) : method === "email" ? (
-              <Mail className="h-6 w-6 text-primary" />
-            ) : (
-              <Phone className="h-6 w-6 text-primary" />
-            )}
-          </div>
+        <CardHeader className="pb-4">
           <CardTitle className="text-xl">
             {step === "otp"
               ? t(locale, "auth.verifyNumber")

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { UserPlus, ShieldCheck, ArrowLeft, Heart } from "lucide-react";
+import { UserPlus, ShieldCheck, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { OltigoWordmark } from "@/components/brand/oltigo-mark";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
 import {
@@ -98,14 +99,12 @@ export default function RegisterPage() {
   if (!PHONE_AUTH_ENABLED) {
     return (
       <div className="w-full max-w-md mx-auto">
-        <div className="text-center mb-6">
-          <div className="flex items-center justify-center gap-2 mb-2">
-            <div className="h-10 w-10 rounded-xl bg-primary flex items-center justify-center">
-              <Heart className="h-5 w-5 text-primary-foreground" />
-            </div>
-          </div>
-          <h1 className="text-xl font-bold">{t(locale, "auth.portalTitle")}</h1>
-          <p className="text-sm text-muted-foreground">{t(locale, "register.subtitle")}</p>
+        <div className="mb-8 text-center">
+          <OltigoWordmark size="lg" className="justify-center" />
+          <p className="mt-3 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-muted-foreground">
+            {t(locale, "auth.portalTitle")}
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">{t(locale, "register.subtitle")}</p>
         </div>
 
         <Card>
@@ -139,14 +138,12 @@ export default function RegisterPage() {
 
   return (
     <div className="w-full max-w-md mx-auto">
-      <div className="text-center mb-6">
-        <div className="flex items-center justify-center gap-2 mb-2">
-          <div className="h-10 w-10 rounded-xl bg-primary flex items-center justify-center">
-            <Heart className="h-5 w-5 text-primary-foreground" />
-          </div>
-        </div>
-        <h1 className="text-xl font-bold">{t(locale, "auth.portalTitle")}</h1>
-        <p className="text-sm text-muted-foreground">{t(locale, "register.subtitle")}</p>
+      <div className="mb-8 text-center">
+        <OltigoWordmark size="lg" className="justify-center" />
+        <p className="mt-3 font-mono text-[0.7rem] uppercase tracking-[0.2em] text-muted-foreground">
+          {t(locale, "auth.portalTitle")}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">{t(locale, "register.subtitle")}</p>
       </div>
 
       <Card>

--- a/src/components/brand/oltigo-mark.tsx
+++ b/src/components/brand/oltigo-mark.tsx
@@ -32,6 +32,7 @@ export function OltigoWordmark({
         WORDMARK_SIZE[size],
         className,
       )}
+      role="img"
       aria-label="Oltigo"
     >
       <span aria-hidden>oltig</span>
@@ -75,6 +76,7 @@ export function OltigoMonogram({
         color: "var(--primary)",
         backgroundColor: "var(--card)",
       }}
+      role="img"
       aria-label="Oltigo"
     >
       <span aria-hidden>o</span>

--- a/src/components/brand/oltigo-mark.tsx
+++ b/src/components/brand/oltigo-mark.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable i18next/no-literal-string -- brand name, never translated */
+import { cn } from "@/lib/utils";
+
+type MarkSize = "sm" | "md" | "lg" | "xl";
+
+const WORDMARK_SIZE: Record<MarkSize, string> = {
+  sm: "text-base", // 16px
+  md: "text-xl", // 20px
+  lg: "text-2xl", // 24px
+  xl: "text-[2rem]", // 32px
+};
+
+/**
+ * Oltigo wordmark — the canonical brand lockup.
+ *
+ * Deliberately typographic (not an icon-in-a-rounded-square): the name set in
+ * Inter, lowercase, tight tracking, with the trailing "o" carried in the
+ * brand green as the single ownable accent. Base glyphs inherit `currentColor`
+ * so the mark adapts to ink-on-bone / bone-on-ink contexts.
+ */
+export function OltigoWordmark({
+  size = "md",
+  className,
+}: {
+  size?: MarkSize;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex select-none items-baseline font-sans font-bold lowercase leading-none tracking-[-0.03em]",
+        WORDMARK_SIZE[size],
+        className,
+      )}
+      aria-label="Oltigo"
+    >
+      <span aria-hidden>oltig</span>
+      <span aria-hidden style={{ color: "var(--primary)" }}>
+        o
+      </span>
+    </span>
+  );
+}
+
+const MONOGRAM_SIZE: Record<MarkSize, string> = {
+  sm: "h-7 w-7 text-base",
+  md: "h-9 w-9 text-lg",
+  lg: "h-11 w-11 text-xl",
+  xl: "h-14 w-14 text-2xl",
+};
+
+/**
+ * Compact monogram for tight spaces (collapsed sidebars, avatars, favicons).
+ *
+ * A hairline-ruled square holding the lowercase "o" with the green accent —
+ * the structural hairline + accent echo the wordmark rather than introducing a
+ * generic filled-tile-with-icon logo.
+ */
+export function OltigoMonogram({
+  size = "md",
+  className,
+}: {
+  size?: MarkSize;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex select-none items-center justify-center rounded-[3px] font-sans font-bold leading-none",
+        MONOGRAM_SIZE[size],
+        className,
+      )}
+      style={{
+        border: "1px solid var(--rule)",
+        color: "var(--primary)",
+        backgroundColor: "var(--card)",
+      }}
+      aria-label="Oltigo"
+    >
+      <span aria-hidden>o</span>
+    </span>
+  );
+}

--- a/src/components/layouts/admin-layout-shell.tsx
+++ b/src/components/layouts/admin-layout-shell.tsx
@@ -29,6 +29,7 @@ import {
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { MobileMenuOverlay } from "@/components/layouts/mobile-menu-overlay";
 import { useLocale } from "@/components/locale-switcher";
 import { GettingStartedChecklist } from "@/components/onboarding/getting-started-checklist";
@@ -210,6 +211,7 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
           >
             <Menu className="h-5 w-5" />
           </button>
+          <OltigoMonogram size="sm" />
           <h2 className="text-sm font-semibold">{t(locale, "nav.clinicAdmin")}</h2>
         </div>
 
@@ -217,7 +219,10 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
         {mobileOpen && (
           <MobileMenuOverlay onClose={() => setMobileOpen(false)}>
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold">{t(locale, "nav.clinicAdmin")}</h2>
+              <div className="flex items-center gap-2">
+                <OltigoMonogram size="sm" />
+                <h2 className="text-lg font-semibold">{t(locale, "nav.clinicAdmin")}</h2>
+              </div>
               <button
                 onClick={() => setMobileOpen(false)}
                 className="rounded-md p-1 hover:bg-muted"
@@ -232,7 +237,10 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
 
         {/* Desktop sidebar */}
         <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
-          <h2 className="text-lg font-semibold mb-6">{t(locale, "nav.clinicAdmin")}</h2>
+          <div className="flex items-center gap-2 mb-6">
+            <OltigoMonogram size="sm" />
+            <h2 className="text-lg font-semibold">{t(locale, "nav.clinicAdmin")}</h2>
+          </div>
           <SidebarContent pathname={pathname} />
         </aside>
 

--- a/src/components/layouts/clinic-dashboard-layout.tsx
+++ b/src/components/layouts/clinic-dashboard-layout.tsx
@@ -5,6 +5,7 @@ import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { FeatureGate } from "@/components/feature-gate";
 import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
 import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
@@ -58,7 +59,7 @@ function SidebarContent({
               onClick={onNavClick}
               className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
                 isActive
-                  ? `bg-${config.accentColor}/10 text-${config.accentColor} font-medium`
+                  ? "bg-primary/10 text-primary font-medium"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground"
               }`}
             >
@@ -84,7 +85,6 @@ export function ClinicDashboardLayout({
 }) {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const IconComponent = config.icon;
   const shortTitle = config.shortTitle ?? config.title;
 
   const content = config.featureKey ? (
@@ -107,7 +107,7 @@ export function ClinicDashboardLayout({
           <Menu className="h-5 w-5" />
         </button>
         <div className="flex items-center gap-2">
-          <IconComponent className={`h-4 w-4 text-${config.accentColor}`} />
+          <OltigoMonogram size="sm" />
           <h2 className="text-sm font-semibold">{shortTitle}</h2>
         </div>
       </div>
@@ -120,7 +120,7 @@ export function ClinicDashboardLayout({
           <aside className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 flex flex-col shadow-xl">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <IconComponent className={`h-5 w-5 text-${config.accentColor}`} />
+                <OltigoMonogram size="sm" />
                 <h2 className="text-lg font-semibold">{config.title}</h2>
               </div>
               <button
@@ -143,11 +143,7 @@ export function ClinicDashboardLayout({
       {/* Desktop sidebar */}
       <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
         <div className="flex items-center gap-2 mb-6">
-          <div
-            className={`h-8 w-8 rounded-lg bg-${config.accentColor} flex items-center justify-center`}
-          >
-            <IconComponent className="h-4 w-4 text-white" />
-          </div>
+          <OltigoMonogram size="sm" />
           <h2 className="text-lg font-semibold">{config.title}</h2>
         </div>
         <SidebarContent config={config} pathname={pathname} />

--- a/src/components/layouts/doctor-layout-shell.tsx
+++ b/src/components/layouts/doctor-layout-shell.tsx
@@ -47,6 +47,7 @@ import {
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useCallback } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { MobileMenuOverlay } from "@/components/layouts/mobile-menu-overlay";
 import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
 import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
@@ -695,7 +696,10 @@ export default function DoctorLayoutShell({ children }: { children: React.ReactN
     <div className="flex min-h-screen">
       {/* Desktop sidebar */}
       <aside className="hidden w-64 border-r bg-card p-4 md:flex flex-col">
-        <h2 className="text-lg font-semibold mb-4">{t(locale, "doctorNav.title")}</h2>
+        <div className="flex items-center gap-2 mb-4">
+          <OltigoMonogram size="sm" />
+          <h2 className="text-lg font-semibold">{t(locale, "doctorNav.title")}</h2>
+        </div>
         <SidebarContent
           pathname={pathname}
           visibleItems={visibleItems}
@@ -711,9 +715,7 @@ export default function DoctorLayoutShell({ children }: { children: React.ReactN
         {/* Mobile Header */}
         <header className="flex items-center justify-between border-b p-3 md:hidden">
           <div className="flex items-center gap-2">
-            <div className="h-7 w-7 rounded-lg bg-primary flex items-center justify-center">
-              <Stethoscope className="h-3.5 w-3.5 text-primary-foreground" />
-            </div>
+            <OltigoMonogram size="sm" />
             <span className="font-semibold text-sm">{t(locale, "doctorNav.title")}</span>
           </div>
           <Button
@@ -731,9 +733,7 @@ export default function DoctorLayoutShell({ children }: { children: React.ReactN
           <MobileMenuOverlay onClose={() => setMobileMenuOpen(false)}>
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">
-                <div className="h-8 w-8 rounded-lg bg-primary flex items-center justify-center">
-                  <Stethoscope className="h-4 w-4 text-primary-foreground" />
-                </div>
+                <OltigoMonogram size="sm" />
                 <h2 className="text-lg font-semibold">{t(locale, "doctorNav.title")}</h2>
               </div>
               <Button

--- a/src/components/layouts/equipment-layout-shell.tsx
+++ b/src/components/layouts/equipment-layout-shell.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import {
-  LayoutDashboard,
-  Package,
-  HandCoins,
-  Wrench,
-  Menu,
-  X,
-  Stethoscope,
-  Languages,
-} from "lucide-react";
+import { LayoutDashboard, Package, HandCoins, Wrench, Menu, X, Languages } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, createContext, useContext, useCallback } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { FeatureGate } from "@/components/feature-gate";
 import { SignOutButton } from "@/components/sign-out-button";
 
@@ -77,7 +69,7 @@ function SidebarContent({
               onClick={onNavClick}
               className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
                 isActive
-                  ? "bg-amber-600/10 text-amber-600 font-medium"
+                  ? "bg-primary/10 text-primary font-medium"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground"
               }`}
             >
@@ -123,7 +115,7 @@ export default function EquipmentLayoutShell({ children }: { children: React.Rea
             <Menu className="h-5 w-5" />
           </button>
           <div className="flex items-center gap-2 flex-1">
-            <Stethoscope className="h-4 w-4 text-amber-600" />
+            <OltigoMonogram size="sm" />
             <h2 className="text-sm font-semibold">{shortTitle}</h2>
           </div>
           <button
@@ -144,7 +136,7 @@ export default function EquipmentLayoutShell({ children }: { children: React.Rea
             <aside className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 flex flex-col shadow-xl">
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-2">
-                  <Stethoscope className="h-5 w-5 text-amber-600" />
+                  <OltigoMonogram size="sm" />
                   <h2 className="text-lg font-semibold">{shortTitle}</h2>
                 </div>
                 <button
@@ -167,9 +159,7 @@ export default function EquipmentLayoutShell({ children }: { children: React.Rea
         {/* Desktop sidebar */}
         <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
           <div className="flex items-center gap-2 mb-6">
-            <div className="h-8 w-8 rounded-lg bg-amber-600 flex items-center justify-center">
-              <Stethoscope className="h-4 w-4 text-white" />
-            </div>
+            <OltigoMonogram size="sm" />
             <h2 className="text-lg font-semibold flex-1">{title}</h2>
             <button
               onClick={toggleLocale}

--- a/src/components/layouts/patient-layout-shell.tsx
+++ b/src/components/layouts/patient-layout-shell.tsx
@@ -20,6 +20,7 @@ import {
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { MobileMenuOverlay } from "@/components/layouts/mobile-menu-overlay";
 import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
 import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
@@ -81,9 +82,7 @@ export default function PatientLayoutShell({ children }: { children: React.React
       {/* Desktop Sidebar */}
       <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
         <div className="flex items-center gap-2 mb-6">
-          <div className="h-8 w-8 rounded-lg bg-primary flex items-center justify-center">
-            <Heart className="h-4 w-4 text-primary-foreground" />
-          </div>
+          <OltigoMonogram size="sm" />
           <h2 className="text-lg font-semibold">{t(locale, "patientNav.title")}</h2>
         </div>
         <nav className="space-y-1 flex-1">
@@ -115,9 +114,7 @@ export default function PatientLayoutShell({ children }: { children: React.React
       <div className="flex flex-1 flex-col">
         <header className="flex items-center justify-between border-b p-3 md:hidden">
           <div className="flex items-center gap-2">
-            <div className="h-7 w-7 rounded-lg bg-primary flex items-center justify-center">
-              <Heart className="h-3.5 w-3.5 text-primary-foreground" />
-            </div>
+            <OltigoMonogram size="sm" />
             <span className="font-semibold text-sm">{t(locale, "patientNav.title")}</span>
           </div>
           <Button
@@ -135,9 +132,7 @@ export default function PatientLayoutShell({ children }: { children: React.React
           <MobileMenuOverlay onClose={() => setMobileMenuOpen(false)}>
             <div className="flex items-center justify-between mb-6">
               <div className="flex items-center gap-2">
-                <div className="h-8 w-8 rounded-lg bg-primary flex items-center justify-center">
-                  <Heart className="h-4 w-4 text-primary-foreground" />
-                </div>
+                <OltigoMonogram size="sm" />
                 <h2 className="text-lg font-semibold">{t(locale, "patientNav.title")}</h2>
               </div>
               <Button

--- a/src/components/layouts/receptionist-layout-shell.tsx
+++ b/src/components/layouts/receptionist-layout-shell.tsx
@@ -9,11 +9,11 @@ import {
   FileText,
   Menu,
   X,
-  ClipboardList,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
 import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
 import { PatientSearchPalette } from "@/components/patient-search-palette";
@@ -74,7 +74,10 @@ export default function ReceptionistLayoutShell({ children }: { children: React.
     <div className="flex min-h-screen">
       {/* Desktop sidebar */}
       <aside className="hidden w-64 border-r bg-card p-4 md:block">
-        <h2 className="text-lg font-semibold mb-6">Reception Panel</h2>
+        <div className="flex items-center gap-2 mb-6">
+          <OltigoMonogram size="sm" />
+          <h2 className="text-lg font-semibold">Reception Panel</h2>
+        </div>
         <NavLinks pathname={pathname} />
         <div className="mt-auto pt-6 border-t mt-6">
           <SignOutButton />
@@ -85,9 +88,7 @@ export default function ReceptionistLayoutShell({ children }: { children: React.
         {/* Mobile Header */}
         <header className="flex items-center justify-between border-b p-3 md:hidden">
           <div className="flex items-center gap-2">
-            <div className="h-7 w-7 rounded-lg bg-primary flex items-center justify-center">
-              <ClipboardList className="h-3.5 w-3.5 text-primary-foreground" />
-            </div>
+            <OltigoMonogram size="sm" />
             <span className="font-semibold text-sm">Reception Panel</span>
           </div>
           <Button
@@ -111,9 +112,7 @@ export default function ReceptionistLayoutShell({ children }: { children: React.
             <div className="absolute left-0 top-0 bottom-0 w-64 bg-card p-4 shadow-lg">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex items-center gap-2">
-                  <div className="h-8 w-8 rounded-lg bg-primary flex items-center justify-center">
-                    <ClipboardList className="h-4 w-4 text-primary-foreground" />
-                  </div>
+                  <OltigoMonogram size="sm" />
                   <h2 className="text-lg font-semibold">Reception Panel</h2>
                 </div>
                 <Button

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -9,7 +9,6 @@ import {
   Menu,
   Bell,
   ChevronDown,
-  Shield,
   Settings,
   User,
   Megaphone,
@@ -22,6 +21,7 @@ import {
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState, useEffect, useRef, useCallback } from "react";
+import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { CommandPalette, type CommandPaletteItem } from "@/components/command-palette";
 import { ImpersonationBanner } from "@/components/impersonation-banner";
 import { LocaleSwitcher } from "@/components/locale-switcher";
@@ -243,9 +243,7 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
         {/* Desktop Sidebar */}
         <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
           <div className="flex items-center gap-2 mb-6">
-            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-              <Shield className="h-4 w-4" />
-            </div>
+            <OltigoMonogram size="sm" />
             <div>
               <h2 className="text-sm font-semibold">Master Control</h2>
               <p className="text-[10px] text-muted-foreground">Super Admin Panel</p>
@@ -368,7 +366,7 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
           <SheetContent side="left" onClose={() => setMobileOpen(false)}>
             <SheetHeader>
               <SheetTitle className="flex items-center gap-2">
-                <Shield className="h-4 w-4" />
+                <OltigoMonogram size="sm" />
                 Master Control
               </SheetTitle>
             </SheetHeader>


### PR DESCRIPTION
## Summary

Kills the "built-by-AI" look on the brand identity — first the auth screens, then **every dashboard shell** — per request to avoid generic logos/layouts.

### New brand mark
- **`OltigoWordmark` / `OltigoMonogram`** (`src/components/brand/oltigo-mark.tsx`) — a deliberately *typographic* brand lockup: the name set in Inter, lowercase, tight tracking, with the trailing "o" carried in brand green as the single ownable accent. No icon-in-a-rounded-gradient-square. Base glyphs inherit `currentColor` so it adapts to ink-on-bone / bone-on-ink. The monogram is a hairline-ruled tile (structural, not a filled icon chip) for tight spaces.

### Auth screens
- `login`, `register`, `forgot-password` — replace the stock lucide **Heart-in-a-green-rounded-square** logo with the wordmark + a mono uppercase eyebrow.
- **Login card** — drop the centered icon-in-a-circle and left-align the header.

### App-shell branding (every role)
- Replace the per-role **icon-in-a-colored-square** logos with the shared hairline `OltigoMonogram`:
  - patient (Heart), doctor (Stethoscope), receptionist (ClipboardList), super-admin (Shield), clinic-admin (added monogram).
  - shared `ClinicDashboardLayout` (powers pharmacist / lab / specialist panels) and the equipment shell — replaced the off-palette **emerald/blue/amber** icon tiles.
- Snap the clinic/equipment panels' **active-nav** color from off-palette emerald/blue/amber onto the editorial **green** (`bg-primary/10 text-primary`) so the whole product reads as one brand.

This makes the product feel hand-built and on-brand rather than a stack of stock per-role icon chips.

Verified locally:
- `tsc --noEmit` clean; `eslint` clean (no new errors) on all changed files.
- WCAG a11y test passes (wordmark carries `role="img"` + `aria-label`).
- `/login`, `/register`, `/forgot-password` render 200 with the wordmark.

**Targets `main` directly** — independent of the palette/typography foundation; CI-validated on its own.

## Review & Testing Checklist for Human

- [ ] Confirm the wordmark + monogram read well in light + dark and at mobile width; check the green "o"/accent contrast in dark mode.
- [ ] Click through each role's sidebar (patient / doctor / receptionist / admin / super-admin / pharmacist / lab / equipment) and confirm the monogram renders and the active-nav highlight is green.
- [ ] Verify removing the login card icon didn't leave awkward spacing across the credential / OTP / MFA / backup-code steps.
- [ ] Confirm no other surface still renders an old icon-in-square brand mark (public headers are a follow-up PR).
- [ ] Sanity-check Arabic (RTL): the lowercase Latin wordmark should still render LTR as a brand mark.

### Notes
- `config.icon` / `config.accentColor` remain on `ClinicDashboardConfig` (data, no longer rendered) to avoid churning the per-panel configs in this PR.
- Register/2FA still use *contextual* state icons (UserPlus, ShieldCheck) inside their cards — those are status glyphs, not the brand logo, left for a later editorial pass.
