### PR TITLE
fix(i18n): use active locale in contact form and chatbot instead of hardcoded French

### DIFF
--- a/src/components/chatbot/chatbot-provider.tsx
+++ b/src/components/chatbot/chatbot-provider.tsx
@@ -9,6 +9,7 @@ import {
   useEffect,
   type ReactNode,
 } from "react";
+import { useLocale } from "@/components/locale-switcher";
 import { t } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
 
@@ -45,6 +46,7 @@ export function ChatbotProvider({
   clinicId?: string;
   children: ReactNode;
 }) {
+  const [locale] = useLocale();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -167,7 +169,7 @@ export function ChatbotProvider({
         const errorMsg: ChatMessage = {
           id: `msg-${Date.now()}-error`,
           role: "assistant",
-          content: t("fr", "chatbot.error"),
+          content: t(locale, "chatbot.error"),
           timestamp: new Date(),
         };
         setMessages((prev) => [...prev, errorMsg]);
@@ -176,7 +178,7 @@ export function ChatbotProvider({
         setIsLoading(false);
       }
     },
-    [clinicId],
+    [clinicId, locale],
   );
 
   const clearMessages = useCallback(() => {

--- a/src/components/public/contact-form.tsx
+++ b/src/components/public/contact-form.tsx
@@ -2,6 +2,7 @@
 
 import { Check } from "lucide-react";
 import { useState } from "react";
+import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -11,6 +12,7 @@ import { t } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
 
 export function ContactForm() {
+  const [locale] = useLocale();
   const [submitted, setSubmitted] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -54,10 +56,10 @@ export function ContactForm() {
           <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
             <Check className="h-8 w-8 text-green-600" />
           </div>
-          <h3 className="text-lg font-semibold mb-2">{t("fr", "contact.successTitle")}</h3>
-          <p className="text-sm text-muted-foreground">{t("fr", "contact.successMessage")}</p>
+          <h3 className="text-lg font-semibold mb-2">{t(locale, "contact.successTitle")}</h3>
+          <p className="text-sm text-muted-foreground">{t(locale, "contact.successMessage")}</p>
           <Button variant="outline" className="mt-6" onClick={() => setSubmitted(false)}>
-            {t("fr", "contact.sendAnother")}
+            {t(locale, "contact.sendAnother")}
           </Button>
         </CardContent>
       </Card>
@@ -67,49 +69,49 @@ export function ContactForm() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t("fr", "contact.title")}</CardTitle>
+        <CardTitle>{t(locale, "contact.title")}</CardTitle>
       </CardHeader>
       <CardContent>
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
-              <Label htmlFor="name">{t("fr", "contact.name")}</Label>
+              <Label htmlFor="name">{t(locale, "contact.name")}</Label>
               <Input
                 id="name"
                 name="name"
-                placeholder={t("fr", "contact.namePlaceholder")}
+                placeholder={t(locale, "contact.namePlaceholder")}
                 required
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="phone">{t("fr", "contact.phone")}</Label>
+              <Label htmlFor="phone">{t(locale, "contact.phone")}</Label>
               <Input id="phone" name="phone" placeholder="+212 6XX XX XX XX" />
             </div>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="email">{t("fr", "contact.email")}</Label>
+            <Label htmlFor="email">{t(locale, "contact.email")}</Label>
             <Input id="email" name="email" type="email" placeholder="votre@email.com" />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="subject">{t("fr", "contact.subject")}</Label>
+            <Label htmlFor="subject">{t(locale, "contact.subject")}</Label>
             <Input
               id="subject"
               name="subject"
-              placeholder={t("fr", "contact.subjectPlaceholder")}
+              placeholder={t(locale, "contact.subjectPlaceholder")}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="message">{t("fr", "contact.message")}</Label>
+            <Label htmlFor="message">{t(locale, "contact.message")}</Label>
             <Textarea
               id="message"
               name="message"
-              placeholder={t("fr", "contact.messagePlaceholder")}
+              placeholder={t(locale, "contact.messagePlaceholder")}
               rows={4}
               required
             />
           </div>
           <Button type="submit" className="w-full" disabled={loading}>
-            {loading ? t("fr", "contact.submitting") : t("fr", "contact.submit")}
+            {loading ? t(locale, "contact.submitting") : t(locale, "contact.submit")}
           </Button>
         </form>
       </CardContent>


### PR DESCRIPTION
## Summary

Two client components called `t("fr", ...)` with a hardcoded locale, so they always rendered French even when the user had selected Arabic/English via the locale switcher:

- `src/components/public/contact-form.tsx` — all labels, placeholders, button text and the success state (14 strings).
- `src/components/chatbot/chatbot-provider.tsx` — the chatbot error message.

Both now read the active locale via the existing `useLocale()` hook (`@/components/locale-switcher`) and pass it to `t(locale, ...)`. The chatbot's `sendMessage` callback gains `locale` in its dependency array so it doesn't capture a stale locale. All keys already exist in fr/ar/en, so no locale-JSON changes are needed.

Scope: `src/components/**` only.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] `npm run lint`, `npm run typecheck`, `npm run test` (1019 passed) green locally

## Observability
- [x] N/A — no observability changes

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes