### PR TITLE
fix(rate-limit): resolve CF bindings via getCloudflareContext + never fail-closed on backend outage (prod 429 outage)

### DIFF
--- a/src/lib/__tests__/rate-limit-binding.test.ts
+++ b/src/lib/__tests__/rate-limit-binding.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression tests for the production 429 outage (P0).
+ *
+ * Root cause: under @opennextjs/cloudflare (v1.17+), Worker bindings live on
+ * `getCloudflareContext().env`, not on `globalThis`. The KV limiter read the
+ * binding off `globalThis`, so KV was always `undefined` in production. Once
+ * the circuit-breaker grace period expired, the limiter failed CLOSED for
+ * EVERY request — including `failClosed: false` limiters such as
+ * `globalPageLimiter` — returning HTTP 429 site-wide.
+ *
+ * These tests simulate "no KV binding available" (the production condition)
+ * and assert the defense-in-depth contract: a `failClosed: false` limiter must
+ * NEVER 429 on a backend outage — it degrades to the in-memory limiter and
+ * keeps allowing/limiting by real count. Only `failClosed: true` limiters may
+ * fail closed once the grace period elapses.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+
+describe("Rate limiter — KV binding unavailable (prod 429 outage regression)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Select the KV backend (as production does via wrangler.toml) and force a
+    // short grace period so the circuit is provably OPEN and grace-expired
+    // while we make the assertion — the exact state that took prod down.
+    vi.stubEnv("RATE_LIMIT_BACKEND", "kv");
+    vi.stubEnv("RATE_LIMIT_KV_GRACE_MS", "1000");
+    // Ensure no KV binding is visible anywhere (matches production: bindings
+    // are on getCloudflareContext().env, which is uninitialised in tests).
+    delete (globalThis as { RATE_LIMIT_KV?: unknown }).RATE_LIMIT_KV;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("globalPageLimiter (failClosed:false) keeps allowing fresh keys after the grace period expires", async () => {
+    vi.useFakeTimers();
+    const { globalPageLimiter } = await import("@/lib/rate-limit");
+
+    // Trip the circuit breaker — every call finds the KV binding missing.
+    for (let i = 0; i < 5; i++) {
+      expect(await globalPageLimiter.check(`warmup-${i}`)).toBe(true);
+    }
+
+    // Advance past the 1s grace period (circuit still open: reset is 60s).
+    vi.advanceTimersByTime(5_000);
+
+    // Regression: previously this returned false (HTTP 429) for EVERYONE.
+    expect(await globalPageLimiter.check("fresh-visitor")).toBe(true);
+  });
+
+  it("globalPageLimiter still limits by real count when degraded to in-memory", async () => {
+    const { globalPageLimiter } = await import("@/lib/rate-limit");
+
+    const key = "noisy-visitor";
+    // globalPageLimiter is 120 req / 60s. The in-memory fallback must enforce
+    // the real count, not blanket-allow.
+    for (let i = 0; i < 120; i++) {
+      expect(await globalPageLimiter.check(key)).toBe(true);
+    }
+    expect(await globalPageLimiter.check(key)).toBe(false);
+  });
+
+  it("failClosed:true limiters still fail closed once the grace period expires with no KV", async () => {
+    vi.useFakeTimers();
+    const { createRateLimiter } = await import("@/lib/rate-limit");
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 5, failClosed: true });
+
+    for (let i = 0; i < 5; i++) {
+      await limiter.check(`warm-${i}`);
+    }
+    vi.advanceTimersByTime(5_000);
+
+    // Security-critical endpoints remain protected: deny after grace expiry.
+    expect(await limiter.check("attacker")).toBe(false);
+  });
+});

--- a/src/lib/cf-bindings.ts
+++ b/src/lib/cf-bindings.ts
@@ -1,0 +1,33 @@
+/**
+ * Request-time resolver for Cloudflare Worker bindings (KV namespaces,
+ * Durable Object namespaces, etc.).
+ *
+ * Under @opennextjs/cloudflare (v1.17+), Worker bindings are exposed on
+ * `getCloudflareContext().env` and are **not** attached to `globalThis`.
+ * Reading them off `globalThis` therefore always yields `undefined` in
+ * production — which previously made the rate limiter treat its KV/DO backend
+ * as permanently unavailable and (after the grace period) fail closed for
+ * every request.
+ *
+ * This helper resolves a binding via the OpenNext context first, then falls
+ * back to `globalThis` for local dev, unit tests, and non-OpenNext runtimes.
+ *
+ * It never throws: `getCloudflareContext()` raises when called outside an
+ * initialised request context (build, module init, tests), and the dynamic
+ * import may itself fail in non-Worker runtimes — both are swallowed so
+ * callers can use this safely at request time.
+ *
+ * Must only be called at request time (inside a handler), never at module
+ * init, since the OpenNext context is request-scoped.
+ */
+export async function getWorkerBinding<T>(name: string): Promise<T | undefined> {
+  try {
+    const { getCloudflareContext } = await import("@opennextjs/cloudflare");
+    const env = getCloudflareContext().env as unknown as Record<string, unknown>;
+    const binding = env?.[name] as T | undefined;
+    if (binding) return binding;
+  } catch {
+    // Context unavailable (build/module-init/tests/non-OpenNext) — fall back.
+  }
+  return (globalThis as unknown as Record<string, T | undefined>)[name];
+}

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -19,6 +19,7 @@
  *   const enabled = await isFeatureEnabledForClinic(clinicId, 'appointments');
  */
 
+import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
 
 /** All possible feature-flag keys stored in features_config. */
