### PR TITLE
fix(security): Season 0 v2 audit — HMAC delimiter, bidi strip, XFF logging, Sentry dedup alert (FP-01, FP-04, FP-07, FP-27, IV-05, IDOR-03, PERF-01)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Every database operation **must** be scoped to a `clinic_id`. Failing to do so c
 4. **RLS is defense-in-depth** — Application-level scoping is required even though database RLS policies exist. Both layers must agree.
 5. **Webhooks must resolve tenant** — In webhook handlers (WhatsApp, Stripe), resolve the `clinic_id` from the webhook payload (e.g., WABA phone number ID, Stripe metadata). If resolution fails, skip processing — never query across tenants.
 6. **Cron jobs iterate per-clinic** — Scheduled tasks must iterate over clinics and scope each operation to the current clinic's ID.
+7. **Never spread request body into DB** — Always destructure and pick specific fields: `.insert({ name: body.name, phone: body.phone })`. Never `.insert({ ...body })` or `.insert(body)` — this prevents mass-assignment of unintended columns (e.g., `role`, `clinic_id`).
 
 ### Key Files
 

--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -163,11 +163,18 @@ export async function POST(request: NextRequest) {
             });
             return apiSuccess({ received: true, duplicate: true });
           }
+          // FP-07: Non-duplicate dedup failure — surface to Sentry so
+          // operators can detect table truncation or schema drift.
           logger.warn("Stripe event dedup insert failed", {
             context: "billing/webhook",
             eventId: stripeEventId,
             error: dedupErr.message,
           });
