### PR TITLE
security: fix PostgREST filter injection and cursor validation

### DIFF
--- a/src/app/api/__tests__/v1-appointments-input-validation.test.ts
+++ b/src/app/api/__tests__/v1-appointments-input-validation.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Route handler + unit tests for GET /api/v1/appointments input validation.
+ *
+ * Covers:
+ *   INJ-02 — Cursor field injection via crafted Base64 payloads
+ *   IV-02  — Date query param format validation
+ *
+ * Cursor fields (`appointment_date`, `start_time`, `id`) are decoded from
+ * Base64 and interpolated into a PostgREST `.or()` filter. Without strict
+ * format validation an attacker could smuggle additional filter clauses.
+ *
+ * The `date` query param is passed to `.eq("appointment_date", date)` and
+ * must conform to `YYYY-MM-DD` to prevent format-based injection.
+ */
+import { NextRequest } from "next/server";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GET } from "@/app/api/v1/appointments/route";
+import { decodeCursor, encodeCursor } from "@/lib/pagination";
+
+// ── Mock setup ───────────────────────────────────────────────────────
+
+const result: { data: unknown[]; error: unknown } = { data: [], error: null };
+
+const query: Record<string, unknown> = {};
+for (const m of ["select", "eq", "order", "limit", "or"]) {
+  query[m] = vi.fn(() => query);
+}
+(query as { then: unknown }).then = (resolve: (v: typeof result) => void) => resolve(result);
+
+const mockSupabase = { from: vi.fn(() => query) };
+
+const authenticateApiKey = vi.fn();
+vi.mock("@/lib/api-auth", () => ({
+  authenticateApiKey: () => authenticateApiKey(),
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createTenantClient: vi.fn(async () => mockSupabase),
+}));
+
+vi.mock("@/lib/tenant-context", () => ({
+  logTenantContext: vi.fn(),
+}));
+
+vi.mock("@/lib/cors", () => ({
+  getCorsHeaders: vi.fn(() => ({})),
+  handlePreflight: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const CLINIC = "11111111-1111-1111-1111-111111111111";
+const VALID_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+function req(params?: Record<string, string>): NextRequest {
+  const url = new URL("http://api.localhost:3000/api/v1/appointments");
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return new NextRequest(url, {
+    headers: { authorization: "Bearer test-key" },
+  });
+}
+
+function makeCursor(fields: Record<string, string>): string {
+  return Buffer.from(JSON.stringify(fields), "utf8")
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+// ── Unit tests: decodeCursor (INJ-02) ────────────────────────────────
+
+describe("decodeCursor — format validation (INJ-02)", () => {
+  it("accepts a well-formed cursor", () => {
+    const encoded = encodeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30",
+      id: VALID_UUID,
+    });
+    const decoded = decodeCursor(encoded);
+    expect(decoded).toEqual({
+      appointment_date: "2025-06-15",
+      start_time: "09:30",
+      id: VALID_UUID,
+    });
+  });
+
+  it("accepts start_time with seconds", () => {
+    const encoded = encodeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30:00",
+      id: VALID_UUID,
+    });
+    expect(decodeCursor(encoded)).not.toBeNull();
+  });
+
+  it("rejects appointment_date containing PostgREST injection", () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15,role.eq.admin",
+      start_time: "09:30",
+      id: VALID_UUID,
+    });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it("rejects start_time containing filter operators", () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30,status.eq.cancelled",
+      id: VALID_UUID,
+    });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it("rejects id that is not a valid UUID", () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30",
+      id: "not-a-uuid,clinic_id.eq.other",
+    });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it("rejects appointment_date with extra characters", () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15T00:00:00",
+      start_time: "09:30",
+      id: VALID_UUID,
+    });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it("rejects start_time with non-digit characters", () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30:00.000",
+      id: VALID_UUID,
+    });
+    expect(decodeCursor(cursor)).toBeNull();
+  });
+
+  it("returns null for garbage base64", () => {
+    expect(decodeCursor("!!!not-valid!!!")).toBeNull();
+  });
+});
+
+// ── Route handler tests: date validation (IV-02) ─────────────────────
+
+describe("GET /api/v1/appointments — date validation (IV-02)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateApiKey.mockResolvedValue({ clinicId: CLINIC });
+  });
+
+  it("rejects unauthenticated requests (401)", async () => {
+    authenticateApiKey.mockResolvedValue(null);
+    const res = await GET(req({ date: "2025-06-15" }));
+    expect(res.status).toBe(401);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid YYYY-MM-DD date", async () => {
+    const res = await GET(req({ date: "2025-06-15" }));
+    expect(res.status).toBe(200);
+    const eq = query.eq as ReturnType<typeof vi.fn>;
+    expect(eq.mock.calls).toContainEqual(["appointment_date", "2025-06-15"]);
+  });
+
+  it("rejects a date with time appended (ISO datetime)", async () => {
+    const res = await GET(req({ date: "2025-06-15T00:00:00" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("rejects a date with PostgREST injection payload", async () => {
+    const res = await GET(req({ date: "2025-06-15,role.eq.admin" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a date with SQL injection payload", async () => {
+    const res = await GET(req({ date: "'; DROP TABLE appointments;--" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty date string", async () => {
+    // Empty string does not match YYYY-MM-DD
+    const res = await GET(req({ date: "" }));
+    // Empty string is falsy — the `if (date)` guard skips validation & filtering
+    expect(res.status).toBe(200);
+  });
+
+  it("succeeds when no date param is supplied", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── Route handler tests: cursor validation (INJ-02) ──────────────────
+
+describe("GET /api/v1/appointments — cursor validation (INJ-02)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateApiKey.mockResolvedValue({ clinicId: CLINIC });
+  });
+
+  it("accepts a valid cursor and applies the .or() filter", async () => {
+    const cursor = encodeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30",
+      id: VALID_UUID,
+    });
+    const res = await GET(req({ cursor }));
+    expect(res.status).toBe(200);
+    expect(query.or).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an injection-laden cursor with 400", async () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15,clinic_id.eq.other",
+      start_time: "09:30",
+      id: VALID_UUID,
+    });
+    const res = await GET(req({ cursor }));
+    expect(res.status).toBe(400);
+    expect(query.or).not.toHaveBeenCalled();
+  });
+
+  it("rejects a cursor with a non-UUID id", async () => {
+    const cursor = makeCursor({
+      appointment_date: "2025-06-15",
+      start_time: "09:30",
+      id: "DROP TABLE appointments",
+    });
+    const res = await GET(req({ cursor }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/__tests__/v1-patients-search-sanitization.test.ts
+++ b/src/app/api/__tests__/v1-patients-search-sanitization.test.ts
@@ -1,12 +1,12 @@
 /**
  * Route handler tests for GET /api/v1/patients.
  *
- * Focus: the PostgREST filter-injection defense (audit MED-05 / A46.3).
+ * Focus: the PostgREST filter-injection defense (INJ-01 / MED-05 / A46.3).
  * The `search` query param is interpolated into a PostgREST `.or()` filter
- * string, so it MUST be sanitized — stripping `% _ , . ( ) |` — to stop a
- * caller from smuggling extra filter clauses (e.g. `role.eq.super_admin`)
- * or OR tokens. These tests invoke the real handler and assert the exact
- * filter string handed to Supabase, plus the auth gate and tenant scoping.
+ * string, so it MUST be sanitized — using an allowlist of safe characters
+ * `[a-zA-Z0-9\s\-'@.]` — to block all PostgREST metacharacters (colons,
+ * bangs, commas, parens, pipes, percent, underscore) that could smuggle
+ * extra filter clauses (e.g. `role.eq.super_admin`) or wildcard patterns.
  */
 import { NextRequest } from "next/server";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -92,24 +92,54 @@ describe("GET /api/v1/patients — search sanitization (MED-05/A46.3)", () => {
 
   it("strips PostgREST metacharacters from the search term", async () => {
     await GET(req("a%_,.()|b"));
-    // Only the sanitized term "ab" should appear inside the ilike patterns.
-    expect(orArg()).toBe("name.ilike.%ab%,name_ar.ilike.%ab%,email.ilike.%ab%,phone.ilike.%ab%");
+    // Allowlist keeps a, ., b — percent, underscore, comma, parens, pipe are stripped.
+    expect(orArg()).toBe(
+      "name.ilike.%a.b%,name_ar.ilike.%a.b%,email.ilike.%a.b%,phone.ilike.%a.b%",
+    );
   });
 
   it("neutralizes an injected filter clause (role.eq.super_admin)", async () => {
     await GET(req("x,role.eq.super_admin"));
     const arg = orArg();
-    // The dots/commas that would terminate the value and start a new clause
-    // are gone, so no extra filter can be smuggled in.
-    expect(arg).not.toContain("role.eq.super_admin");
-    expect(arg).not.toContain(".eq.");
+    // Comma and underscore are stripped; the remaining text is a harmless
+    // literal inside the ilike value — no extra filter clause is created.
     expect(arg).toBe(
-      "name.ilike.%xroleeqsuperadmin%,name_ar.ilike.%xroleeqsuperadmin%,email.ilike.%xroleeqsuperadmin%,phone.ilike.%xroleeqsuperadmin%",
+      "name.ilike.%xrole.eq.superadmin%,name_ar.ilike.%xrole.eq.superadmin%,email.ilike.%xrole.eq.superadmin%,phone.ilike.%xrole.eq.superadmin%",
+    );
+  });
+
+  it("blocks colon-based PostgREST modifier injection", async () => {
+    await GET(req("test:is.null"));
+    const arg = orArg();
+    // Colon is not in the allowlist and is stripped, preventing modifier injection.
+    expect(arg).not.toContain(":");
+    expect(arg).toBe(
+      "name.ilike.%testis.null%,name_ar.ilike.%testis.null%,email.ilike.%testis.null%,phone.ilike.%testis.null%",
+    );
+  });
+
+  it("blocks bang-based PostgREST negation injection", async () => {
+    await GET(req("!name.is.null"));
+    const arg = orArg();
+    // Bang is not in the allowlist and is stripped.
+    expect(arg).not.toContain("!");
+    expect(arg).toBe(
+      "name.ilike.%name.is.null%,name_ar.ilike.%name.is.null%,email.ilike.%name.is.null%,phone.ilike.%name.is.null%",
+    );
+  });
+
+  it("blocks in.() operator injection", async () => {
+    await GET(req('role.in.("admin","super_admin")'));
+    const arg = orArg();
+    // Parens, commas, double-quotes, underscores are all outside the allowlist.
+    expect(arg).not.toContain("in.(");
+    expect(arg).toBe(
+      "name.ilike.%role.in.adminsuperadmin%,name_ar.ilike.%role.in.adminsuperadmin%,email.ilike.%role.in.adminsuperadmin%,phone.ilike.%role.in.adminsuperadmin%",
     );
   });
 
   it("does not build an .or() filter when the term sanitizes to empty", async () => {
-    await GET(req("%_,.()|"));
+    await GET(req("%_,()|:"));
     expect(query.or).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -76,7 +76,11 @@ export async function GET(request: NextRequest) {
     .order("id", { ascending: false })
     .limit(limit + 1);
 
+  // IV-02: Validate date format before passing to PostgREST `.eq()`.
   if (date) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return apiError("Invalid date format", 400, "INVALID_DATE", cors);
+    }
     query = query.eq("appointment_date", date);
   }
   if (status) {

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -55,11 +55,12 @@ export async function GET(request: NextRequest) {
     .range(offset, offset + limit - 1);
 
   if (search) {
-    // MED-05 + A46.3: Sanitize search input to prevent PostgREST filter injection.
-    // Strip %, _, comma, parens, dots (PostgREST filter separator) AND pipes
-    // (PostgREST OR operator token). Without stripping |, an attacker could
-    // inject additional filter clauses like `role.eq.super_admin`.
-    const sanitized = search.replace(/[%_,.()|]/g, "");
+    // INJ-01: Allowlist-based sanitization to prevent PostgREST filter injection.
+    // Only permit alphanumerics, whitespace, hyphens, apostrophes, at-signs,
+    // and dots. This blocks all PostgREST metacharacters — colons, bangs,
+    // commas, parens, pipes, percent, underscore — that could smuggle extra
+    // filter clauses (e.g. `role.eq.super_admin`) or wildcard patterns.
+    const sanitized = search.replace(/[^a-zA-Z0-9\s\-'@.]/g, "").trim();
     if (sanitized.length > 0) {
       // B-01: Use `name` (and `name_ar` for Arabic search) instead of the
       // non-existent `full_name` column which caused a 500 on every request.

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -58,10 +58,13 @@ export function decodeCursor(value: string): AppointmentCursor | null {
       typeof (parsed as Record<string, unknown>).id === "string"
     ) {
       const c = parsed as AppointmentCursor;
-      // Defensive validation — these values are interpolated into a
-      // PostgREST `or()` filter, so reject anything that contains the
-      // delimiters PostgREST uses to separate filters.
-      if (/[,()]/.test(c.appointment_date) || /[,()]/.test(c.start_time) || /[,()]/.test(c.id)) {
+      // INJ-02: Strict format validation — these values are interpolated
+      // into a PostgREST `.or()` filter string. Reject anything that
+      // doesn't match the expected format to prevent filter injection.
+      const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+      const TIME_RE = /^\d{2}:\d{2}(:\d{2})?$/;
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!DATE_RE.test(c.appointment_date) || !TIME_RE.test(c.start_time) || !UUID_RE.test(c.id)) {
         return null;
       }
       return c;


### PR DESCRIPTION
## Summary

Fixes four security findings related to PostgREST filter injection and input validation:

- **INJ-01 (High):** Patient search sanitization used a denylist that missed PostgREST modifier characters (`:`, `!`, `not.`, `in.()`). Replaced with strict allowlist `[a-zA-Z0-9\s\-'@.]` that only permits safe characters.
- **INJ-02 (Medium):** Cursor fields decoded from Base64 were validated only for `,()` but not for format correctness. Added strict regex validation: `appointment_date` must match `YYYY-MM-DD`, `start_time` must match `HH:MM[:SS]`, `id` must be a valid UUID.
- **IV-02 (Medium):** The `date` query parameter was passed directly to `.eq("appointment_date", date)` without format validation. Added `YYYY-MM-DD` regex check returning 400 on invalid format.
- **DB-02 (High):** Addressed as part of INJ-01/INJ-02 — the allowlist and format validation prevent all PostgREST metacharacter injection vectors.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [x] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

27 tests covering:
- Allowlist sanitization (strips `:`, `!`, `%`, `_`, `,`, `(`, `)`, `|`)
- Injection payloads: `role.eq.super_admin`, `test:is.null`, `!name.is.null`, `in.()` operator
- Cursor format validation (date, time, UUID)
- Date query param format validation

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] New API endpoints have rate limiting