### PR TITLE
fix(rls): close header-spoof tenant bypass on notification_queue

### DIFF
--- a/supabase/migrations/00100_fix_header_based_rls_notification_queue.sql
+++ b/supabase/migrations/00100_fix_header_based_rls_notification_queue.sql
@@ -1,0 +1,64 @@
+-- =============================================================================
+-- Migration 00100: Header-based RLS remediation for notification_queue
+--
+-- AUDIT FINDING (Critical, tenant isolation / broken access control):
+-- Same class as 00086 (restaurant) and 00098 (pet_profiles/partner_api_keys).
+-- notification_queue (created in 00050) has a single PERMISSIVE SELECT policy
+-- that trusts the unsigned `x-tenant-clinic-id` request header with NO
+-- auth.uid() / is_clinic_staff() / is_super_admin() gate:
+--
+--   clinic_id::text = coalesce(
+--     current_setting('request.headers', true)::json->>'x-tenant-clinic-id', '')
+--
+-- The `anon` role holds the default table SELECT grant, so a direct Supabase
+-- REST call with the public anon key and a spoofed `x-tenant-clinic-id` header
+-- reads any clinic's queued notification bodies — which contain PHI
+-- (patient names, appointment details, reminders)
+-- (CWE-639 Authorization Bypass Through User-Controlled Key,
+--  OWASP A01:2021 Broken Access Control).
+--
+-- Compatibility:
+--   notification_queue is read and written exclusively by server-side code
+--   using the service-role admin client (createAdminClient(...) in
+--   src/lib/notification-queue.ts, cron and webhook routes). The service role
+--   bypasses RLS, so no legitimate client ever relied on the header policy.
+--   The header name (`x-tenant-clinic-id`) does not even match the
+--   `x-clinic-id` header the app sends, confirming no client read path used it.
+--
+-- This migration mirrors 00086 / 00098:
+--   1. Drops the legacy header-based policy.
+--   2. Adds modern auth-aware policies (super admin + clinic staff).
+--   3. Revokes anon table privileges (defense-in-depth).
+-- =============================================================================
+
+BEGIN;
+
+-- Step 1: Drop the legacy header-only SELECT policy from 00050.
+DROP POLICY IF EXISTS "notification_queue_select_own_clinic" ON notification_queue;
+
+-- Step 2: Add modern auth-aware read policies (idempotent).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'notification_queue' AND policyname = 'sa_notification_queue_all'
+  ) THEN
+    CREATE POLICY "sa_notification_queue_all" ON notification_queue FOR ALL
+      USING (is_super_admin())
+      WITH CHECK (is_super_admin());
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'notification_queue' AND policyname = 'staff_notification_queue_select'
+  ) THEN
+    CREATE POLICY "staff_notification_queue_select" ON notification_queue FOR SELECT
+      USING (clinic_id = get_user_clinic_id() AND is_clinic_staff());
+  END IF;
+END $$;
+
+-- Step 3: Defense-in-depth — anon has no business reading queued PHI.
+REVOKE ALL ON notification_queue FROM anon;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Closes a **Critical** tenant-isolation hole on `notification_queue` — the same header-spoof class fixed for restaurant (00086) and pet_profiles/partner_api_keys (00098).

`notification_queue` (created in 00050) has a single PERMISSIVE SELECT policy gated **solely** on the unsigned `x-tenant-clinic-id` request header, with no auth/role check. The `anon` role holds the default table SELECT grant, so a direct Supabase REST call with the public anon key and a spoofed `x-tenant-clinic-id` header reads **any clinic's queued notification bodies** — which contain PHI (patient names, appointment details, reminders). CWE-639 / OWASP A01:2021.

### Proof (full `supabase/postgres` migration replay + live exploit)
Before fix, as `anon` with a spoofed header:
```
anon_rows | leaked_body
----------+---------------------------------------
        1 | PHI: patient Ahmed appt tomorrow 10am
```
After this migration:
```
ERROR: permission denied for table notification_queue   -- anon
svc_rows = 1                                             -- service_role still reads (BYPASSRLS)
```

## Changes
`supabase/migrations/00100_fix_header_based_rls_notification_queue.sql` (append-only):
- DROP the header-only `notification_queue_select_own_clinic` policy.
- Add auth-gated `sa_notification_queue_all` (super admin) + `staff_notification_queue_select` (clinic staff), idempotent.
- `REVOKE ALL ON notification_queue FROM anon`.

## Compatibility
`notification_queue` is read/written **exclusively** by server-side code via the service-role admin client (`createAdminClient(...)` in `src/lib/notification-queue.ts`, cron, and webhook routes). Service role bypasses RLS, so no legitimate client relied on the header policy. The header name (`x-tenant-clinic-id`) doesn't even match the `x-clinic-id` the app sends, confirming no client read path used it.

## Review & Testing Checklist for Human
- [ ] Confirm no client-side (anon/authenticated browser) code reads `notification_queue` directly — all access should be server-side service-role.
- [ ] Verify in staging: the notification cron/dispatch still enqueues and processes items (service-role path), and a raw anon REST call with a spoofed `x-tenant-clinic-id` now returns permission denied.
- [ ] Confirm the new `staff_notification_queue_select` policy is acceptable if any admin UI is later built to view the queue.

### Notes
Independent of PR #756 (00098) and #759 (00099); touches a different table. Numbered 00100 to avoid colliding with those once they land. A related finding on `patient_feedback` (same header-spoof class, but its INSERT path may serve a server-side webhook flow that needs verification) is being reported separately rather than auto-fixed.
