### PR TITLE
Disable MFA enforcement by default + fix 2FA redirect

### DIFF
--- a/src/app/(auth)/setup-2fa/page.tsx
+++ b/src/app/(auth)/setup-2fa/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ShieldCheck, Copy, Check, ArrowLeft, AlertTriangle, Download } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
@@ -22,8 +22,19 @@ import { formatDisplayDate } from "@/lib/utils";
 
 type Step = "loading" | "qr" | "verify" | "backup" | "done";
 
+const ROLE_DASHBOARD: Record<string, string> = {
+  super_admin: "/super-admin/dashboard",
+  clinic_admin: "/admin/dashboard",
+  receptionist: "/receptionist/dashboard",
+  doctor: "/doctor/dashboard",
+  patient: "/patient/dashboard",
+};
+
 export default function Setup2FAPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const requiredRole = searchParams.get("required") ?? "doctor";
+  const dashboardPath = ROLE_DASHBOARD[requiredRole] ?? "/doctor/dashboard";
   const [locale] = useLocale();
   const [step, setStep] = useState<Step>("loading");
   const [enrollment, setEnrollment] = useState<MFAEnrollment | null>(null);
@@ -174,7 +185,7 @@ export default function Setup2FAPage() {
             </p>
           </CardContent>
           <CardFooter>
-            <Button className="w-full" onClick={() => router.push("/doctor/dashboard")}>
+            <Button className="w-full" onClick={() => router.push(dashboardPath)}>
               {t(locale, "mfa.goToDashboard")}
             </Button>
           </CardFooter>
@@ -193,7 +204,7 @@ export default function Setup2FAPage() {
             </div>
             <h2 className="text-xl font-bold mb-2">{t(locale, "mfa.enabled")}</h2>
             <p className="text-muted-foreground mb-6">{t(locale, "mfa.setupCompleteDesc")}</p>
-            <Button onClick={() => router.push("/doctor/dashboard")}>
+            <Button onClick={() => router.push(dashboardPath)}>
               {t(locale, "mfa.goToDashboard")}
             </Button>
           </CardContent>

--- a/src/lib/middleware/__tests__/mfa-enforcement.test.ts
+++ b/src/lib/middleware/__tests__/mfa-enforcement.test.ts
@@ -7,7 +7,7 @@
  * doctor/clinic_admin step-up redirects, and the non-privileged pass-through.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { enforceMfa } from "../mfa-enforcement";
 
 type Aal = { currentLevel: string | null; nextLevel: string | null };
@@ -24,7 +24,33 @@ function mockSupabase(aal: Aal): SupabaseClient {
 
 const URL_BASE = "https://clinic.oltigo.com";
 
-describe("enforceMfa — super_admin", () => {
+describe("enforceMfa — disabled by default", () => {
+  it("returns null for super_admin when ENFORCE_MFA is not set", async () => {
+    delete process.env.ENFORCE_MFA;
+    const result = await enforceMfa(
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
+      "super_admin",
+      "/admin",
+      `${URL_BASE}/admin`,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null for doctor when ENFORCE_MFA is not set", async () => {
+    delete process.env.ENFORCE_MFA;
+    const result = await enforceMfa(
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
+      "doctor",
+      "/dashboard",
+      `${URL_BASE}/dashboard`,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("enforceMfa — super_admin (ENFORCE_MFA=true)", () => {
+  beforeEach(() => { process.env.ENFORCE_MFA = "true"; });
+  afterEach(() => { delete process.env.ENFORCE_MFA; });
   it("passes when the session is already AAL2", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal2", nextLevel: "aal2" }),
@@ -68,7 +94,9 @@ describe("enforceMfa — super_admin", () => {
   });
 });
 
-describe("enforceMfa — doctor / clinic_admin mandatory 2FA", () => {
+describe("enforceMfa — doctor / clinic_admin mandatory 2FA (ENFORCE_MFA=true)", () => {
+  beforeEach(() => { process.env.ENFORCE_MFA = "true"; });
+  afterEach(() => { delete process.env.ENFORCE_MFA; });
   it("redirects a doctor with an enrolled-but-unverified factor to login", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),

--- a/src/lib/middleware/mfa-enforcement.ts
+++ b/src/lib/middleware/mfa-enforcement.ts
@@ -2,6 +2,12 @@
  * §3.5 — MFA enforcement logic for privileged roles.
  *
  * Extracted from middleware.ts to keep the orchestrator under ~300 lines.
+ *
+ * MFA enforcement is currently disabled while the platform is in early
+ * access. Set the `ENFORCE_MFA` environment variable to `"true"` to
+ * re-enable it. When disabled, users who have already enrolled MFA will
+ * still be prompted to verify (their session already carries the factor),
+ * but unenrolled users will not be forced to set it up.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { secureRedirect } from "@/lib/middleware/security-headers";
@@ -9,11 +15,15 @@ import { secureRedirect } from "@/lib/middleware/security-headers";
 /**
  * Enforce MFA requirements based on role.
  *
+ * When `ENFORCE_MFA` is `"true"`:
  * - `super_admin`: MUST have MFA enrolled AND verified (AAL2).
  * - `doctor` / `clinic_admin`: MUST have MFA enrolled AND verified (AAL2).
  *   Redirects to /setup-2fa if no factors are enrolled, or to /login if
  *   factors exist but the session is still AAL1.
  * - `patient` / `receptionist`: MFA is never enforced.
+ *
+ * When `ENFORCE_MFA` is not `"true"` (default):
+ * - All roles pass through without MFA checks.
  *
  * Returns a redirect Response if MFA is required, or `null` if the user passes.
  */
@@ -23,6 +33,10 @@ export async function enforceMfa(
   pathname: string,
   requestUrl: string,
 ): Promise<Response | null> {
+  if (process.env.ENFORCE_MFA !== "true") {
+    return null;
+  }
+
   if (role === "super_admin") {
     const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
     if (aalData?.currentLevel !== "aal2") {


### PR DESCRIPTION
## Summary

Disables mandatory MFA enforcement for all roles by gating it behind the `ENFORCE_MFA` environment variable. When ready for mandatory 2FA, set `ENFORCE_MFA=true` in Cloudflare Worker secrets.

Also fixes the 2FA setup page hardcoding `/doctor/dashboard` as the post-setup redirect — now uses `?required=` query param to redirect to the role-appropriate dashboard.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR modifies authentication or authorization logic