### PR TITLE
fix(husky): use POSIX-portable redirect in pre-commit gitleaks check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@ npx tsc --noEmit
 # Requires gitleaks to be installed locally (brew install gitleaks / go install).
 # If gitleaks is not installed, warn but do not block the commit — CI will
 # still catch secrets via the gitleaks GitHub Action in the security job.
-if command -v gitleaks &> /dev/null; then
+if command -v gitleaks > /dev/null 2>&1; then
   gitleaks protect --staged --verbose
 else
   echo "warning: gitleaks is not installed locally — secrets will still be scanned in CI"


### PR DESCRIPTION
## Summary

Fixes a portability bug in the `.husky/pre-commit` hook. The gitleaks guard used a bash-only `&>` redirect:

```sh
if command -v gitleaks &> /dev/null; then
```

Husky hooks run under `sh` (dash), where `&>` is parsed as "run in background (`&`) then redirect (`>`)" rather than "redirect stdout+stderr". As a result `command -v` is backgrounded, the `if` always evaluates true, and `gitleaks` is invoked even when it is not installed — so the commit fails with `gitleaks: not found` (exit 127) instead of the intended warn-and-continue fallback. This blocks commits on any machine without gitleaks installed locally.

Fix: use the POSIX-portable `> /dev/null 2>&1`. When gitleaks is present it still runs; when absent the hook now correctly prints the warning and lets the commit proceed (CI still scans for secrets via the gitleaks Action).

## Review & Testing Checklist for Human

- [ ] On a machine WITHOUT gitleaks installed, `git commit` succeeds and prints the "gitleaks is not installed locally" warning (previously it errored with exit 127).
- [ ] On a machine WITH gitleaks installed, the staged-secret scan still runs and blocks a commit containing a secret.

### Notes

One-line change to a shell hook; no application code. Verified locally: commits succeed both with gitleaks installed (scan runs, "no leaks found") and the redirect is now POSIX-correct.