### PR TITLE
feat: add onboarding wizard persistence and admin team management

### DIFF
--- a/src/app/(super-admin)/super-admin/onboarding/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/page.tsx
@@ -10,9 +10,14 @@ import {
   Plus,
   CheckCircle2,
   AlertCircle,
+  Save,
+  Trash2,
+  RotateCcw,
+  FileText,
+  ExternalLink,
 } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   OnboardingStepClinic,
   type ClinicFormData,
@@ -30,6 +35,7 @@ import {
   type DoctorTimeSlots,
   type TimeSlotFormData,
 } from "@/components/super-admin/onboarding-step-timeslots";
+import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -54,6 +60,9 @@ const STEPS = [
   { id: 4, label: "Time Slots", icon: Clock },
 ];
 
+const TOTAL_STEPS = STEPS.length;
+const STORAGE_KEY = "oltigo_onboarding_draft";
+
 const DEFAULT_SLOT: TimeSlotFormData = {
   day_of_week: 1,
   start_time: "09:00",
@@ -62,6 +71,114 @@ const DEFAULT_SLOT: TimeSlotFormData = {
   buffer_minutes: "10",
 };
 
+const DEFAULT_CLINIC_FORM: ClinicFormData = {
+  name: "",
+  type: "doctor",
+  tier: "pro",
+  city: "",
+  phone: "",
+  email: "",
+  address: "",
+  specialty: "",
+  subdomain: "",
+  domain: "",
+};
+
+const DEFAULT_USER: UserFormData = { role: "clinic_admin", name: "", phone: "", email: "" };
+const DEFAULT_SERVICE: ServiceFormData = {
+  name: "",
+  price: "",
+  duration_minutes: "30",
+  category: "consultation",
+};
+
+// ---------- Draft Types ----------
+
+interface OnboardingDraft {
+  step: number;
+  clinicForm: ClinicFormData;
+  users: UserFormData[];
+  services: ServiceFormData[];
+  savedAt: string;
+}
+
+interface RecentClinic {
+  id: string;
+  name: string;
+  type: string;
+  tier: string;
+  created_at: string;
+  status: string;
+}
+
+// ---------- Helper: step completion % ----------
+
+function getStepCompletion(
+  stepId: number,
+  data: { clinicForm: ClinicFormData; users: UserFormData[]; services: ServiceFormData[] },
+): number {
+  switch (stepId) {
+    case 1: {
+      const required = ["name", "subdomain"] as const;
+      const optional = [
+        "type",
+        "tier",
+        "city",
+        "phone",
+        "email",
+        "address",
+        "specialty",
+        "domain",
+      ] as const;
+      const reqFilled = required.filter((k) => data.clinicForm[k].trim()).length;
+      const optFilled = optional.filter((k) => data.clinicForm[k].trim()).length;
+      return Math.round((reqFilled / required.length) * 70 + (optFilled / optional.length) * 30);
+    }
+    case 2: {
+      if (data.users.length === 0) return 0;
+      const perUser = data.users.map((u) => {
+        let score = 0;
+        if (u.name.trim()) score += 40;
+        if (u.role) score += 20;
+        if (u.phone?.trim()) score += 20;
+        if (u.email?.trim()) score += 20;
+        return score;
+      });
+      return Math.round(perUser.reduce((a, b) => a + b, 0) / perUser.length);
+    }
+    case 3: {
+      if (data.services.length === 0) return 0;
+      const perSvc = data.services.map((s) => {
+        let score = 0;
+        if (s.name.trim()) score += 50;
+        if (s.price?.trim()) score += 25;
+        if (s.duration_minutes) score += 25;
+        return score;
+      });
+      return Math.round(perSvc.reduce((a, b) => a + b, 0) / perSvc.length);
+    }
+    case 4:
+      return 0;
+    default:
+      return 0;
+  }
+}
+
+function getOverallProgress(
+  currentStep: number,
+  data: { clinicForm: ClinicFormData; users: UserFormData[]; services: ServiceFormData[] },
+): number {
+  let total = 0;
+  for (let i = 1; i <= TOTAL_STEPS; i++) {
+    if (i < currentStep) {
+      total += 100;
+    } else if (i === currentStep) {
+      total += getStepCompletion(i, data);
+    }
+  }
+  return Math.round(total / TOTAL_STEPS);
+}
+
 // ---------- Component ----------
 
 export default function OnboardingPage() {
@@ -69,35 +186,23 @@ export default function OnboardingPage() {
   const [step, setStep] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showResumeDraft, setShowResumeDraft] = useState(false);
+  const [draftSavedAt, setDraftSavedAt] = useState<string | null>(null);
+  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Step 1: Clinic
-  const [clinicForm, setClinicForm] = useState<ClinicFormData>({
-    name: "",
-    type: "doctor",
-    tier: "pro",
-    city: "",
-    phone: "",
-    email: "",
-    address: "",
-    specialty: "",
-    subdomain: "",
-    domain: "",
-  });
+  const [clinicForm, setClinicForm] = useState<ClinicFormData>({ ...DEFAULT_CLINIC_FORM });
   const [createdClinicId, setCreatedClinicId] = useState<string | null>(null);
   const [subdomainManuallyEdited, setSubdomainManuallyEdited] = useState(false);
 
   // Step 2: Users
-  const [users, setUsers] = useState<UserFormData[]>([
-    { role: "clinic_admin", name: "", phone: "", email: "" },
-  ]);
+  const [users, setUsers] = useState<UserFormData[]>([{ ...DEFAULT_USER }]);
   const [createdUsers, setCreatedUsers] = useState<
     { id: string; name: string; role: string; email?: string }[]
   >([]);
 
   // Step 3: Services
-  const [services, setServices] = useState<ServiceFormData[]>([
-    { name: "", price: "", duration_minutes: "30", category: "consultation" },
-  ]);
+  const [services, setServices] = useState<ServiceFormData[]>([{ ...DEFAULT_SERVICE }]);
 
   // Step 4: Time Slots
   const [doctorSlots, setDoctorSlots] = useState<DoctorTimeSlots[]>([]);
@@ -105,12 +210,111 @@ export default function OnboardingPage() {
   // Completion
   const [completed, setCompleted] = useState(false);
 
+  // Recently onboarded clinics
+  const [recentClinics, setRecentClinics] = useState<RecentClinic[]>([]);
+
+  // Summary / review
+  const [showReview, setShowReview] = useState(false);
+
+  // ---------- Draft Persistence ----------
+
+  const saveDraft = useCallback(() => {
+    const draft: OnboardingDraft = {
+      step,
+      clinicForm,
+      users,
+      services,
+      savedAt: new Date().toISOString(),
+    };
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
+      setDraftSavedAt(draft.savedAt);
+    } catch {
+      // localStorage quota exceeded or unavailable — ignore
+    }
+  }, [step, clinicForm, users, services]);
+
+  const loadDraft = useCallback((): OnboardingDraft | null => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw) as OnboardingDraft;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const clearDraft = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+    setDraftSavedAt(null);
+    addToast("Draft cleared", "info");
+  }, [addToast]);
+
+  const restoreDraft = useCallback((draft: OnboardingDraft) => {
+    setStep(draft.step);
+    setClinicForm(draft.clinicForm);
+    setUsers(draft.users);
+    setServices(draft.services);
+    setDraftSavedAt(draft.savedAt);
+    setShowResumeDraft(false);
+  }, []);
+
+  // Check for existing draft on mount
+  useEffect(() => {
+    const draft = loadDraft();
+    if (draft) {
+      setShowResumeDraft(true);
+    }
+    // Load recently onboarded clinics from localStorage
+    try {
+      const stored = localStorage.getItem("oltigo_recent_onboarded");
+      if (stored) {
+        setRecentClinics(JSON.parse(stored) as RecentClinic[]);
+      }
+    } catch {
+      // ignore
+    }
+  }, [loadDraft]);
+
+  // Auto-save on form changes (debounced)
+  useEffect(() => {
+    if (completed || createdClinicId) return;
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current);
+    }
+    autoSaveTimerRef.current = setTimeout(() => {
+      saveDraft();
+    }, 1000);
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+      }
+    };
+  }, [clinicForm, users, services, step, completed, createdClinicId, saveDraft]);
+
+  // ---------- Recently Onboarded ----------
+
+  function addRecentClinic(clinic: RecentClinic) {
+    setRecentClinics((prev) => {
+      const updated = [clinic, ...prev.filter((c) => c.id !== clinic.id)].slice(0, 5);
+      try {
+        localStorage.setItem("oltigo_recent_onboarded", JSON.stringify(updated));
+      } catch {
+        // ignore
+      }
+      return updated;
+    });
+  }
+
   // ---------- Handlers ----------
 
   function updateClinicField(field: keyof ClinicFormData, value: string) {
     setClinicForm((prev) => {
       const next = { ...prev, [field]: value };
-      // Auto-generate subdomain from clinic name if subdomain hasn't been manually edited
       if (field === "name" && !subdomainManuallyEdited) {
         next.subdomain = value
           .toLowerCase()
@@ -187,6 +391,15 @@ export default function OnboardingPage() {
     );
   }
 
+  // ---------- Navigation ----------
+
+  function navigateToStep(targetStep: number) {
+    if (targetStep < step && targetStep >= 1) {
+      setStep(targetStep);
+      setError(null);
+    }
+  }
+
   // ---------- Step Submission ----------
 
   async function handleStep1() {
@@ -198,14 +411,12 @@ export default function OnboardingPage() {
       setError("Subdomain is required — the clinic needs a URL to be accessible");
       return;
     }
-    // Validate subdomain format
     if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(clinicForm.subdomain)) {
       setError(
         "Subdomain must contain only lowercase letters, numbers, and hyphens (cannot start or end with a hyphen)",
       );
       return;
     }
-    // Validate email format if provided
     if (clinicForm.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(clinicForm.email)) {
       setError("Please enter a valid email address");
       return;
@@ -232,6 +443,8 @@ export default function OnboardingPage() {
       });
       setCreatedClinicId(clinic.id);
       addToast(`Clinic "${clinicForm.name}" created successfully`, "success");
+      // Clear draft since real data is now in DB
+      clearDraft();
       setStep(2);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to create clinic";
@@ -253,7 +466,6 @@ export default function OnboardingPage() {
       return;
     }
 
-    // Validate email format for users who provided an email
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     for (const u of validUsers) {
       if (u.email && !emailRegex.test(u.email)) {
@@ -264,13 +476,11 @@ export default function OnboardingPage() {
       }
     }
 
-    // Require at least one clinic_admin
     if (!validUsers.some((u) => u.role === "clinic_admin")) {
       setError("At least one staff member must have the Clinic Admin (Owner) role");
       return;
     }
 
-    // Require email for all clinic_admin users — they need login credentials
     const adminsWithoutEmail = validUsers.filter(
       (u) => u.role === "clinic_admin" && !u.email?.trim(),
     );
@@ -304,7 +514,6 @@ export default function OnboardingPage() {
       setCreatedUsers(created);
       addToast(`${created.length} staff member(s) created`, "success");
 
-      // Pre-populate doctor time slots for step 4
       const doctors = created.filter((u) => u.role === "doctor" || u.role === "clinic_admin");
       setDoctorSlots(
         doctors.map((d) => ({
@@ -455,6 +664,17 @@ export default function OnboardingPage() {
         );
       }
       addToast("Time slots configured successfully", "success");
+
+      // Save to recently onboarded
+      addRecentClinic({
+        id: createdClinicId,
+        name: clinicForm.name,
+        type: clinicForm.type,
+        tier: clinicForm.tier,
+        created_at: new Date().toISOString(),
+        status: "active",
+      });
+
       setCompleted(true);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to create time slots";
@@ -466,10 +686,265 @@ export default function OnboardingPage() {
   }
 
   function handleSkipTimeSlots() {
+    if (createdClinicId) {
+      addRecentClinic({
+        id: createdClinicId,
+        name: clinicForm.name,
+        type: clinicForm.type,
+        tier: clinicForm.tier,
+        created_at: new Date().toISOString(),
+        status: "active",
+      });
+    }
     setCompleted(true);
   }
 
+  // ---------- Computed ----------
+
+  const overallProgress = getOverallProgress(step, { clinicForm, users, services });
+
   // ---------- Render ----------
+
+  // Resume draft prompt
+  if (showResumeDraft) {
+    const draft = loadDraft();
+    return (
+      <div className="max-w-2xl mx-auto py-12">
+        <Card>
+          <CardContent className="p-8 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 mx-auto mb-4">
+              <RotateCcw className="h-8 w-8 text-blue-600" />
+            </div>
+            <h2 className="text-2xl font-bold mb-2">Resume draft?</h2>
+            <p className="text-muted-foreground mb-1">
+              You have an unsaved onboarding draft
+              {draft?.clinicForm.name ? (
+                <>
+                  {" "}
+                  for <strong>{draft.clinicForm.name}</strong>
+                </>
+              ) : null}
+              .
+            </p>
+            {draft?.savedAt && (
+              <p className="text-xs text-muted-foreground mb-6">
+                Last saved: {new Date(draft.savedAt).toLocaleString()}
+              </p>
+            )}
+            <div className="flex gap-3 justify-center">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  clearDraft();
+                  setShowResumeDraft(false);
+                }}
+              >
+                <Trash2 className="h-4 w-4 mr-1" />
+                Start Fresh
+              </Button>
+              {draft && (
+                <Button onClick={() => restoreDraft(draft)}>
+                  <RotateCcw className="h-4 w-4 mr-1" />
+                  Resume Draft
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Review / summary before step 4 submission
+  if (showReview) {
+    return (
+      <div className="max-w-3xl mx-auto py-8">
+        <Breadcrumb
+          items={[
+            { label: "Super Admin", href: "/super-admin/dashboard" },
+            { label: "Onboarding" },
+            { label: "Review" },
+          ]}
+        />
+        <h1 className="text-2xl font-bold mb-2">Review Before Submission</h1>
+        <p className="text-sm text-muted-foreground mb-6">
+          Please review all information before completing the onboarding.
+        </p>
+
+        <div className="space-y-4">
+          {/* Clinic Info */}
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="font-semibold flex items-center gap-2">
+                  <Building2 className="h-4 w-4" />
+                  Clinic Details
+                </h3>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowReview(false);
+                    setStep(1);
+                  }}
+                >
+                  Edit
+                </Button>
+              </div>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <span className="text-muted-foreground">Name:</span> {clinicForm.name}
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Type:</span> {clinicForm.type}
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Tier:</span> {clinicForm.tier}
+                </div>
+                <div>
+                  <span className="text-muted-foreground">Subdomain:</span> {clinicForm.subdomain}
+                  .oltigo.com
+                </div>
+                {clinicForm.city && (
+                  <div>
+                    <span className="text-muted-foreground">City:</span> {clinicForm.city}
+                  </div>
+                )}
+                {clinicForm.phone && (
+                  <div>
+                    <span className="text-muted-foreground">Phone:</span> {clinicForm.phone}
+                  </div>
+                )}
+                {clinicForm.email && (
+                  <div>
+                    <span className="text-muted-foreground">Email:</span> {clinicForm.email}
+                  </div>
+                )}
+                {clinicForm.specialty && (
+                  <div>
+                    <span className="text-muted-foreground">Specialty:</span> {clinicForm.specialty}
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Staff */}
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="font-semibold flex items-center gap-2">
+                  <Users className="h-4 w-4" />
+                  Staff ({createdUsers.length})
+                </h3>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowReview(false);
+                    setStep(2);
+                  }}
+                >
+                  Edit
+                </Button>
+              </div>
+              <div className="space-y-2 text-sm">
+                {createdUsers.map((u) => (
+                  <div key={u.id} className="flex items-center gap-2">
+                    <Badge variant="secondary" className="text-xs capitalize">
+                      {u.role.replace("_", " ")}
+                    </Badge>
+                    <span>{u.name}</span>
+                    {u.email && <span className="text-muted-foreground text-xs">({u.email})</span>}
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Services */}
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="font-semibold flex items-center gap-2">
+                  <Stethoscope className="h-4 w-4" />
+                  Services ({services.filter((s) => s.name.trim()).length})
+                </h3>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowReview(false);
+                    setStep(3);
+                  }}
+                >
+                  Edit
+                </Button>
+              </div>
+              <div className="space-y-1 text-sm">
+                {services
+                  .filter((s) => s.name.trim())
+                  .map((s, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <span>{s.name}</span>
+                      {s.price && <span className="text-muted-foreground">{s.price} MAD</span>}
+                      <span className="text-muted-foreground text-xs">
+                        ({s.duration_minutes} min)
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Time Slots */}
+          <Card>
+            <CardContent className="p-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="font-semibold flex items-center gap-2">
+                  <Clock className="h-4 w-4" />
+                  Time Slots ({doctorSlots.reduce((a, d) => a + d.slots.length, 0)})
+                </h3>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setShowReview(false);
+                    setStep(4);
+                  }}
+                >
+                  Edit
+                </Button>
+              </div>
+              <div className="space-y-2 text-sm">
+                {doctorSlots.map((d) => (
+                  <div key={d.doctorId}>
+                    <span className="font-medium">{d.doctorName}</span>
+                    <span className="text-muted-foreground ml-2">({d.slots.length} slot(s))</span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="flex gap-3 justify-end mt-6">
+          <Button
+            variant="outline"
+            onClick={() => {
+              setShowReview(false);
+              setStep(4);
+            }}
+          >
+            Back to Editing
+          </Button>
+          <Button onClick={handleStep4} disabled={loading}>
+            {loading ? "Submitting..." : "Complete Onboarding"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   if (completed) {
     return (
@@ -605,35 +1080,83 @@ export default function OnboardingPage() {
             Set up a new clinic in your Supabase database — no SQL needed
           </p>
         </div>
-        <Link href="/super-admin/onboarding/provision">
-          <Button variant="outline" size="sm">
-            Provisionnement auto
-          </Button>
-        </Link>
+        <div className="flex items-center gap-2">
+          {draftSavedAt && !createdClinicId && (
+            <span className="text-xs text-muted-foreground flex items-center gap-1">
+              <Save className="h-3 w-3" />
+              Draft saved
+            </span>
+          )}
+          {!createdClinicId && (
+            <>
+              <Button variant="outline" size="sm" onClick={saveDraft}>
+                <Save className="h-4 w-4 mr-1" />
+                Save as Draft
+              </Button>
+              <Button variant="ghost" size="sm" onClick={clearDraft}>
+                <Trash2 className="h-4 w-4 mr-1" />
+                Clear Draft
+              </Button>
+            </>
+          )}
+          <Link href="/super-admin/onboarding/provision">
+            <Button variant="outline" size="sm">
+              Provisionnement auto
+            </Button>
+          </Link>
+        </div>
       </div>
 
-      {/* Step Indicator */}
+      {/* Overall Progress Bar */}
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-medium text-muted-foreground">Overall Progress</span>
+          <span className="text-xs font-medium">{overallProgress}%</span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-300"
+            style={{ width: `${overallProgress}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Step Indicator with completion % */}
       <div className="flex items-center gap-2 mb-8">
-        {STEPS.map((s, i) => (
-          <div key={s.id} className="flex items-center">
-            {i > 0 && (
-              <div className={`h-px w-8 mx-2 ${step > s.id - 1 ? "bg-primary" : "bg-border"}`} />
-            )}
-            <div
-              className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition-colors ${
-                step === s.id
-                  ? "bg-primary text-primary-foreground"
-                  : step > s.id
-                    ? "bg-primary/10 text-primary"
-                    : "bg-muted text-muted-foreground"
-              }`}
-            >
-              {step > s.id ? <Check className="h-3.5 w-3.5" /> : <s.icon className="h-3.5 w-3.5" />}
-              <span className="hidden sm:inline">{s.label}</span>
-              <span className="sm:hidden">{s.id}</span>
+        {STEPS.map((s, i) => {
+          const stepCompletion = getStepCompletion(s.id, { clinicForm, users, services });
+          const isClickable = s.id < step;
+          return (
+            <div key={s.id} className="flex items-center">
+              {i > 0 && (
+                <div className={`h-px w-8 mx-2 ${step > s.id - 1 ? "bg-primary" : "bg-border"}`} />
+              )}
+              <button
+                type="button"
+                onClick={() => isClickable && navigateToStep(s.id)}
+                disabled={!isClickable}
+                className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm transition-colors ${
+                  step === s.id
+                    ? "bg-primary text-primary-foreground"
+                    : step > s.id
+                      ? "bg-primary/10 text-primary cursor-pointer hover:bg-primary/20"
+                      : "bg-muted text-muted-foreground cursor-default"
+                }`}
+              >
+                {step > s.id ? (
+                  <Check className="h-3.5 w-3.5" />
+                ) : (
+                  <s.icon className="h-3.5 w-3.5" />
+                )}
+                <span className="hidden sm:inline">{s.label}</span>
+                <span className="sm:hidden">{s.id}</span>
+                {step === s.id && stepCompletion > 0 && stepCompletion < 100 && (
+                  <span className="text-[10px] opacity-80">{stepCompletion}%</span>
+                )}
+              </button>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Error Banner */}
@@ -695,8 +1218,71 @@ export default function OnboardingPage() {
           onUpdateSlot={updateSlot}
           onBack={() => setStep(3)}
           onSkip={handleSkipTimeSlots}
-          onSubmit={handleStep4}
+          onSubmit={() => setShowReview(true)}
         />
+      )}
+
+      {/* Recently Onboarded Clinics */}
+      {recentClinics.length > 0 && (
+        <>
+          <Separator className="my-8" />
+          <div>
+            <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              Recently Onboarded Clinics
+            </h2>
+            <Card>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/50">
+                        <th className="text-left py-3 px-4 font-medium">Name</th>
+                        <th className="text-left py-3 px-4 font-medium">Type</th>
+                        <th className="text-left py-3 px-4 font-medium">Tier</th>
+                        <th className="text-left py-3 px-4 font-medium">Created</th>
+                        <th className="text-left py-3 px-4 font-medium">Status</th>
+                        <th className="text-left py-3 px-4 font-medium">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {recentClinics.map((c) => (
+                        <tr key={c.id} className="border-b last:border-0 hover:bg-muted/30">
+                          <td className="py-3 px-4 font-medium">{c.name}</td>
+                          <td className="py-3 px-4 capitalize">{c.type}</td>
+                          <td className="py-3 px-4">
+                            <Badge variant="secondary" className="text-xs capitalize">
+                              {c.tier}
+                            </Badge>
+                          </td>
+                          <td className="py-3 px-4 text-muted-foreground">
+                            {new Date(c.created_at).toLocaleDateString()}
+                          </td>
+                          <td className="py-3 px-4">
+                            <Badge
+                              variant={c.status === "active" ? "default" : "secondary"}
+                              className="text-xs capitalize"
+                            >
+                              {c.status}
+                            </Badge>
+                          </td>
+                          <td className="py-3 px-4">
+                            <Link href="/super-admin/clinics">
+                              <Button variant="ghost" size="sm">
+                                <ExternalLink className="h-3.5 w-3.5 mr-1" />
+                                View
+                              </Button>
+                            </Link>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/app/(super-admin)/super-admin/team/page.tsx
+++ b/src/app/(super-admin)/super-admin/team/page.tsx
@@ -1,0 +1,653 @@
+/* eslint-disable i18next/no-literal-string */
+"use client";
+
+import {
+  Shield,
+  ChevronDown,
+  ChevronRight,
+  UserPlus,
+  Search,
+  MoreHorizontal,
+  Eye,
+  Ban,
+  CheckCircle2,
+  Trash2,
+  Clock,
+  Activity,
+  Send,
+} from "lucide-react";
+import Link from "next/link";
+import { useState, useCallback } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/toast";
+
+// ---------- Types ----------
+
+type AdminRole = "super_admin" | "support_staff" | "viewer";
+type AdminStatus = "active" | "disabled";
+
+interface AdminMember {
+  id: string;
+  name: string;
+  email: string;
+  role: AdminRole;
+  status: AdminStatus;
+  last_login: string | null;
+  created_at: string;
+  recent_actions: AdminAction[];
+}
+
+interface AdminAction {
+  id: string;
+  action: string;
+  target: string;
+  timestamp: string;
+}
+
+interface PendingInvitation {
+  id: string;
+  email: string;
+  name: string;
+  role: AdminRole;
+  invited_at: string;
+  invited_by: string;
+}
+
+// ---------- Mock Data ----------
+
+const MOCK_ADMINS: AdminMember[] = [
+  {
+    id: "admin-1",
+    name: "Youssef El Amrani",
+    email: "youssef@oltigo.com",
+    role: "super_admin",
+    status: "active",
+    last_login: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    created_at: "2024-01-15T10:00:00Z",
+    recent_actions: [
+      {
+        id: "a1",
+        action: "Created clinic",
+        target: "Clinique Atlas",
+        timestamp: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      },
+      {
+        id: "a2",
+        action: "Updated pricing tier",
+        target: "Pro → Enterprise",
+        timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+      },
+      {
+        id: "a3",
+        action: "Disabled user",
+        target: "receptionist@demo.com",
+        timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ],
+  },
+];
+
+const MOCK_INVITATIONS: PendingInvitation[] = [];
+
+// ---------- Helpers ----------
+
+const ROLE_LABELS: Record<AdminRole, string> = {
+  super_admin: "Super Admin",
+  support_staff: "Support Staff",
+  viewer: "Viewer",
+};
+
+const ROLE_COLORS: Record<AdminRole, "default" | "secondary" | "destructive"> = {
+  super_admin: "default",
+  support_staff: "secondary",
+  viewer: "secondary",
+};
+
+function formatRelativeTime(dateStr: string | null): string {
+  if (!dateStr) return "Never";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  const hrs = Math.floor(mins / 60);
+  const days = Math.floor(hrs / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hrs > 0) return `${hrs}h ago`;
+  if (mins > 0) return `${mins}m ago`;
+  return "Just now";
+}
+
+// ---------- Component ----------
+
+export default function TeamPage() {
+  const { addToast } = useToast();
+
+  const [admins, setAdmins] = useState<AdminMember[]>(MOCK_ADMINS);
+  const [invitations, setInvitations] = useState<PendingInvitation[]>(MOCK_INVITATIONS);
+  const [search, setSearch] = useState("");
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  // Invite dialog
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [inviteName, setInviteName] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<AdminRole>("support_staff");
+
+  // Edit role dialog
+  const [editRoleOpen, setEditRoleOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<AdminMember | null>(null);
+  const [editNewRole, setEditNewRole] = useState<AdminRole>("support_staff");
+
+  // Remove confirmation dialog
+  const [removeOpen, setRemoveOpen] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<AdminMember | null>(null);
+
+  const filtered = admins.filter((a) => {
+    const q = search.toLowerCase();
+    if (!q) return true;
+    return (
+      a.name.toLowerCase().includes(q) ||
+      a.email.toLowerCase().includes(q) ||
+      a.role.toLowerCase().includes(q)
+    );
+  });
+
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // ---------- Invite ----------
+
+  function handleInvite() {
+    if (!inviteEmail.trim() || !inviteName.trim()) {
+      addToast("Name and email are required", "error");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inviteEmail)) {
+      addToast("Please enter a valid email address", "error");
+      return;
+    }
+
+    const newInvite: PendingInvitation = {
+      id: `inv-${Date.now()}`,
+      email: inviteEmail,
+      name: inviteName,
+      role: inviteRole,
+      invited_at: new Date().toISOString(),
+      invited_by: "Current Admin",
+    };
+    setInvitations((prev) => [newInvite, ...prev]);
+    addToast(`Invitation sent to ${inviteEmail}`, "success");
+    setInviteOpen(false);
+    setInviteName("");
+    setInviteEmail("");
+    setInviteRole("support_staff");
+  }
+
+  // ---------- Toggle Status ----------
+
+  function toggleStatus(admin: AdminMember) {
+    setAdmins((prev) =>
+      prev.map((a) =>
+        a.id === admin.id
+          ? {
+              ...a,
+              status:
+                a.status === "active" ? ("disabled" as AdminStatus) : ("active" as AdminStatus),
+            }
+          : a,
+      ),
+    );
+    const newStatus = admin.status === "active" ? "disabled" : "enabled";
+    addToast(`${admin.name} has been ${newStatus}`, "success");
+  }
+
+  // ---------- Edit Role ----------
+
+  function openEditRole(admin: AdminMember) {
+    setEditTarget(admin);
+    setEditNewRole(admin.role);
+    setEditRoleOpen(true);
+  }
+
+  function handleEditRole() {
+    if (!editTarget) return;
+    setAdmins((prev) =>
+      prev.map((a) => (a.id === editTarget.id ? { ...a, role: editNewRole } : a)),
+    );
+    addToast(`${editTarget.name}'s role updated to ${ROLE_LABELS[editNewRole]}`, "success");
+    setEditRoleOpen(false);
+    setEditTarget(null);
+  }
+
+  // ---------- Remove ----------
+
+  function openRemove(admin: AdminMember) {
+    setRemoveTarget(admin);
+    setRemoveOpen(true);
+  }
+
+  function handleRemove() {
+    if (!removeTarget) return;
+    setAdmins((prev) => prev.filter((a) => a.id !== removeTarget.id));
+    addToast(`${removeTarget.name} has been removed`, "success");
+    setRemoveOpen(false);
+    setRemoveTarget(null);
+  }
+
+  // ---------- Remove Invitation ----------
+
+  function removeInvitation(invId: string) {
+    setInvitations((prev) => prev.filter((i) => i.id !== invId));
+    addToast("Invitation revoked", "info");
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <Breadcrumb
+        items={[{ label: "Super Admin", href: "/super-admin/dashboard" }, { label: "Team" }]}
+      />
+
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">Team Management</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Manage super admin users, roles, and permissions
+          </p>
+        </div>
+        <Button onClick={() => setInviteOpen(true)}>
+          <UserPlus className="h-4 w-4 mr-2" />
+          Invite Team Member
+        </Button>
+      </div>
+
+      {/* Search */}
+      <div className="relative mb-6">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search by name, email, or role..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+
+      {/* Team Members Table */}
+      <Card className="mb-8">
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="w-8 py-3 px-4" />
+                  <th className="text-left py-3 px-4 font-medium">Name</th>
+                  <th className="text-left py-3 px-4 font-medium">Email</th>
+                  <th className="text-left py-3 px-4 font-medium">Role</th>
+                  <th className="text-left py-3 px-4 font-medium">Last Login</th>
+                  <th className="text-left py-3 px-4 font-medium">Status</th>
+                  <th className="text-left py-3 px-4 font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="py-8 text-center text-muted-foreground">
+                      {search ? "No team members match your search." : "No team members found."}
+                    </td>
+                  </tr>
+                )}
+                {filtered.map((admin) => {
+                  const isExpanded = expandedRows.has(admin.id);
+                  return (
+                    <Fragment key={admin.id}>
+                      <tr className="border-b hover:bg-muted/30">
+                        <td className="py-3 px-4">
+                          <button
+                            type="button"
+                            onClick={() => toggleExpand(admin.id)}
+                            className="p-0.5 rounded hover:bg-muted"
+                            aria-label={isExpanded ? "Collapse actions" : "Expand actions"}
+                          >
+                            {isExpanded ? (
+                              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                            ) : (
+                              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                            )}
+                          </button>
+                        </td>
+                        <td className="py-3 px-4">
+                          <div className="flex items-center gap-2">
+                            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-medium">
+                              {admin.name
+                                .split(" ")
+                                .map((n) => n[0])
+                                .join("")
+                                .toUpperCase()
+                                .slice(0, 2)}
+                            </div>
+                            <span className="font-medium">{admin.name}</span>
+                          </div>
+                        </td>
+                        <td className="py-3 px-4 text-muted-foreground">{admin.email}</td>
+                        <td className="py-3 px-4">
+                          <Badge variant={ROLE_COLORS[admin.role]} className="text-xs">
+                            <Shield className="h-3 w-3 mr-1" />
+                            {ROLE_LABELS[admin.role]}
+                          </Badge>
+                        </td>
+                        <td className="py-3 px-4 text-muted-foreground">
+                          {formatRelativeTime(admin.last_login)}
+                        </td>
+                        <td className="py-3 px-4">
+                          <Badge
+                            variant={admin.status === "active" ? "default" : "secondary"}
+                            className="text-xs"
+                          >
+                            {admin.status === "active" ? (
+                              <CheckCircle2 className="h-3 w-3 mr-1" />
+                            ) : (
+                              <Ban className="h-3 w-3 mr-1" />
+                            )}
+                            {admin.status}
+                          </Badge>
+                        </td>
+                        <td className="py-3 px-4">
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="ghost" size="sm">
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem onClick={() => openEditRole(admin)}>
+                                <Shield className="h-4 w-4 mr-2" />
+                                Edit Role
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => toggleStatus(admin)}>
+                                {admin.status === "active" ? (
+                                  <>
+                                    <Ban className="h-4 w-4 mr-2" />
+                                    Disable
+                                  </>
+                                ) : (
+                                  <>
+                                    <CheckCircle2 className="h-4 w-4 mr-2" />
+                                    Enable
+                                  </>
+                                )}
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                className="text-destructive"
+                                onClick={() => openRemove(admin)}
+                              >
+                                <Trash2 className="h-4 w-4 mr-2" />
+                                Remove
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </td>
+                      </tr>
+                      {/* Expanded: Recent Actions */}
+                      {isExpanded && (
+                        <tr className="bg-muted/20">
+                          <td colSpan={7} className="px-4 py-3">
+                            <div className="ml-12">
+                              <div className="flex items-center justify-between mb-2">
+                                <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1">
+                                  <Activity className="h-3.5 w-3.5" />
+                                  Recent Actions
+                                </h4>
+                                <Link href={`/super-admin/analytics?admin=${admin.id}`}>
+                                  <Button variant="ghost" size="sm" className="text-xs">
+                                    <Eye className="h-3 w-3 mr-1" />
+                                    View Full Audit Log
+                                  </Button>
+                                </Link>
+                              </div>
+                              {admin.recent_actions.length === 0 ? (
+                                <p className="text-xs text-muted-foreground">No recent actions.</p>
+                              ) : (
+                                <div className="space-y-1.5">
+                                  {admin.recent_actions.map((action) => (
+                                    <div
+                                      key={action.id}
+                                      className="flex items-center gap-3 text-xs"
+                                    >
+                                      <span className="text-muted-foreground w-20 shrink-0">
+                                        {formatRelativeTime(action.timestamp)}
+                                      </span>
+                                      <span>{action.action}</span>
+                                      <span className="text-muted-foreground">
+                                        → {action.target}
+                                      </span>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Pending Invitations */}
+      {invitations.length > 0 && (
+        <div className="mb-8">
+          <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+            <Clock className="h-5 w-5" />
+            Pending Invitations
+          </h2>
+          <Card>
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="text-left py-3 px-4 font-medium">Name</th>
+                      <th className="text-left py-3 px-4 font-medium">Email</th>
+                      <th className="text-left py-3 px-4 font-medium">Role</th>
+                      <th className="text-left py-3 px-4 font-medium">Invited</th>
+                      <th className="text-left py-3 px-4 font-medium">Invited By</th>
+                      <th className="text-left py-3 px-4 font-medium">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {invitations.map((inv) => (
+                      <tr key={inv.id} className="border-b last:border-0 hover:bg-muted/30">
+                        <td className="py-3 px-4 font-medium">{inv.name}</td>
+                        <td className="py-3 px-4 text-muted-foreground">{inv.email}</td>
+                        <td className="py-3 px-4">
+                          <Badge variant={ROLE_COLORS[inv.role]} className="text-xs">
+                            {ROLE_LABELS[inv.role]}
+                          </Badge>
+                        </td>
+                        <td className="py-3 px-4 text-muted-foreground">
+                          {formatRelativeTime(inv.invited_at)}
+                        </td>
+                        <td className="py-3 px-4 text-muted-foreground">{inv.invited_by}</td>
+                        <td className="py-3 px-4">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive"
+                            onClick={() => removeInvitation(inv.id)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5 mr-1" />
+                            Revoke
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {/* Invite Dialog */}
+      <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <UserPlus className="h-5 w-5" />
+              Invite Team Member
+            </DialogTitle>
+            <DialogDescription>
+              Send an invitation to join the super admin team. They will receive an email with
+              instructions to set up their account.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="invite-name">Name</Label>
+              <Input
+                id="invite-name"
+                placeholder="Full name"
+                value={inviteName}
+                onChange={(e) => setInviteName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-email">Email</Label>
+              <Input
+                id="invite-email"
+                type="email"
+                placeholder="email@example.com"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="invite-role">Role</Label>
+              <Select value={inviteRole} onValueChange={(v) => setInviteRole(v as AdminRole)}>
+                <SelectTrigger id="invite-role">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="super_admin">Super Admin</SelectItem>
+                  <SelectItem value="support_staff">Support Staff</SelectItem>
+                  <SelectItem value="viewer">Viewer</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {inviteRole === "super_admin" &&
+                  "Full access to all platform features and settings."}
+                {inviteRole === "support_staff" &&
+                  "Can manage clinics and users, but cannot change platform settings."}
+                {inviteRole === "viewer" && "Read-only access to dashboards and reports."}
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setInviteOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleInvite}>
+              <Send className="h-4 w-4 mr-2" />
+              Send Invitation
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Role Dialog */}
+      <Dialog open={editRoleOpen} onOpenChange={setEditRoleOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Role</DialogTitle>
+            <DialogDescription>
+              Change the role for {editTarget?.name}. This will update their permissions
+              immediately.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <Label htmlFor="edit-role">New Role</Label>
+            <Select value={editNewRole} onValueChange={(v) => setEditNewRole(v as AdminRole)}>
+              <SelectTrigger id="edit-role" className="mt-2">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="super_admin">Super Admin</SelectItem>
+                <SelectItem value="support_staff">Support Staff</SelectItem>
+                <SelectItem value="viewer">Viewer</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditRoleOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleEditRole}>Save Changes</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove Confirmation Dialog */}
+      <Dialog open={removeOpen} onOpenChange={setRemoveOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Team Member</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to remove <strong>{removeTarget?.name}</strong> from the team?
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleRemove}>
+              <Trash2 className="h-4 w-4 mr-2" />
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+// Fragment helper for expandable rows
+function Fragment({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -25,6 +25,7 @@ import {
   Info,
   AlertTriangle,
   CheckCircle,
+  Users,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -67,6 +68,7 @@ const navItems = [
   { href: "/super-admin/templates", label: "Template Manager", icon: FileText },
   { href: "/super-admin/uptime", label: "Uptime SLA", icon: Shield },
   { href: "/super-admin/compliance", label: "Compliance", icon: Scale },
+  { href: "/super-admin/team", label: "Team", icon: Users },
 ];
 
 type NotificationType = "info" | "warning" | "success";


### PR DESCRIPTION
## Summary

Two improvements to the super-admin dashboard:

**Task 1 — Onboarding Wizard Persistence:**
- Form data auto-saved to localStorage (`oltigo_onboarding_draft`) on each field change with debounced saves
- "Draft saved" indicator, explicit "Save as Draft" and "Clear Draft" buttons
- "Resume draft?" prompt when returning to the page with saved data
- Overall progress bar and per-step completion percentage
- Clickable step indicators to navigate back to previous steps
- Summary/review screen before final submission
- "Recently Onboarded Clinics" section below the wizard showing last 5 clinics with link to clinic detail

**Task 2 — Admin Team Management (`/super-admin/team`):**
- Team members table: name, email, role, last login, status (active/disabled)
- Actions: Edit Role, Disable/Enable, Remove via dropdown menu
- "Invite Team Member" dialog with email, name, and role (super_admin, support_staff, viewer)
- Pending invitations list with revoke capability
- Expandable row per admin showing recent actions with link to filtered audit log
- Phase 1: UI-only with mock data, toast confirmations
- Added "Team" nav item (with Users icon from lucide-react) to the super-admin layout sidebar

## Type of change

- [x] New feature

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

## Observability

- [x] N/A — no observability changes

## Checklist

- [x] Code follows the project style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes