### PR TITLE
fix(admin): do not report save success when the request fails

### DIFF
--- a/src/app/(admin)/admin/branding/page.tsx
+++ b/src/app/(admin)/admin/branding/page.tsx
@@ -135,7 +135,7 @@ export default function BrandingPage() {
 
     setSaving(true);
     try {
-      await fetch("/api/branding", {
+      const res = await fetch("/api/branding", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -149,8 +149,15 @@ export default function BrandingPage() {
           body_font: branding.body_font,
         }),
       });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        alert(err?.error ?? "Failed to save branding settings");
+        return;
+      }
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+    } catch {
+      alert("Failed to save branding settings");
     } finally {
       setSaving(false);
     }

--- a/src/app/(admin)/admin/sections/page.tsx
+++ b/src/app/(admin)/admin/sections/page.tsx
@@ -54,12 +54,19 @@ export default function SectionsPage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      await fetch("/api/branding", {
+      const res = await fetch("/api/branding", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ section_visibility: visibility }),
       });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        alert(err?.error ?? "Failed to save section settings");
+        return;
+      }
       setSavedState(visibility);
+    } catch {
+      alert("Failed to save section settings");
     } finally {
       setSaving(false);
     }

--- a/src/app/(admin)/admin/templates/page.tsx
+++ b/src/app/(admin)/admin/templates/page.tsx
@@ -75,12 +75,19 @@ export default function TemplatesPage() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      await fetch("/api/branding", {
+      const res = await fetch("/api/branding", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ template_id: selected }),
       });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        alert(err?.error ?? "Failed to save template");
+        return;
+      }
       setSaved(selected);
+    } catch {
+      alert("Failed to save template");
     } finally {
       setSaving(false);
     }


### PR DESCRIPTION
## Summary

The branding, templates, and sections admin pages each `PUT` to `/api/branding` and then updated their "saved" state **unconditionally**, without checking the response. A failed save (4xx/5xx or a network error) still showed a "Saved" confirmation, so users believed changes persisted when they did not.

Fix: check `res.ok`, surface the error via `alert(...)` (consistent with the existing upload/preset handlers in the same files), wrap in `try/catch` for network failures, and only mark state saved on success. Happy path is unchanged.

Files (all in-lane):
- `src/app/(admin)/admin/branding/page.tsx` (`handleSave`)
- `src/app/(admin)/admin/templates/page.tsx` (`handleSave`)
- `src/app/(admin)/admin/sections/page.tsx` (`handleSave`)

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

Local on this branch: `npm run lint` 0 errors (no new warnings — `alert()` strings are not JSX); `npm run typecheck` clean; `npm run test` 99 files, 1019 passed / 38 skipped.

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