+          import("@sentry/nextjs")
+            .then((Sentry) =>
+              Sentry.captureMessage(`Stripe dedup insert failed: ${dedupErr.message}`, "warning"),
+            )
+            .catch(() => {});
         }
       } catch (dedupCatchErr) {
         logger.warn("Stripe event dedup threw — continuing without dedup", {

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -26,6 +26,7 @@ import { createTenantClient } from "@/lib/supabase-server";
 import { requireTenantWithConfig } from "@/lib/tenant";
 import { computeEndTime } from "@/lib/timezone";
 import { APPOINTMENT_STATUS, BOOKING_SOURCE } from "@/lib/types/database";
+import { safeName, safeText } from "@/lib/validations/primitives";
 // findOrCreatePatient is used by authenticated routes (recurring, emergency-slot, etc.)
 // For the anonymous booking flow we use the booking_find_or_create_patient RPC instead
 // (SECURITY DEFINER function that bypasses users-table RLS).
@@ -40,14 +41,15 @@ const bookingRequestSchema = z.object({
   isFirstVisit: z.boolean(),
   hasInsurance: z.boolean(),
   patient: z.object({
-    name: z.string().min(2).max(200),
+    // IV-05: Use safeName/safeText to strip bidi overrides + NFC normalize.
+    name: safeName.pipe(z.string().min(2).max(200)),
     phone: z
       .string()
       .min(8)
       .max(30)
       .regex(/^\+?[0-9 ()\-]{8,30}$/, "Invalid phone number format"),
-    email: z.string().email().optional(),
-    reason: z.string().max(1000).optional(),
+    email: z.string().email().max(254).optional(),
+    reason: safeText.pipe(z.string().max(1000)).optional(),
   }),
   slotDuration: z.number().int().positive(),
   bufferTime: z.number().int().min(0),

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -56,6 +56,7 @@ function sanitizeUserInput(text: string): string {
       .replace(/[\u200B-\u200D\u2028-\u202F\uFEFF\u00AD]/g, "")
       // Strip attempts to impersonate system/assistant roles
       // (covers whitespace/zero-width tricks between characters)
+      // PERF-01: ^-anchored so .replace is O(n); safe from ReDoS.
       .replace(/^\s*(s\s*y\s*s\s*t\s*e\s*m|a\s*s\s*s\s*i\s*s\s*t\s*a\s*n\s*t)\s*:/gi, "")
       // Remove markdown-style "instruction" fences
       .replace(/```(system|instructions?)[\s\S]*?```/gi, "")

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -213,14 +213,14 @@ export async function POST(request: NextRequest) {
             const updateData: Record<string, string> = {
               status: statusUpdate.status,
             };
+            // FP-27: Use explicit isNaN check instead of falsy || for timestamp.
+            // parseInt("0") returns 0 which is falsy, causing incorrect Date.now() fallback.
+            const parsedTs = parseInt(statusUpdate.timestamp);
+            const tsMs = isNaN(parsedTs) ? Date.now() : parsedTs * 1000;
             if (statusUpdate.status === "delivered") {
-              updateData.delivered_at = new Date(
-                parseInt(statusUpdate.timestamp) * 1000 || Date.now(),
-              ).toISOString();
+              updateData.delivered_at = new Date(tsMs).toISOString();
             } else if (statusUpdate.status === "read") {
-              updateData.read_at = new Date(
-                parseInt(statusUpdate.timestamp) * 1000 || Date.now(),
-              ).toISOString();
+              updateData.read_at = new Date(tsMs).toISOString();
             }
 
             await admin

--- a/src/lib/profile-header-hmac.ts
+++ b/src/lib/profile-header-hmac.ts
@@ -76,7 +76,9 @@ function getOldProfileHeaderSecret(): string | null {
 }
 
 function buildPayload(profile: SignedProfile, iat: number): string {
-  return `${profile.id}:${profile.role}:${profile.clinic_id ?? ""}:${iat}`;
+  // FP-01: JSON-encode to avoid delimiter collision — a role containing ":"
+  // would let a forged (id, "role:clinic_X", "", iat) match (id, "role", "clinic_X", iat).
+  return JSON.stringify([profile.id, profile.role, profile.clinic_id ?? "", iat]);
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -107,6 +107,16 @@ export function extractClientIp(request: NextRequest): string {
     return realIp;
   }
 
+  // FP-04: In production without CF-Connecting-IP, all spoofable headers
+  // failed. Return "unknown" which groups all unidentified requests into
+  // a single bucket — effectively fail-closed for rate limiting since
+  // the shared bucket fills quickly under abuse.
+  if (isProduction) {
+    logger.error(
+      "Rate limiter: no trusted IP source available in production (CF-Connecting-IP, XFF, X-Real-IP all absent)",
+      { context: "rate-limit" },
+    );
+  }
   return "unknown";
 }
 

--- a/src/lib/validations/primitives.ts
+++ b/src/lib/validations/primitives.ts
@@ -20,7 +20,13 @@ export const timeHHMM = z.string().regex(/^\d{2}:\d{2}$/, "Expected HH:MM");
  * Use `safeText` for free-form fields and `safeName` for short identifiers.
  */
 export function normalizeText(value: string): string {
-  return value.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "").normalize("NFC");
+  return (
+    value
+      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+      // IV-05: Strip bidi override characters to prevent text spoofing.
+      .replace(/[\u202A-\u202E\u2066-\u2069\u200E\u200F]/g, "")
+      .normalize("NFC")
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements 7 new findings from the Season 0 v2 audit (77 findings total, cross-referenced with PRs #700-703 and #695).

### Changes

| Finding | Severity | File | Fix |
|---|---|---|---|
| **FP-01** | Low | `profile-header-hmac.ts` | JSON-encode HMAC payload to prevent delimiter collision (`:` in role could forge matching signature) |
| **FP-04** | Low | `rate-limit.ts` | Add error-level log when no trusted IP source available in production |
| **FP-07** | Low | `billing/webhook/route.ts` | Surface non-duplicate Stripe dedup failures to Sentry |
| **FP-27** | Low | `webhooks/route.ts` | Use explicit `isNaN()` for WhatsApp timestamps instead of falsy `\|\|` (`parseInt("0")` returns 0) |
| **IV-05** | Info | `validations/primitives.ts`, `booking/route.ts` | Add bidi override stripping to `normalizeText()`, wire booking schema through `safeName`/`safeText` |
| **IDOR-03** | Low | `AGENTS.md` | Document \"Never insert `...body`\" mass-assignment rule |
| **PERF-01** | Low | `chat/route.ts` | Document ^-anchored ReDoS safety invariant |

### Already fixed (by existing PRs)

- AUTH-01/IDOR-01 → PR #700
- AUTH-02/IDOR-02/DB-01 → PR #700
- IV-01, IV-02, IV-03, FP-24/FP-25 → PR #701
- TF-02, PERF-02, CVE-003 → PR #702
- FP-08, FP-03, TF-04 → PR #703
- DIFF-01 → PR #695

### Not actionable (forbidden files or Info-only)

- FP-11/FP-12/FP-13 → `encryption.ts` (AGENTS.md forbidden)
- AUTH-06/FP-05/FP-23 → `middleware.ts` (AGENTS.md forbidden)
- PERF-03/INJ-02/FP-09/FP-16 → `with-auth.ts` (AGENTS.md forbidden)
- FP-10 → Verified: `stripe-signature.ts` already uses `timingSafeEqual` ✓
- IV-04 → Verified: `buildUploadKey()` allowlist strips null bytes ✓
- All Info-severity items → documented observations, no code change needed

## Testing

- [x] TypeScript: 0 errors (`tsc --noEmit`)
- [x] ESLint: 0 errors on all changed files
- [x] All 828 tests pass (`vitest run`)

## Deployment Note

FP-01 changes the profile header HMAC payload format from colon-delimited to JSON-encoded. In-flight headers (up to 5 min old per `MAX_HEADER_AGE_SECONDS=300`) will fail verification and require re-authentication. Impact is minimal — affected users simply re-authenticate within 5 minutes of deploy.