### PR TITLE
chore(api): remove unused imports in lab/radiology report routes

### DIFF
--- a/src/app/api/lab/report-html/route.ts
+++ b/src/app/api/lab/report-html/route.ts
@@ -27,8 +27,7 @@ import { getDirection, isRTL, t, type Locale } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
 import { buildUploadKey } from "@/lib/r2";
 import { encryptAndUpload } from "@/lib/r2-encrypted";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber, formatDisplayDate } from "@/lib/utils";
+import { formatDisplayDate } from "@/lib/utils";
 import { labReportSchema } from "@/lib/validations";
 
 const SUPPORTED_LOCALES: readonly Locale[] = ["fr", "ar", "en"] as const;

--- a/src/app/api/radiology/report-pdf/route.ts
+++ b/src/app/api/radiology/report-pdf/route.ts
@@ -14,8 +14,7 @@ import { STAFF_ROLES } from "@/lib/auth-roles";
 import { updateRadiologyOrderPdfUrl } from "@/lib/data/server";
 import { escapeHtml } from "@/lib/escape-html";
 import { uploadToR2, isR2Configured, buildUploadKey } from "@/lib/r2";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber, formatDisplayDate } from "@/lib/utils";
+import { formatDisplayDate } from "@/lib/utils";
 import { radiologyReportPdfSchema } from "@/lib/validations";
 
 function generateReportHtml(data: {


### PR DESCRIPTION
## Summary

Dead-code cleanup in the API lane. Two report-generation routes imported `formatCurrency` and `formatNumber` from `@/lib/utils` but only ever used `formatDisplayDate`. The unused imports were masked by `// eslint-disable-next-line @typescript-eslint/no-unused-vars` directives. This PR drops the unused imports and the now-unnecessary disable directives.

- `src/app/api/lab/report-html/route.ts`
- `src/app/api/radiology/report-pdf/route.ts`

Behavior-preserving — no runtime change. Verified via grep that `formatCurrency`/`formatNumber` had zero non-import references in either file and `formatDisplayDate` is still imported and used.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint` (0 errors), `npm run typecheck` (0 errors), and `npx vitest run src/app/api` (200 passed) all green locally.

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
