### PR TITLE
fix: convert remaining English UI strings to French across 3 features

### DIFF
--- a/src/app/(doctor)/doctor/patients/[id]/timeline/page.tsx
+++ b/src/app/(doctor)/doctor/patients/[id]/timeline/page.tsx
@@ -54,7 +54,7 @@ export default function PatientTimelinePage() {
       setEvents(data.events);
       setPagination(data.pagination);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load timeline");
+      setError(err instanceof Error ? err.message : "Échec du chargement de l'historique");
     } finally {
       setLoading(false);
     }
@@ -80,9 +80,9 @@ export default function PatientTimelinePage() {
         <div className="space-y-1">
           <Breadcrumb
             items={[
-              { label: "Doctor", href: "/doctor" },
+              { label: "Médecin", href: "/doctor" },
               { label: "Patients", href: "/doctor/patients" },
-              { label: "Timeline" },
+              { label: "Historique" },
             ]}
           />
           <div className="flex items-center gap-2">
@@ -91,7 +91,7 @@ export default function PatientTimelinePage() {
                 <ArrowLeft className="h-4 w-4" />
               </Button>
             </Link>
-            <h1 className="text-2xl font-bold tracking-tight">Patient Timeline</h1>
+            <h1 className="text-2xl font-bold tracking-tight">Historique du patient</h1>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -102,7 +102,7 @@ export default function PatientTimelinePage() {
             className="print:hidden"
           >
             <Printer className="h-4 w-4" />
-            Print Dossier
+            Imprimer le dossier
           </Button>
         </div>
       </div>
@@ -132,7 +132,7 @@ export default function PatientTimelinePage() {
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
           {error}
           <Button variant="outline" size="sm" className="ml-3" onClick={loadTimeline}>
-            Retry
+            Réessayer
           </Button>
         </div>
       )}
@@ -140,11 +140,11 @@ export default function PatientTimelinePage() {
       {!loading && !error && events.length === 0 && (
         <EmptyState
           icon={Clock}
-          title="No events found"
+          title="Aucun événement trouvé"
           description={
             activeFilter || searchQuery || dateFrom || dateTo
-              ? "Try adjusting your filters or search query"
-              : "This patient has no recorded interactions yet"
+              ? "Essayez d'ajuster vos filtres ou votre recherche"
+              : "Ce patient n'a encore aucune interaction enregistrée"
           }
           action={
             (activeFilter || searchQuery || dateFrom || dateTo) && (
@@ -158,7 +158,7 @@ export default function PatientTimelinePage() {
                   setDateTo("");
                 }}
               >
-                Clear all filters
+                Effacer tous les filtres
               </Button>
             )
           }
@@ -169,10 +169,10 @@ export default function PatientTimelinePage() {
         <>
           {/* Stats */}
           <div className="flex items-center gap-2 text-sm text-muted-foreground print:hidden">
-            <Badge variant="secondary">{pagination?.total ?? events.length} events</Badge>
+            <Badge variant="secondary">{pagination?.total ?? events.length} événements</Badge>
             {pagination && pagination.totalPages > 1 && (
               <span>
-                Page {pagination.page} of {pagination.totalPages}
+                Page {pagination.page} sur {pagination.totalPages}
               </span>
             )}
           </div>
@@ -202,7 +202,7 @@ export default function PatientTimelinePage() {
                 disabled={page <= 1}
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
               >
-                Previous
+                Précédent
               </Button>
               <span className="text-sm text-muted-foreground">
                 {page} / {pagination.totalPages}
@@ -213,7 +213,7 @@ export default function PatientTimelinePage() {
                 disabled={page >= pagination.totalPages}
                 onClick={() => setPage((p) => p + 1)}
               >
-                Next
+                Suivant
               </Button>
             </div>
           )}
@@ -248,8 +248,8 @@ function formatGroupDate(dateStr: string): string {
   const yesterday = new Date(today);
   yesterday.setDate(yesterday.getDate() - 1);
 
-  if (dateStr === today.toISOString().split("T")[0]) return "Today";
-  if (dateStr === yesterday.toISOString().split("T")[0]) return "Yesterday";
+  if (dateStr === today.toISOString().split("T")[0]) return "Aujourd'hui";
+  if (dateStr === yesterday.toISOString().split("T")[0]) return "Hier";
 
   return date.toLocaleDateString("fr-FR", {
     weekday: "long",

--- a/src/app/api/ai/team/alerts/route.ts
+++ b/src/app/api/ai/team/alerts/route.ts
@@ -20,7 +20,7 @@ export const PATCH = withAuthValidation(
     const clinicId = profile.clinic_id;
 
     if (!clinicId) {
-      return apiError("No clinic associated with this account", 403, "NO_CLINIC");
+      return apiError("Aucune clinique associée à ce compte", 403, "NO_CLINIC");
     }
 
     const { alertId } = data;
@@ -36,7 +36,7 @@ export const PATCH = withAuthValidation(
         .single();
 
       if (error || !updated) {
-        return apiError("Alert not found", 404, "NOT_FOUND");
+        return apiError("Alerte introuvable", 404, "NOT_FOUND");
       }
 
       return apiSuccess({ alert: updated as { id: string; is_read: boolean } });

--- a/src/app/api/ai/team/chat/route.ts
+++ b/src/app/api/ai/team/chat/route.ts
@@ -127,7 +127,7 @@ export const POST = withAuthValidation(
     const userId = profile.id;
 
     if (!clinicId) {
-      return apiError("No clinic associated with this account", 403, "NO_CLINIC");
+      return apiError("Aucune clinique associée à ce compte", 403, "NO_CLINIC");
     }
 
     const allowed = await aiManagerLimiter.check(`ai-team:${userId}`);

--- a/src/app/api/ai/team/dashboard/route.ts
+++ b/src/app/api/ai/team/dashboard/route.ts
@@ -22,7 +22,7 @@ async function handler(_request: NextRequest, auth: AuthContext) {
   const clinicId = profile.clinic_id;
 
   if (!clinicId) {
-    return apiError("No clinic associated with this account", 403, "NO_CLINIC");
+    return apiError("Aucune clinique associée à ce compte", 403, "NO_CLINIC");
   }
 
   try {

--- a/src/app/api/ai/team/generate/route.ts
+++ b/src/app/api/ai/team/generate/route.ts
@@ -138,7 +138,7 @@ export const POST = withAuthValidation(
     const userId = profile.id;
 
     if (!clinicId) {
-      return apiError("No clinic associated with this account", 403, "NO_CLINIC");
+      return apiError("Aucune clinique associée à ce compte", 403, "NO_CLINIC");
     }
 
     const allowed = await aiManagerLimiter.check(`ai-team-gen:${userId}`);
@@ -282,7 +282,7 @@ export const POST = withAuthValidation(
         type: "admin",
         clinicId,
         actor: userId,
-        description: `AI Team ${agentType} generated ${savedTasks.length} tasks and ${savedAlerts.length} alerts`,
+        description: `Équipe IA ${agentType} : ${savedTasks.length} tâche(s) et ${savedAlerts.length} alerte(s) générée(s)`,
         metadata: {
           agentType,
           tasksCount: String(savedTasks.length),

--- a/src/app/api/ai/team/tasks/route.ts
+++ b/src/app/api/ai/team/tasks/route.ts
@@ -22,7 +22,7 @@ export const PATCH = withAuthValidation(
     const userId = profile.id;
 
     if (!clinicId) {
-      return apiError("No clinic associated with this account", 403, "NO_CLINIC");
+      return apiError("Aucune clinique associée à ce compte", 403, "NO_CLINIC");
     }
 
     const { taskId, status } = data;
@@ -53,7 +53,7 @@ export const PATCH = withAuthValidation(
           clinicId,
           taskId,
         });
-        return apiError("Task not found", 404, "NOT_FOUND");
+        return apiError("Tâche introuvable", 404, "NOT_FOUND");
       }
 
       const task = updated as { id: string; status: string; agent_type: string };

--- a/src/app/api/cron/daily-briefing/route.ts
+++ b/src/app/api/cron/daily-briefing/route.ts
@@ -218,14 +218,14 @@ async function handler(request: NextRequest) {
       .in("status", ["active"]);
 
     if (!clinics || clinics.length === 0) {
-      return apiSuccess({ message: "No active clinics", sent: 0 });
+      return apiSuccess({ message: "Aucune clinique active", sent: 0 });
     }
 
     let totalSent = 0;
 
     for (const clinic of clinics) {
       const clinicId = clinic.id as string;
-      const clinicName = (clinic.name as string) || "Clinic";
+      const clinicName = (clinic.name as string) || "Clinique";
 
       try {
         const { data: configData } = await supabase
@@ -327,7 +327,7 @@ async function handler(request: NextRequest) {
           type: "admin",
           clinicId,
           clinicName,
-          description: `Daily briefing sent to ${recipients.length} recipients`,
+          description: `Rapport quotidien envoyé à ${recipients.length} destinataire(s)`,
           metadata: {
             totalAppointments: summary.totalAppointments,
             cancellations: summary.cancellations,
@@ -345,13 +345,13 @@ async function handler(request: NextRequest) {
       }
     }
 
-    return apiSuccess({ message: "Daily briefings sent", sent: totalSent });
+    return apiSuccess({ message: "Rapports quotidiens envoyés", sent: totalSent });
   } catch (err) {
     logger.error("Daily briefing cron failed", {
       context: "cron/daily-briefing",
       error: err,
     });
-    return apiInternalError("Failed to send daily briefings");
+    return apiInternalError("Échec de l'envoi des rapports quotidiens");
   }
 }
 

--- a/src/app/api/patient/timeline/route.ts
+++ b/src/app/api/patient/timeline/route.ts
@@ -53,7 +53,7 @@ async function handleGet(request: NextRequest, auth: AuthContext) {
     if (!parsed.success) {
       const count = parsed.error.issues.length;
       return apiError(
-        `Validation error: ${count} field${count !== 1 ? "s" : ""} invalid`,
+        `Erreur de validation : ${count} champ${count !== 1 ? "s" : ""} invalide${count !== 1 ? "s" : ""}`,
         422,
         "VALIDATION_ERROR",
       );
@@ -69,7 +69,7 @@ async function handleGet(request: NextRequest, auth: AuthContext) {
       .single();
 
     if (!patientCheck.data) {
-      return apiError("Patient not found in this clinic", 404, "PATIENT_NOT_FOUND");
+      return apiError("Patient introuvable dans cette clinique", 404, "PATIENT_NOT_FOUND");
     }
 
     const offset = (page - 1) * limit;

--- a/src/components/patient/timeline/timeline-event-card.tsx
+++ b/src/components/patient/timeline/timeline-event-card.tsx
@@ -24,31 +24,31 @@ const EVENT_CONFIG: Record<
 > = {
   visit: {
     icon: Calendar,
-    label: "Visit",
+    label: "Consultation",
     color: "text-blue-600 dark:text-blue-400",
     dotColor: "bg-blue-500",
   },
   prescription: {
     icon: Pill,
-    label: "Prescription",
+    label: "Ordonnance",
     color: "text-purple-600 dark:text-purple-400",
     dotColor: "bg-purple-500",
   },
   lab_result: {
     icon: FlaskConical,
-    label: "Lab Result",
+    label: "Résultat labo",
     color: "text-green-600 dark:text-green-400",
     dotColor: "bg-green-500",
   },
   imaging: {
     icon: ScanLine,
-    label: "Imaging",
+    label: "Imagerie",
     color: "text-orange-600 dark:text-orange-400",
     dotColor: "bg-orange-500",
   },
   payment: {
     icon: CreditCard,
-    label: "Payment",
+    label: "Paiement",
     color: "text-emerald-600 dark:text-emerald-400",
     dotColor: "bg-emerald-500",
   },
@@ -147,7 +147,7 @@ export function TimelineEventCard({ event, className }: TimelineEventCardProps) 
             <button
               onClick={() => setExpanded(!expanded)}
               className="shrink-0 p-1 rounded-md hover:bg-muted transition-colors"
-              aria-label={expanded ? "Collapse" : "Expand"}
+              aria-label={expanded ? "Réduire" : "Développer"}
             >
               {expanded ? (
                 <ChevronUp className="h-4 w-4 text-muted-foreground" />
@@ -173,25 +173,25 @@ function renderSummary(event: TimelineEvent) {
       return (
         <p className="text-sm text-foreground mt-1 truncate">
           {meta.source === "walk_in"
-            ? "Walk-in"
+            ? "Sans rendez-vous"
             : meta.source === "whatsapp"
-              ? "WhatsApp booking"
-              : "Appointment"}
-          {meta.is_first_visit ? " (First visit)" : ""}
+              ? "Réservation WhatsApp"
+              : "Rendez-vous"}
+          {meta.is_first_visit ? " (Première visite)" : ""}
         </p>
       );
     case "prescription":
       return (
         <p className="text-sm text-foreground mt-1 truncate">
           {Array.isArray(meta.items)
-            ? `${(meta.items as unknown[]).length} medication(s)`
-            : "Prescription issued"}
+            ? `${(meta.items as unknown[]).length} médicament(s)`
+            : "Ordonnance émise"}
         </p>
       );
     case "lab_result":
       return (
         <p className="text-sm text-foreground mt-1 truncate">
-          {(meta.title as string) ?? "Lab result"}
+          {(meta.title as string) ?? "Résultat d'analyse"}
         </p>
       );
     case "imaging":
@@ -203,7 +203,7 @@ function renderSummary(event: TimelineEvent) {
     case "payment":
       return (
         <p className="text-sm text-foreground mt-1 truncate">
-          {meta.amount ? `${meta.amount} MAD` : ""} via {(meta.method as string) ?? "N/A"}
+          {meta.amount ? `${meta.amount} MAD` : ""} par {(meta.method as string) ?? "N/A"}
         </p>
       );
     case "note":
@@ -211,13 +211,13 @@ function renderSummary(event: TimelineEvent) {
         <p className="text-sm text-foreground mt-1 truncate">
           {(meta.diagnosis as string) ??
             (meta.notes as string)?.slice(0, 80) ??
-            "Consultation note"}
+            "Note de consultation"}
         </p>
       );
     case "communication":
       return (
         <p className="text-sm text-foreground mt-1 truncate">
-          {(meta.trigger as string) ?? "WhatsApp message"} — {(meta.recipient_name as string) ?? ""}
+          {(meta.trigger as string) ?? "Message WhatsApp"} — {(meta.recipient_name as string) ?? ""}
         </p>
       );
     default:

--- a/src/components/patient/timeline/timeline-filters.tsx
+++ b/src/components/patient/timeline/timeline-filters.tsx
@@ -18,11 +18,11 @@ import { cn } from "@/lib/utils";
 import { TIMELINE_EVENT_TYPES, type TimelineEventType } from "@/lib/validations/patient-timeline";
 
 const EVENT_FILTER_CONFIG: Record<TimelineEventType, { icon: typeof Calendar; label: string }> = {
-  visit: { icon: Calendar, label: "Visits" },
-  prescription: { icon: Pill, label: "Prescriptions" },
-  lab_result: { icon: FlaskConical, label: "Lab Results" },
-  imaging: { icon: ScanLine, label: "Imaging" },
-  payment: { icon: CreditCard, label: "Payments" },
+  visit: { icon: Calendar, label: "Consultations" },
+  prescription: { icon: Pill, label: "Ordonnances" },
+  lab_result: { icon: FlaskConical, label: "Résultats labo" },
+  imaging: { icon: ScanLine, label: "Imagerie" },
+  payment: { icon: CreditCard, label: "Paiements" },
   note: { icon: FileText, label: "Notes" },
   communication: { icon: MessageSquare, label: "WhatsApp" },
 };
@@ -60,7 +60,7 @@ export function TimelineFilters({
               : "bg-transparent text-muted-foreground border-input hover:bg-muted",
           )}
         >
-          All
+          Tout
         </button>
         {TIMELINE_EVENT_TYPES.map((type) => {
           const config = EVENT_FILTER_CONFIG[type];
@@ -87,7 +87,7 @@ export function TimelineFilters({
       {/* Date range filters */}
       <div className="flex items-center gap-2 flex-wrap">
         <label className="text-xs text-muted-foreground" htmlFor="timeline-from">
-          From:
+          Du :
         </label>
         <input
           id="timeline-from"
@@ -97,7 +97,7 @@ export function TimelineFilters({
           className="h-8 rounded-md border border-input bg-transparent px-2 text-xs"
         />
         <label className="text-xs text-muted-foreground" htmlFor="timeline-to">
-          To:
+          Au :
         </label>
         <input
           id="timeline-to"
@@ -117,7 +117,7 @@ export function TimelineFilters({
             className="h-8 px-2"
           >
             <X className="h-3 w-3" />
-            Clear dates
+            Effacer les dates
           </Button>
         )}
       </div>
@@ -126,11 +126,11 @@ export function TimelineFilters({
       {activeFilter && (
         <div className="flex items-center gap-2">
           <Badge variant="secondary" className="gap-1">
-            Showing: {EVENT_FILTER_CONFIG[activeFilter].label}
+            Filtre : {EVENT_FILTER_CONFIG[activeFilter].label}
             <button
               onClick={() => onFilterChange(undefined)}
               className="ml-1 hover:text-destructive"
-              aria-label="Clear filter"
+              aria-label="Effacer le filtre"
             >
               <X className="h-3 w-3" />
             </button>

--- a/src/components/patient/timeline/timeline-search.tsx
+++ b/src/components/patient/timeline/timeline-search.tsx
@@ -20,7 +20,7 @@ export function TimelineSearch({ value, onChange, className }: TimelineSearchPro
       <Input
         ref={inputRef}
         type="text"
-        placeholder="Search timeline..."
+        placeholder="Rechercher dans l'historique..."
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="pl-9 pr-8 h-9"
@@ -32,7 +32,7 @@ export function TimelineSearch({ value, onChange, className }: TimelineSearchPro
             inputRef.current?.focus();
           }}
           className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded-sm hover:bg-muted"
-          aria-label="Clear search"
+          aria-label="Effacer la recherche"
         >
           <X className="h-3 w-3 text-muted-foreground" />
         </button>


### PR DESCRIPTION
## Summary

Converts all remaining English user-facing strings to French across three recently merged features (Patient Timeline, WhatsApp Briefing, AI Team Dashboard). Oltigo Health is a French-first application for Moroccan clinics.

### Patient Timeline (PR #785)
- Breadcrumbs, page title, button labels, empty states, filter labels
- Date labels, event card labels, event summaries, search placeholder
- API error messages translated

### WhatsApp Briefing (PR #786)
- API response messages, fallback clinic name, audit log descriptions

### AI Team Dashboard (PR #789)
- API error messages across all 5 routes
- Task/alert not found errors, audit log descriptions

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed
- [x] E2E tests pass locally

## Observability
- [x] N/A — no observability changes

## Checklist
- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes (max-warnings 4119)
- [x] `npm run typecheck` passes
- [x] All 1145 tests pass (111 test files)