### PR TITLE
fix(patient): remove hardcoded "Room 1" from appointments list

### DIFF
--- a/src/app/(patient)/patient/appointments/page.tsx
+++ b/src/app/(patient)/patient/appointments/page.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import {
-  Calendar,
-  Clock,
-  User,
-  MapPin,
-  X,
-  RefreshCw,
-  AlertTriangle,
-  Repeat,
-  Plus,
-} from "lucide-react";
+import { Calendar, Clock, User, X, RefreshCw, AlertTriangle, Repeat, Plus } from "lucide-react";
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { RescheduleDialog } from "@/components/patient/reschedule-dialog";
@@ -253,10 +243,6 @@ export default function PatientAppointmentsPage() {
                       <span className="flex items-center gap-1">
                         <User className="h-3.5 w-3.5" />
                         {appt.doctorName}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <MapPin className="h-3.5 w-3.5" />
-                        Room 1
                       </span>
                     </div>
                     {appt.cancellationReason && (


### PR DESCRIPTION
## Summary

The patient appointments list rendered a hardcoded `Room 1` location (with a MapPin icon) for **every** appointment. `AppointmentView` (src/lib/data/client/appointments.ts) has no room field, so this was static placeholder text shown to real patients regardless of the actual appointment location. This removes the misleading field and the now-unused MapPin import so the metadata row only shows verified data (date, time, doctor).

Scope: src/app/(patient)/** only.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Testing
- [x] Manual testing performed; npm run lint + typecheck pass locally.