### PR TITLE
fix(rls): close header-spoof tenant bypass on pet_profiles and partner_api_keys

### DIFF
--- a/supabase/migrations/00098_fix_header_based_rls_pet_partner.sql
+++ b/supabase/migrations/00098_fix_header_based_rls_pet_partner.sql
@@ -1,0 +1,128 @@
+-- =============================================================================
+-- Migration 00098: Complete header-based RLS remediation
+--                  (pet_profiles + partner_api_keys)
+--
+-- AUDIT FINDING (Critical, tenant isolation / broken access control):
+-- The same class of vulnerability that was fixed for the restaurant vertical
+-- in 00086_drop_legacy_restaurant_rls.sql still affects two tables:
+--
+--   * pet_profiles    (created in 00061_veterinary_vertical.sql)
+--   * partner_api_keys (created in 00068_consolidated_audit_fixes.sql)
+--
+-- Both define PERMISSIVE RLS policies that trust the unsigned `x-clinic-id`
+-- request header with NO auth.uid() / is_clinic_staff() / is_super_admin()
+-- gate, e.g.:
+--
+--   clinic_id::text = current_setting('request.headers', true)::json->>'x-clinic-id'
+--   clinic_id       = (current_setting('request.header.x-clinic-id', true))::uuid
+--
+-- PostgreSQL PERMISSIVE policies are OR-combined, so the modern auth-aware
+-- policies (00063 for pet_profiles; the staff/SA policies for clinic_api_keys)
+-- do NOT override these loose ones. A direct Supabase REST call using the
+-- public anon key with a spoofed `x-clinic-id` header bypasses Next.js
+-- middleware entirely and can read/write any clinic's rows
+-- (CWE-639 Authorization Bypass Through User-Controlled Key,
+--  OWASP A01:2021 Broken Access Control).
+--
+-- This migration mirrors 00086:
+--   1. Drops the legacy header-based policies.
+--   2. Ensures the modern auth-aware policies exist (idempotent).
+--   3. Revokes anon table privileges (defense-in-depth).
+--
+-- Compatibility:
+--   * pet_profiles is only accessed via authenticated API routes
+--     (src/app/api/pets/**, all wrapped in withAuth), which use the
+--     `authenticated` role + get_user_clinic_id()/is_clinic_staff().
+--     No anonymous/public surface reads pet_profiles.
+--   * partner_api_keys has no application code path; locking anon access
+--     cannot break any current flow.
+-- =============================================================================
+
+BEGIN;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- PART 1: pet_profiles
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Step 1: Drop the legacy header-based / auth.uid()-mismatched policies from
+-- 00061. (The owner policies used `owner_id = auth.uid()`, comparing the
+-- users.id PK against the auth UUID — they never matched anyway. The secure
+-- owner read policy is owner_pet_profiles_read, recreated below.)
+DROP POLICY IF EXISTS "pet_profiles_select_clinic_staff" ON pet_profiles;
+DROP POLICY IF EXISTS "pet_profiles_insert_staff" ON pet_profiles;
+DROP POLICY IF EXISTS "pet_profiles_update_staff" ON pet_profiles;
+DROP POLICY IF EXISTS "pet_profiles_delete_staff" ON pet_profiles;
+DROP POLICY IF EXISTS "pet_profiles_select_owner" ON pet_profiles;
+DROP POLICY IF EXISTS "pet_profiles_insert_owner" ON pet_profiles;
+DROP POLICY IF EXISTS "pet_profiles_update_owner" ON pet_profiles;
+
+-- Step 2: Ensure the modern auth-aware policies from 00063 exist (idempotent).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'pet_profiles' AND policyname = 'sa_pet_profiles_all'
+  ) THEN
+    CREATE POLICY "sa_pet_profiles_all" ON pet_profiles FOR ALL
+      USING (is_super_admin())
+      WITH CHECK (is_super_admin());
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'pet_profiles' AND policyname = 'staff_pet_profiles'
+  ) THEN
+    CREATE POLICY "staff_pet_profiles" ON pet_profiles FOR ALL
+      USING (clinic_id = get_user_clinic_id() AND is_clinic_staff())
+      WITH CHECK (clinic_id = get_user_clinic_id() AND is_clinic_staff());
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'pet_profiles' AND policyname = 'owner_pet_profiles_read'
+  ) THEN
+    CREATE POLICY "owner_pet_profiles_read" ON pet_profiles FOR SELECT
+      USING (owner_id = get_my_user_id());
+  END IF;
+END $$;
+
+-- Step 3: Defense-in-depth — anon has no business touching pet PII.
+REVOKE ALL ON pet_profiles FROM anon;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- PART 2: partner_api_keys
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Step 1: Drop the header-only FOR ALL policy from 00068.
+DROP POLICY IF EXISTS "partner_api_keys_clinic_scope" ON partner_api_keys;
+
+-- Step 2: Add modern auth-aware policies (super admin + clinic staff scoped).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'partner_api_keys' AND policyname = 'sa_partner_api_keys_all'
+  ) THEN
+    CREATE POLICY "sa_partner_api_keys_all" ON partner_api_keys FOR ALL
+      USING (is_super_admin())
+      WITH CHECK (is_super_admin());
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'partner_api_keys' AND policyname = 'staff_partner_api_keys'
+  ) THEN
+    CREATE POLICY "staff_partner_api_keys" ON partner_api_keys FOR ALL
+      USING (clinic_id = get_user_clinic_id() AND is_clinic_staff())
+      WITH CHECK (clinic_id = get_user_clinic_id() AND is_clinic_staff());
+  END IF;
+END $$;
+
+-- Step 3: Defense-in-depth — anon must never read API key material.
+REVOKE ALL ON partner_api_keys FROM anon;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Closes two **Critical** tenant-isolation holes (broken access control — CWE-639 / OWASP A01) in RLS — the same vulnerability class fixed for the restaurant vertical in `00086`, but which was missed on two tables.

Both tables have PERMISSIVE RLS policies that gate **solely** on the unsigned, client-controllable `x-clinic-id` request header, with no `auth.uid()` / role check. Because PERMISSIVE policies are OR-combined, the modern auth-aware policies added later do **not** override them. A direct Supabase REST call using the public anon key with a spoofed `x-clinic-id` header bypasses Next.js middleware entirely and can read/write any clinic's rows.

- **`pet_profiles`** — legacy policies from `00061` were never dropped; `00063` only *added* secure policies alongside them. Net effect: anon can read/write (FOR ALL) any clinic's pet PII.
- **`partner_api_keys`** (`00068`) — `partner_api_keys_clinic_scope` is `FOR ALL` header-only. Anon can read key hashes and INSERT a forged API-key row for any clinic.

### Effective-schema proof (replayed all migrations in order)
- No `DROP POLICY` / `ALTER POLICY` for any `pet_profiles_*` exists in any migration <= `00097` (only `00061` creates the header policies; `00063` adds new ones).
- No `DROP`/`ALTER` for `partner_api_keys_clinic_scope` anywhere <= `00097`.
- The literal `USING (true)` leaks (00015/00037/00013) were already remediated (by 00033 / 00039+00041 / 00032) and are intentionally left untouched here.

## Changes
`supabase/migrations/00098_fix_header_based_rls_pet_partner.sql` (append-only):
- DROP the 7 legacy header-based policies on `pet_profiles`; ensure `00063`'s `sa_pet_profiles_all` / `staff_pet_profiles` / `owner_pet_profiles_read` exist (idempotent `IF NOT EXISTS`); `REVOKE ALL ON pet_profiles FROM anon`.
- DROP `partner_api_keys_clinic_scope`; add auth-gated `sa_partner_api_keys_all` + `staff_partner_api_keys`; `REVOKE ALL ON partner_api_keys FROM anon`.

## Review & Testing Checklist for Human
- [ ] Confirm no anonymous/public surface legitimately reads `pet_profiles` (the pets API is 100% `withAuth`; the authenticated client does not send `x-clinic-id`).
- [ ] Confirm `partner_api_keys` has no app code path needing anon access before relying on the REVOKE.
- [ ] On staging: staff pet CRUD still works; patient sees only own pets; raw anon REST with spoofed `x-clinic-id` now returns 0 rows / denies writes on both tables.
- [ ] Migration applies cleanly in CI (`supabase start` replay) and the RLS assertion suite stays green.

### Notes
Mirrors `00086_drop_legacy_restaurant_rls.sql`. Relies on existing helpers `is_super_admin()`, `get_user_clinic_id()`, `is_clinic_staff()`, `get_my_user_id()`. A separate coupled finding (DB-03: `email_verifications` `USING (true)` SELECT/UPDATE) is NOT in this PR because its fix also needs an app-code change — flagged for routing.
