### PR TITLE
fix(templates): surface preset-apply network errors

### DIFF
--- a/src/app/(admin)/admin/templates/page.tsx
+++ b/src/app/(admin)/admin/templates/page.tsx
@@ -112,6 +112,8 @@ export default function TemplatesPage() {
       setSelected(preset.templateId);
       setSaved(preset.templateId);
       setTimeout(() => setAppliedPreset(null), 3000);
+    } catch {
+      alert("Failed to apply preset");
     } finally {
       setApplyingPreset(null);
     }


### PR DESCRIPTION
## Summary

`handleApplyPreset` in the admin Templates page (`src/app/(admin)/admin/templates/page.tsx`) handled the `!res.ok` case but had a `try { … } finally { … }` with **no `catch`**. A network failure (fetch throws) therefore rejected silently — an **unhandled promise rejection** with **no feedback** to the user; the "Applying…" state just reset.

Now it `alert`s on failure, matching `handleSave` in the same file. Success behavior is unchanged.

## Type of change
- [x] Bug fix (non-breaking)

## Testing
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] Unit suite verified green on the prior batch PR (1047 passed); this is a 2-line catch with no logic change.

## Checklist
- [x] Self-review completed
- [x] In-lane only (single admin page); no shared lib/component/locale/API changes
- [x] No secrets or PHI in the diff
