### PR TITLE
fix(onboarding): read clinic_id from wrapped API response

### DIFF
--- a/src/app/(auth)/onboarding/page.tsx
+++ b/src/app/(auth)/onboarding/page.tsx
@@ -356,46 +356,54 @@ export default function OnboardingPage() {
         throw new Error(data?.error ?? "Registration failed");
       }
 
+      // API responses are wrapped by apiSuccess as { ok, data }. Read the
+      // payload from `data`, falling back to the top level for resilience.
       const createResult: {
+        data?: { clinic_id?: string; subdomain?: string | null };
         clinic_id?: string;
         subdomain?: string | null;
       } | null = await createRes.json().catch(() => null);
-      const newClinicId = createResult?.clinic_id;
-      const newSubdomain = createResult?.subdomain;
+      const createPayload = createResult?.data ?? createResult;
+      const newClinicId = createPayload?.clinic_id;
+      const newSubdomain = createPayload?.subdomain;
 
       setCreatedSubdomain(newSubdomain ?? null);
 
+      // The clinic was created but no ID came back — fail loudly instead of
+      // showing a success screen for a setup that never seeded or went live.
+      if (!newClinicId) {
+        throw new Error("Registration failed");
+      }
+
       // 2. Save wizard data + auto-seed + go live
-      if (newClinicId) {
-        // Upload logo if provided
-        if (logoFile) {
-          const formData = new FormData();
-          formData.append("file", logoFile);
-          formData.append("category", "logos");
-          formData.append("clinicId", newClinicId);
-          await fetch("/api/upload", {
-            method: "POST",
-            body: formData,
-          }).catch(() => {
-            // Logo upload failure is non-fatal
-          });
-        }
-
-        const wizardRes = await fetch("/api/onboarding/wizard", {
+      // Upload logo if provided
+      if (logoFile) {
+        const formData = new FormData();
+        formData.append("file", logoFile);
+        formData.append("category", "logos");
+        formData.append("clinicId", newClinicId);
+        await fetch("/api/upload", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            clinic_id: newClinicId,
-            preset_id: selectedPreset?.id ?? null,
-            auto_seed: true,
-            go_live: true,
-          }),
+          body: formData,
+        }).catch(() => {
+          // Logo upload failure is non-fatal
         });
+      }
 
-        if (!wizardRes.ok) {
-          const data: { error?: string } | null = await wizardRes.json().catch(() => null);
-          throw new Error(data?.error ?? "Failed to complete setup");
-        }
+      const wizardRes = await fetch("/api/onboarding/wizard", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clinic_id: newClinicId,
+          preset_id: selectedPreset?.id ?? null,
+          auto_seed: true,
+          go_live: true,
+        }),
+      });
+
+      if (!wizardRes.ok) {
+        const data: { error?: string } | null = await wizardRes.json().catch(() => null);
+        throw new Error(data?.error ?? "Failed to complete setup");
       }
 
       setCompleted(true);


### PR DESCRIPTION
## Summary

The onboarding wizard's "Go Live" step (`src/app/(auth)/onboarding/page.tsx`) read `clinic_id` and `subdomain` from the **top level** of the `/api/onboarding` JSON response. That endpoint returns the standard `apiSuccess` envelope `{ ok: true, data: { clinic_id, subdomain, ... } }`, so both fields were **always `undefined`**.

Consequences:
- `newClinicId` was always undefined, so the entire second stage — logo upload + `POST /api/onboarding/wizard` (auto-seed + `go_live: true`) — was **silently skipped**. New clinics were created but never seeded and never set live.
- `createdSubdomain` was always `null`, so the `CelebrationPage` (gated on `completed && createdSubdomain`) **never rendered**; the user was stuck on step 5 even though `setCompleted(true)` had run.

Fix: unwrap the payload from `.data` (with a top-level fallback for resilience) and fail loudly if no `clinic_id` comes back. Matches the `json.data ?? json` convention used across the admin pages. Touches only the in-lane file `src/app/(auth)/onboarding/page.tsx`.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

Local on this branch: `npm run lint` 0 errors (only pre-existing i18n warnings); `npm run typecheck` clean; `npm run test` 99 files, 1019 passed / 38 skipped.

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
