### PR TITLE
fix(setup-2fa): await clipboard write to prevent false 'Copied' state

### DIFF
--- a/src/app/(auth)/setup-2fa/page.tsx
+++ b/src/app/(auth)/setup-2fa/page.tsx
@@ -72,18 +72,26 @@ export default function Setup2FAPage() {
     setLoading(false);
   }
 
-  function handleCopySecret() {
+  async function handleCopySecret() {
     if (!enrollment) return;
-    navigator.clipboard.writeText(enrollment.secret);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(enrollment.secret);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard write can reject (permissions / insecure context).
+    }
   }
 
-  function handleCopyBackupCodes() {
+  async function handleCopyBackupCodes() {
     const codesText = backupCodes.join("\n");
-    navigator.clipboard.writeText(codesText);
-    setBackupCopied(true);
-    setTimeout(() => setBackupCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(codesText);
+      setBackupCopied(true);
+      setTimeout(() => setBackupCopied(false), 2000);
+    } catch {
+      // Clipboard write can reject (permissions / insecure context).
+    }
   }
 
   function handleDownloadBackupCodes() {


### PR DESCRIPTION
## Summary

`src/app/(auth)/setup-2fa/page.tsx` — both `handleCopySecret` and `handleCopyBackupCodes` called `navigator.clipboard.writeText` **without awaiting** the returned Promise and immediately set `copied`/`backupCopied` to `true`. If the write rejects (permission denied, insecure context, etc.) the UI showed "Copied" while nothing was actually on the clipboard, and an unhandled promise rejection was thrown in the console.

Fix: `await` the clipboard write inside a `try/catch` and only set the copied indicator on success. On failure the indicator simply stays off (no error message added to avoid i18n churn in the strict `no-literal-string=error` folder).

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

Local on this branch: `npm run lint` 0 errors (0 problems); `npm run typecheck` clean; `npm run test` 99 files, 1019 passed / 38 skipped.

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
