### PR TITLE
feat(infra): add npm audit to CI, enforce 2FA for admin/doctor, geo-restrict admin routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,13 @@ jobs:
             if (failed) process.exit(1);
           '
 
+      # SEC-009: Full dependency audit (prod + dev) at high severity.
+      # Catches high/critical CVEs in devDependencies that the --omit=dev
+      # step above skips. A compromised devdep can hijack the CI runner
+      # or inject malicious code into the build output.
+      - name: Audit all dependencies (prod + dev)
+        run: npm audit --audit-level=high
+
       # R-08: Ban direct process.env.CRON_SECRET access outside cron-auth.ts
       - name: Guard CRON_SECRET access
         run: |

--- a/src/lib/__tests__/geo-restriction.test.ts
+++ b/src/lib/__tests__/geo-restriction.test.ts
@@ -29,7 +29,26 @@ describe("geo-restriction", () => {
     process.env = originalEnv;
   });
 
-  it("allows all requests when GEO_RESTRICT_ADMIN is unset", async () => {
+  it("defaults to blocking non-MA requests when no env vars are set", async () => {
+    delete process.env.GEO_RESTRICT_ADMIN;
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
+    const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
+    const req = createMockRequest("/admin/settings", { "cf-ipcountry": "US" });
+    const result = checkGeoRestriction(req);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(403);
+  });
+
+  it("allows MA requests by default when no env vars are set", async () => {
+    delete process.env.GEO_RESTRICT_ADMIN;
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
+    const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
+    const req = createMockRequest("/admin/settings", { "cf-ipcountry": "MA" });
+    expect(checkGeoRestriction(req)).toBeNull();
+  });
+
+  it("allows all requests when ADMIN_GEO_RESTRICTION_ENABLED=false", async () => {
+    process.env.ADMIN_GEO_RESTRICTION_ENABLED = "false";
     delete process.env.GEO_RESTRICT_ADMIN;
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/admin/settings", { "cf-ipcountry": "US" });
@@ -38,6 +57,7 @@ describe("geo-restriction", () => {
 
   it("allows requests from allowed countries", async () => {
     process.env.GEO_RESTRICT_ADMIN = "MA,FR";
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/admin/settings", { "cf-ipcountry": "MA" });
     expect(checkGeoRestriction(req)).toBeNull();
@@ -45,16 +65,17 @@ describe("geo-restriction", () => {
 
   it("blocks requests from non-allowed countries", async () => {
     process.env.GEO_RESTRICT_ADMIN = "MA,FR";
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/admin/settings", { "cf-ipcountry": "US" });
     const result = checkGeoRestriction(req);
     expect(result).not.toBeNull();
-    // Verify it's a 403 response
     expect(result?.status).toBe(403);
   });
 
   it("blocks Tor exit nodes (T1)", async () => {
     process.env.GEO_RESTRICT_ADMIN = "MA,FR";
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/dashboard/patients", { "cf-ipcountry": "T1" });
     const result = checkGeoRestriction(req);
@@ -63,6 +84,7 @@ describe("geo-restriction", () => {
   });
 
   it("skips non-admin routes", async () => {
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
     process.env.GEO_RESTRICT_ADMIN = "MA";
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/booking/new", { "cf-ipcountry": "US" });
@@ -70,6 +92,7 @@ describe("geo-restriction", () => {
   });
 
   it("skips when CF-IPCountry header is absent (non-Cloudflare)", async () => {
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
     process.env.GEO_RESTRICT_ADMIN = "MA";
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/admin/settings", {});
@@ -77,6 +100,7 @@ describe("geo-restriction", () => {
   });
 
   it("is case-insensitive for country codes", async () => {
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
     process.env.GEO_RESTRICT_ADMIN = "ma,fr";
     const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
     const req = createMockRequest("/admin/settings", { "cf-ipcountry": "MA" });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -281,6 +281,22 @@ const ENV_RULES: EnvRule[] = [
   // line ~91 under "security" group and again here under "encryption").
   // The first entry (C-08, group: "security") is the canonical one.
 
+  // ── Geo-restriction ──────────────────────────────────────────────────
+  {
+    name: "ADMIN_GEO_RESTRICTION_ENABLED",
+    required: false,
+    description:
+      "Toggle admin-route geo-restriction (defaults to true; set to 'false' to disable)",
+    group: "security",
+  },
+  {
+    name: "GEO_RESTRICT_ADMIN",
+    required: false,
+    description:
+      "Comma-separated ISO 3166-1 alpha-2 country codes allowed to access admin routes (defaults to 'MA')",
+    group: "security",
+  },
+
   // ── Custom Domains ─────────────────────────────────────────────────
   // These are gated by NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS — when the flag is
   // "true" they become required, so the app refuses to boot with a half-wired
@@ -345,6 +361,26 @@ export function isCustomDomainsEnabled(): boolean {
  */
 function customDomainsEnabledFromEnv(): boolean {
   return process.env.NEXT_PUBLIC_ENABLE_CUSTOM_DOMAINS === "true";
+}
+
+/**
+ * Whether admin-route geo-restriction is enabled.
+ *
+ * Defaults to `true`. Set `ADMIN_GEO_RESTRICTION_ENABLED=false` (or `0`)
+ * to disable. Read through this helper rather than `process.env` directly.
+ */
+export function isAdminGeoRestrictionEnabled(): boolean {
+  const raw = process.env.ADMIN_GEO_RESTRICTION_ENABLED;
+  if (raw === undefined || raw === "") return true;
+  return raw.trim().toLowerCase() !== "false" && raw.trim() !== "0";
+}
+
+/**
+ * Comma-separated list of allowed country codes for admin routes, or
+ * `undefined` when the env var is unset (caller should default to `"MA"`).
+ */
+export function getGeoRestrictAdminCountries(): string | undefined {
+  return process.env.GEO_RESTRICT_ADMIN;
 }
 
 export interface EnvValidationResult {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -285,8 +285,7 @@ const ENV_RULES: EnvRule[] = [
   {
     name: "ADMIN_GEO_RESTRICTION_ENABLED",
     required: false,
-    description:
-      "Toggle admin-route geo-restriction (defaults to true; set to 'false' to disable)",
+    description: "Toggle admin-route geo-restriction (defaults to true; set to 'false' to disable)",
     group: "security",
   },
   {

--- a/src/lib/middleware/__tests__/mfa-enforcement.test.ts
+++ b/src/lib/middleware/__tests__/mfa-enforcement.test.ts
@@ -68,8 +68,8 @@ describe("enforceMfa — super_admin", () => {
   });
 });
 
-describe("enforceMfa — doctor / clinic_admin step-up", () => {
-  it("redirects a doctor with an enrolled-but-unverified factor", async () => {
+describe("enforceMfa — doctor / clinic_admin mandatory 2FA", () => {
+  it("redirects a doctor with an enrolled-but-unverified factor to login", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),
       "doctor",
@@ -80,9 +80,30 @@ describe("enforceMfa — doctor / clinic_admin step-up", () => {
     expect(result?.headers.get("location")).toContain("/login?mfa=required");
   });
 
-  it("lets a doctor without enrolled factors through", async () => {
+  it("redirects a doctor without enrolled factors to /setup-2fa", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
+      "doctor",
+      "/dashboard",
+      `${URL_BASE}/dashboard`,
+    );
+    expect(result?.status).toBe(307);
+    expect(result?.headers.get("location")).toContain("/setup-2fa?required=doctor");
+  });
+
+  it("does not loop-redirect a doctor already on /setup-2fa", async () => {
+    const result = await enforceMfa(
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
+      "doctor",
+      "/setup-2fa",
+      `${URL_BASE}/setup-2fa`,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("passes a doctor with AAL2", async () => {
+    const result = await enforceMfa(
+      mockSupabase({ currentLevel: "aal2", nextLevel: "aal2" }),
       "doctor",
       "/dashboard",
       `${URL_BASE}/dashboard`,
@@ -90,7 +111,7 @@ describe("enforceMfa — doctor / clinic_admin step-up", () => {
     expect(result).toBeNull();
   });
 
-  it("redirects a clinic_admin on an /admin path with an unverified factor", async () => {
+  it("redirects a clinic_admin with an unverified factor to login", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),
       "clinic_admin",
@@ -101,16 +122,25 @@ describe("enforceMfa — doctor / clinic_admin step-up", () => {
     expect(result?.headers.get("location")).toContain("/login?mfa=required");
   });
 
-  it("does not enforce MFA for a clinic_admin outside /admin", async () => {
-    const supabase = mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" });
+  it("redirects a clinic_admin without enrolled factors to /setup-2fa", async () => {
     const result = await enforceMfa(
-      supabase,
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
       "clinic_admin",
       "/dashboard",
       `${URL_BASE}/dashboard`,
     );
+    expect(result?.status).toBe(307);
+    expect(result?.headers.get("location")).toContain("/setup-2fa?required=clinic_admin");
+  });
+
+  it("does not loop-redirect a clinic_admin already on /setup-2fa", async () => {
+    const result = await enforceMfa(
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
+      "clinic_admin",
+      "/setup-2fa",
+      `${URL_BASE}/setup-2fa`,
+    );
     expect(result).toBeNull();
-    expect(supabase.auth.mfa.getAuthenticatorAssuranceLevel).not.toHaveBeenCalled();
   });
 });
 
@@ -118,6 +148,13 @@ describe("enforceMfa — non-privileged roles", () => {
   it("never enforces MFA for a patient", async () => {
     const supabase = mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" });
     const result = await enforceMfa(supabase, "patient", "/admin", `${URL_BASE}/admin`);
+    expect(result).toBeNull();
+    expect(supabase.auth.mfa.getAuthenticatorAssuranceLevel).not.toHaveBeenCalled();
+  });
+
+  it("never enforces MFA for a receptionist", async () => {
+    const supabase = mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" });
+    const result = await enforceMfa(supabase, "receptionist", "/admin", `${URL_BASE}/admin`);
     expect(result).toBeNull();
     expect(supabase.auth.mfa.getAuthenticatorAssuranceLevel).not.toHaveBeenCalled();
   });

--- a/src/lib/middleware/geo-restriction.ts
+++ b/src/lib/middleware/geo-restriction.ts
@@ -20,6 +20,7 @@
  * access controls.
  */
 import { NextResponse, type NextRequest } from "next/server";
+import { isAdminGeoRestrictionEnabled, getGeoRestrictAdminCountries } from "@/lib/env";
 import { logger } from "@/lib/logger";
 
 /** Admin route prefixes that should be geo-restricted. */
@@ -27,21 +28,15 @@ const ADMIN_PREFIXES = ["/admin", "/dashboard", "/api/admin"] as const;
 
 let _allowedCountries: Set<string> | null | undefined;
 
-function isGeoRestrictionEnabled(): boolean {
-  const raw = process.env.ADMIN_GEO_RESTRICTION_ENABLED;
-  if (raw === undefined || raw === "") return true;
-  return raw.trim().toLowerCase() !== "false" && raw.trim() !== "0";
-}
-
 function getAllowedCountries(): Set<string> | null {
   if (_allowedCountries !== undefined) return _allowedCountries;
 
-  if (!isGeoRestrictionEnabled()) {
+  if (!isAdminGeoRestrictionEnabled()) {
     _allowedCountries = null;
     return null;
   }
 
-  const raw = process.env.GEO_RESTRICT_ADMIN;
+  const raw = getGeoRestrictAdminCountries();
   if (!raw || raw.trim() === "") {
     _allowedCountries = new Set(["MA"]);
     return _allowedCountries;

--- a/src/lib/middleware/geo-restriction.ts
+++ b/src/lib/middleware/geo-restriction.ts
@@ -7,13 +7,14 @@
  * country code of the client.
  *
  * Behaviour:
- *   - When `GEO_RESTRICT_ADMIN` env var is set to a comma-separated list
- *     of country codes (e.g. "MA,FR,ES"), requests to admin dashboard
- *     routes from outside those countries receive a 403.
- *   - When `GEO_RESTRICT_ADMIN` is unset or empty, geo-restriction is
- *     disabled (fail-open for backward compatibility).
+ *   - Geo-restriction is **enabled by default**. Set
+ *     `ADMIN_GEO_RESTRICTION_ENABLED=false` to disable.
+ *   - When enabled, admin routes are restricted to Morocco (`MA`) unless
+ *     `GEO_RESTRICT_ADMIN` overrides the allowed country list with a
+ *     comma-separated set of codes (e.g. "MA,FR,ES").
  *   - The `CF-IPCountry` header is only present on Cloudflare-proxied
  *     requests. In dev/staging without Cloudflare, the check is skipped.
+ *   - Patient-facing routes are never restricted.
  *
  * This is defense-in-depth: authentication and RBAC remain the primary
  * access controls.
@@ -26,12 +27,24 @@ const ADMIN_PREFIXES = ["/admin", "/dashboard", "/api/admin"] as const;
 
 let _allowedCountries: Set<string> | null | undefined;
 
+function isGeoRestrictionEnabled(): boolean {
+  const raw = process.env.ADMIN_GEO_RESTRICTION_ENABLED;
+  if (raw === undefined || raw === "") return true;
+  return raw.trim().toLowerCase() !== "false" && raw.trim() !== "0";
+}
+
 function getAllowedCountries(): Set<string> | null {
   if (_allowedCountries !== undefined) return _allowedCountries;
-  const raw = process.env.GEO_RESTRICT_ADMIN;
-  if (!raw || raw.trim() === "") {
+
+  if (!isGeoRestrictionEnabled()) {
     _allowedCountries = null;
     return null;
+  }
+
+  const raw = process.env.GEO_RESTRICT_ADMIN;
+  if (!raw || raw.trim() === "") {
+    _allowedCountries = new Set(["MA"]);
+    return _allowedCountries;
   }
   _allowedCountries = new Set(
     raw

--- a/src/lib/middleware/mfa-enforcement.ts
+++ b/src/lib/middleware/mfa-enforcement.ts
@@ -10,7 +10,10 @@ import { secureRedirect } from "@/lib/middleware/security-headers";
  * Enforce MFA requirements based on role.
  *
  * - `super_admin`: MUST have MFA enrolled AND verified (AAL2).
- * - `doctor` / `clinic_admin`: redirect to verify if factors enrolled but session is AAL1.
+ * - `doctor` / `clinic_admin`: MUST have MFA enrolled AND verified (AAL2).
+ *   Redirects to /setup-2fa if no factors are enrolled, or to /login if
+ *   factors exist but the session is still AAL1.
+ * - `patient` / `receptionist`: MFA is never enforced.
  *
  * Returns a redirect Response if MFA is required, or `null` if the user passes.
  */
@@ -33,18 +36,17 @@ export async function enforceMfa(
     return null;
   }
 
-  if (role === "doctor") {
+  if (role === "doctor" || role === "clinic_admin") {
     const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-    if (aalData?.currentLevel === "aal1" && aalData?.nextLevel === "aal2") {
-      return secureRedirect(new URL("/login?mfa=required", requestUrl));
+    if (aalData?.currentLevel !== "aal2") {
+      if (aalData?.nextLevel === "aal2") {
+        return secureRedirect(new URL("/login?mfa=required", requestUrl));
+      }
+      if (!pathname.startsWith("/setup-2fa")) {
+        return secureRedirect(new URL(`/setup-2fa?required=${role}`, requestUrl));
+      }
     }
-  }
-
-  if (role === "clinic_admin" && pathname.startsWith("/admin")) {
-    const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-    if (aalData?.currentLevel === "aal1" && aalData?.nextLevel === "aal2") {
-      return secureRedirect(new URL("/login?mfa=required", requestUrl));
-    }
+    return null;
   }
 
   return null;


### PR DESCRIPTION
## Summary

Infrastructure improvements and security hardening across CI pipeline, MFA enforcement, and geo-restriction middleware.

### 1. Full npm audit in CI (HIGH)
Added `npm audit --audit-level=high` step after lint in `.github/workflows/ci.yml`. This audits **all** dependencies (prod + dev) at high severity, complementing the existing `--omit=dev` step that only checks production deps. A compromised devDependency can hijack the CI runner or inject malicious code into the build.

### 2. Mandatory 2FA for clinic_admin and doctor roles (HIGH)
Updated `src/lib/middleware/mfa-enforcement.ts` to enforce MFA enrollment for `clinic_admin` and `doctor` roles. Previously, these roles were only prompted to verify an *already-enrolled* factor. Now:
- If no MFA factors are enrolled → redirect to `/setup-2fa`
- If factors are enrolled but session is AAL1 → redirect to `/login?mfa=required`
- `patient` and `receptionist` roles are **not** affected

### 3. Geo-restriction for admin routes (MEDIUM)
Updated `src/lib/middleware/geo-restriction.ts` to restrict admin dashboard routes (`/admin/*`, `/dashboard/*`, `/api/admin/*`) to Moroccan IPs (`MA`) **by default**. Changes:
- New `ADMIN_GEO_RESTRICTION_ENABLED` env var (defaults to `true`; set to `false` to disable)
- When enabled with no `GEO_RESTRICT_ADMIN` override, defaults to `MA` only
- `GEO_RESTRICT_ADMIN` still supports comma-separated country code overrides
- Patient-facing routes are never restricted
- Non-Moroccan IPs accessing admin routes receive a 403

### 4. Bundle size check in CI (LOW)
Verified that `scripts/check-bundle-budget.mjs` is already run in CI (step "Bundle size budget check"). No changes needed.

## Type of change

- [x] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met

## Verification

```
✓ npx tsc --noEmit — clean
✓ npx vitest run — 22 tests passed (mfa-enforcement + geo-restriction)
✓ npx eslint --max-warnings 4119 — passes within baseline
```