### PR TITLE
fix(ci): anchor KV id regex in pre-deploy check to unblock prod deploy

### DIFF
--- a/scripts/pre-deploy-check.sh
+++ b/scripts/pre-deploy-check.sh
@@ -45,9 +45,11 @@ if errors:
 python3 -c "
 import re, sys
 lines = open('wrangler.toml').read()
-# Find all kv_namespaces blocks and check id vs preview_id
-ids = re.findall(r'id\s*=\s*\"([^\"]+)\"', lines)
-preview_ids = re.findall(r'preview_id\s*=\s*\"([^\"]+)\"', lines)
+# Find all kv_namespaces blocks and check id vs preview_id.
+# Anchor the production-id match to the start of a line so it does not also
+# match the 'id' inside 'preview_id = ...' (which produced a false positive).
+ids = re.findall(r'(?m)^\s*id\s*=\s*\"([^\"]+)\"', lines)
+preview_ids = re.findall(r'(?m)^\s*preview_id\s*=\s*\"([^\"]+)\"', lines)
 for i, (kid, pid) in enumerate(zip(ids, preview_ids)):
     if kid == pid and 'PLACEHOLDER' not in pid:
         print(f'::error::KV namespace #{i+1}: preview_id matches production id ({kid}). Create a separate preview namespace.')


### PR DESCRIPTION
## Summary

**Production deploys are currently blocked** by a false positive in `scripts/pre-deploy-check.sh`. The "Build & Deploy" job fails at the config-validation step with:

```
::error::KV namespace #2: preview_id matches production id (854c78ea8c9442ed8706d3ec31fe292e). Create a separate preview namespace.
```

…even though `wrangler.toml` is correct — the production `id` (`7ac37dff…`) and `preview_id` (`854c78ea…`) are different.

### Root cause
The collision check used `re.findall(r'id\s*=\s*"([^"]+)"', ...)` to gather production ids. That pattern **also matches the `id` inside `preview_id = "…"`**, so the `ids` list interleaved real ids and preview ids:

```
ids        = [7ac37dff, 854c78ea, 7ac37dff, 854c78ea, 7ac37dff, 854c78ea]
preview_id = [854c78ea, 854c78ea, 854c78ea]
```

`zip(ids, preview_ids)` then paired `854c78ea` (a preview id miscaptured as an id) against `854c78ea` (the real preview id) → false "equal" → deploy blocked.

### Fix
Anchor both patterns to the start of a line (`re.MULTILINE`) so only true `id =` / `preview_id =` lines are captured. Verified locally:
- `bash scripts/pre-deploy-check.sh` now exits 0 on the current `wrangler.toml` ("Configuration check passed.").
- A synthetic `preview_id == id` block is still correctly flagged, so the guard's intent is preserved.

This is pre-existing (the deploy was already failing on `main` before recent merges) but now critical: it blocks the just-merged emergency rate-limit fixes (#753/#754) from reaching production.

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact
- [x] No security impact (tightens a deploy-time guard; still catches real preview/prod KV collisions)

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed (ran the script against real and synthetic configs)

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
