### PR TITLE
feat: disable MFA enforcement for all roles

### DIFF
--- a/src/lib/middleware/__tests__/mfa-enforcement.test.ts
+++ b/src/lib/middleware/__tests__/mfa-enforcement.test.ts
@@ -1,10 +1,8 @@
 /**
  * MFA enforcement tests (§3.5).
  *
- * Exercises the real `enforceMfa` from `../mfa-enforcement` with a minimal
- * Supabase mock that returns a configurable Authenticator Assurance Level.
- * Covers the super_admin hard requirement (enrolled + AAL2), the
- * doctor/clinic_admin step-up redirects, and the non-privileged pass-through.
+ * MFA enforcement is currently disabled — enforceMfa always returns null.
+ * These tests verify that behavior for all roles.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { describe, it, expect, vi } from "vitest";
@@ -24,10 +22,10 @@ function mockSupabase(aal: Aal): SupabaseClient {
 
 const URL_BASE = "https://clinic.oltigo.com";
 
-describe("enforceMfa — super_admin", () => {
-  it("passes when the session is already AAL2", async () => {
+describe("enforceMfa — disabled", () => {
+  it("passes super_admin without MFA", async () => {
     const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal2", nextLevel: "aal2" }),
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
       "super_admin",
       "/admin",
       `${URL_BASE}/admin`,
@@ -35,75 +33,9 @@ describe("enforceMfa — super_admin", () => {
     expect(result).toBeNull();
   });
 
-  it("redirects to login step-up when factors are enrolled but session is AAL1", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),
-      "super_admin",
-      "/admin",
-      `${URL_BASE}/admin`,
-    );
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("location")).toContain("/login?mfa=required");
-  });
-
-  it("redirects to 2FA setup when no factor is enrolled", async () => {
+  it("passes doctor without MFA", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
-      "super_admin",
-      "/admin",
-      `${URL_BASE}/admin`,
-    );
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("location")).toContain("/setup-2fa?required=super_admin");
-  });
-
-  it("does not loop-redirect when already on the setup-2fa page", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
-      "super_admin",
-      "/setup-2fa",
-      `${URL_BASE}/setup-2fa`,
-    );
-    expect(result).toBeNull();
-  });
-});
-
-describe("enforceMfa — doctor / clinic_admin mandatory 2FA", () => {
-  it("redirects a doctor with an enrolled-but-unverified factor to login", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),
-      "doctor",
-      "/dashboard",
-      `${URL_BASE}/dashboard`,
-    );
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("location")).toContain("/login?mfa=required");
-  });
-
-  it("redirects a doctor without enrolled factors to /setup-2fa", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
-      "doctor",
-      "/dashboard",
-      `${URL_BASE}/dashboard`,
-    );
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("location")).toContain("/setup-2fa?required=doctor");
-  });
-
-  it("does not loop-redirect a doctor already on /setup-2fa", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
-      "doctor",
-      "/setup-2fa",
-      `${URL_BASE}/setup-2fa`,
-    );
-    expect(result).toBeNull();
-  });
-
-  it("passes a doctor with AAL2", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal2", nextLevel: "aal2" }),
       "doctor",
       "/dashboard",
       `${URL_BASE}/dashboard`,
@@ -111,51 +43,33 @@ describe("enforceMfa — doctor / clinic_admin mandatory 2FA", () => {
     expect(result).toBeNull();
   });
 
-  it("redirects a clinic_admin with an unverified factor to login", async () => {
+  it("passes clinic_admin without MFA", async () => {
     const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
       "clinic_admin",
       "/admin/settings",
       `${URL_BASE}/admin/settings`,
     );
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("location")).toContain("/login?mfa=required");
+    expect(result).toBeNull();
   });
 
-  it("redirects a clinic_admin without enrolled factors to /setup-2fa", async () => {
+  it("passes patient without MFA", async () => {
     const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
-      "clinic_admin",
-      "/dashboard",
-      `${URL_BASE}/dashboard`,
-    );
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("location")).toContain("/setup-2fa?required=clinic_admin");
-  });
-
-  it("does not loop-redirect a clinic_admin already on /setup-2fa", async () => {
-    const result = await enforceMfa(
-      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
-      "clinic_admin",
-      "/setup-2fa",
-      `${URL_BASE}/setup-2fa`,
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" }),
+      "patient",
+      "/booking",
+      `${URL_BASE}/booking`,
     );
     expect(result).toBeNull();
   });
-});
 
-describe("enforceMfa — non-privileged roles", () => {
-  it("never enforces MFA for a patient", async () => {
-    const supabase = mockSupabase({ currentLevel: "aal1", nextLevel: "aal2" });
-    const result = await enforceMfa(supabase, "patient", "/admin", `${URL_BASE}/admin`);
+  it("passes receptionist without MFA", async () => {
+    const result = await enforceMfa(
+      mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }),
+      "receptionist",
+      "/reception",
+      `${URL_BASE}/reception`,
+    );
     expect(result).toBeNull();
-    expect(supabase.auth.mfa.getAuthenticatorAssuranceLevel).not.toHaveBeenCalled();
-  });
-
-  it("never enforces MFA for a receptionist", async () => {
-    const supabase = mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" });
-    const result = await enforceMfa(supabase, "receptionist", "/admin", `${URL_BASE}/admin`);
-    expect(result).toBeNull();
-    expect(supabase.auth.mfa.getAuthenticatorAssuranceLevel).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/middleware/mfa-enforcement.ts
+++ b/src/lib/middleware/mfa-enforcement.ts
@@ -4,50 +4,21 @@
  * Extracted from middleware.ts to keep the orchestrator under ~300 lines.
  */
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { secureRedirect } from "@/lib/middleware/security-headers";
 
 /**
  * Enforce MFA requirements based on role.
  *
- * - `super_admin`: MUST have MFA enrolled AND verified (AAL2).
- * - `doctor` / `clinic_admin`: MUST have MFA enrolled AND verified (AAL2).
- *   Redirects to /setup-2fa if no factors are enrolled, or to /login if
- *   factors exist but the session is still AAL1.
- * - `patient` / `receptionist`: MFA is never enforced.
+ * MFA enforcement is currently disabled — all roles pass through without
+ * requiring multi-factor authentication. To re-enable, restore the original
+ * AAL2 checks per role.
  *
- * Returns a redirect Response if MFA is required, or `null` if the user passes.
+ * Returns `null` unconditionally (no redirect).
  */
 export async function enforceMfa(
-  supabase: SupabaseClient,
-  role: string,
-  pathname: string,
-  requestUrl: string,
+  _supabase: SupabaseClient,
+  _role: string,
+  _pathname: string,
+  _requestUrl: string,
 ): Promise<Response | null> {
-  if (role === "super_admin") {
-    const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-    if (aalData?.currentLevel !== "aal2") {
-      if (aalData?.nextLevel === "aal2") {
-        return secureRedirect(new URL("/login?mfa=required", requestUrl));
-      }
-      if (!pathname.startsWith("/setup-2fa")) {
-        return secureRedirect(new URL("/setup-2fa?required=super_admin", requestUrl));
-      }
-    }
-    return null;
-  }
-
-  if (role === "doctor" || role === "clinic_admin") {
-    const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-    if (aalData?.currentLevel !== "aal2") {
-      if (aalData?.nextLevel === "aal2") {
-        return secureRedirect(new URL("/login?mfa=required", requestUrl));
-      }
-      if (!pathname.startsWith("/setup-2fa")) {
-        return secureRedirect(new URL(`/setup-2fa?required=${role}`, requestUrl));
-      }
-    }
-    return null;
-  }
-
   return null;
 }


### PR DESCRIPTION
## Summary

Disables MFA enforcement so super_admin, doctor, and clinic_admin users can access the dashboard without being redirected to /setup-2fa.

## Type of change
- [x] New feature

## Security Impact
- [x] This PR modifies authentication or authorization logic

## Testing
- [x] Unit tests added/updated
- [x] npm run lint passes
- [x] npm run typecheck passes