### PR TITLE
fix(a11y): add accessible names to icon-only dismiss buttons in patient appointments

### DIFF
--- a/src/app/(patient)/patient/appointments/page.tsx
+++ b/src/app/(patient)/patient/appointments/page.tsx
@@ -182,6 +182,7 @@ export default function PatientAppointmentsPage() {
             variant="ghost"
             size="sm"
             className="ml-auto"
+            aria-label="Dismiss"
             onClick={() => setCancelError(null)}
           >
             <X className="h-3 w-3" />
@@ -196,6 +197,7 @@ export default function PatientAppointmentsPage() {
             variant="ghost"
             size="sm"
             className="ml-auto"
+            aria-label="Dismiss"
             onClick={() => setCancelSuccess(null)}
           >
             <X className="h-3 w-3" />


### PR DESCRIPTION
## Summary

The cancel-error and cancel-success alert banners on the patient appointments page each render an icon-only dismiss button (`<X/>` only) with no accessible name, so screen-reader users hear an unlabeled "button". This adds `aria-label="Dismiss"` to both. `aria-label` is in the eslint i18n `ignoreAttribute` allowlist, so no new lint warnings and no locale-JSON changes.

Scope: `src/app/(patient)/**` only.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] `npm run lint`, `npm run typecheck`, `npm run test` (1019 passed) green locally

## Observability
- [x] N/A — no observability changes

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes