### PR TITLE
ci(semgrep): add mass-assignment guard against raw request-body DB writes

### DIFF
--- a/.semgrep/mass-assignment-guard.yml
+++ b/.semgrep/mass-assignment-guard.yml
@@ -1,0 +1,55 @@
+rules:
+  # AGENTS.md rule #7: Never spread a request body into a DB write.
+  #
+  # Mass-assignment guard. Passing an untrusted request body straight into
+  # a Supabase `.insert()` / `.update()` / `.upsert()` — either as the whole
+  # argument (`.insert(body)`) or via an object spread (`.insert({ ...body })`)
+  # — lets a caller over-post columns they should never control (e.g. `role`,
+  # `clinic_id`, `is_seed`, `status`). Always destructure and pick the
+  # specific allowed fields: `.insert({ name: body.name, phone: body.phone })`.
+  #
+  # If a write genuinely needs to forward a fully server-constructed object
+  # (not derived from the request body), rename it away from these reserved
+  # names or add a `// nosemgrep: mass-assignment-guard` line with a reason.
+  - id: mass-assignment-guard
+    patterns:
+      - pattern-either:
+          # Whole request body passed directly as the write payload.
+          - pattern: $CLIENT.from($TABLE).$METHOD($BODY)
+          # Request body spread into the write payload object.
+          - pattern: $CLIENT.from($TABLE).$METHOD({ ..., ...$BODY, ... })
+          - pattern: $CLIENT.from($TABLE).$METHOD({ ...$BODY })
+      - metavariable-regex:
+          metavariable: $METHOD
+          regex: ^(insert|update|upsert)$
+      - metavariable-regex:
+          metavariable: $BODY
+          # High-signal names for a raw/parsed HTTP request body. Deliberately
+          # narrow: generic names like `data`/`payload`/`input` are excluded
+          # because the typed data-access layer legitimately forwards
+          # already-validated objects under those names.
+          regex: ^(body|reqBody|requestBody|rawBody|req\.body|request\.body|parsedBody)$
+    message: >
+      Possible mass-assignment: `$METHOD` is being passed `$BODY` directly or
+      via spread. Never spread a request body into a DB write — destructure and
+      pick only the allowed columns (e.g. `.insert({ name: body.name })`) to
+      prevent over-posting `role`/`clinic_id`/etc. See AGENTS.md rule #7.
+      If `$BODY` is a server-built object (not request-derived), rename it or
+      add `// nosemgrep: mass-assignment-guard` with justification.
+    severity: WARNING
+    languages: [typescript, javascript]
+    paths:
+      exclude:
+        - "src/**/__tests__/**"
+        - "**/*.test.ts"
+        - "**/*.test.tsx"
+    metadata:
+      category: security
+      cwe:
+        - "CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      technology:
+        - supabase
+      references:
+        - https://github.com/groupsmix/webs-alots/blob/main/AGENTS.md


### PR DESCRIPTION
## Summary

Adds `.semgrep/mass-assignment-guard.yml` — a custom Semgrep rule enforcing AGENTS.md rule #7 ("Never spread a request body into a DB write"). It flags Supabase `.insert()` / `.update()` / `.upsert()` calls that receive a raw HTTP request body either directly (`.insert(body)`) or via object spread (`.insert({ ...body })`), which would allow over-posting columns a caller should never control (`role`, `clinic_id`, `is_seed`, `status`, …).

This implements the in-lane portion of audit routed-finding #4 (the *guard* is CI/config; the data-access layer itself is already compliant). The rule auto-loads via the existing CI step `semgrep --config .semgrep/` (security job), severity WARNING — consistent with the other 6 custom rules.

Detection scope (high-signal, deliberately narrow to avoid false positives):
- Payload metavar matches only request-body names: `body`, `reqBody`, `requestBody`, `rawBody`, `req.body`, `request.body`, `parsedBody`. Generic names like `data`/`payload`/`input` are intentionally excluded because the typed data-access layer (`src/lib/data/**`) legitimately forwards already-validated objects under those names.
- Tests and `__tests__` paths are excluded.
- Escape hatch: `// nosemgrep: mass-assignment-guard` for genuinely server-built objects.

## Review & Testing Checklist for Human

- [ ] Confirm the WARNING severity (non-blocking, reported to the Security tab) matches intent — flip to ERROR if you want it to fail CI.
- [ ] Confirm the narrow name list covers your conventions; widen it if route handlers use other names for the parsed body.
- [ ] Spot-check that no legitimate write is incorrectly flagged after merge (the security job's SARIF upload will show any).

### Notes

Local validation (semgrep 1.164.0):
- `semgrep --config .semgrep/ --validate` → 7 rules, 0 config errors.
- Rule fixture (4 violations + 3 compliant cases): exactly the 4 violations flagged, 0 false positives.
- `semgrep --config .semgrep/mass-assignment-guard.yml src/` → **0 findings** (the existing codebase is already compliant), so this PR adds the guard without introducing new findings.

Config-only change (one YAML rule); no application code, no `package.json`/`supabase` touched.