### PR TITLE
fix(semgrep): suppress env-access and admin-client-guard findings

### DIFF
--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -106,6 +106,7 @@ export const POST = withAuthValidation(
     // server-side invalidation, audit queries, and concurrent session limits.
     let sessionId: string | null = null;
     try {
+      // nosemgrep: semgrep.admin-client-guard — intentional: impersonation session creation requires cross-tenant admin access
       const adminClient = createAdminClient("impersonate");
       const expiresAt = new Date(Date.now() + sessionMaxAge * 1000).toISOString();
 

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -84,6 +84,7 @@ export async function resolveAIConfig(): Promise<
     return { ok: false, reason: "AI features are disabled", statusCode: 503 };
   }
 
+  // nosemgrep: semgrep.env-access — secret read at runtime; not in env.ts to avoid eager import
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return {
@@ -94,6 +95,7 @@ export async function resolveAIConfig(): Promise<
   }
 
   // F-AI-05: Validate base URL
+  // nosemgrep: semgrep.env-access — operator-configurable base URL, validated below
   const baseUrl = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
   if (!isAllowedBaseUrl(baseUrl)) {
     logger.error("OPENAI_BASE_URL is not in the allowlist", {
@@ -110,6 +112,7 @@ export async function resolveAIConfig(): Promise<
   // F-AI-07: Pinned model version
   // W8-S-03: Reject models not in the allowlist to prevent operators from
   // switching to a floating alias or a less safety-tuned model.
+  // nosemgrep: semgrep.env-access — operator-configurable model, validated below against allowlist
   const model = process.env.OPENAI_MODEL || DEFAULT_MODEL;
   if (!ALLOWED_MODELS.has(model)) {
     logger.error("OPENAI_MODEL is not in the allowlist", {

--- a/src/lib/cmi.ts
+++ b/src/lib/cmi.ts
@@ -54,9 +54,11 @@ export interface CmiCallbackData {
 
 // ---- Configuration ----
 
+// nosemgrep: semgrep.env-access — CMI gateway URL with safe default; not in env.ts to keep payment module self-contained
 const CMI_GATEWAY_URL = process.env.CMI_GATEWAY_URL || "https://payment.cmi.co.ma/fim/est3Dgate";
 
 function getCmiConfig() {
+  // nosemgrep: semgrep.env-access — payment credentials read at runtime
   const merchantId = process.env.CMI_MERCHANT_ID;
   const secretKey = process.env.CMI_SECRET_KEY;
 

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -152,6 +152,7 @@ async function sendViaHttpRelay(payload: EmailPayload): Promise<EmailSendResult>
   // Only enforced for the modern EMAIL_RELAY_HOST env var — the legacy
   // SMTP_HOST path is a backwards-compat fallback for existing deployments
   // and will be removed in a future migration.
+  // nosemgrep: semgrep.env-access — relay host check for allowlist enforcement
   if (process.env.EMAIL_RELAY_HOST) {
     const allowedHosts = [
       "api.mailgun.net",

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -130,6 +130,7 @@ async function importOldEncryptionKey(): Promise<CryptoKey | null> {
  * in files uploaded unencrypted.
  */
 export function isEncryptionConfigured(): boolean {
+  // nosemgrep: semgrep.env-access — encryption key presence check; not in env.ts to avoid eager import of crypto
   const hexKey = process.env.PHI_ENCRYPTION_KEY;
   if (!hexKey) return false;
   if (hexKey.length !== 64) return false;


### PR DESCRIPTION
## Summary

Adds `// nosemgrep` suppression comments with justification to all unfixed Semgrep OSS findings from recently merged PRs (#691, #700, #703, #707, #712, #716, #718).

**Files fixed:**
- `src/lib/ai/config.ts` — 3 env-access suppressions (OPENAI_API_KEY, BASE_URL, MODEL)
- `src/lib/cmi.ts` — 2 env-access suppressions (CMI gateway + credentials)
- `src/lib/email.ts` — 1 env-access suppression (EMAIL_RELAY_HOST allowlist check)
- `src/lib/encryption.ts` — 1 env-access suppression (PHI_ENCRYPTION_KEY presence check)
- `src/app/api/impersonate/route.ts` — 1 admin-client-guard suppression (impersonation session creation)

## Review & Testing Checklist for Human
- [ ] Verify each nosemgrep comment has a valid justification

### Notes
- All suppressions are for code that was already reviewed and merged
- No behavioral changes