### PR TITLE
fix(chatbot): surface save failures instead of silent false success

### DIFF
--- a/src/app/(admin)/admin/settings/chatbot/page.tsx
+++ b/src/app/(admin)/admin/settings/chatbot/page.tsx
@@ -179,25 +179,30 @@ export default function ChatbotSettingsPage() {
     if (configError) {
       void configError;
       setSaving(false);
+      alert("Échec de l'enregistrement de la configuration");
       return;
     }
 
     // Save FAQs: delete removed ones, upsert existing and new
     const existingIds = faqs.filter((f) => !f.isNew).map((f) => f.id);
 
+    let faqSaveFailed = false;
+
     // Delete FAQs that were removed
     if (existingIds.length > 0) {
-      await supabase
+      const { error } = await supabase
         .from("chatbot_faqs")
         .delete()
         .eq("clinic_id", clinicId)
         .not("id", "in", `(${existingIds.join(",")})`);
+      if (error) faqSaveFailed = true;
     } else {
-      await supabase.from("chatbot_faqs").delete().eq("clinic_id", clinicId);
+      const { error } = await supabase.from("chatbot_faqs").delete().eq("clinic_id", clinicId);
+      if (error) faqSaveFailed = true;
     }
 
     // Upsert FAQs
-    for (let i = 0; i < faqs.length; i++) {
+    for (let i = 0; i < faqs.length && !faqSaveFailed; i++) {
       const faq = faqs[i];
       const faqPayload = {
         clinic_id: clinicId,
@@ -210,10 +215,18 @@ export default function ChatbotSettingsPage() {
       };
 
       if (faq.isNew) {
-        await supabase.from("chatbot_faqs").insert(faqPayload);
+        const { error } = await supabase.from("chatbot_faqs").insert(faqPayload);
+        if (error) faqSaveFailed = true;
       } else {
-        await supabase.from("chatbot_faqs").update(faqPayload).eq("id", faq.id);
+        const { error } = await supabase.from("chatbot_faqs").update(faqPayload).eq("id", faq.id);
+        if (error) faqSaveFailed = true;
       }
+    }
+
+    if (faqSaveFailed) {
+      setSaving(false);
+      alert("Échec de l'enregistrement des questions fréquentes");
+      return;
     }
 
     setSaving(false);


### PR DESCRIPTION
## Summary

`src/app/(admin)/admin/settings/chatbot/page.tsx` — `saveConfig` had two silent-failure paths:

1. **Config upsert error:** `configError` was swallowed (`void configError; return`) with no user feedback — the save button re-enabled silently, so the user had no idea the config wasn't saved.
2. **FAQ save errors:** The delete, insert, and update calls for `chatbot_faqs` never checked for errors. A failed FAQ write still showed "Paramètres sauvegardés !" and continued to the refresh step.

Fix: `alert(...)` on config upsert failure (consistent with sibling admin handlers). Track FAQ operation errors via a boolean, stop the save chain early on first failure, and alert instead of showing the success toast. Happy path unchanged.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

Local on this branch: `npm run lint` 0 errors (22 pre-existing warnings); `npm run typecheck` clean; `npm run test` 99 files, 1019 passed / 38 skipped.

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
