### PR TITLE
fix(patient): make medical-timeline locale-aware instead of hardcoded French

### DIFF
--- a/src/app/(patient)/patient/medical-timeline/page.tsx
+++ b/src/app/(patient)/patient/medical-timeline/page.tsx
@@ -1,6 +1,7 @@
+import { cookies, headers } from "next/headers";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { t } from "@/lib/i18n";
+import { t, type Locale } from "@/lib/i18n";
 import { createClient } from "@/lib/supabase-server";
 import { requireTenant } from "@/lib/tenant";
 
@@ -24,6 +25,7 @@ async function getPatientTimeline(
   supabase: Awaited<ReturnType<typeof createClient>>,
   clinicId: string,
   userId: string,
+  locale: Locale,
 ): Promise<TimelineEvent[]> {
   const events: TimelineEvent[] = [];
 
@@ -42,7 +44,7 @@ async function getPatientTimeline(
         id: `appt-${appt.id}`,
         type: "appointment",
         date: appt.appointment_date ?? "",
-        title: `${t("fr", "nav.appointments")} — ${appt.status}`,
+        title: `${t(locale, "nav.appointments")} — ${appt.status}`,
         description: appt.notes ?? `${appt.start_time ?? ""}`,
       });
     }
@@ -63,7 +65,7 @@ async function getPatientTimeline(
         id: `rx-${rx.id}`,
         type: "prescription",
         date: rx.created_at?.split("T")[0] ?? "",
-        title: t("fr", "prescription.title"),
+        title: t(locale, "prescription.title"),
         description: rx.notes ?? "",
       });
     }
@@ -79,13 +81,20 @@ export default async function MedicalTimelinePage() {
   const tenant = await requireTenant();
   const supabase = await createClient();
 
+  // Resolve the active locale the same way the root layout does, so the
+  // timeline renders in the patient's / clinic's language instead of always
+  // defaulting to French.
+  const [h, cookieStore] = await Promise.all([headers(), cookies()]);
+  const preferredLocale = cookieStore.get("preferred-locale")?.value as Locale | undefined;
+  const locale: Locale = preferredLocale || (h.get("x-tenant-locale") as Locale) || "fr";
+
   // Get the current user's profile
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
     return (
-      <div className="p-6 text-center text-muted-foreground">{t("fr", "auth.genericError")}</div>
+      <div className="p-6 text-center text-muted-foreground">{t(locale, "auth.genericError")}</div>
     );
   }
 
@@ -98,11 +107,11 @@ export default async function MedicalTimelinePage() {
 
   if (!profile) {
     return (
-      <div className="p-6 text-center text-muted-foreground">{t("fr", "auth.genericError")}</div>
+      <div className="p-6 text-center text-muted-foreground">{t(locale, "auth.genericError")}</div>
     );
   }
 
-  const timeline = await getPatientTimeline(supabase, tenant.clinicId, profile.id);
+  const timeline = await getPatientTimeline(supabase, tenant.clinicId, profile.id, locale);
 
   const typeColors: Record<string, string> = {
     appointment: "bg-blue-100 text-blue-800",
@@ -114,12 +123,12 @@ export default async function MedicalTimelinePage() {
       <Breadcrumb
         items={[{ label: "Patient", href: "/patient/dashboard" }, { label: "Medical Timeline" }]}
       />
-      <h1 className="text-2xl font-bold">{t("fr", "carnet.title")}</h1>
+      <h1 className="text-2xl font-bold">{t(locale, "carnet.title")}</h1>
 
       {timeline.length === 0 ? (
         <Card>
           <CardContent className="p-8 text-center text-muted-foreground">
-            {t("fr", "directory.noResults")}
+            {t(locale, "directory.noResults")}
           </CardContent>
         </Card>
       ) : (


### PR DESCRIPTION
## Summary

`src/app/(patient)/patient/medical-timeline/page.tsx` called `t("fr", ...)` everywhere, so the Health Booklet timeline (titles, prescription label, empty-state, error messages) always rendered in French regardless of the patient's `preferred-locale` cookie or the clinic's `x-tenant-locale` (set by middleware). Arabic/English users saw French.

This resolves the active locale the same way the root layout does (`preferred-locale` cookie > `x-tenant-locale` header > `fr`) and threads it through `getPatientTimeline` and the render. All keys used (`nav.appointments`, `prescription.title`, `auth.genericError`, `carnet.title`, `directory.noResults`) already exist in fr/ar/en locale files, so no locale JSON changes are needed.

Scope: `src/app/(patient)/**` only.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed; `npm run lint` + `npm run typecheck` pass locally

## Observability
- [x] N/A — no observability changes

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes