### PR TITLE
fix(deploy): remove unexported RateLimiterDO binding+migration — unblocks prod deploy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -58,28 +58,18 @@ id = "7ac37dff0a794542b0c766f38e73f105"
 preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
 
 # ── Durable Objects ───────────────────────────────────────────────────
-# H-03: Strongly consistent rate limiting across all edge locations.
-# Each rate-limited key (IP, email) maps to a single DO instance,
-# providing atomic counter increments with no eventual-consistency races.
-#
-# To activate:
-#   1. Deploy this config: wrangler deploy
-#   2. Set RATE_LIMIT_BACKEND=do in [vars] below
-#   3. The factory in rate-limit.ts auto-detects the DO binding
-#
-# To keep using KV (current): leave RATE_LIMIT_BACKEND=kv (no change needed)
-#
-# NOTE: Durable Objects require Workers Paid plan. The DO class is exported
-# from src/lib/rate-limit-do.ts. After deploying, Cloudflare automatically
-# provisions DO instances on demand.
-[durable_objects]
-bindings = [
-  { name = "RATE_LIMITER_DO", class_name = "RateLimiterDO" }
-]
-
-[[migrations]]
-tag = "v1"
-new_classes = ["RateLimiterDO"]
+# H-03 (DEFERRED): Strongly consistent rate limiting via a RateLimiterDO
+# Durable Object was scaffolded in src/lib/rate-limit-do.ts, but the
+# @opennextjs/cloudflare build does NOT re-export custom Durable Object
+# classes from the generated entrypoint (.open-next/worker.js). Declaring the
+# binding/migration here therefore made every `wrangler deploy` fail with:
+#   "Your Worker depends on the following Durable Objects, which are not
+#    exported in your entrypoint file: RateLimiterDO."
+# blocking ALL production deploys. The DO is unused (RATE_LIMIT_BACKEND is
+# kv/memory, never "do") and the limiter factory in rate-limit.ts already
+# falls back gracefully when the binding is absent, so the binding and its
+# migration are removed until the DO is properly wired through OpenNext
+# (e.g. a custom worker entry that re-exports RateLimiterDO).
 
 # ── R2 Buckets ────────────────────────────────────────────────────────
 # AUDIT-LB3: IaC — PHI file storage (encrypted uploads).


### PR DESCRIPTION
## Summary

**P0 deploy unblock (second blocker).** After #758 fixed the false-positive in `pre-deploy-check.sh`, the deploy got past the build step but then failed at `Deploy to Cloudflare Workers (Production)`:

```
✘ [ERROR] Your Worker depends on the following Durable Objects, which are not exported in your entrypoint file: RateLimiterDO.
```

**Root cause:** `wrangler.toml` declared a Durable Object binding (`RATE_LIMITER_DO` → class `RateLimiterDO`) plus a `[[migrations]]` v1 `new_classes = ["RateLimiterDO"]`. But `@opennextjs/cloudflare` does **not** re-export custom Durable Object classes from its generated entrypoint (`.open-next/worker.js`), and `open-next.config.ts` has no DO wiring. So wrangler refused to deploy. This silently blocked **every** production deploy — which is why the rate-limit 429 outage fix sitting on `main` never reached production.

**Fix:** remove the unsatisfiable DO binding and its migration. The DO is **unused**:
- `RATE_LIMIT_BACKEND` is `kv`/`memory` (never `do`).
- The limiter factory in `rate-limit.ts` already falls back gracefully when the binding is absent.

No live DO instances exist (this config never deployed successfully), so no `deleted_classes` migration is needed. The `RateLimiterDO` class in `src/lib/rate-limit-do.ts` is left in place for a future PR that wires it through a custom OpenNext worker entry.

## Type of change
- [x] Bug fix
- [x] Infrastructure / CI / deploy config

## Security Impact
- [x] No security impact — rate limiting continues via KV/in-memory; no auth/validation weakened.

## Migration Safety
- [x] N/A — removes a Workers DO migration that was never applied (no live DO instances). No DB migration.

## Testing
- [x] `scripts/pre-deploy-check.sh` passes; `wrangler.toml` validates as TOML; no remaining `durable_objects`/`migrations` config.
- [x] Verified per-env blocks ([env.production], [env.staging]) never redeclared the DO, so removing the top-level block fully clears it.

## Observability
- [x] N/A

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] Minimal, focused diff (config-only)
