### PR TITLE
fix(branding): surface image-upload and preset-apply failures

### DIFF
--- a/src/app/(admin)/admin/branding/page.tsx
+++ b/src/app/(admin)/admin/branding/page.tsx
@@ -192,6 +192,8 @@ export default function BrandingPage() {
               ? "cover_photo_url"
               : "hero_image_url";
       setBranding((prev) => ({ ...prev, [urlField]: url }));
+    } catch {
+      alert("Upload failed");
     } finally {
       setUploading(null);
     }
@@ -291,7 +293,11 @@ export default function BrandingPage() {
                     secondary_color: preset.theme.secondaryColor,
                   }));
                   setTimeout(() => setAppliedPreset(null), 3000);
+                } else {
+                  alert("Failed to apply preset");
                 }
+              } catch {
+                alert("Failed to apply preset");
               } finally {
                 setApplyingPreset(null);
               }


### PR DESCRIPTION
## Summary

Two silent-failure bugs in the admin Branding page (`src/app/(admin)/admin/branding/page.tsx`), same class as the earlier "false success" fixes:

1. **`handleUpload`** had a `try { … } finally { … }` with **no `catch`**. A network error (or a non-JSON error body) rejected the promise, and since `onFileChange` calls `handleUpload(field, file)` without `await` or `.catch`, it became an **unhandled promise rejection** with **no feedback** to the user — the "Uploading…" state just reset. Now it `alert`s on failure, matching the existing `!res.ok` branch and `handleSave`.

2. **Preset `onApply`** only acted on `res.ok` and had no `else`/`catch`, so a failed preset-apply (HTTP error or network throw) **silently did nothing** — the user had no idea it failed. Now it surfaces the failure via `alert`.

Behavior on success is unchanged.

## Type of change
- [x] Bug fix (non-breaking)

## Testing
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 103 files, 1047 passed / 38 skipped

## Checklist
- [x] Self-review completed
- [x] In-lane only (single admin page); no shared lib/component/locale/API changes
- [x] No secrets or PHI in the diff