@@ -116,6 +117,11 @@ interface CloudflareKV {
  *
  * Replaces the ad-hoc `(globalThis as unknown as { ... }).FEATURE_FLAGS_KV`
  * casts scattered in the codebase with a single, type-safe helper.
+ *
+ * Resolves the binding via `getCloudflareContext().env` (where
+ * @opennextjs/cloudflare v1.17+ exposes bindings) at request time, falling
+ * back to `globalThis` for tests/dev. Async because the OpenNext context must
+ * be loaded lazily so this never throws at module-init.
  */
 interface WorkersEnvBindings {
   FEATURE_FLAGS_KV?: CloudflareKV;
@@ -124,8 +130,8 @@ interface WorkersEnvBindings {
 
 export function getKVBinding<K extends keyof WorkersEnvBindings>(
   name: K,
-): WorkersEnvBindings[K] | undefined {
-  return (globalThis as unknown as WorkersEnvBindings)[name];
+): Promise<WorkersEnvBindings[K] | undefined> {
+  return getWorkerBinding<NonNullable<WorkersEnvBindings[K]>>(name as string);
 }
 
 /**
@@ -141,7 +147,7 @@ export async function isAIEnabled(): Promise<boolean> {
   if (process.env.AI_DISABLED === "true") return false;
 
   try {
-    const kv = getKVBinding("FEATURE_FLAGS_KV");
+    const kv = await getKVBinding("FEATURE_FLAGS_KV");
     if (!kv) {
       // No KV binding — default to enabled (backwards-compatible)
       return true;

--- a/src/lib/rate-limit-do.ts
+++ b/src/lib/rate-limit-do.ts
@@ -20,6 +20,7 @@
  * @see https://developers.cloudflare.com/durable-objects/
  */
 
+import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
 import type { RateLimiter, RateLimiterOptions } from "./rate-limit";
 
@@ -149,8 +150,10 @@ export function createDORateLimiter(options: RateLimiterOptions): RateLimiter {
   return {
     async check(key: string): Promise<boolean> {
       try {
-        const ns = (globalThis as unknown as { RATE_LIMITER_DO?: DurableObjectNamespace })
-          .RATE_LIMITER_DO;
+        // Bindings live on getCloudflareContext().env under
+        // @opennextjs/cloudflare (v1.17+), NOT on globalThis — resolve at
+        // request time, falling back to globalThis for tests/dev.
+        const ns = await getWorkerBinding<DurableObjectNamespace>("RATE_LIMITER_DO");
 
         if (!ns) {
           logger.warn("Rate limiter DO binding not available", { context: "rate-limit" });

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -27,6 +27,7 @@
 
 import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 import { NextRequest } from "next/server";
+import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
 import { createDORateLimiter, shouldUseDO } from "@/lib/rate-limit-do";
 
@@ -452,34 +453,49 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
     return Number.isFinite(parsed) ? parsed : DEFAULT_KV_GRACE_MS;
   };
 
+  /**
+   * Backend is unreachable (binding missing, KV error, or circuit open).
+   *
+   * Defense-in-depth: a `failClosed: false` limiter must NEVER return `false`
+   * just because the backend is down — a single backend outage must not take
+   * the whole site offline. It always degrades to the in-memory limiter, which
+   * still allows/limits by real per-isolate count. Only `failClosed: true`
+   * limiters (security-critical endpoints) may hard-deny, and only once the
+   * grace period since the first failure has elapsed.
+   */
+  const degradeOrFailClosed = (key: string): boolean | Promise<boolean> => {
+    if (!circuitBreaker.fallback) {
+      circuitBreaker.fallback = createMemoryRateLimiter(options);
+    }
+    if (failClosed) {
+      const elapsed = Date.now() - (circuitBreaker.lastFailure || 0);
+      if (elapsed > getKvGraceMs()) {
+        logger.error("Rate limiter KV grace period expired, failing closed", {
+          context: "rate-limit",
+          key,
+          elapsedMs: elapsed,
+        });
+        return false;
+      }
+    }
+    return circuitBreaker.fallback.check(key);
+  };
+
   return {
     async check(key: string): Promise<boolean> {
       // If circuit breaker is tripped, degrade to in-memory rate limiting.
       if (isCircuitOpen(circuitBreaker)) {
-        if (circuitBreaker.fallback) {
-          // Enforce the grace period fail-closed boundary
-          const elapsed = Date.now() - (circuitBreaker.lastFailure || 0);
-          if (elapsed > getKvGraceMs()) {
-            logger.error("Rate limiter KV grace period expired, failing closed", {
-              context: "rate-limit",
-              key,
-              elapsedMs: elapsed,
-            });
-            return false;
-          }
-          return circuitBreaker.fallback.check(key);
-        }
-        return !failClosed;
+        return degradeOrFailClosed(key);
       }
 
       const now = Date.now();
       const windowStart = now - windowMs;
 
       try {
-        // Get existing timestamps from KV
-        // In production, RATE_LIMIT_KV would be bound to the Worker
-        // For now, we'll check if the binding exists
-        const kv = (globalThis as unknown as { RATE_LIMIT_KV?: CloudflareKV }).RATE_LIMIT_KV;
+        // A: bindings live on getCloudflareContext().env under
+        // @opennextjs/cloudflare (v1.17+), NOT on globalThis — resolve at
+        // request time, falling back to globalThis for tests/dev.
+        const kv = await getWorkerBinding<CloudflareKV>("RATE_LIMIT_KV");
 
         if (!kv) {
           // KV binding not available, fall back to memory
@@ -487,13 +503,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
             context: "rate-limit",
           });
           recordFailure(circuitBreaker, options);
-          if (circuitBreaker.failClosed) return false;
-          const elapsed = Date.now() - (circuitBreaker.lastFailure || 0);
-          if (elapsed > getKvGraceMs()) return false; // Fail closed after grace period
-          if (circuitBreaker.fallback) {
-            return circuitBreaker.fallback.check(key);
-          }
-          return !failClosed;
+          return degradeOrFailClosed(key);
         }
 
         const stored = await kv.get(`rate_limit:${key}`, { type: "json" });
@@ -523,14 +533,8 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
       } catch (err) {
         logger.error("Rate limiter KV failure", { context: "rate-limit", error: err });
         recordFailure(circuitBreaker, options);
-        if (circuitBreaker.failClosed) return false;
-        const elapsed = Date.now() - (circuitBreaker.lastFailure || 0);
-        if (elapsed > getKvGraceMs()) return false; // Fail closed after grace period
         void reportRateLimitBackendError("kv", err);
-        if (circuitBreaker.fallback) {
-          return circuitBreaker.fallback.check(key);
-        }
-        return !failClosed;
+        return degradeOrFailClosed(key);
       }
     },
   };


### PR DESCRIPTION
## P0 production outage — homepage + all non-redirecting pages returned HTTP 429 `RATE_LIMIT_EXCEEDED` for everyone

### Root cause
Under `@opennextjs/cloudflare` v1.17+, Worker bindings live on `getCloudflareContext().env`, **not** on `globalThis`. `src/lib/rate-limit.ts` read the KV namespace via `globalThis.RATE_LIMIT_KV` (and `rate-limit-do.ts` read `globalThis.RATE_LIMITER_DO`), so the binding was **always `undefined`** in production.

With `RATE_LIMIT_BACKEND=kv` set in `wrangler.toml`, the KV limiter was selected, repeatedly recorded "binding missing" failures, tripped the circuit breaker, and after the 60s grace window **failed closed for every request** — including `failClosed: false` limiters like `globalPageLimiter`. The three grace-expiry branches returned `false` unconditionally, ignoring `failClosed`. Result: `/` → 429 site-wide (`/login` → 308 redirected before the limiter ran). The prod KV namespace had zero writes ever, and `wrangler tail` showed `"Rate limiter KV binding not available, falling back to in-memory"`.

### Fix (src/lib only)
1. **Binding resolution** — new `src/lib/cf-bindings.ts` exposes `getWorkerBinding(name)`, which resolves bindings from `getCloudflareContext().env` at request time and falls back to `globalThis` for tests/dev. It never throws (the OpenNext context raises at module-init/build/tests) and is only called inside `check()`. Used for `RATE_LIMIT_KV` (rate-limit.ts) and `RATE_LIMITER_DO` (rate-limit-do.ts).
2. **Defense-in-depth** — all three KV grace-expiry branches now go through a single `degradeOrFailClosed()` helper: a `failClosed: false` limiter **never** returns `false` on a backend outage — it degrades to the in-memory limiter (real allow/limit by count). Only `failClosed: true` limiters may hard-deny, and only after the grace period elapses. A single backend outage can no longer take the whole site down.
3. **Regression test** — `src/lib/__tests__/rate-limit-binding.test.ts`: with no KV binding available, `globalPageLimiter` (failClosed:false) keeps allowing fresh keys after the grace period (was 429), still limits by real count after `max` hits, and `failClosed: true` limiters still fail closed after grace.

### Verification
- `npm run typecheck` → 0 errors
- `npm run lint` → 0 errors (4104 pre-existing i18next warnings, under baseline)
- `npm run test` → 1022 passed / 38 skipped (3 new regression tests)

### Note for orchestrator (out of scope for this PR)
`src/lib/features.ts` `getKVBinding()` has the **same latent bug** — it reads `FEATURE_FLAGS_KV` off `globalThis`, so the AI kill-switch / feature flags are also always unavailable in prod. It fails open (defaults enabled), so it isn't an outage, but it should be migrated to `getWorkerBinding()` in a follow-up.


---

### Follow-up included in this PR (same root cause)
- `src/lib/features.ts` `getKVBinding()` now resolves `FEATURE_FLAGS_KV` / `RATE_LIMIT_KV` via `getWorkerBinding()` (getCloudflareContext().env, globalThis fallback). It is now async; its only caller `isAIEnabled()` awaits it. This restores the AI kill-switch / feature-flag reads in production.

### Still flagged for a follow-up (out of scope here)
- `src/lib/subdomain-cache.ts` `getKV()` reads `FEATURE_FLAGS_KV` off `globalThis` with the same bug. It is synchronous and sits on hot cache paths, so converting it to the async resolver needs its own change — flagging rather than expanding this PR.
