### PR TITLE
chore: trigger redeploy with rotated Supabase publishable key

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,7 @@
 # secrets) remain in CI secrets / Cloudflare dashboard.
 #
 # Docs: https://developers.cloudflare.com/workers/wrangler/configuration/
+# Last key rotation: 2026-05-29
 # =============================================================================
 
 name = "webs-alots"


### PR DESCRIPTION
Triggers a redeploy to pick up the new sb_publishable_ Supabase API key after key rotation. The old JWT keys are disabled — Next.js inlines NEXT_PUBLIC_* at build time so a rebuild is required.