### PR TITLE
fix: address injection findings from security audit (INJ-01, INJ-02, IV-02, INJ-05)

### DIFF
--- a/src/app/api/__tests__/v1-patients-search-sanitization.test.ts
+++ b/src/app/api/__tests__/v1-patients-search-sanitization.test.ts
@@ -3,10 +3,10 @@
  *
  * Focus: the PostgREST filter-injection defense (audit MED-05 / A46.3).
  * The `search` query param is interpolated into a PostgREST `.or()` filter
- * string, so it MUST be sanitized — stripping `% _ , . ( ) |` — to stop a
- * caller from smuggling extra filter clauses (e.g. `role.eq.super_admin`)
- * or OR tokens. These tests invoke the real handler and assert the exact
- * filter string handed to Supabase, plus the auth gate and tenant scoping.
+ * string, so it MUST be sanitized with an allowlist (INJ-01: only
+ * `[a-zA-Z0-9\s\-'@.]`) to prevent PostgREST filter injection.
+ * Dots are kept for email search; commas, pipes, and parens are stripped
+ * so attackers cannot inject new filter clauses or OR tokens.
  */
 import { NextRequest } from "next/server";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -92,24 +92,26 @@ describe("GET /api/v1/patients — search sanitization (MED-05/A46.3)", () => {
 
   it("strips PostgREST metacharacters from the search term", async () => {
     await GET(req("a%_,.()|b"));
-    // Only the sanitized term "ab" should appear inside the ilike patterns.
-    expect(orArg()).toBe("name.ilike.%ab%,name_ar.ilike.%ab%,email.ilike.%ab%,phone.ilike.%ab%");
+    // Dots are allowed (email search); %, _, commas, parens, pipes are stripped.
+    expect(orArg()).toBe(
+      "name.ilike.%a.b%,name_ar.ilike.%a.b%,email.ilike.%a.b%,phone.ilike.%a.b%",
+    );
   });
 
   it("neutralizes an injected filter clause (role.eq.super_admin)", async () => {
     await GET(req("x,role.eq.super_admin"));
     const arg = orArg();
-    // The dots/commas that would terminate the value and start a new clause
-    // are gone, so no extra filter can be smuggled in.
+    // Commas (clause separators), underscores, and pipes are stripped.
+    // Dots remain but are harmless inside ilike values — PostgREST does
+    // not re-parse operators inside a value position.
     expect(arg).not.toContain("role.eq.super_admin");
-    expect(arg).not.toContain(".eq.");
     expect(arg).toBe(
-      "name.ilike.%xroleeqsuperadmin%,name_ar.ilike.%xroleeqsuperadmin%,email.ilike.%xroleeqsuperadmin%,phone.ilike.%xroleeqsuperadmin%",
+      "name.ilike.%xrole.eq.superadmin%,name_ar.ilike.%xrole.eq.superadmin%,email.ilike.%xrole.eq.superadmin%,phone.ilike.%xrole.eq.superadmin%",
     );
   });
 
   it("does not build an .or() filter when the term sanitizes to empty", async () => {
-    await GET(req("%_,.()|"));
+    await GET(req("%_,()|"));
     expect(query.or).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/patient/export/route.ts
+++ b/src/app/api/patient/export/route.ts
@@ -24,7 +24,7 @@ function escapeCSV(value: unknown): string {
   if (str.length > 0 && FORMULA_PREFIXES.has(str[0])) {
     str = `'${str}`;
   }
-  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\t")) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;

--- a/src/app/api/v1/appointments/route.ts
+++ b/src/app/api/v1/appointments/route.ts
@@ -76,7 +76,11 @@ export async function GET(request: NextRequest) {
     .order("id", { ascending: false })
     .limit(limit + 1);
 
+  // IV-02: Validate date format to prevent malformed input reaching Supabase.
   if (date) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return apiError("Invalid date format", 400, "INVALID_DATE", cors);
+    }
     query = query.eq("appointment_date", date);
   }
   if (status) {
@@ -84,9 +88,16 @@ export async function GET(request: NextRequest) {
   }
 
   if (cursor) {
-    // Row-tuple comparison `(appointment_date, start_time, id) < (cd, ct, ci)`
-    // expressed as the disjunction PostgREST supports via `.or()`.
+    // INJ-02: Validate cursor fields to prevent PostgREST filter injection.
     const { appointment_date: cd, start_time: ct, id: ci } = cursor;
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (
+      !/^\d{4}-\d{2}-\d{2}$/.test(cd) ||
+      !/^\d{2}:\d{2}(:\d{2})?$/.test(ct) ||
+      !UUID_RE.test(ci)
+    ) {
+      return apiError("Invalid cursor", 400, "INVALID_CURSOR", cors);
+    }
     query = query.or(
       [
         `appointment_date.lt.${cd}`,

--- a/src/app/api/v1/patients/route.ts
+++ b/src/app/api/v1/patients/route.ts
@@ -55,11 +55,9 @@ export async function GET(request: NextRequest) {
     .range(offset, offset + limit - 1);
 
   if (search) {
-    // MED-05 + A46.3: Sanitize search input to prevent PostgREST filter injection.
-    // Strip %, _, comma, parens, dots (PostgREST filter separator) AND pipes
-    // (PostgREST OR operator token). Without stripping |, an attacker could
-    // inject additional filter clauses like `role.eq.super_admin`.
-    const sanitized = search.replace(/[%_,.()|]/g, "");
+    // INJ-01: Allowlist-based sanitization to prevent PostgREST filter injection.
+    // Only permit alphanumerics, spaces, hyphens, apostrophes, @, and dots.
+    const sanitized = search.replace(/[^a-zA-Z0-9\s\-'@.]/g, "");
     if (sanitized.length > 0) {
       // B-01: Use `name` (and `name_ar` for Arabic search) instead of the
       // non-existent `full_name` column which caused a 500 on every request.


### PR DESCRIPTION
## Summary

Fixes four injection-related findings from the security audit:

- **INJ-01 (High)** — `src/app/api/v1/patients/route.ts`: Replaced denylist-based search sanitization with a strict allowlist regex `[a-zA-Z0-9\s\-'@.]`. Prevents PostgREST filter injection via `&`, `!`, `<`, `>`, `=`, `:`, quotes, etc.

- **INJ-02 (Medium)** — `src/app/api/v1/appointments/route.ts`: Added format validation for decoded cursor fields before interpolation into `.or()` filter strings: `appointment_date` must match date format, `start_time` must match time format, `id` must be a valid UUID.

- **IV-02 (Medium)** — `src/app/api/v1/appointments/route.ts`: Added date query parameter validation before passing to `.eq()`. Returns 400 on invalid format.

- **INJ-05 (Low)** — `src/app/api/patient/export/route.ts`: Added `\t` to CSV wrapping condition in `escapeCSV()` to prevent CSV formula injection.

Updated existing search sanitization tests to match the new allowlist behavior.

## Type of change

- [x] Bug fix

## Security Impact

- [x] No security impact

> Note: Tightens input validation on existing API routes, does not change auth/RLS architecture.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes