### PR TITLE
fix(custom-fields): surface load and delete failures

### DIFF
--- a/src/app/(admin)/admin/custom-fields/page.tsx
+++ b/src/app/(admin)/admin/custom-fields/page.tsx
@@ -99,6 +99,14 @@ export default function CustomFieldsAdminPage() {
         url += `&entity_type=${encodeURIComponent(selectedEntity)}`;
       }
       const res = await fetch(url);
+      if (!res.ok) {
+        logger.warn("Failed to load custom field definitions", {
+          context: "custom-fields",
+          status: res.status,
+        });
+        setDefinitions([]);
+        return;
+      }
       const json = await res.json();
       const data = json.data ?? json;
       setDefinitions(data.definitions ?? []);
@@ -121,7 +129,12 @@ export default function CustomFieldsAdminPage() {
   const handleDelete = async (id: string) => {
     if (!confirm("Êtes-vous sûr de vouloir supprimer ce champ ?")) return;
     try {
-      await fetch(`/api/custom-fields?id=${id}`, { method: "DELETE" });
+      const res = await fetch(`/api/custom-fields?id=${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        alert(err?.error ?? "Échec de la suppression du champ");
+        return;
+      }
       loadDefinitions();
     } catch (err) {
       logger.warn("Failed to delete custom field", { context: "custom-fields", error: err });


### PR DESCRIPTION
## Summary

`src/app/(admin)/admin/custom-fields/page.tsx` had two silent-failure paths:

- `loadDefinitions` called `res.json()` and read `json.data ?? json` **without checking `res.ok`**, so an error response body could be parsed as if it were definition data.
- `handleDelete` called `loadDefinitions()` **regardless of whether the DELETE succeeded**, so a failed delete silently left the field in place with no feedback to the user.

Fix: check `res.ok` in both handlers — clear definitions and bail on a failed load (logging the status), and `alert(...)` the user on a failed delete (consistent with the sibling handlers in this lane) instead of pretending it worked. Happy path unchanged.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

Local on this branch: `npm run lint` 0 errors; `npm run typecheck` clean; `npm run test` 99 files, 1019 passed / 38 skipped.

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
