### PR TITLE
fix(ci): anchor KV id regex in pre-deploy-check — unblocks prod deploy

### DIFF
--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -45,9 +45,12 @@ if errors:
 python3 -c "
 import re, sys
 lines = open('wrangler.toml').read()
-# Find all kv_namespaces blocks and check id vs preview_id
-ids = re.findall(r'id\s*=\s*\"([^\"]+)\"', lines)
-preview_ids = re.findall(r'preview_id\s*=\s*\"([^\"]+)\"', lines)
+# Find all kv_namespaces blocks and check id vs preview_id.
+# Anchor to line start so 'preview_id = ...' is NOT also captured by the
+# 'id = ...' pattern (otherwise a valid preview_id is mis-parsed as a
+# production id and falsely flagged as a collision).
+ids = re.findall(r'(?m)^\s*id\s*=\s*\"([^\"]+)\"', lines)
+preview_ids = re.findall(r'(?m)^\s*preview_id\s*=\s*\"([^\"]+)\"', lines)
 for i, (kid, pid) in enumerate(zip(ids, preview_ids)):
     if kid == pid and 'PLACEHOLDER' not in pid:
         print(f'::error::KV namespace #{i+1}: preview_id matches production id ({kid}). Create a separate preview namespace.')


### PR DESCRIPTION
## Summary

**P0 deploy unblock.** The production deploy pipeline has been failing at the `Build for Cloudflare` step for every push that sets a KV `preview_id`, so no fix can reach production (including the rate-limit outage fixes in #753/#754).

**Root cause:** the preview_id==id collision guard in `scripts/pre-deploy-check.sh` used the regex `id\s*=\s*"..."`, which **also matches** `preview_id = "..."` (it ends in `id`). Every `preview_id` value was therefore captured into the `ids` list, mis-paired by `zip()`, and a perfectly valid config (`id` `7ac37...` != `preview_id` `854c78...`) was falsely flagged:

```
::error::KV namespace #2: preview_id matches production id (854c78ea8c9442ed8706d3ec31fe292e). Create a separate preview namespace.
```

**Fix:** anchor both patterns to line start (`(?m)^\s*id` / `(?m)^\s*preview_id`) so `preview_id` lines are no longer captured as `id`. Verified locally:
- current (valid) config -> check **passes**
- a genuine `id == preview_id` collision -> still correctly **detected and fails**

No config values changed; this only fixes the validator's regex.

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact
- [x] No security impact (the real preview/production KV separation check is preserved and still enforced)

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed (ran `scripts/pre-deploy-check.sh` against current config: passes; against a synthetic collision: fails as intended)

## Observability
- [x] N/A

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff (KV namespace IDs are resource identifiers, not secrets — already committed)
- [x] Shell/Python-only validator change; app lint/typecheck/tests unaffected
