### PR TITLE
fix(a11y): add accessible names to icon-only buttons across shared components

### DIFF
--- a/src/components/chatbot/chatbot-widget.tsx
+++ b/src/components/chatbot/chatbot-widget.tsx
@@ -178,6 +178,7 @@ export function ChatbotWidget() {
               size="sm"
               className="h-8 w-8 p-0 shrink-0"
               disabled={!input.trim() || isLoading}
+              aria-label="Send message"
             >
               <Send className="h-4 w-4" />
             </Button>

--- a/src/components/doctor/rebooking-status.tsx
+++ b/src/components/doctor/rebooking-status.tsx
@@ -89,7 +89,7 @@ export function RebookingStatus({ clinicId, doctorId }: RebookingStatusProps) {
             <RefreshCw className="h-4 w-4" />
             Rebooking Status
           </CardTitle>
-          <Button variant="ghost" size="sm" onClick={fetchStatus}>
+          <Button variant="ghost" size="sm" onClick={fetchStatus} aria-label="Refresh">
             <RefreshCw className="h-3 w-3" />
           </Button>
         </div>

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -266,6 +266,7 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
               size="sm"
               className="md:hidden"
               onClick={() => setMobileOpen(true)}
+              aria-label="Open menu"
             >
               <Menu className="h-5 w-5" />
             </Button>

--- a/src/components/para-medical/exercise-program-builder.tsx
+++ b/src/components/para-medical/exercise-program-builder.tsx
@@ -112,6 +112,7 @@ export function ExerciseProgramBuilder({
                         e.stopPropagation();
                         onUpdateStatus?.(program.id, "paused");
                       }}
+                      aria-label="Pause program"
                     >
                       <Pause className="h-3.5 w-3.5" />
                     </Button>
@@ -124,6 +125,7 @@ export function ExerciseProgramBuilder({
                         e.stopPropagation();
                         onUpdateStatus?.(program.id, "active");
                       }}
+                      aria-label="Resume program"
                     >
                       <Play className="h-3.5 w-3.5" />
                     </Button>
@@ -136,6 +138,7 @@ export function ExerciseProgramBuilder({
                         e.stopPropagation();
                         onUpdateStatus?.(program.id, "completed");
                       }}
+                      aria-label="Mark program completed"
                     >
                       <CheckCircle className="h-3.5 w-3.5 text-green-600" />
                     </Button>
@@ -188,6 +191,7 @@ export function ExerciseProgramBuilder({
                         <Button
                           variant="ghost"
                           size="sm"
+                          aria-label="Remove exercise"
                           onClick={() => onRemoveExercise?.(program.id, idx)}
                         >
                           <Trash2 className="h-3.5 w-3.5 text-red-500" />

--- a/src/components/para-medical/meal-plan-builder.tsx
+++ b/src/components/para-medical/meal-plan-builder.tsx
@@ -167,6 +167,8 @@ export function MealPlanBuilder({
                                   <span className="w-14 text-right">{item.calories} kcal</span>
                                   {editable && (
                                     <button
+                                      type="button"
+                                      aria-label="Remove item"
                                       onClick={() =>
                                         onRemoveMealItem?.(plan.id, expandedDay, slot, idx)
                                       }

--- a/src/components/receptionist/waiting-room-manager.tsx
+++ b/src/components/receptionist/waiting-room-manager.tsx
@@ -295,6 +295,7 @@ export function WaitingRoomManager() {
                         className="h-5 w-5 p-0"
                         onClick={() => moveUp(patient.id)}
                         disabled={index === 0}
+                        aria-label="Move up"
                       >
                         <ArrowUp className="h-3 w-3" />
                       </Button>
@@ -303,6 +304,7 @@ export function WaitingRoomManager() {
                         size="sm"
                         className="h-5 w-5 p-0"
                         onClick={() => moveDown(patient.id)}
+                        aria-label="Move down"
                         disabled={index === queue.length - 1}
                       >
                         <ArrowDown className="h-3 w-3" />

--- a/src/components/super-admin/onboarding-step-services.tsx
+++ b/src/components/super-admin/onboarding-step-services.tsx
@@ -55,6 +55,7 @@ export function OnboardingStepServices({
                   variant="ghost"
                   size="sm"
                   className="text-destructive"
+                  aria-label="Remove service"
                   onClick={() => onRemoveService(index)}
                 >
                   <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/super-admin/onboarding-step-staff.tsx
+++ b/src/components/super-admin/onboarding-step-staff.tsx
@@ -58,6 +58,7 @@ export function OnboardingStepStaff({
                   variant="ghost"
                   size="sm"
                   className="text-destructive"
+                  aria-label="Remove staff member"
                   onClick={() => onRemoveUser(index)}
                 >
                   <Trash2 className="h-3.5 w-3.5" />

--- a/src/components/super-admin/onboarding-step-timeslots.tsx
+++ b/src/components/super-admin/onboarding-step-timeslots.tsx
@@ -117,6 +117,7 @@ export function OnboardingStepTimeSlots({
                         variant="ghost"
                         size="sm"
                         className="text-destructive"
+                        aria-label="Remove time slot"
                         onClick={() => onRemoveSlot(dIndex, sIndex)}
                       >
                         <Trash2 className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Several icon-only buttons in shared components had no accessible name, so screen-reader users heard an unlabeled "button". Added concise `aria-label`s (consistent with the existing literal `aria-label` convention in the repo, e.g. "Open menu"/"Close menu"):

- `chatbot/chatbot-widget.tsx` — send button (`Send`) → "Send message"
- `receptionist/waiting-room-manager.tsx` — queue reorder (`ArrowUp`/`ArrowDown`) → "Move up"/"Move down"
- `doctor/rebooking-status.tsx` — refresh (`RefreshCw`) → "Refresh"
- `super-admin/onboarding-step-staff.tsx` / `-services.tsx` / `-timeslots.tsx` — delete (`Trash2`) → "Remove staff member"/"Remove service"/"Remove time slot"
- `para-medical/exercise-program-builder.tsx` — `Pause`/`Play`/`CheckCircle`/`Trash2` → "Pause program"/"Resume program"/"Mark program completed"/"Remove exercise"
- `para-medical/meal-plan-builder.tsx` — remove item (`Trash2`) → "Remove item" (also added explicit `type="button"`)
- `layouts/super-admin-layout-shell.tsx` — mobile menu (`Menu`) → "Open menu"

`aria-label` is in the eslint i18n `ignoreAttribute` allowlist, so no new lint warnings and no locale-JSON changes. Purely additive attributes; no behavior change.

Scope: `src/components/**` only.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] `npm run lint`, `npm run typecheck`, `npm run test` (1019 passed) green locally

## Observability
- [x] N/A — no observability changes

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes