### PR TITLE
fix(patient): remove dead 'View' button on invoices page

### DIFF
--- a/src/app/(patient)/patient/invoices/page.tsx
+++ b/src/app/(patient)/patient/invoices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, CreditCard, Eye, FileText, CheckCircle2 } from "lucide-react";
+import { Download, CreditCard, FileText, CheckCircle2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -154,9 +154,6 @@ export default function PatientInvoicesPage() {
                     </td>
                     <td className="py-3 text-right">
                       <div className="flex gap-1 justify-end">
-                        <Button variant="ghost" size="sm" title="View">
-                          <Eye className="h-3.5 w-3.5" />
-                        </Button>
                         <Button
                           variant="ghost"
                           size="sm"


### PR DESCRIPTION
## Summary

The patient invoices table rendered a ghost "View" eye button (`title="View"`) with **no `onClick` handler** — clicking it did nothing, misleading users into thinking an invoice detail view exists. Removed the dead control and the now-unused `Eye` import. The working "Download Receipt" button is unchanged.

Note: the receipt download itself is still a placeholder (`setTimeout` spinner, no real file) — that needs a receipt endpoint outside this lane and is reported separately to the orchestrator.

Scope: `src/app/(patient)/patient/invoices/page.tsx` only.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] `npm run lint` (0 errors) + `npm run typecheck` green locally

## Observability
- [x] N/A

## Checklist
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes