### PR TITLE
fix(deploy): RATE_LIMIT_BACKEND=memory — restore prod (429 outage)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -94,7 +94,12 @@ bucket_name = "webs-alots-uploads"
 # or Cloudflare dashboard. Only non-sensitive defaults go here.
 [vars]
 NODE_ENV = "production"
-RATE_LIMIT_BACKEND = "kv"
+# HOTFIX (prod 429 outage): under @opennextjs/cloudflare v1.17 the KV binding
+# is exposed via getCloudflareContext().env, not globalThis. The limiter reads
+# globalThis.RATE_LIMIT_KV, so KV is never found, the circuit breaker trips and
+# fails closed after the grace window — 429'ing every non-redirecting page.
+# Use the in-memory backend until the code resolves bindings correctly.
+RATE_LIMIT_BACKEND = "memory"
 
 # ── Production Environment ────────────────────────────────────────────
 # INF-004: Explicit production block prevents top-level debug toggles
@@ -109,7 +114,9 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 [env.production.vars]
 NODE_ENV = "production"
-RATE_LIMIT_BACKEND = "kv"
+# HOTFIX (prod 429 outage): see [vars] note — in-memory until bindings are
+# resolved via getCloudflareContext().env instead of globalThis.
+RATE_LIMIT_BACKEND = "memory"
 
 [[env.production.r2_buckets]]
 binding = "UPLOADS_BUCKET"
@@ -156,7 +163,8 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 [env.staging.vars]
 NODE_ENV = "production"
-RATE_LIMIT_BACKEND = "kv"
+# HOTFIX (prod 429 outage): see [vars] note.
+RATE_LIMIT_BACKEND = "memory"
 
 # INF-003: Staging uses a separate R2 bucket to prevent cross-environment
 # PHI contamination. Create with: wrangler r2 bucket create webs-alots-uploads-staging


### PR DESCRIPTION
## Summary

Emergency hotfix for a **full production outage**: `https://oltigo.com/` and every non-redirecting page returned `429 RATE_LIMIT_EXCEEDED` for **all** visitors (confirmed from a fresh IP). `/login` only worked because it 308-redirects before the limiter runs.

**Root cause:** Under `@opennextjs/cloudflare` v1.17, Cloudflare bindings are exposed via `getCloudflareContext().env`, **not** `globalThis`. The limiter reads `globalThis.RATE_LIMIT_KV` (`src/lib/rate-limit.ts:478`), which is always `undefined` in the deployed Worker. KV is therefore never available, the circuit breaker records failures, and after the 60s grace window (`RATE_LIMIT_KV_GRACE_MS`) `check()` **fails closed and returns 429 for every request** — even for `failClosed:false` limiters like `globalPageLimiter`.

**Evidence:**
- Live `wrangler tail`: `"Rate limiter KV binding not available, falling back to in-memory"`
- Prod KV namespace `7ac37dff0a794542b0c766f38e73f105` has **zero** keys (never written)
- `/` -> 429 (12/12), `/login` -> 308 (8/8)

**This change:** Sets `RATE_LIMIT_BACKEND=memory` in `wrangler.toml` (`[vars]`, `[env.production.vars]`, `[env.staging.vars]`). With the explicit `memory` backend, the code skips the broken KV path entirely and uses the in-memory limiter directly (no circuit breaker, never fails closed), restoring the site on deploy.

**Tradeoff (temporary):** in-memory counters are per-Worker-isolate and reset on cold starts, so distributed rate limiting is weaker until the follow-up lands.

**Follow-up (separate PR, in progress):** resolve bindings via `getCloudflareContext().env` so KV works again, and harden so a `failClosed:false` limiter can never fail closed on a backend outage. Then revert this to `kv`.

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact
- [x] No security impact (rate-limiting backend swap; per-IP limiting still active, temporarily per-isolate)

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed (reproduced 429 on prod `/`, traced to KV-binding circuit-breaker fail-closed via `wrangler tail`)

## Observability
- [x] N/A — no observability changes

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] Config-only change (no app code; lint/typecheck/coverage unaffected)
