### PR TITLE
refactor: fix DRY violations in date formatting, currency display, phone validation, NextResponse cleanup

### DIFF
--- a/src/app/(admin)/admin/billing/subscription/page.tsx
+++ b/src/app/(admin)/admin/billing/subscription/page.tsx
@@ -26,6 +26,7 @@ import {
   type PlanSlug,
 } from "@/lib/config/subscription-plans";
 import { logger } from "@/lib/logger";
+import { formatCurrency } from "@/lib/utils";
 
 interface ClinicSubscriptionInfo {
   plan: PlanSlug;
@@ -188,7 +189,9 @@ export default function SubscriptionBillingPage() {
             <div>
               <p className="text-xs text-muted-foreground mb-1">Prix</p>
               <p className="text-lg font-bold">
-                {currentPlanConfig.price === 0 ? "Gratuit" : `${currentPlanConfig.price} MAD`}
+                {currentPlanConfig.price === 0
+                  ? "Gratuit"
+                  : `${formatCurrency(currentPlanConfig.price)}`}
               </p>
               {currentPlanConfig.price > 0 && (
                 <p className="text-xs text-muted-foreground">/ mois</p>

--- a/src/app/(admin)/admin/doctors/page.tsx
+++ b/src/app/(admin)/admin/doctors/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getCurrentUser, fetchDoctors, type DoctorView } from "@/lib/data/client";
+import { formatCurrency } from "@/lib/utils";
 
 type Doctor = DoctorView;
 
@@ -187,7 +188,7 @@ export default function ManageDoctorsPage() {
                 </div>
               </div>
               <div className="text-right text-sm text-muted-foreground">
-                <p>Consultation: {doctor.consultationFee} MAD</p>
+                <p>Consultation: {formatCurrency(doctor.consultationFee)}</p>
                 <p>{doctor.phone}</p>
                 <p className="text-xs">{doctor.email}</p>
               </div>

--- a/src/app/(admin)/admin/holidays/page.tsx
+++ b/src/app/(admin)/admin/holidays/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface Holiday {
   id: string;
@@ -69,11 +70,11 @@ export default function AdminHolidaysPage() {
   };
 
   const upcoming = [...holidays]
-    .filter((h) => h.date >= new Date().toISOString().split("T")[0])
+    .filter((h) => h.date >= getLocalDateStr())
     .sort((a, b) => a.date.localeCompare(b.date));
 
   const past = [...holidays]
-    .filter((h) => h.date < new Date().toISOString().split("T")[0])
+    .filter((h) => h.date < getLocalDateStr())
     .sort((a, b) => b.date.localeCompare(a.date));
 
   return (

--- a/src/app/(admin)/admin/receptionists/page.tsx
+++ b/src/app/(admin)/admin/receptionists/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface Receptionist {
   id: string;
@@ -104,7 +105,7 @@ export default function ManageReceptionistsPage() {
           email: formEmail,
           phone: formPhone,
           active: formActive,
-          createdAt: new Date().toISOString().split("T")[0],
+          createdAt: getLocalDateStr(),
         },
       ]);
     }

--- a/src/app/(clinic-public)/tv/page.tsx
+++ b/src/app/(clinic-public)/tv/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { TVQueueDisplay } from "@/components/morocco/tv-queue-display";
 import { createClient } from "@/lib/supabase-client";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface QueuePatient {
   id: string;
@@ -42,7 +43,7 @@ function mapStatus(status: string): "waiting" | "called" | "in-consultation" | n
  * Uses appointments with statuses that indicate the patient is present.
  */
 async function fetchQueue(supabase: ReturnType<typeof createClient>): Promise<QueuePatient[]> {
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateStr();
 
   const { data } = await supabase
     .from("appointments")
@@ -156,7 +157,7 @@ export default function TVPage() {
   const handleRealtimeSubscribe = useCallback(
     (callback: (patients: QueuePatient[]) => void) => {
       const supabase = createClient();
-      const today = new Date().toISOString().split("T")[0];
+      const today = getLocalDateStr();
 
       const channel = supabase
         .channel("tv-queue-realtime")

--- a/src/app/(doctor)/doctor/cardiology/page.tsx
+++ b/src/app/(doctor)/doctor/cardiology/page.tsx
@@ -31,6 +31,7 @@ import {
   type BloodPressureView,
   type HeartMonitoringNoteView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 function bpCategory(systolic: number, diastolic: number): { label: string; color: string } {
   // AHA BP classification (checked top-down; Stage 2 must be tested before Stage 1)
@@ -143,7 +144,7 @@ export default function CardiologyPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          recordDate: new Date().toISOString().split("T")[0],
+          recordDate: getLocalDateStr(),
           fileUrl: "",
           heartRate: ecgForm.heartRate ? parseInt(ecgForm.heartRate) : null,
           rhythm: ecgForm.rhythm,
@@ -186,7 +187,7 @@ export default function CardiologyPage() {
           systolic: parseInt(bpForm.systolic),
           diastolic: parseInt(bpForm.diastolic),
           heartRate: bpForm.heartRate ? parseInt(bpForm.heartRate) : null,
-          readingDate: new Date().toISOString().split("T")[0],
+          readingDate: getLocalDateStr(),
           position: bpForm.position,
           arm: bpForm.arm,
           notes: bpForm.notes,
@@ -223,7 +224,7 @@ export default function CardiologyPage() {
         {
           id: newId,
           patientId: user.id,
-          noteDate: new Date().toISOString().split("T")[0],
+          noteDate: getLocalDateStr(),
           category: noteForm.category,
           title: noteForm.title,
           content: noteForm.content,

--- a/src/app/(doctor)/doctor/certificates/page.tsx
+++ b/src/app/(doctor)/doctor/certificates/page.tsx
@@ -13,6 +13,7 @@ import {
   type MedicalCertificateView,
   type PatientView,
 } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function DoctorCertificatesPage() {
   const tenant = useTenant();
@@ -91,8 +92,8 @@ export default function DoctorCertificatesPage() {
         doctorName: user.name ?? "Doctor",
         type: data.type,
         content: data.content,
-        issuedDate: new Date().toISOString().split("T")[0],
-        createdAt: new Date().toISOString().split("T")[0],
+        issuedDate: getLocalDateStr(),
+        createdAt: getLocalDateStr(),
       };
       setCertificates((prev) => [newCert, ...prev]);
     }

--- a/src/app/(doctor)/doctor/child-info/page.tsx
+++ b/src/app/(doctor)/doctor/child-info/page.tsx
@@ -29,6 +29,7 @@ import {
   type PatientView,
 } from "@/lib/data/client";
 import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
+import { getLocalDateStr } from "@/lib/utils";
 
 const MILESTONE_TEMPLATES: Record<string, { milestone: string; expectedAgeMonths: number }[]> = {
   motor: [
@@ -193,7 +194,7 @@ export default function ChildInfoPage() {
   const handleStatusUpdate = async (id: string, status: MilestoneView["status"]) => {
     // Issue 22: Optimistic UI — update milestone status locally before server response
     const previousMilestones = [...milestones];
-    const achievedDate = status === "achieved" ? new Date().toISOString().split("T")[0] : null;
+    const achievedDate = status === "achieved" ? getLocalDateStr() : null;
     setMilestones((prev) =>
       prev.map((m) =>
         m.id === id ? { ...m, status, achievedDate: achievedDate ?? m.achievedDate } : m,

--- a/src/app/(doctor)/doctor/dermatology/page.tsx
+++ b/src/app/(doctor)/doctor/dermatology/page.tsx
@@ -41,6 +41,7 @@ import {
   type SkinPhotoView,
   type SkinConditionView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const BODY_REGIONS = [
   "Face",
@@ -162,7 +163,7 @@ export default function DermatologyPage() {
           bodyRegion: photoForm.bodyRegion,
           description: photoForm.description,
           imageUrl: "",
-          photoDate: new Date().toISOString().split("T")[0],
+          photoDate: getLocalDateStr(),
           tags: photoForm.tags
             .split(",")
             .map((t) => t.trim())
@@ -182,7 +183,7 @@ export default function DermatologyPage() {
       ? [
           {
             name: conditionForm.treatmentName,
-            startDate: new Date().toISOString().split("T")[0],
+            startDate: getLocalDateStr(),
             notes: conditionForm.treatmentNotes,
           },
         ]
@@ -207,7 +208,7 @@ export default function DermatologyPage() {
           bodyRegion: conditionForm.bodyRegion,
           severity: conditionForm.severity,
           status: "active",
-          diagnosisDate: new Date().toISOString().split("T")[0],
+          diagnosisDate: getLocalDateStr(),
           notes: conditionForm.notes,
           treatments,
         },

--- a/src/app/(doctor)/doctor/endocrinology/page.tsx
+++ b/src/app/(doctor)/doctor/endocrinology/page.tsx
@@ -31,6 +31,7 @@ import {
   type HormoneLevelView,
   type DiabetesManagementView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 function glucoseCategory(level: number, type: string): { label: string; color: string } {
   if (type === "fasting") {
@@ -143,7 +144,7 @@ export default function EndocrinologyPage() {
         {
           id: newId,
           patientId: user.id,
-          readingDate: new Date().toISOString().split("T")[0],
+          readingDate: getLocalDateStr(),
           glucoseLevel: parseFloat(sugarForm.glucoseLevel),
           readingType: sugarForm.readingType,
           unit: sugarForm.unit,
@@ -175,7 +176,7 @@ export default function EndocrinologyPage() {
         {
           id: newId,
           patientId: user.id,
-          testDate: new Date().toISOString().split("T")[0],
+          testDate: getLocalDateStr(),
           hormoneName: hormoneForm.hormoneName,
           value: parseFloat(hormoneForm.value),
           unit: hormoneForm.unit,

--- a/src/app/(doctor)/doctor/ent/page.tsx
+++ b/src/app/(doctor)/doctor/ent/page.tsx
@@ -28,6 +28,7 @@ import {
   type HearingTestView,
   type ENTExamView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const AUDIOGRAM_FREQUENCIES = ["250", "500", "1000", "2000", "4000", "8000"];
 
@@ -146,7 +147,7 @@ export default function ENTPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          testDate: new Date().toISOString().split("T")[0],
+          testDate: getLocalDateStr(),
           testType: testForm.testType,
           leftEarData: leftData,
           rightEarData: rightData,
@@ -188,7 +189,7 @@ export default function ENTPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          examDate: new Date().toISOString().split("T")[0],
+          examDate: getLocalDateStr(),
           templateType: examForm.templateType,
           findings: examForm.findings,
           diagnosis: examForm.diagnosis,

--- a/src/app/(doctor)/doctor/growth-charts/page.tsx
+++ b/src/app/(doctor)/doctor/growth-charts/page.tsx
@@ -27,6 +27,7 @@ import {
   type PatientView,
 } from "@/lib/data/client";
 import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
+import { getLocalDateStr } from "@/lib/utils";
 
 // WHO Weight-for-age reference data (boys, simplified percentiles: 3rd, 50th, 97th)
 const WHO_WEIGHT_BOYS: Record<number, [number, number, number]> = {
@@ -81,7 +82,7 @@ export default function GrowthChartsPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [form, setFormRaw] = useState({
     patientId: "",
-    measuredAt: new Date().toISOString().split("T")[0],
+    measuredAt: getLocalDateStr(),
     ageMonths: "",
     weightKg: "",
     heightCm: "",
@@ -163,7 +164,7 @@ export default function GrowthChartsPage() {
     clearGrowthDraft();
     setFormRaw({
       patientId: "",
-      measuredAt: new Date().toISOString().split("T")[0],
+      measuredAt: getLocalDateStr(),
       ageMonths: "",
       weightKg: "",
       heightCm: "",

--- a/src/app/(doctor)/doctor/installments/page.tsx
+++ b/src/app/(doctor)/doctor/installments/page.tsx
@@ -9,7 +9,7 @@ import { PageLoader } from "@/components/ui/page-loader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { getCurrentUser, fetchInstallmentPlans, type InstallmentPlanView } from "@/lib/data/client";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { getLocalDateStr, formatCurrency, formatNumber } from "@/lib/utils";
 
 export default function DoctorInstallmentsPage() {
   const [locale] = useLocale();
@@ -66,7 +66,7 @@ export default function DoctorInstallmentsPage() {
           ...p,
           installments: p.installments.map((i) =>
             i.id === installmentId
-              ? { ...i, status: "paid" as const, paidDate: new Date().toISOString().split("T")[0] }
+              ? { ...i, status: "paid" as const, paidDate: getLocalDateStr() }
               : i,
           ),
         };

--- a/src/app/(doctor)/doctor/iop-tracking/page.tsx
+++ b/src/app/(doctor)/doctor/iop-tracking/page.tsx
@@ -27,6 +27,7 @@ import {
   type PatientView,
 } from "@/lib/data/client";
 import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
+import { getLocalDateStr } from "@/lib/utils";
 
 const METHODS = [
   { value: "goldmann", label: "Goldmann Applanation" },
@@ -51,7 +52,7 @@ export default function IopTrackingPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [form, setFormRaw] = useState({
     patientId: "",
-    measuredAt: new Date().toISOString().split("T")[0],
+    measuredAt: getLocalDateStr(),
     odPressure: "",
     osPressure: "",
     method: "goldmann",
@@ -128,7 +129,7 @@ export default function IopTrackingPage() {
     clearIopDraft();
     setFormRaw({
       patientId: "",
-      measuredAt: new Date().toISOString().split("T")[0],
+      measuredAt: getLocalDateStr(),
       odPressure: "",
       osPressure: "",
       method: "goldmann",

--- a/src/app/(doctor)/doctor/lab-orders/page.tsx
+++ b/src/app/(doctor)/doctor/lab-orders/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { PageLoader } from "@/components/ui/page-loader";
 import { getCurrentUser, fetchLabOrders, createLabOrder } from "@/lib/data/client";
 import type { LabOrder } from "@/lib/types/dental";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function DoctorLabOrdersPage() {
   const [orders, setOrders] = useState<LabOrder[]>([]);
@@ -54,9 +55,7 @@ export default function DoctorLabOrdersPage() {
 
   const handleUpdateStatus = (orderId: string, status: LabOrder["status"]) => {
     setOrders((prev) =>
-      prev.map((o) =>
-        o.id === orderId ? { ...o, status, updatedAt: new Date().toISOString().split("T")[0] } : o,
-      ),
+      prev.map((o) => (o.id === orderId ? { ...o, status, updatedAt: getLocalDateStr() } : o)),
     );
   };
 
@@ -74,7 +73,7 @@ export default function DoctorLabOrdersPage() {
       due_date: order.dueDate || undefined,
     });
 
-    const today = new Date().toISOString().split("T")[0];
+    const today = getLocalDateStr();
     setOrders((prev) => [
       {
         ...order,

--- a/src/app/(doctor)/doctor/neurology/page.tsx
+++ b/src/app/(doctor)/doctor/neurology/page.tsx
@@ -21,6 +21,7 @@ import {
   type EEGRecordView,
   type NeuroExamView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const NEURO_EXAM_SECTIONS = [
   {
@@ -162,7 +163,7 @@ export default function NeurologyPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          recordDate: new Date().toISOString().split("T")[0],
+          recordDate: getLocalDateStr(),
           fileUrl: "",
           durationMinutes: eegForm.durationMinutes ? parseInt(eegForm.durationMinutes) : null,
           findings: eegForm.findings,
@@ -207,7 +208,7 @@ export default function NeurologyPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          examDate: new Date().toISOString().split("T")[0],
+          examDate: getLocalDateStr(),
           mentalStatus: examForm.sections["mentalStatus"] ?? {},
           cranialNerves: examForm.sections["cranialNerves"] ?? {},
           motorFunction: examForm.sections["motorFunction"] ?? {},

--- a/src/app/(doctor)/doctor/odontogram/page.tsx
+++ b/src/app/(doctor)/doctor/odontogram/page.tsx
@@ -15,6 +15,7 @@ import {
   type OdontogramView,
 } from "@/lib/data/client";
 import type { ToothStatus, OdontogramEntry } from "@/lib/types/dental";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function DoctorOdontogramPage() {
   const [patients, setPatients] = useState<PatientView[]>([]);
@@ -79,7 +80,7 @@ export default function DoctorOdontogramPage() {
       toothNumber,
       status,
       notes,
-      lastUpdated: new Date().toISOString().split("T")[0],
+      lastUpdated: getLocalDateStr(),
     };
     setEntries((prev) => {
       const existingIdx = prev.findIndex((e) => e.toothNumber === toothNumber);

--- a/src/app/(doctor)/doctor/orthopedics/page.tsx
+++ b/src/app/(doctor)/doctor/orthopedics/page.tsx
@@ -43,6 +43,7 @@ import {
   type FractureRecordView,
   type RehabPlanView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const FRACTURE_STATUSES: Record<
   string,
@@ -144,7 +145,7 @@ export default function OrthopedicsPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          recordDate: new Date().toISOString().split("T")[0],
+          recordDate: getLocalDateStr(),
           bodyPart: xrayForm.bodyPart,
           imageUrl: "",
           annotations: [],
@@ -168,7 +169,7 @@ export default function OrthopedicsPage() {
       location: fractureForm.location,
       fracture_type: fractureForm.fractureType,
       severity: fractureForm.severity,
-      injury_date: fractureForm.injuryDate || new Date().toISOString().split("T")[0],
+      injury_date: fractureForm.injuryDate || getLocalDateStr(),
       expected_healing_date: fractureForm.expectedHealingDate || undefined,
       notes: fractureForm.notes,
     });
@@ -182,8 +183,8 @@ export default function OrthopedicsPage() {
           fractureType: fractureForm.fractureType,
           severity: fractureForm.severity,
           status: "diagnosed",
-          injuryDate: fractureForm.injuryDate || new Date().toISOString().split("T")[0],
-          diagnosisDate: new Date().toISOString().split("T")[0],
+          injuryDate: fractureForm.injuryDate || getLocalDateStr(),
+          diagnosisDate: getLocalDateStr(),
           expectedHealingDate: fractureForm.expectedHealingDate,
           notes: fractureForm.notes,
           xrayRecordId: "",
@@ -229,7 +230,7 @@ export default function OrthopedicsPage() {
           patientName: "",
           title: rehabForm.title,
           condition: rehabForm.condition,
-          startDate: new Date().toISOString().split("T")[0],
+          startDate: getLocalDateStr(),
           targetEndDate: rehabForm.targetEndDate,
           status: "active",
           milestones,

--- a/src/app/(doctor)/doctor/prescriptions/page.tsx
+++ b/src/app/(doctor)/doctor/prescriptions/page.tsx
@@ -18,6 +18,7 @@ import {
   type PrescriptionView,
   type PatientView,
 } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 type Prescription = PrescriptionView;
 
@@ -198,7 +199,7 @@ export default function DoctorPrescriptionsPage() {
         patientId: patient.id,
         patientName: patient.name,
         doctorName: user.name ?? "Doctor",
-        date: new Date().toISOString().split("T")[0],
+        date: getLocalDateStr(),
         medications: items,
         notes: notes || undefined,
       };
@@ -237,7 +238,7 @@ export default function DoctorPrescriptionsPage() {
       patientId: patient.id,
       patientName: patient.name,
       doctorName: user.name ?? "Doctor",
-      date: new Date().toISOString().split("T")[0],
+      date: getLocalDateStr(),
       medications: items,
       notes: notes || undefined,
     };
@@ -336,7 +337,7 @@ export default function DoctorPrescriptionsPage() {
               </div>
               <div className="space-y-2">
                 <Label>Date</Label>
-                <Input type="date" defaultValue={new Date().toISOString().split("T")[0]} />
+                <Input type="date" defaultValue={getLocalDateStr()} />
               </div>
               <div className="space-y-2 sm:col-span-2">
                 <Label>Diagnosis</Label>

--- a/src/app/(doctor)/doctor/psychiatry/page.tsx
+++ b/src/app/(doctor)/doctor/psychiatry/page.tsx
@@ -29,6 +29,7 @@ import {
   type PsychSessionNoteView,
   type PsychMedicationView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const MOOD_LABELS = [
   "",
@@ -146,7 +147,7 @@ export default function PsychiatryPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          sessionDate: new Date().toISOString().split("T")[0],
+          sessionDate: getLocalDateStr(),
           sessionNumber: nextNum,
           sessionType: sessionForm.sessionType,
           moodRating: parseInt(sessionForm.moodRating),
@@ -193,7 +194,7 @@ export default function PsychiatryPage() {
           medicationName: medForm.medicationName,
           dosage: medForm.dosage,
           frequency: medForm.frequency,
-          startDate: new Date().toISOString().split("T")[0],
+          startDate: getLocalDateStr(),
           endDate: "",
           status: "active",
           reason: medForm.reason,
@@ -210,9 +211,7 @@ export default function PsychiatryPage() {
 
   const handleMedStatus = async (id: string, status: string) => {
     const endDate =
-      status === "discontinued" || status === "completed"
-        ? new Date().toISOString().split("T")[0]
-        : undefined;
+      status === "discontinued" || status === "completed" ? getLocalDateStr() : undefined;
     const ok = await updatePsychMedication(id, { status, end_date: endDate });
     if (ok)
       setMedications((prev) =>

--- a/src/app/(doctor)/doctor/pulmonology/page.tsx
+++ b/src/app/(doctor)/doctor/pulmonology/page.tsx
@@ -28,6 +28,7 @@ import {
   type SpirometryRecordView,
   type RespiratoryTestView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 function spirometryInterpretation(fev1FvcRatio: number | null): string {
   if (fev1FvcRatio === null) return "Insufficient data";
@@ -128,7 +129,7 @@ export default function PulmonologyPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          testDate: new Date().toISOString().split("T")[0],
+          testDate: getLocalDateStr(),
           fvc: fvc ?? null,
           fev1: fev1 ?? null,
           fev1FvcRatio: ratio ?? null,
@@ -168,7 +169,7 @@ export default function PulmonologyPage() {
         {
           id: newId,
           patientId: user.id,
-          testDate: new Date().toISOString().split("T")[0],
+          testDate: getLocalDateStr(),
           testType: testForm.testType,
           results: testForm.results,
           interpretation: testForm.interpretation,

--- a/src/app/(doctor)/doctor/rheumatology/page.tsx
+++ b/src/app/(doctor)/doctor/rheumatology/page.tsx
@@ -28,6 +28,7 @@ import {
   type JointAssessmentView,
   type MobilityTestView,
 } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const JOINTS = [
   "Left Shoulder",
@@ -157,7 +158,7 @@ export default function RheumatologyPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          assessmentDate: new Date().toISOString().split("T")[0],
+          assessmentDate: getLocalDateStr(),
           jointsData: assessmentForm.jointsData,
           vasPainScore: assessmentForm.vasPainScore ? parseInt(assessmentForm.vasPainScore) : null,
           morningStiffnessMinutes: assessmentForm.morningStiffnessMinutes
@@ -207,7 +208,7 @@ export default function RheumatologyPage() {
         {
           id: newId,
           patientId: user.id,
-          testDate: new Date().toISOString().split("T")[0],
+          testDate: getLocalDateStr(),
           testType: mobilityForm.testType,
           joint: mobilityForm.joint,
           rangeOfMotion: rom,

--- a/src/app/(doctor)/doctor/schedule/page.tsx
+++ b/src/app/(doctor)/doctor/schedule/page.tsx
@@ -9,6 +9,7 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageLoader } from "@/components/ui/page-loader";
 import { getCurrentUser, fetchDoctorAppointments, type AppointmentView } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
@@ -65,9 +66,7 @@ export default function DoctorSchedulePage() {
       setDoctorAppointments(appts);
       // Fetch tenant-specific working hours from the API
       try {
-        const res = await fetch(
-          `/api/booking?doctorId=${user.id}&date=${new Date().toISOString().split("T")[0]}`,
-        );
+        const res = await fetch(`/api/booking?doctorId=${user.id}&date=${getLocalDateStr()}`);
         if (res.ok) {
           const json = await res.json();
           if (json.data?.slotDuration) {

--- a/src/app/(doctor)/doctor/treatment-plans/page.tsx
+++ b/src/app/(doctor)/doctor/treatment-plans/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { PageLoader } from "@/components/ui/page-loader";
 import { getCurrentUser, fetchTreatmentPlans, updateTreatmentPlan } from "@/lib/data/client";
 import type { TreatmentPlan, TreatmentStep } from "@/lib/types/dental";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function DoctorTreatmentPlansPage() {
   const [plans, setPlans] = useState<TreatmentPlan[]>([]);
@@ -73,11 +74,11 @@ export default function DoctorTreatmentPlansPage() {
           status,
           date:
             status === "completed" || status === "in_progress"
-              ? new Date().toISOString().split("T")[0]
+              ? getLocalDateStr()
               : steps[stepIndex].date,
         };
         updatedSteps = steps;
-        return { ...p, steps, updatedAt: new Date().toISOString().split("T")[0] };
+        return { ...p, steps, updatedAt: getLocalDateStr() };
       }),
     );
 
@@ -115,7 +116,7 @@ export default function DoctorTreatmentPlansPage() {
           ...p,
           steps: allSteps,
           totalCost: p.totalCost + cost,
-          updatedAt: new Date().toISOString().split("T")[0],
+          updatedAt: getLocalDateStr(),
         };
       }),
     );
@@ -149,7 +150,7 @@ export default function DoctorTreatmentPlansPage() {
           ...p,
           steps: remainingSteps,
           totalCost: p.totalCost - removedCost,
-          updatedAt: new Date().toISOString().split("T")[0],
+          updatedAt: getLocalDateStr(),
         };
       }),
     );

--- a/src/app/(doctor)/doctor/ultrasounds/page.tsx
+++ b/src/app/(doctor)/doctor/ultrasounds/page.tsx
@@ -27,6 +27,7 @@ import {
   type PregnancyView,
 } from "@/lib/data/client";
 import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function UltrasoundsPage() {
   const [ultrasounds, setUltrasounds] = useState<UltrasoundView[]>([]);
@@ -36,7 +37,7 @@ export default function UltrasoundsPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [form, setFormRaw] = useState({
     pregnancyId: "",
-    scanDate: new Date().toISOString().split("T")[0],
+    scanDate: getLocalDateStr(),
     trimester: "1",
     gestationalWeeks: "",
     gestationalDays: "",
@@ -135,7 +136,7 @@ export default function UltrasoundsPage() {
     clearUsDraft();
     setFormRaw({
       pregnancyId: "",
-      scanDate: new Date().toISOString().split("T")[0],
+      scanDate: getLocalDateStr(),
       trimester: "1",
       gestationalWeeks: "",
       gestationalDays: "",

--- a/src/app/(doctor)/doctor/urology/page.tsx
+++ b/src/app/(doctor)/doctor/urology/page.tsx
@@ -20,6 +20,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { getCurrentUser } from "@/lib/data/client";
 import { fetchUrologyExams, createUrologyExam, type UrologyExamView } from "@/lib/data/specialists";
+import { getLocalDateStr } from "@/lib/utils";
 
 const UROLOGY_TEMPLATES = [
   { value: "general", label: "General Urology Exam" },
@@ -112,7 +113,7 @@ export default function UrologyPage() {
           id: newId,
           patientId: user.id,
           patientName: "",
-          examDate: new Date().toISOString().split("T")[0],
+          examDate: getLocalDateStr(),
           templateType: form.templateType,
           findings: form.findings,
           labResults: form.labResults,

--- a/src/app/(doctor)/doctor/vaccinations/page.tsx
+++ b/src/app/(doctor)/doctor/vaccinations/page.tsx
@@ -27,6 +27,7 @@ import {
   type VaccinationView,
   type PatientView,
 } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 const COMMON_VACCINES = [
   "BCG",
@@ -70,7 +71,7 @@ export default function VaccinationsPage() {
     patientId: "",
     vaccineName: "",
     doseNumber: "1",
-    scheduledDate: new Date().toISOString().split("T")[0],
+    scheduledDate: getLocalDateStr(),
     notes: "",
   });
 
@@ -82,7 +83,7 @@ export default function VaccinationsPage() {
       fetchPatients(user.clinic_id),
     ]);
     // Auto-mark overdue
-    const today = new Date().toISOString().split("T")[0];
+    const today = getLocalDateStr();
     const vaccinations = v.map((vac) => {
       if (vac.status === "scheduled" && vac.scheduledDate < today) {
         return { ...vac, status: "overdue" as const };
@@ -139,7 +140,7 @@ export default function VaccinationsPage() {
       patientId: "",
       vaccineName: "",
       doseNumber: "1",
-      scheduledDate: new Date().toISOString().split("T")[0],
+      scheduledDate: getLocalDateStr(),
       notes: "",
     });
     reload();
@@ -148,7 +149,7 @@ export default function VaccinationsPage() {
   const handleAdminister = async (id: string) => {
     await updateVaccination(id, {
       status: "administered",
-      administered_date: new Date().toISOString().split("T")[0],
+      administered_date: getLocalDateStr(),
     });
     reload();
   };

--- a/src/app/(doctor)/doctor/vision-tests/page.tsx
+++ b/src/app/(doctor)/doctor/vision-tests/page.tsx
@@ -27,6 +27,7 @@ import {
   type PatientView,
 } from "@/lib/data/client";
 import { useOfflineDrafts } from "@/lib/hooks/use-offline-drafts";
+import { getLocalDateStr } from "@/lib/utils";
 
 function formatRx(sphere: number | null, cylinder: number | null, axis: number | null): string {
   if (sphere === null && cylinder === null) return "—";
@@ -45,7 +46,7 @@ export default function VisionTestsPage() {
   const [showAdd, setShowAdd] = useState(false);
   const [form, setFormRaw] = useState({
     patientId: "",
-    testDate: new Date().toISOString().split("T")[0],
+    testDate: getLocalDateStr(),
     odAcuity: "",
     osAcuity: "",
     odSphere: "",
@@ -137,7 +138,7 @@ export default function VisionTestsPage() {
     clearVisionDraft();
     setFormRaw({
       patientId: "",
-      testDate: new Date().toISOString().split("T")[0],
+      testDate: getLocalDateStr(),
       odAcuity: "",
       osAcuity: "",
       odSphere: "",

--- a/src/app/(lab)/lab-panel/dashboard/page.tsx
+++ b/src/app/(lab)/lab-panel/dashboard/page.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PageLoader } from "@/components/ui/page-loader";
 import { fetchLabTestOrders } from "@/lib/data/client";
 import type { LabTestOrderView } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function LabDashboardPage() {
   const tenant = useTenant();
@@ -64,7 +65,7 @@ export default function LabDashboardPage() {
   );
   const completedToday = orders.filter((o) => {
     if (o.status !== "completed" && o.status !== "validated") return false;
-    const today = new Date().toISOString().split("T")[0];
+    const today = getLocalDateStr();
     return o.completedAt?.startsWith(today);
   });
   const urgent = orders.filter((o) => o.priority === "urgent" || o.priority === "stat");

--- a/src/app/(patient)/patient/documents/page.tsx
+++ b/src/app/(patient)/patient/documents/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getLocalDateStr } from "@/lib/utils";
 
 type DocType = "analysis" | "radiology" | "insurance" | "other";
 
@@ -124,7 +125,7 @@ export default function PatientDocumentsPage() {
         id: `doc${Date.now()}`,
         name: fileName || "Uploaded Document",
         type: fileType,
-        date: new Date().toISOString().split("T")[0],
+        date: getLocalDateStr(),
         size: "1.0 MB",
         icon: fileType === "radiology" ? Image : fileType === "insurance" ? CreditCard : FileText,
       };

--- a/src/app/(patient)/patient/invoices/page.tsx
+++ b/src/app/(patient)/patient/invoices/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PageLoader } from "@/components/ui/page-loader";
 import { getCurrentUser, fetchInvoices, type InvoiceView } from "@/lib/data/client";
+import { formatCurrency } from "@/lib/utils";
 
 const statusVariant: Record<string, "success" | "warning" | "destructive"> = {
   paid: "success",
@@ -90,7 +91,7 @@ export default function PatientInvoicesPage() {
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Total Paid</p>
-              <p className="text-lg font-bold">{totalPaid} MAD</p>
+              <p className="text-lg font-bold">{formatCurrency(totalPaid)}</p>
             </div>
           </CardContent>
         </Card>
@@ -101,7 +102,7 @@ export default function PatientInvoicesPage() {
             </div>
             <div>
               <p className="text-xs text-muted-foreground">Pending</p>
-              <p className="text-lg font-bold">{totalPending} MAD</p>
+              <p className="text-lg font-bold">{formatCurrency(totalPending)}</p>
             </div>
           </CardContent>
         </Card>

--- a/src/app/(patient)/patient/settings/page.tsx
+++ b/src/app/(patient)/patient/settings/page.tsx
@@ -6,6 +6,7 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { logger } from "@/lib/logger";
+import { getLocalDateStr } from "@/lib/utils";
 
 export default function PatientSettingsPage() {
   const [exportLoading, setExportLoading] = useState(false);
@@ -28,7 +29,7 @@ export default function PatientSettingsPage() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `my-data-${new Date().toISOString().split("T")[0]}.${format}`;
+      a.download = `my-data-${getLocalDateStr()}.${format}`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);

--- a/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/dashboard/page.tsx
@@ -677,7 +677,7 @@ export default function PharmacistDashboardPage() {
                     </p>
                   </div>
                   <div className="text-right">
-                    <p className="font-semibold text-sm">{sale.total} MAD</p>
+                    <p className="font-semibold text-sm">{formatCurrency(sale.total)}</p>
                     <Badge variant="outline" className="text-xs capitalize">
                       {sale.paymentMethod}
                     </Badge>

--- a/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/loyalty/page.tsx
@@ -27,7 +27,6 @@ import { Input } from "@/components/ui/input";
 import { PageLoader } from "@/components/ui/page-loader";
 import { fetchLoyaltyMembers, fetchLoyaltyTransactions, getPointsValue } from "@/lib/data/client";
 import type { LoyaltyMemberView, LoyaltyTransactionView } from "@/lib/data/client";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatCurrency, formatNumber } from "@/lib/utils";
 
 type LoyaltyTier = "bronze" | "silver" | "gold" | "platinum";
@@ -299,7 +298,7 @@ export default function LoyaltyPage() {
                       <span className="text-sm font-normal">pts</span>
                     </p>
                     <p className="text-xs opacity-80">
-                      = {getPointsValue(member.availablePoints)} MAD discount
+                      = {formatCurrency(getPointsValue(member.availablePoints))} discount
                     </p>
                     <div className="flex items-center justify-between mt-3">
                       <span className="text-xs">{member.patientName}</span>

--- a/src/app/(pharmacist)/pharmacist/orders/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/orders/page.tsx
@@ -203,7 +203,7 @@ export default function OrdersPage() {
                         >
                           <span>{item.productName}</span>
                           <span className="text-right">{item.quantity}</span>
-                          <span className="text-right">{item.unitPrice} MAD</span>
+                          <span className="text-right">{formatCurrency(item.unitPrice)}</span>
                           <span className="text-right font-medium">
                             {formatCurrency(
                               item.quantity * item.unitPrice,

--- a/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/prescriptions/page.tsx
@@ -238,7 +238,7 @@ export default function PrescriptionsPage() {
                               <span className="text-muted-foreground">x{item.quantity}</span>
                             </div>
                             <div className="flex items-center gap-3">
-                              <span>{item.price} MAD</span>
+                              <span>{formatCurrency(item.price)}</span>
                               {!item.available && item.notes && (
                                 <span className="text-xs text-orange-500">{item.notes}</span>
                               )}
@@ -269,7 +269,9 @@ export default function PrescriptionsPage() {
                   {/* Actions */}
                   <div className="flex flex-col gap-2 min-w-[180px]">
                     <div className="text-right mb-2">
-                      <p className="text-2xl font-bold text-emerald-600">{rx.totalPrice} MAD</p>
+                      <p className="text-2xl font-bold text-emerald-600">
+                        {formatCurrency(rx.totalPrice)}
+                      </p>
                     </div>
                     {rx.status === "pending" && (
                       <Button className="bg-blue-600 hover:bg-blue-700 w-full">

--- a/src/app/(pharmacist)/pharmacist/sales/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/sales/page.tsx
@@ -10,8 +10,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { PageLoader } from "@/components/ui/page-loader";
 import { fetchDailySales } from "@/lib/data/client";
 import type { DailySaleView } from "@/lib/data/client";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { getLocalDateStr, formatCurrency, formatNumber } from "@/lib/utils";
 
 export default function SalesPage() {
   const [locale] = useLocale();
@@ -20,7 +19,7 @@ export default function SalesPage() {
   const [allSales, setAllSales] = useState<DailySaleView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
-  const today = new Date().toISOString().split("T")[0] ?? "";
+  const today = getLocalDateStr() ?? "";
   const yesterday = (() => {
     const d = new Date();
     d.setDate(d.getDate() - 1);
@@ -197,12 +196,14 @@ export default function SalesPage() {
                       <div className="space-y-0.5">
                         {sale.items.map((item, idx) => (
                           <p key={idx} className="text-xs">
-                            {item.productName} x{item.quantity} = {item.price} MAD
+                            {item.productName} x{item.quantity} = {formatCurrency(item.price)}
                           </p>
                         ))}
                       </div>
                     </td>
-                    <td className="py-3 px-2 font-bold text-emerald-600">{sale.total} MAD</td>
+                    <td className="py-3 px-2 font-bold text-emerald-600">
+                      {formatCurrency(sale.total)}
+                    </td>
                     <td className="py-3 px-2">
                       <Badge variant="outline" className="text-xs capitalize gap-1">
                         {paymentIcon[sale.paymentMethod]}

--- a/src/app/(pharmacist)/pharmacist/stock/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/stock/page.tsx
@@ -16,7 +16,6 @@ import {
   getExpiryStatus,
 } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatCurrency, formatNumber } from "@/lib/utils";
 
 const categories = [
@@ -247,7 +246,7 @@ export default function StockPage() {
                           {product.category.replace("-", " ")}
                         </Badge>
                       </td>
-                      <td className="py-3 px-2 font-medium">{product.price} MAD</td>
+                      <td className="py-3 px-2 font-medium">{formatCurrency(product.price)}</td>
                       <td className="py-3 px-2">
                         <span
                           className={`font-bold ${stock === "out" ? "text-red-500" : stock === "low" ? "text-orange-500" : "text-emerald-600"}`}

--- a/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
@@ -15,6 +15,7 @@ import {
   TOP_CITY_SPECIALTY_COMBOS,
 } from "@/lib/directory-constants";
 import { safeJsonLdStringify } from "@/lib/json-ld";
+import { formatCurrency } from "@/lib/utils";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
 const ROOT_DOMAIN = process.env.ROOT_DOMAIN ?? "oltigo.com";
@@ -215,7 +216,7 @@ export default async function CitySpecialtyPage({ params }: CitySpecialtyPagePro
                       </div>
                       {doctor.consultationFee > 0 && (
                         <p className="text-sm font-medium mt-2">
-                          Consultation : {doctor.consultationFee} MAD
+                          Consultation : {formatCurrency(doctor.consultationFee)}
                         </p>
                       )}
                       {doctor.languages.length > 0 && (

--- a/src/app/(public)/annuaire/[city]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/data/directory";
 import { DIRECTORY_CITIES, getCityBySlug, getSpecialtyBySlug } from "@/lib/directory-constants";
 import { safeJsonLdStringify } from "@/lib/json-ld";
+import { formatCurrency } from "@/lib/utils";
 
 const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://oltigo.com";
 const ROOT_DOMAIN = process.env.ROOT_DOMAIN ?? "oltigo.com";
@@ -238,7 +239,7 @@ function DoctorProfileView({
                   <div className="flex items-center gap-2 text-sm">
                     <Award className="h-4 w-4 text-primary flex-shrink-0" />
                     <span>
-                      Consultation : <strong>{doctor.consultationFee} MAD</strong>
+                      Consultation : <strong>{formatCurrency(doctor.consultationFee)}</strong>
                     </span>
                   </div>
                 )}
@@ -467,7 +468,9 @@ function CityListingView({
                   </div>
                   <div className="mt-3 flex items-center justify-between">
                     {doctor.consultationFee > 0 && (
-                      <span className="text-sm font-medium">{doctor.consultationFee} MAD</span>
+                      <span className="text-sm font-medium">
+                        {formatCurrency(doctor.consultationFee)}
+                      </span>
                     )}
                     {doctor.clinicSubdomain && (
                       <span className={buttonVariants({ variant: "outline", size: "sm" })}>

--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -32,6 +32,7 @@ import {
   type AppointmentView,
   type PatientView,
 } from "@/lib/data/client";
+import { formatCurrency } from "@/lib/utils";
 
 const statusVariant: Record<
   string,
@@ -110,7 +111,7 @@ export default function ReceptionistDashboardPage() {
     {
       icon: CreditCard,
       label: "Revenue (Month)",
-      value: `${totalRevenue} MAD`,
+      value: `${formatCurrency(totalRevenue)}`,
       color: "text-orange-600",
     },
   ];

--- a/src/app/(receptionist)/receptionist/payments/page.tsx
+++ b/src/app/(receptionist)/receptionist/payments/page.tsx
@@ -15,6 +15,7 @@ import {
   fetchInvoices,
   type InvoiceView,
 } from "@/lib/data/client";
+import { formatCurrency } from "@/lib/utils";
 
 interface PaymentEntry {
   id: string;
@@ -128,13 +129,13 @@ export default function PaymentsPage() {
       <div className="grid gap-4 grid-cols-2 md:grid-cols-4 mb-6">
         <Card>
           <CardContent className="pt-4 pb-4 text-center">
-            <p className="text-2xl font-bold text-green-600">{totalCollected} MAD</p>
+            <p className="text-2xl font-bold text-green-600">{formatCurrency(totalCollected)}</p>
             <p className="text-xs text-muted-foreground">Total Collected</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-4 pb-4 text-center">
-            <p className="text-2xl font-bold text-orange-600">{totalPending} MAD</p>
+            <p className="text-2xl font-bold text-orange-600">{formatCurrency(totalPending)}</p>
             <p className="text-xs text-muted-foreground">Pending</p>
           </CardContent>
         </Card>
@@ -186,7 +187,7 @@ export default function PaymentsPage() {
                     <p className="text-xs text-muted-foreground">{entry.serviceName}</p>
                   </div>
                   <div className="text-right mr-2">
-                    <p className="text-sm font-bold">{entry.amount} MAD</p>
+                    <p className="text-sm font-bold">{formatCurrency(entry.amount)}</p>
                     {entry.status === "paid" && (
                       <p className="text-xs text-muted-foreground capitalize">{entry.method}</p>
                     )}

--- a/src/app/(specialist)/equipment/maintenance/page.tsx
+++ b/src/app/(specialist)/equipment/maintenance/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/data/client";
 import type { EquipmentMaintenanceView, EquipmentItemView } from "@/lib/data/client";
 import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
+import { getLocalDateStr } from "@/lib/utils";
 import { useEquipmentLocale } from "../layout";
 
 const STATUS_OPTIONS = ["all", "scheduled", "in_progress", "completed", "cancelled"] as const;
@@ -71,7 +72,7 @@ const emptyForm: MaintenanceFormState = {
   type: "routine",
   description: "",
   performedBy: "",
-  performedAt: new Date().toISOString().split("T")[0],
+  performedAt: getLocalDateStr(),
   nextDue: "",
   cost: "",
   status: "scheduled",

--- a/src/app/(specialist)/equipment/rentals/page.tsx
+++ b/src/app/(specialist)/equipment/rentals/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/data/client";
 import type { EquipmentRentalView, EquipmentItemView } from "@/lib/data/client";
 import { useEquipmentI18n } from "@/lib/hooks/use-equipment-i18n";
+import { getLocalDateStr } from "@/lib/utils";
 import { useEquipmentLocale } from "../layout";
 
 const STATUS_OPTIONS = ["all", "reserved", "active", "returned", "overdue", "cancelled"] as const;
@@ -246,7 +247,7 @@ export default function EquipmentRentalsPage() {
     await updateEquipmentRental(returnDialog.id, {
       status: "returned",
       condition_in: returnCondition,
-      actual_return: new Date().toISOString().split("T")[0],
+      actual_return: getLocalDateStr(),
     });
     setReturnDialog(null);
     reload();

--- a/src/app/(specialist)/parapharmacy/inventory/page.tsx
+++ b/src/app/(specialist)/parapharmacy/inventory/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { PageLoader } from "@/components/ui/page-loader";
 import { fetchParapharmacyProducts, getStockStatus, getExpiryStatus } from "@/lib/data/client";
 import type { ProductView } from "@/lib/data/client";
+import { formatCurrency } from "@/lib/utils";
 
 export default function ParapharmacyInventoryPage() {
   const tenant = useTenant();
@@ -129,7 +130,7 @@ export default function ParapharmacyInventoryPage() {
                     )}
                   </td>
                   <td className="py-3 text-muted-foreground">{p.category}</td>
-                  <td className="py-3 text-right">{p.price} MAD</td>
+                  <td className="py-3 text-right">{formatCurrency(p.price)}</td>
                   <td className="py-3 text-right font-medium">{p.stockQuantity}</td>
                   <td className="py-3 text-right text-muted-foreground">{p.minimumStock}</td>
                   <td className="py-3">

--- a/src/app/(specialist)/parapharmacy/sales/page.tsx
+++ b/src/app/(specialist)/parapharmacy/sales/page.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/lib/data/client";
 import type { DailySaleView, ProductView } from "@/lib/data/client";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { getLocalDateStr, formatCurrency, formatNumber } from "@/lib/utils";
 
 interface CartItem {
   productId: string;
@@ -190,7 +190,7 @@ export default function ParapharmacySalesPage() {
     );
   });
 
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateStr();
   const todaySales = filtered.filter((s) => s.date === today);
   const todayRevenue = todaySales.reduce((sum, s) => sum + s.total, 0);
 
@@ -245,7 +245,7 @@ export default function ParapharmacySalesPage() {
                   </div>
                 </div>
                 <div className="text-right">
-                  <p className="font-semibold">{sale.total} MAD</p>
+                  <p className="font-semibold">{formatCurrency(sale.total)}</p>
                   <Badge variant="outline" className="text-xs capitalize">
                     {sale.paymentMethod}
                   </Badge>
@@ -324,7 +324,7 @@ export default function ParapharmacySalesPage() {
                       }}
                     >
                       <span>{p.name}</span>
-                      <span className="text-muted-foreground">{p.price} MAD</span>
+                      <span className="text-muted-foreground">{formatCurrency(p.price)}</span>
                     </button>
                   ))}
                   {filteredProducts.length === 0 && (
@@ -347,7 +347,9 @@ export default function ParapharmacySalesPage() {
                   >
                     <div className="flex-1">
                       <p className="font-medium">{item.productName}</p>
-                      <p className="text-xs text-muted-foreground">{item.unitPrice} MAD each</p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatCurrency(item.unitPrice)} each
+                      </p>
                     </div>
                     <div className="flex items-center gap-2">
                       <Button
@@ -386,7 +388,7 @@ export default function ParapharmacySalesPage() {
                 ))}
                 <div className="flex items-center justify-between px-3 py-2 border-t bg-muted/50 font-semibold">
                   <span>Total</span>
-                  <span>{cartTotal.toFixed(2)} MAD</span>
+                  <span>{formatCurrency(cartTotal)}</span>
                 </div>
               </div>
             )}
@@ -400,7 +402,7 @@ export default function ParapharmacySalesPage() {
               disabled={saving || cart.length === 0 || !customerName}
             >
               {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-              Complete Sale ({cartTotal.toFixed(2)} MAD)
+              Complete Sale ({formatCurrency(cartTotal)})
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/(super-admin)/super-admin/announcements/page.tsx
+++ b/src/app/(super-admin)/super-admin/announcements/page.tsx
@@ -32,6 +32,7 @@ import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
 import { fetchAnnouncements, type Announcement } from "@/lib/super-admin-actions";
+import { getLocalDateStr } from "@/lib/utils";
 
 type TypeFilter = "all" | "info" | "warning" | "critical";
 
@@ -143,7 +144,7 @@ export default function AnnouncementsPage() {
         type: formType,
         target: formTarget,
         targetLabel: targetLabels[formTarget] || formTarget,
-        publishedAt: new Date().toISOString().split("T")[0],
+        publishedAt: getLocalDateStr(),
         expiresAt: formExpires || undefined,
         active: true,
         createdBy: "Super Admin",

--- a/src/app/(super-admin)/super-admin/billing/page.tsx
+++ b/src/app/(super-admin)/super-admin/billing/page.tsx
@@ -32,6 +32,7 @@ import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
 import { fetchBillingRecords, type BillingRecord } from "@/lib/super-admin-actions";
+import { getLocalDateStr } from "@/lib/utils";
 
 type StatusFilter = "all" | "paid" | "pending" | "overdue" | "cancelled";
 
@@ -96,7 +97,7 @@ export default function BillingPage() {
               ...r,
               status: "paid" as const,
               amountPaid: r.amountDue,
-              paidDate: new Date().toISOString().split("T")[0],
+              paidDate: getLocalDateStr(),
             }
           : r,
       ),

--- a/src/app/(super-admin)/super-admin/billing/revenue/page.tsx
+++ b/src/app/(super-admin)/super-admin/billing/revenue/page.tsx
@@ -17,6 +17,7 @@ import {
   fetchRevenueStats as fetchRevenueStatsAction,
   type RevenueStats,
 } from "@/lib/super-admin-actions";
+import { formatCurrency } from "@/lib/utils";
 
 export default function RevenueDashboardPage() {
   const [stats, setStats] = useState<RevenueStats | null>(null);
@@ -125,7 +126,7 @@ export default function RevenueDashboardPage() {
                       <div className="flex items-center justify-between mb-2">
                         <h4 className="text-sm font-medium">{plan.name}</h4>
                         <Badge variant="outline" className="text-[10px]">
-                          {plan.price === 0 ? "Gratuit" : `${plan.price} MAD`}
+                          {plan.price === 0 ? "Gratuit" : `${formatCurrency(plan.price)}`}
                         </Badge>
                       </div>
                       <p className="text-3xl font-bold">{count}</p>
@@ -133,7 +134,7 @@ export default function RevenueDashboardPage() {
                         <p className="text-xs text-muted-foreground">{percentage}% des cliniques</p>
                         {plan.price > 0 && (
                           <p className="text-xs font-medium text-green-600">
-                            {revenue.toLocaleString()} MAD/mois
+                            {formatCurrency(revenue)}/mois
                           </p>
                         )}
                       </div>
@@ -167,9 +168,7 @@ export default function RevenueDashboardPage() {
                       className="flex items-center justify-between rounded-lg border p-3"
                     >
                       <span className="text-sm font-medium">{entry.month}</span>
-                      <span className="text-sm font-bold">
-                        {entry.revenue.toLocaleString()} MAD
-                      </span>
+                      <span className="text-sm font-bold">{formatCurrency(entry.revenue)}</span>
                     </div>
                   ))}
                 </div>
@@ -182,7 +181,7 @@ export default function RevenueDashboardPage() {
                   </p>
                   <p className="text-xs text-muted-foreground mt-1">
                     MRR estimé actuel :{" "}
-                    <span className="font-medium">{stats.mrr.toLocaleString()} MAD</span>
+                    <span className="font-medium">{formatCurrency(stats.mrr)}</span>
                   </p>
                 </div>
               )}

--- a/src/app/(super-admin)/super-admin/clinics/page.tsx
+++ b/src/app/(super-admin)/super-admin/clinics/page.tsx
@@ -42,7 +42,7 @@ import { useToast } from "@/components/ui/toast";
 import { exportToCSV } from "@/lib/export-data";
 import { logger } from "@/lib/logger";
 import { fetchClinics, updateClinicStatus } from "@/lib/super-admin-actions";
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { getLocalDateStr, formatCurrency, formatNumber } from "@/lib/utils";
 
 /** Subset of the clinics.config JSONB column used in clinic management. */
 interface ClinicConfigJson {
@@ -251,7 +251,7 @@ export default function AllClinicsPage() {
         { key: "userCountRange", label: "Users (range)" },
         { key: "createdAt", label: "Created" },
       ],
-      `clinics-export-${new Date().toISOString().split("T")[0]}.csv`,
+      `clinics-export-${getLocalDateStr()}.csv`,
     );
   }
 

--- a/src/app/(super-admin)/super-admin/dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.tsx
@@ -29,6 +29,7 @@ import {
   type Announcement,
   type ActivityLog,
 } from "@/lib/super-admin-actions";
+import { formatCurrency } from "@/lib/utils";
 
 /** Subset of the clinics.config JSONB column used in the dashboard. */
 interface ClinicConfigJson {
@@ -146,7 +147,7 @@ export default function SuperAdminDashboardPage() {
     {
       icon: TrendingUp,
       label: t(locale, "superAdmin.monthlyRevenue"),
-      value: `${totalRevenue.toLocaleString()} MAD`,
+      value: `${formatCurrency(totalRevenue)}`,
       change: t(locale, "superAdmin.fromPayments"),
       color: "text-orange-600",
       bg: "bg-orange-50",
@@ -156,7 +157,7 @@ export default function SuperAdminDashboardPage() {
   const financialStats = [
     {
       label: t(locale, "superAdmin.mrr"),
-      value: `${mrr.toLocaleString()} MAD`,
+      value: `${formatCurrency(mrr)}`,
       icon: CreditCard,
       color: "text-emerald-600",
     },

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -36,6 +36,7 @@ import {
   type PricingTierRow,
   type FeatureToggleRow,
 } from "@/lib/super-admin-actions";
+import { formatCurrency } from "@/lib/utils";
 
 type TabView = "tiers" | "features";
 type SystemFilter = "all" | SystemType;
@@ -449,9 +450,7 @@ export default function PricingPage() {
                           <td className="py-3 px-4 hidden md:table-cell text-muted-foreground capitalize">
                             {sub.billingCycle === "monthly" ? "Mensuel" : "Annuel"}
                           </td>
-                          <td className="py-3 px-4 font-medium">
-                            {sub.amount.toLocaleString()} MAD
-                          </td>
+                          <td className="py-3 px-4 font-medium">{formatCurrency(sub.amount)}</td>
                           <td className="py-3 px-4">
                             <Badge
                               variant={

--- a/src/app/(super-admin)/super-admin/subscriptions/page.tsx
+++ b/src/app/(super-admin)/super-admin/subscriptions/page.tsx
@@ -40,6 +40,7 @@ import {
   type ClientSubscription,
   type SystemType,
 } from "@/lib/super-admin-actions";
+import { formatCurrency } from "@/lib/utils";
 
 type StatusFilter = "all" | ClientSubscription["status"];
 type SystemFilter = "all" | SystemType;
@@ -398,7 +399,7 @@ export default function SubscriptionsPage() {
                         <div className="flex items-center gap-3">
                           <span className="font-mono text-xs text-muted-foreground">{inv.id}</span>
                           <span>{inv.date}</span>
-                          <span className="font-medium">{inv.amount.toLocaleString()} MAD</span>
+                          <span className="font-medium">{formatCurrency(inv.amount)}</span>
                         </div>
                         <div className="flex items-center gap-2">
                           <Badge
@@ -518,7 +519,7 @@ export default function SubscriptionsPage() {
                           <span>{inv.date}</span>
                         </div>
                         <div className="flex items-center gap-2">
-                          <span className="font-medium">{inv.amount.toLocaleString()} MAD</span>
+                          <span className="font-medium">{formatCurrency(inv.amount)}</span>
                           <Badge
                             variant={
                               inv.status === "paid"

--- a/src/app/(super-admin)/super-admin/templates/page.tsx
+++ b/src/app/(super-admin)/super-admin/templates/page.tsx
@@ -31,7 +31,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/toast";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { getLocalDateStr, formatCurrency, formatNumber } from "@/lib/utils";
 
 interface Template {
   id: string;
@@ -246,7 +246,7 @@ export default function TemplateManagerPage() {
                 type: formType,
                 clinicType: formClinicType,
                 content: formContent,
-                updatedAt: new Date().toISOString().split("T")[0],
+                updatedAt: getLocalDateStr(),
               }
             : t,
         ),
@@ -259,8 +259,8 @@ export default function TemplateManagerPage() {
         type: formType,
         clinicType: formClinicType,
         content: formContent,
-        createdAt: new Date().toISOString().split("T")[0],
-        updatedAt: new Date().toISOString().split("T")[0],
+        createdAt: getLocalDateStr(),
+        updatedAt: getLocalDateStr(),
         usageCount: 0,
         active: true,
       };
@@ -275,8 +275,8 @@ export default function TemplateManagerPage() {
       ...item,
       id: `tpl-${Date.now()}`,
       name: `${item.name} (Copy)`,
-      createdAt: new Date().toISOString().split("T")[0],
-      updatedAt: new Date().toISOString().split("T")[0],
+      createdAt: getLocalDateStr(),
+      updatedAt: getLocalDateStr(),
       usageCount: 0,
     };
     setTemplates((prev) => [dup, ...prev]);

--- a/src/app/api/ai/manager/route.ts
+++ b/src/app/api/ai/manager/route.ts
@@ -22,6 +22,7 @@ import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { logger } from "@/lib/logger";
 import { aiClinicCeilingLimiter, aiManagerLimiter } from "@/lib/rate-limit";
+import { formatCurrency } from "@/lib/utils";
 import { aiManagerRequestSchema } from "@/lib/validations";
 import type { AuthContext } from "@/lib/with-auth";
 
@@ -301,8 +302,8 @@ function buildUserMessage(
   }
 
   parts.push(`\nREVENUS:`);
-  parts.push(`- Ce mois: ${metrics.revenueThisMonth} MAD`);
-  parts.push(`- Mois dernier: ${metrics.revenueLastMonth} MAD`);
+  parts.push(`- Ce mois: ${formatCurrency(metrics.revenueThisMonth)}`);
+  parts.push(`- Mois dernier: ${formatCurrency(metrics.revenueLastMonth)}`);
   if (metrics.revenueLastMonth > 0) {
     const change = (
       ((metrics.revenueThisMonth - metrics.revenueLastMonth) / metrics.revenueLastMonth) *

--- a/src/app/api/checkin/confirm/route.ts
+++ b/src/app/api/checkin/confirm/route.ts
@@ -3,6 +3,7 @@ import { withValidation } from "@/lib/api-validate";
 import { logger } from "@/lib/logger";
 import { createTenantClient } from "@/lib/supabase-server";
 import { getTenant } from "@/lib/tenant";
+import { getLocalDateStr } from "@/lib/utils";
 import { checkinConfirmSchema } from "@/lib/validations";
 
 /**
@@ -49,7 +50,7 @@ export const POST = withValidation(checkinConfirmSchema, async (body) => {
 
   // Calculate queue position: count how many people checked in today
   // before this patient (same clinic, status = checked_in, today)
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateStr();
 
   const { data: checkedInToday } = await supabase
     .from("appointments")

--- a/src/app/api/checkin/lookup/route.ts
+++ b/src/app/api/checkin/lookup/route.ts
@@ -3,6 +3,7 @@ import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { createTenantClient } from "@/lib/supabase-server";
 import { getTenant } from "@/lib/tenant";
+import { getLocalDateStr } from "@/lib/utils";
 
 /**
  * GET /api/checkin/lookup?phone=...
@@ -77,7 +78,7 @@ async function findTodayAppointments(
   patientId: string,
   clinicId: string,
 ) {
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateStr();
 
   const { data: appointments } = await supabase
     .from("appointments")

--- a/src/app/api/cron/audit-log-flush/route.ts
+++ b/src/app/api/cron/audit-log-flush/route.ts
@@ -10,7 +10,8 @@
  * Protected by CRON_SECRET via Authorization: Bearer header.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { apiSuccess } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
 import { logger } from "@/lib/logger";
 import { withSentryCron } from "@/lib/sentry-cron";
@@ -68,7 +69,7 @@ async function handler(request: NextRequest) {
         error: fetchErr.message,
       });
     }
-    return NextResponse.json({ ok: true, flushed: 0, failed: 0 });
+    return apiSuccess({ flushed: 0, failed: 0 });
   }
 
   for (const row of pending) {
@@ -141,7 +142,7 @@ async function handler(request: NextRequest) {
     total: pending.length,
   });
 
-  return NextResponse.json({ ok: true, flushed, failed });
+  return apiSuccess({ flushed, failed });
 }
 
 export const GET = withSentryCron("audit-log-flush", "*/15 * * * *", handler);

--- a/src/app/api/cron/billing/route.ts
+++ b/src/app/api/cron/billing/route.ts
@@ -16,6 +16,7 @@ import { withSentryCron } from "@/lib/sentry-cron";
 import { processRenewal } from "@/lib/subscription-billing";
 // B-02: Cron jobs have no user session — use service-role client.
 import { createAdminClient } from "@/lib/supabase-server";
+import { getLocalDateStr } from "@/lib/utils";
 
 async function handler(request: NextRequest) {
   // DRY: Use shared cron secret verification helper
@@ -25,7 +26,7 @@ async function handler(request: NextRequest) {
   const supabase = createAdminClient("cron");
 
   // Fetch all active subscriptions that may need renewal
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateStr();
   const { data: subscriptions, error } = await supabase
     .from("clinic_subscriptions")
     .select("clinic_id, current_period_end, status")

--- a/src/app/api/cron/dedup-purge/route.ts
+++ b/src/app/api/cron/dedup-purge/route.ts
@@ -14,7 +14,8 @@
  * Protected by CRON_SECRET via Authorization: Bearer header.
  */
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { apiSuccess } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
 import { logger } from "@/lib/logger";
 import { withSentryCron } from "@/lib/sentry-cron";
@@ -92,8 +93,7 @@ async function handler(request: NextRequest) {
     waRetention: WA_RETENTION_DAYS,
   });
 
-  return NextResponse.json({
-    ok: true,
+  return apiSuccess({
     purged: results,
     retention: {
       stripe: STRIPE_RETENTION_DAYS,

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { apiError, apiRateLimited } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
 
@@ -66,11 +67,11 @@ export async function POST(request: NextRequest) {
   try {
     raw = await request.text();
   } catch {
-    return new NextResponse(null, { status: 400 });
+    return apiError("Bad request", 400);
   }
 
   if (raw.length > MAX_CSP_REPORT_BYTES) {
-    return new NextResponse(null, { status: 413 });
+    return apiError("Payload too large", 413);
   }
 
   // Per-IP rate limit. Applied after the size check so a flood of large
@@ -78,7 +79,7 @@ export async function POST(request: NextRequest) {
   const ip = extractClientIp(request);
   const allowed = await cspReportLimiter.check(`csp-report:${ip}`);
   if (!allowed) {
-    return new NextResponse(null, { status: 429 });
+    return apiRateLimited();
   }
 
   let parsed: CspViolationReport;

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { apiSuccess, apiSupabaseError } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
+import { formatCurrency } from "@/lib/utils";
 import { withAuth, type AuthContext } from "@/lib/with-auth";
 
 const orderItemSchema = z.object({
@@ -100,7 +101,7 @@ export const POST = withAuthValidation(
       action: "order.created",
       type: "payment",
       clinicId,
-      description: `Order created: ${body.items.length} items, total ${total} MAD`,
+      description: `Order created: ${body.items.length} items, total ${formatCurrency(total)}`,
     });
 
     return apiSuccess(data, 201);

--- a/src/app/api/patient/export/route.ts
+++ b/src/app/api/patient/export/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { apiError, apiNotFound } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
+import { getLocalDateStr } from "@/lib/utils";
 import { withAuth } from "@/lib/with-auth";
 
 /** Characters that trigger formula execution in Excel/Google Sheets. */
@@ -150,7 +151,7 @@ export const GET = withAuth(
         status: 200,
         headers: {
           "Content-Type": "application/json",
-          "Content-Disposition": `attachment; filename="my-data-${new Date().toISOString().split("T")[0]}.json"`,
+          "Content-Disposition": `attachment; filename="my-data-${getLocalDateStr()}.json"`,
         },
       });
     }
@@ -189,7 +190,7 @@ export const GET = withAuth(
       status: 200,
       headers: {
         "Content-Type": "text/csv; charset=utf-8",
-        "Content-Disposition": `attachment; filename="my-data-${new Date().toISOString().split("T")[0]}.csv"`,
+        "Content-Disposition": `attachment; filename="my-data-${getLocalDateStr()}.csv"`,
       },
     });
   },

--- a/src/components/admin/admin-dashboard-view.tsx
+++ b/src/components/admin/admin-dashboard-view.tsx
@@ -10,7 +10,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import type { DashboardStats, RecentActivityItem } from "@/lib/data/server";
 import { t } from "@/lib/i18n";
-import { formatDisplayDate } from "@/lib/utils";
+import { formatCurrency, formatDisplayDate } from "@/lib/utils";
 
 const activityVariant: Record<string, "default" | "success" | "warning" | "destructive"> = {
   booking: "default",
@@ -56,7 +56,7 @@ export function AdminDashboardView({ stats }: AdminDashboardViewProps) {
     {
       icon: CreditCard,
       label: t(locale, "admin.monthlyRevenue"),
-      value: `${totalRevenue} MAD`,
+      value: `${formatCurrency(totalRevenue)}`,
       color: "text-purple-600",
     },
     {

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -50,6 +50,7 @@ import {
   type AnalyticsPeriod,
 } from "@/lib/data/client";
 import { exportToCSV } from "@/lib/export-data";
+import { formatCurrency, getLocalDateStr } from "@/lib/utils";
 
 const COLORS = [
   "#2563eb",
@@ -238,7 +239,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
                   { key: "onlineBookings", label: "Online Bookings" },
                   { key: "walkIns", label: "Walk-Ins" },
                 ],
-                `analytics-${new Date().toISOString().split("T")[0]}.csv`,
+                `analytics-${getLocalDateStr()}.csv`,
               );
             }}
           >
@@ -273,12 +274,10 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
               <TrendingUp className="h-5 w-5 text-green-600" />
               <ChangeIndicator value={periodComparison.revenueChange} />
             </div>
-            <p className="text-2xl font-bold">
-              {periodComparison.currentRevenue.toLocaleString()} MAD
-            </p>
+            <p className="text-2xl font-bold">{formatCurrency(periodComparison.currentRevenue)}</p>
             <p className="text-xs text-muted-foreground">Revenue ({PERIOD_LABELS[timePeriod]})</p>
             <p className="text-[10px] text-muted-foreground mt-0.5">
-              vs prev: {periodComparison.previousRevenue.toLocaleString()} MAD
+              vs prev: {formatCurrency(periodComparison.previousRevenue)}
             </p>
           </CardContent>
         </Card>
@@ -342,7 +341,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
               <XAxis dataKey="name" tick={{ fontSize: 11 }} />
               <YAxis tick={{ fontSize: 11 }} />
               <Tooltip
-                formatter={(value) => [`${Number(value).toLocaleString()} MAD`, "Revenue"]}
+                formatter={(value) => [`${formatCurrency(Number(value))}`, "Revenue"]}
                 contentStyle={{ borderRadius: "8px", fontSize: "12px" }}
               />
               <Area
@@ -624,7 +623,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
                   <div key={service.serviceName}>
                     <div className="flex items-center justify-between text-sm mb-1">
                       <span>{service.serviceName}</span>
-                      <span className="font-medium">{service.revenue.toLocaleString()} MAD</span>
+                      <span className="font-medium">{formatCurrency(service.revenue)}</span>
                     </div>
                     <div className="flex items-center gap-2">
                       <div className="flex-1 h-2 bg-muted rounded-full overflow-hidden">
@@ -673,7 +672,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
                   <XAxis dataKey="month" tick={{ fontSize: 10 }} />
                   <YAxis tick={{ fontSize: 11 }} />
                   <Tooltip
-                    formatter={(value) => [`${Number(value).toLocaleString()} MAD`]}
+                    formatter={(value) => [`${formatCurrency(Number(value))}`]}
                     contentStyle={{ borderRadius: "8px", fontSize: "12px" }}
                   />
                   <Legend />

--- a/src/components/booking/booking-form.tsx
+++ b/src/components/booking/booking-form.tsx
@@ -24,7 +24,8 @@ import { fetchDoctors, fetchServices, type DoctorView, type ServiceView } from "
 import { useFormValidation, commonRules } from "@/lib/hooks/use-form-validation";
 import { t } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
-import { formatDisplayDate } from "@/lib/utils";
+import { formatCurrency, formatDisplayDate } from "@/lib/utils";
+import { isValidMoroccanPhone } from "@/lib/validations/primitives";
 import { BookingCalendar } from "./calendar";
 import { TimeSlotPicker } from "./time-slots";
 
@@ -44,16 +45,6 @@ const STEP_KEYS = [
   "booking.steps.dateTime",
   "booking.steps.confirmation",
 ] as const;
-
-/**
- * Validate Moroccan phone numbers.
- * Accepted formats: +212 6XXXXXXXX, +212 7XXXXXXXX, 06XXXXXXXX, 07XXXXXXXX
- * (with or without spaces/dashes).
- */
-function isValidMoroccanPhone(phone: string): boolean {
-  const digits = phone.replace(/[\s\-().]/g, "");
-  return /^(?:\+212|0)[67]\d{8}$/.test(digits);
-}
 
 interface Doctor {
   id: string;
@@ -623,7 +614,7 @@ export function BookingForm() {
                         <p className="text-xs text-muted-foreground">{d.specialty}</p>
                       </div>
                       <Badge variant="outline" className="text-xs shrink-0">
-                        {d.consultationFee} MAD
+                        {formatCurrency(d.consultationFee)}
                       </Badge>
                     </div>
                   </button>

--- a/src/components/dental-lab/materials-inventory.tsx
+++ b/src/components/dental-lab/materials-inventory.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatCurrency, formatNumber } from "@/lib/utils";
 
 interface MaterialView {
@@ -281,7 +280,9 @@ export function MaterialsInventory({
                           {m.quantity} {m.unit}
                         </td>
                         <td className="p-2 text-right text-muted-foreground">{m.minThreshold}</td>
-                        <td className="p-2 text-right">{m.unitCost ? `${m.unitCost} MAD` : "—"}</td>
+                        <td className="p-2 text-right">
+                          {m.unitCost ? `${formatCurrency(m.unitCost)}` : "—"}
+                        </td>
                         <td className="p-2 text-muted-foreground">{m.supplier || "—"}</td>
                         <td className="p-2">
                           {m.expiryDate ? (

--- a/src/components/dental-lab/prosthetic-orders.tsx
+++ b/src/components/dental-lab/prosthetic-orders.tsx
@@ -13,6 +13,7 @@ import type {
   ProstheticOrderStatus,
   ProstheticPriority,
 } from "@/lib/types/database";
+import { formatCurrency } from "@/lib/utils";
 
 interface OrderView {
   id: string;
@@ -357,7 +358,7 @@ export function ProstheticOrders({
                         )}
                         {order.price !== null && (
                           <span className="font-medium">
-                            {order.price.toLocaleString()} MAD
+                            {formatCurrency(order.price)}
                             {order.isPaid ? (
                               <CheckCircle className="h-3 w-3 inline ml-0.5 text-green-600" />
                             ) : (

--- a/src/components/dental/before-after-gallery.tsx
+++ b/src/components/dental/before-after-gallery.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { BeforeAfterPhotoView } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface BeforeAfterGalleryProps {
   photos: BeforeAfterPhotoView[];
@@ -34,7 +35,7 @@ export function BeforeAfterGallery({
         patientName: newPhoto.patientName || "Patient",
         treatmentPlanId: "",
         description: newPhoto.description,
-        beforeDate: new Date().toISOString().split("T")[0],
+        beforeDate: getLocalDateStr(),
         afterDate: null,
         category: newPhoto.category || "General",
       });

--- a/src/components/dental/treatment-plan-builder.tsx
+++ b/src/components/dental/treatment-plan-builder.tsx
@@ -19,8 +19,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { TreatmentPlan, TreatmentStep } from "@/lib/types/dental";
-import { formatDisplayDate } from "@/lib/utils";
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { formatDisplayDate, formatCurrency, formatNumber } from "@/lib/utils";
 
 const STATUS_ICON = {
   pending: Circle,

--- a/src/components/dialysis/session-scheduler.tsx
+++ b/src/components/dialysis/session-scheduler.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { DialysisSessionStatus, DialysisRecurrencePattern } from "@/lib/types/database";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface SessionView {
   id: string;
@@ -99,7 +100,7 @@ export function SessionScheduler({
     }
   };
 
-  const todayStr = new Date().toISOString().split("T")[0];
+  const todayStr = getLocalDateStr();
   const todaySessions = sessions.filter((s) => s.sessionDate === todayStr);
   const upcomingSessions = sessions.filter((s) => s.sessionDate > todayStr);
 

--- a/src/components/doctor/doctor-dashboard-view.tsx
+++ b/src/components/doctor/doctor-dashboard-view.tsx
@@ -43,7 +43,7 @@ import type {
 import { useOptimisticUpdate } from "@/lib/hooks/use-optimistic-update";
 import { t } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
-import { getLocalDateStr, formatDisplayDate } from "@/lib/utils";
+import { formatCurrency, getLocalDateStr, formatDisplayDate } from "@/lib/utils";
 
 // ── Date helpers ──
 
@@ -194,7 +194,7 @@ export function DoctorDashboardView({
     {
       icon: DollarSign,
       label: t(locale, "dashboard.revenueMonth"),
-      value: `${monthRevenue.toLocaleString()} MAD`,
+      value: `${formatCurrency(monthRevenue)}`,
       color: "text-emerald-600",
     },
     {
@@ -628,7 +628,7 @@ export function DoctorDashboardView({
                     <p className="text-xs text-muted-foreground">
                       {t(locale, "dashboard.revenue")}
                     </p>
-                    <p className="text-2xl font-bold">{weekStats.revenue.toLocaleString()} MAD</p>
+                    <p className="text-2xl font-bold">{formatCurrency(weekStats.revenue)}</p>
                   </div>
                   <TrendingUp className="h-5 w-5 text-green-500" />
                 </CardContent>
@@ -682,7 +682,7 @@ export function DoctorDashboardView({
                     <p className="text-xs text-muted-foreground">
                       {t(locale, "dashboard.revenue")}
                     </p>
-                    <p className="text-2xl font-bold">{monthStats.revenue.toLocaleString()} MAD</p>
+                    <p className="text-2xl font-bold">{formatCurrency(monthStats.revenue)}</p>
                   </div>
                   <TrendingUp className="h-5 w-5 text-green-500" />
                 </CardContent>

--- a/src/components/doctor/mark-unavailable-dialog.tsx
+++ b/src/components/doctor/mark-unavailable-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface MarkUnavailableDialogProps {
   doctorId: string;
@@ -123,7 +124,7 @@ export function MarkUnavailableDialog({
                       type="date"
                       value={startDate}
                       onChange={(e) => setStartDate(e.target.value)}
-                      min={new Date().toISOString().split("T")[0]}
+                      min={getLocalDateStr()}
                     />
                   </div>
                   <div className="space-y-2">
@@ -132,7 +133,7 @@ export function MarkUnavailableDialog({
                       type="date"
                       value={endDate}
                       onChange={(e) => setEndDate(e.target.value)}
-                      min={startDate || new Date().toISOString().split("T")[0]}
+                      min={startDate || getLocalDateStr()}
                     />
                   </div>
                 </div>

--- a/src/components/installments/installment-form.tsx
+++ b/src/components/installments/installment-form.tsx
@@ -8,8 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { formatDisplayDate } from "@/lib/utils";
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import { getLocalDateStr, formatDisplayDate, formatCurrency, formatNumber } from "@/lib/utils";
 
 interface InstallmentFormProps {
   patientName?: string;
@@ -38,7 +37,7 @@ export function InstallmentForm({
     totalAmount: defaultTotal,
     downPayment: 0,
     numberOfInstallments: 6,
-    startDate: new Date().toISOString().split("T")[0],
+    startDate: getLocalDateStr(),
     whatsappReminder: true,
   });
   const [submitted, setSubmitted] = useState(false);

--- a/src/components/para-medical/frame-catalog.tsx
+++ b/src/components/para-medical/frame-catalog.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import type { FrameCatalogItem } from "@/lib/types/para-medical";
+import { formatCurrency } from "@/lib/utils";
 
 const FRAME_TYPE_LABELS: Record<string, string> = {
   full_rim: "Full Rim",
@@ -159,7 +160,7 @@ export function FrameCatalog({ frames }: FrameCatalogProps) {
                 <span>Size: {frame.size}</span>
               </div>
               <div className="flex items-center justify-between mt-2 pt-2 border-t">
-                <p className="text-sm font-bold">{frame.price} MAD</p>
+                <p className="text-sm font-bold">{formatCurrency(frame.price)}</p>
                 <div className="flex items-center gap-1">
                   {frame.stock_quantity === 0 ? (
                     <Badge variant="destructive" className="text-[10px]">

--- a/src/components/para-medical/lens-inventory-manager.tsx
+++ b/src/components/para-medical/lens-inventory-manager.tsx
@@ -7,7 +7,6 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import type { LensInventoryItem } from "@/lib/types/para-medical";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { formatCurrency, formatNumber } from "@/lib/utils";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -164,10 +163,10 @@ export function LensInventoryManager({ items }: LensInventoryManagerProps) {
                           )}
                         </td>
                         <td className="py-2.5 px-3 text-right text-muted-foreground">
-                          {item.unit_cost} MAD
+                          {formatCurrency(item.unit_cost)}
                         </td>
                         <td className="py-2.5 px-3 text-right font-medium">
-                          {item.selling_price} MAD
+                          {formatCurrency(item.selling_price)}
                         </td>
                         <td className="py-2.5 px-3 text-muted-foreground">{item.supplier}</td>
                       </tr>

--- a/src/components/receptionist/booking-calendar.tsx
+++ b/src/components/receptionist/booking-calendar.tsx
@@ -22,6 +22,7 @@ import {
   type AppointmentView,
   type DoctorView,
 } from "@/lib/data/client";
+import { getLocalDateStr } from "@/lib/utils";
 import { ManualBookingDialog } from "./manual-booking-dialog";
 import { WalkInDialog } from "./walk-in-dialog";
 
@@ -112,7 +113,7 @@ export function ReceptionistBookingCalendar() {
   };
 
   const weekDates = getWeekDates();
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateStr();
 
   const prevWeek = () => {
     const d = new Date(currentDate);

--- a/src/components/receptionist/cash-register.tsx
+++ b/src/components/receptionist/cash-register.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { formatCurrency } from "@/lib/utils";
 
 interface CashRegisterProps {
   onPaymentRecorded?: (payment: {
@@ -115,7 +116,7 @@ export function CashRegister({ onPaymentRecorded }: CashRegisterProps) {
           {amount && method && (
             <div className="rounded-lg border border-green-200 bg-green-50 p-2 dark:border-green-900 dark:bg-green-950/20">
               <p className="text-xs font-medium text-green-800 dark:text-green-200">
-                {parseFloat(amount).toFixed(2)} MAD via{" "}
+                {formatCurrency(parseFloat(amount))} via{" "}
                 {paymentMethods.find((p) => p.value === method)?.label ?? method}
               </p>
             </div>

--- a/src/components/receptionist/daily-report.tsx
+++ b/src/components/receptionist/daily-report.tsx
@@ -19,6 +19,7 @@ import {
   type InvoiceView,
 } from "@/lib/data/client";
 import { exportAppointments, exportInvoices } from "@/lib/export-data";
+import { formatCurrency, getLocalDateStr } from "@/lib/utils";
 
 const statusVariant: Record<
   string,
@@ -51,7 +52,7 @@ export function DailyReport() {
         setLoading(false);
         return;
       }
-      const today = new Date().toISOString().split("T")[0];
+      const today = getLocalDateStr();
       const [appts, docs, pts, invs] = await Promise.all([
         fetchTodayAppointments(user.clinic_id),
         fetchDoctors(user.clinic_id),
@@ -257,7 +258,7 @@ export function DailyReport() {
           <Card>
             <CardContent className="pt-4 pb-4 text-center">
               <CreditCard className="h-5 w-5 mx-auto mb-1 text-orange-600" />
-              <p className="text-2xl font-bold">{totalRevenue} MAD</p>
+              <p className="text-2xl font-bold">{formatCurrency(totalRevenue)}</p>
               <p className="text-xs text-muted-foreground">Revenue</p>
             </CardContent>
           </Card>
@@ -395,7 +396,7 @@ export function DailyReport() {
           <CardContent>
             <div className="grid grid-cols-3 gap-4 text-center">
               <div>
-                <p className="text-lg font-bold text-green-600">{totalRevenue} MAD</p>
+                <p className="text-lg font-bold text-green-600">{formatCurrency(totalRevenue)}</p>
                 <p className="text-xs text-muted-foreground">Total Collected</p>
               </div>
               <div>

--- a/src/components/receptionist/end-of-day-report-button.tsx
+++ b/src/components/receptionist/end-of-day-report-button.tsx
@@ -12,7 +12,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { getCurrentUser, fetchTodayAppointments, fetchInvoices } from "@/lib/data/client";
-import { getLocalDateStr } from "@/lib/utils";
+import { formatCurrency, getLocalDateStr } from "@/lib/utils";
 
 interface EndOfDayReportButtonProps {
   trigger?: React.ReactNode;
@@ -139,7 +139,7 @@ export function EndOfDayReportButton({ trigger }: EndOfDayReportButtonProps) {
                   <CardContent className="p-3 flex items-center gap-3">
                     <CreditCard className="h-5 w-5 text-orange-600" />
                     <div>
-                      <p className="text-lg font-bold">{report.totalRevenue} MAD</p>
+                      <p className="text-lg font-bold">{formatCurrency(report.totalRevenue)}</p>
                       <p className="text-[10px] text-muted-foreground">Revenue</p>
                     </div>
                   </CardContent>
@@ -194,7 +194,7 @@ export function EndOfDayReportButton({ trigger }: EndOfDayReportButtonProps) {
                   <div className="grid grid-cols-3 gap-2 text-center">
                     <div>
                       <p className="text-base font-bold text-green-600">
-                        {report.totalRevenue} MAD
+                        {formatCurrency(report.totalRevenue)}
                       </p>
                       <p className="text-[10px] text-muted-foreground">Collected</p>
                     </div>

--- a/src/components/receptionist/manual-booking-dialog.tsx
+++ b/src/components/receptionist/manual-booking-dialog.tsx
@@ -30,6 +30,7 @@ import {
   type PatientView,
 } from "@/lib/data/client";
 import { maskPhone } from "@/lib/mask";
+import { getLocalDateStr } from "@/lib/utils";
 
 interface ManualBookingDialogProps {
   trigger?: React.ReactNode;
@@ -77,7 +78,7 @@ export function ManualBookingDialog({ trigger, onBook }: ManualBookingDialogProp
     };
   }, []);
 
-  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
+  const [date, setDate] = useState(getLocalDateStr());
   const [time, setTime] = useState("");
   const [notes, setNotes] = useState("");
   const [source, setSource] = useState<"phone" | "walk_in">("phone");
@@ -109,7 +110,7 @@ export function ManualBookingDialog({ trigger, onBook }: ManualBookingDialogProp
     setPatientId("");
     setDoctorId("");
     setServiceId("");
-    setDate(new Date().toISOString().split("T")[0]);
+    setDate(getLocalDateStr());
     setTime("");
     setNotes("");
     setSource("phone");

--- a/src/components/receptionist/payment-dialog.tsx
+++ b/src/components/receptionist/payment-dialog.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { formatCurrency } from "@/lib/utils";
 
 interface PaymentDialogProps {
   trigger?: React.ReactNode;
@@ -130,7 +131,7 @@ export function PaymentDialog({
             {amount && method && (
               <div className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-900 dark:bg-green-950/20">
                 <p className="text-sm font-medium text-green-800 dark:text-green-200">
-                  Collecting {parseFloat(amount).toFixed(2)} MAD via {method}
+                  Collecting {formatCurrency(parseFloat(amount))} via {method}
                 </p>
               </div>
             )}

--- a/src/lib/__tests__/chatbot-data.test.ts
+++ b/src/lib/__tests__/chatbot-data.test.ts
@@ -62,7 +62,7 @@ describe("buildSystemPrompt", () => {
   it("includes services and prices", () => {
     const result = buildSystemPrompt(baseContext);
     expect(result).toContain("Consultation générale");
-    expect(result).toContain("200 MAD");
+    expect(result).toContain("200,00\u00A0MAD");
     expect(result).toContain("30 min");
   });
 
@@ -164,13 +164,13 @@ describe("getBasicResponse", () => {
     const result = getBasicResponse("Quels sont vos tarifs?", baseContext);
     expect(result).toContain("services et tarifs");
     expect(result).toContain("Consultation générale");
-    expect(result).toContain("200 MAD");
+    expect(result).toContain("200,00\u00A0MAD");
   });
 
   it("responds to specific service query", () => {
     const result = getBasicResponse("Combien coûte une consultation générale?", baseContext);
     expect(result).toContain("Consultation générale");
-    expect(result).toContain("200 MAD");
+    expect(result).toContain("200,00\u00A0MAD");
     expect(result).toContain("30 min");
   });
 

--- a/src/lib/chatbot-data.ts
+++ b/src/lib/chatbot-data.ts
@@ -6,6 +6,7 @@
 
 import { sanitizeUntrustedText } from "@/lib/ai/sanitize";
 import { createClient } from "@/lib/supabase-server";
+import { formatCurrency } from "@/lib/utils";
 
 /** Shape of the `clinics.config` JSONB column (subset used by chatbot). */
 interface ClinicConfigJson {
@@ -171,7 +172,7 @@ export function buildSystemPrompt(ctx: ChatbotClinicContext): string {
     services.length > 0
       ? services
           .map((s) => {
-            const price = s.price != null ? `${s.price} MAD` : "Prix sur demande";
+            const price = s.price != null ? `${formatCurrency(s.price)}` : "Prix sur demande";
             const cat = s.category ? ` (${sanitizeUntrustedText(s.category)})` : "";
             return `- ${sanitizeUntrustedText(s.name)}${cat}: ${price} — ${s.duration_minutes} min`;
           })
@@ -303,13 +304,15 @@ export function getBasicResponse(userMessage: string, ctx: ChatbotClinicContext)
 
     if (matchedService) {
       const price =
-        matchedService.price != null ? `${matchedService.price} MAD` : "Prix sur demande";
+        matchedService.price != null
+          ? `${formatCurrency(matchedService.price)}`
+          : "Prix sur demande";
       return `${matchedService.name} chez ${clinicName} : ${price} (durée : ${matchedService.duration_minutes} min).\nVoulez-vous prendre rendez-vous ?`;
     }
 
     const list = services
       .map((s) => {
-        const price = s.price != null ? `${s.price} MAD` : "Sur demande";
+        const price = s.price != null ? `${formatCurrency(s.price)}` : "Sur demande";
         return `• ${s.name} — ${price}`;
       })
       .join("\n");

--- a/src/lib/export-data.ts
+++ b/src/lib/export-data.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { getLocalDateStr } from "@/lib/utils";
+
 /**
  * Data export utilities — CSV generation and download for clinic data.
  * Supports appointments, patients, invoices, and generic record arrays.
@@ -88,7 +90,7 @@ export function exportAppointments(
   appointments: ExportableAppointment[],
   filenamePrefix = "appointments",
 ) {
-  const date = new Date().toISOString().split("T")[0];
+  const date = getLocalDateStr();
   exportToCSV(appointments, appointmentColumns, `${filenamePrefix}-${date}.csv`);
 }
 
@@ -118,7 +120,7 @@ const patientColumns: { key: keyof ExportablePatient; label: string }[] = [
 ];
 
 export function exportPatients(patients: ExportablePatient[], filenamePrefix = "patients") {
-  const date = new Date().toISOString().split("T")[0];
+  const date = getLocalDateStr();
   exportToCSV(patients, patientColumns, `${filenamePrefix}-${date}.csv`);
 }
 
@@ -144,6 +146,6 @@ const invoiceColumns: { key: keyof ExportableInvoice; label: string }[] = [
 ];
 
 export function exportInvoices(invoices: ExportableInvoice[], filenamePrefix = "invoices") {
-  const date = new Date().toISOString().split("T")[0];
+  const date = getLocalDateStr();
   exportToCSV(invoices, invoiceColumns, `${filenamePrefix}-${date}.csv`);
 }

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -10,6 +10,7 @@ import { assertClinicId } from "@/lib/assert-tenant";
 import { logger } from "@/lib/logger";
 import { createTenantClient } from "@/lib/supabase-server";
 import { logTenantContext } from "@/lib/tenant-context";
+import { getLocalDateStr } from "@/lib/utils";
 
 // ---- Types ----
 
@@ -434,7 +435,7 @@ async function chargeViaStripe(
   // HIGH-02: Add idempotency key to prevent duplicate charges on retry.
   // The key is scoped to the customer + current date to ensure that a
   // failed cron retry on the same day does not create a second charge.
-  const idempotencyKey = `renewal-${customerId}-${new Date().toISOString().split("T")[0]}`;
+  const idempotencyKey = `renewal-${customerId}-${getLocalDateStr()}`;
 
   const response = await fetch("https://api.stripe.com/v1/payment_intents", {
     method: "POST",

--- a/src/lib/validations/primitives.ts
+++ b/src/lib/validations/primitives.ts
@@ -42,6 +42,16 @@ export const phoneNumber = z
   .max(30, "Phone number too long")
   .regex(/^\+?[0-9 ()\-]{8,30}$/, "Invalid phone number format");
 
+/**
+ * Validate Moroccan phone numbers.
+ * Accepted formats: +212 6XXXXXXXX, +212 7XXXXXXXX, 06XXXXXXXX, 07XXXXXXXX
+ * (with or without spaces/dashes).
+ */
+export function isValidMoroccanPhone(phone: string): boolean {
+  const digits = phone.replace(/[\s\-().]/g, "");
+  return /^(?:\+212|0)[67]\d{8}$/.test(digits);
+}
+
 /** Free-form user-supplied text (notes, content, descriptions). */
 export const safeText = z.string().transform(normalizeText);
 


### PR DESCRIPTION
## Summary

Fix 4 code quality / DRY violations across the codebase:

1. **Date formatting** — Replace all 51 instances of `new Date().toISOString().split('T')[0]` with timezone-aware `getLocalDateStr()` from `@/lib/utils` (uses `Africa/Casablanca`).
2. **Currency display** — Replace 61 hardcoded `MAD` display patterns with `formatCurrency()` utility across 34 files.
3. **Phone validation** — Extract `isValidMoroccanPhone()` to `@/lib/validations/primitives.ts` and import from shared module in `booking-form.tsx`.
4. **Raw NextResponse cleanup** — Replace `NextResponse.json()` / `new NextResponse(...)` with `apiSuccess()` / `apiError()` / `apiRateLimited()` in cron routes and csp-report endpoint (6 conversions).

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

Updated 3 chatbot-data test assertions to expect `Intl.NumberFormat` output (non-breaking space U+00A0 between number and currency code).

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] New API endpoints have rate limiting