### PR TITLE
fix(nav): add missing MobileTabBar to 6 layouts, fix broken bottom nav links

### DIFF
--- a/src/components/layouts/admin-layout-shell.tsx
+++ b/src/components/layouts/admin-layout-shell.tsx
@@ -31,6 +31,8 @@ import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { MobileMenuOverlay } from "@/components/layouts/mobile-menu-overlay";
+import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
+import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
 import { useLocale } from "@/components/locale-switcher";
 import { GettingStartedChecklist } from "@/components/onboarding/getting-started-checklist";
 import { OnboardingProvider, useOnboarding } from "@/components/onboarding/onboarding-provider";
@@ -192,6 +194,13 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
   const [mobileOpen, setMobileOpen] = useState(false);
   const [locale] = useLocale();
 
+  const adminMobileTabs: MobileTabItem[] = [
+    { href: "/admin/dashboard", label: "Dashboard", icon: LayoutDashboard },
+    { href: "/admin/patients", label: "Patients", icon: Users },
+    { href: "/admin/reports", label: "Analytics", icon: BarChart3 },
+    { href: "/admin/settings", label: "Settings", icon: Settings },
+  ];
+
   return (
     <OnboardingProvider>
       <div className="flex min-h-screen">
@@ -244,12 +253,15 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
           <SidebarContent pathname={pathname} />
         </aside>
 
-        <main id="main-content" className="flex-1 p-6 pt-16 md:pt-6">
+        <main id="main-content" className="flex-1 p-4 pt-16 pb-20 md:p-6 md:pb-6">
           <AutoBreadcrumb />
           {children}
         </main>
         <OnboardingTourOverlay />
         <SessionTimeoutWarning onLogout={() => signOut()} />
+
+        {/* Mobile bottom tab bar */}
+        <MobileTabBar tabs={adminMobileTabs} onMoreClick={() => setMobileOpen(true)} />
       </div>
     </OnboardingProvider>
   );

--- a/src/components/layouts/clinic-dashboard-layout.tsx
+++ b/src/components/layouts/clinic-dashboard-layout.tsx
@@ -151,7 +151,7 @@ export function ClinicDashboardLayout({
 
       <main
         id="main-content"
-        className={`flex-1 p-6 pt-16 md:pt-6${config.mobileTabs ? " pb-20 md:pb-6" : ""}`}
+        className={`flex-1 ${config.mobileTabs ? "p-4 pt-16 pb-20 md:p-6 md:pb-6" : "p-6 pt-16 md:pt-6"}`}
       >
         {content}
       </main>

--- a/src/components/layouts/equipment-layout-shell.tsx
+++ b/src/components/layouts/equipment-layout-shell.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import { useState, createContext, useContext, useCallback } from "react";
 import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { FeatureGate } from "@/components/feature-gate";
+import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
 import { SignOutButton } from "@/components/sign-out-button";
 
 export type EquipmentLocale = "fr" | "ar";
@@ -173,11 +174,21 @@ export default function EquipmentLayoutShell({ children }: { children: React.Rea
           <SidebarContent pathname={pathname} locale={locale} />
         </aside>
 
-        <main id="main-content" className="flex-1 p-6 pt-16 md:pt-6">
+        <main id="main-content" className="flex-1 p-4 pt-16 pb-20 md:p-6 md:pb-6">
           <FeatureGate featureKey="equipment_rentals" moduleName="Medical Equipment">
             {children}
           </FeatureGate>
         </main>
+
+        {/* Mobile bottom tab bar */}
+        <MobileTabBar
+          tabs={navItems.map((item) => ({
+            href: item.href,
+            label: navLabels[item.href]?.[locale] ?? item.href,
+            icon: item.icon,
+          }))}
+          onMoreClick={() => setMobileOpen(true)}
+        />
       </div>
     </EquipmentI18nContext.Provider>
   );

--- a/src/components/layouts/lab-layout-shell.tsx
+++ b/src/components/layouts/lab-layout-shell.tsx
@@ -10,6 +10,14 @@ import {
   ClinicDashboardLayout,
   type ClinicDashboardConfig,
 } from "@/components/layouts/clinic-dashboard-layout";
+import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
+
+const labMobileTabs: MobileTabItem[] = [
+  { href: "/lab-panel/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/lab-panel/test-orders", label: "Orders", icon: ClipboardList },
+  { href: "/lab-panel/results", label: "Results", icon: FlaskConical },
+  { href: "/lab-panel/reports", label: "Reports", icon: FileText },
+];
 
 const config: ClinicDashboardConfig = {
   title: "Analysis Lab",
@@ -24,6 +32,7 @@ const config: ClinicDashboardConfig = {
     { href: "/lab-panel/reports", label: "Reports", icon: FileText },
     { href: "/lab-panel/patient-history", label: "Patient History", icon: History },
   ],
+  mobileTabs: labMobileTabs,
 };
 
 export function LabLayoutShell({ children }: { children: React.ReactNode }) {

--- a/src/components/layouts/pharmacist-layout-shell.tsx
+++ b/src/components/layouts/pharmacist-layout-shell.tsx
@@ -13,6 +13,14 @@ import {
   ClinicDashboardLayout,
   type ClinicDashboardConfig,
 } from "@/components/layouts/clinic-dashboard-layout";
+import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
+
+const pharmacistMobileTabs: MobileTabItem[] = [
+  { href: "/pharmacist/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/pharmacist/prescriptions", label: "Prescriptions", icon: ClipboardList },
+  { href: "/pharmacist/stock", label: "Stock", icon: Package },
+  { href: "/pharmacist/sales", label: "Sales", icon: Receipt },
+];
 
 const config: ClinicDashboardConfig = {
   title: "Pharmacist",
@@ -29,6 +37,7 @@ const config: ClinicDashboardConfig = {
     { href: "/pharmacist/suppliers", label: "Suppliers", icon: Truck },
     { href: "/pharmacist/loyalty", label: "Loyalty Program", icon: Gift },
   ],
+  mobileTabs: pharmacistMobileTabs,
 };
 
 export function PharmacistLayoutShell({ children }: { children: React.ReactNode }) {

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -24,6 +24,8 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { OltigoMonogram } from "@/components/brand/oltigo-mark";
 import { CommandPalette, type CommandPaletteItem } from "@/components/command-palette";
 import { ImpersonationBanner } from "@/components/impersonation-banner";
+import { MobileTabBar } from "@/components/layouts/mobile-tab-bar";
+import type { MobileTabItem } from "@/components/layouts/mobile-tab-bar";
 import { LocaleSwitcher } from "@/components/locale-switcher";
 import { SignOutButton } from "@/components/sign-out-button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -94,6 +96,13 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [cmdOpen, setCmdOpen] = useState(false);
   const [cmdItems, setCmdItems] = useState<CommandPaletteItem[]>([]);
+
+  const superAdminMobileTabs: MobileTabItem[] = [
+    { href: "/super-admin/dashboard", label: "Dashboard", icon: LayoutDashboard },
+    { href: "/super-admin/clinics", label: "Clinics", icon: Building2 },
+    { href: "/super-admin/billing", label: "Billing", icon: CreditCard },
+    { href: "/super-admin/subscriptions", label: "Subs", icon: Receipt },
+  ];
   const mountedRef = useRef(true);
 
   // Build command palette items
@@ -357,10 +366,13 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
             </DropdownMenu>
           </header>
 
-          <main id="main-content" className="flex-1 p-4 md:p-6">
+          <main id="main-content" className="flex-1 p-4 pb-20 md:p-6 md:pb-6">
             {children}
           </main>
         </div>
+
+        {/* Mobile bottom tab bar */}
+        <MobileTabBar tabs={superAdminMobileTabs} onMoreClick={() => setMobileOpen(true)} />
 
         {/* Mobile Sidebar Sheet */}
         <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>

--- a/src/config/specialist-registry.ts
+++ b/src/config/specialist-registry.ts
@@ -71,6 +71,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
       },
       { href: "/nutritionist/bmi", label: "BMI Calculator", icon: Calculator },
     ],
+    mobileTabs: [
+      { href: "/nutritionist/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/nutritionist/meal-plans", label: "Meals", icon: Apple },
+      { href: "/nutritionist/measurements", label: "Measures", icon: Scale },
+      { href: "/nutritionist/bmi", label: "BMI", icon: Calculator },
+    ],
   },
   optician: {
     title: "Opticien",
@@ -99,6 +105,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
         requiredFeature: "optical_prescriptions",
       },
     ],
+    mobileTabs: [
+      { href: "/optician/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/optician/lens-inventory", label: "Lenses", icon: Package },
+      { href: "/optician/frame-catalog", label: "Frames", icon: Glasses },
+      { href: "/optician/prescriptions", label: "Rx", icon: FileText },
+    ],
   },
   parapharmacy: {
     title: "Parapharmacy",
@@ -109,6 +121,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
     navItems: [
       { href: "/parapharmacy/dashboard", label: "Dashboard", icon: LayoutDashboard },
       { href: "/parapharmacy/catalog", label: "Product Catalog", icon: ShoppingBag },
+      { href: "/parapharmacy/sales", label: "Sales", icon: Receipt },
+      { href: "/parapharmacy/inventory", label: "Inventory", icon: Package },
+    ],
+    mobileTabs: [
+      { href: "/parapharmacy/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/parapharmacy/catalog", label: "Catalog", icon: ShoppingBag },
       { href: "/parapharmacy/sales", label: "Sales", icon: Receipt },
       { href: "/parapharmacy/inventory", label: "Inventory", icon: Package },
     ],
@@ -140,6 +158,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
         requiredFeature: "progress_photos",
       },
     ],
+    mobileTabs: [
+      { href: "/physiotherapist/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/physiotherapist/exercise-programs", label: "Exercises", icon: Dumbbell },
+      { href: "/physiotherapist/sessions", label: "Sessions", icon: ClipboardList },
+      { href: "/physiotherapist/progress-photos", label: "Photos", icon: Camera },
+    ],
   },
   psychologist: {
     title: "Psychologue",
@@ -162,6 +186,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
         requiredFeature: "therapy_plans",
       },
       { href: "/psychologist/progress", label: "Progress Tracking", icon: TrendingUp },
+    ],
+    mobileTabs: [
+      { href: "/psychologist/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/psychologist/session-notes", label: "Notes", icon: Brain },
+      { href: "/psychologist/therapy-plans", label: "Plans", icon: Target },
+      { href: "/psychologist/progress", label: "Progress", icon: TrendingUp },
     ],
   },
   "speech-therapist": {
@@ -191,6 +221,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
         requiredFeature: "speech_reports",
       },
     ],
+    mobileTabs: [
+      { href: "/speech-therapist/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/speech-therapist/sessions", label: "Sessions", icon: ClipboardList },
+      { href: "/speech-therapist/exercise-library", label: "Exercises", icon: BookOpen },
+      { href: "/speech-therapist/reports", label: "Reports", icon: FileText },
+    ],
   },
   radiology: {
     title: "Radiology",
@@ -206,6 +242,12 @@ const specialistRegistry: Record<SpecialistSlug, ClinicDashboardConfig> = {
       { href: "/radiology/viewer", label: "DICOM Viewer", icon: Eye },
       { href: "/radiology/reports", label: "Reports", icon: FileText },
       { href: "/radiology/templates", label: "Report Templates", icon: FileStack },
+    ],
+    mobileTabs: [
+      { href: "/radiology/dashboard", label: "Dashboard", icon: LayoutDashboard },
+      { href: "/radiology/orders", label: "Orders", icon: ClipboardList },
+      { href: "/radiology/images", label: "Images", icon: Image },
+      { href: "/radiology/reports", label: "Reports", icon: FileText },
     ],
   },
 };


### PR DESCRIPTION
## Summary

Add the missing `MobileTabBar` component to 6 layout shells that were lacking mobile bottom navigation, and verify all existing bottom tab links point to real routes.

### Part 1: Added MobileTabBar to 6 layouts

1. **admin-layout-shell.tsx** — Added 4 tabs: Dashboard, Patients, Analytics, Settings
2. **pharmacist-layout-shell.tsx** — Added `mobileTabs` to config: Dashboard, Prescriptions, Stock, Sales
3. **lab-layout-shell.tsx** — Added `mobileTabs` to config: Dashboard, Orders, Results, Reports
4. **super-admin-layout-shell.tsx** — Added 4 tabs: Dashboard, Clinics, Billing, Subs
5. **specialist-registry.ts** — Added `mobileTabs` to all 7 specialist configs (nutritionist, optician, parapharmacy, physiotherapist, psychologist, speech-therapist, radiology)
6. **equipment-layout-shell.tsx** — Added locale-aware tabs using existing French/Arabic `navLabels`

### Part 2: Verified existing bottom tab links

Cross-referenced all existing `MobileTabItem` hrefs against actual `page.tsx` files under `src/app/`:
- **receptionist-layout-shell.tsx**: All 4 routes verified
- **doctor-layout-shell.tsx**: All 4 routes verified
- **patient-layout-shell.tsx**: All 4 routes verified
- **clinic-dashboard-layout.tsx**: Generic layout — mobileTabs now passed via config

### Supporting changes

- **clinic-dashboard-layout.tsx** — Updated main padding to `p-4 pt-16 pb-20 md:p-6 md:pb-6` when `mobileTabs` is present
- Added `pb-20 md:pb-6` bottom padding to admin, super-admin, and equipment main content areas

## Type of change

- [x] Bug fix

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

Verified locally:
- `npx tsc --noEmit` — passes clean
- `npx vitest run` — 109 test files, 1142 tests passed
- `npx eslint --max-warnings 4119` — passes (4112 warnings)

## Checklist

- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes