### PR TITLE
fix(migrations): restore stub files for 00003 and 00025 to match remote Supabase DB

### DIFF
--- a/supabase/migrations/00003_seed_data.sql
+++ b/supabase/migrations/00003_seed_data.sql
@@ -1,0 +1,8 @@
+-- Stub migration: retained for Supabase version-history compatibility.
+--
+-- The original seed-data migration was removed in commit 4b23d082
+-- (audit AUD-005, 2026-05-28) because seed data was consolidated into
+-- migration 00040_repopulate_test_clinic_data.sql.
+--
+-- The remote Supabase project still records this version as applied,
+-- so this placeholder keeps local and remote migration lists in sync.

--- a/supabase/migrations/00025_seed_features_pricing.sql
+++ b/supabase/migrations/00025_seed_features_pricing.sql
@@ -1,0 +1,8 @@
+-- Stub migration: retained for Supabase version-history compatibility.
+--
+-- The original seed-features-pricing migration was removed in commit
+-- 4b23d082 (audit AUD-005, 2026-05-28) because its data was folded
+-- into later migrations.
+--
+-- The remote Supabase project still records this version as applied,
+-- so this placeholder keeps local and remote migration lists in sync.

--- a/supabase/migrations/CHANGELOG.md
+++ b/supabase/migrations/CHANGELOG.md
@@ -6,11 +6,11 @@ The following migration numbers are absent from the sequence. Each was
 reserved during development but never committed. They are documented here
 so future auditors do not flag them as missing or out-of-order.
 
-| Number | Status                       |
-| ------ | ---------------------------- |
-| 00003  | Reserved — never used        |
-| 00025  | Reserved — never used        |
-| 00044  | Reserved — never used        |
-| 00078  | Reserved — never used        |
+| Number | Status                                          |
+| ------ | ----------------------------------------------- |
+| 00003  | Stub restored — remote DB has this version      |
+| 00025  | Stub restored — remote DB has this version      |
+| 00044  | Reserved — never used                           |
+| 00078  | Reserved — never used                           |
 
 Going forward: keep sequential numbering. Do not renumber existing migrations.


### PR DESCRIPTION
## Summary

The Supabase Preview CI check has been failing with **"Remote migration versions not found in local migrations directory."**

Using `supabase migration list` against the linked production project, I confirmed exactly two remote versions are missing locally:

| Version | Original file | Deleted in |
|---------|--------------|------------|
| `00003` | `00003_seed_data.sql` | `4b23d082` (audit AUD-005) |
| `00025` | `00025_seed_features_pricing.sql` | `4b23d082` (audit AUD-005) |

These seed-data migrations were removed during the May 2026 security audit because the data was consolidated into `00040_repopulate_test_clinic_data.sql`. However, the remote Supabase production database still records them as applied, causing the version mismatch.

**Fix:** Add empty stub SQL files (comment-only) so the local migration list matches the remote. Updated `CHANGELOG.md` to reflect the restored stubs.

**Verification:**
- `npm run lint` → 4115 warnings (under 4119 limit)
- `npm run typecheck` → clean
- `npm run test` → 1145 passed, 38 skipped

## Type of change

- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact

- [x] This PR changes RLS policies or database migrations
- [x] No security impact

The stub files contain only SQL comments — no schema changes, no data, no RLS modifications.

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] N/A — stubs are empty (comment-only); they will not execute any SQL

## Testing

- [x] Manual testing performed
- [x] E2E tests pass locally

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes