### PR TITLE
fix: use role-based redirect after MFA and backup code verification

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -22,9 +22,11 @@ import {
   signInWithPassword,
   signInWithEmailOTP,
   verifyEmailOTP,
+  getUserProfile,
 } from "@/lib/auth";
 import { t, type TranslationKey } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
+import { ROLE_DASHBOARD_MAP } from "@/lib/middleware/routes";
 import { createClient } from "@/lib/supabase-client";
 const PHONE_AUTH_ENABLED = process.env.NEXT_PUBLIC_PHONE_AUTH_ENABLED === "true";
 
@@ -173,8 +175,10 @@ export default function LoginPage() {
         return;
       }
 
-      // MFA verified — redirect will happen via auth state change
-      window.location.href = "/doctor/dashboard";
+      // MFA verified — redirect based on user role
+      const mfaProfile = await getUserProfile();
+      window.location.href =
+        (mfaProfile && ROLE_DASHBOARD_MAP[mfaProfile.role]) || "/doctor/dashboard";
     } catch (err) {
       logger.warn("MFA verification failed", { context: "login", error: err });
       setError(t(locale, "error.unexpected"));
@@ -196,8 +200,10 @@ export default function LoginPage() {
         return;
       }
 
-      // Backup code verified — redirect
-      window.location.href = "/doctor/dashboard";
+      // Backup code verified — redirect based on user role
+      const backupProfile = await getUserProfile();
+      window.location.href =
+        (backupProfile && ROLE_DASHBOARD_MAP[backupProfile.role]) || "/doctor/dashboard";
     } catch (err) {
       logger.warn("Backup code verification failed", { context: "login", error: err });
       setError(t(locale, "error.unexpected"));


### PR DESCRIPTION
## Summary

The login page hardcoded `window.location.href = "/doctor/dashboard"` after MFA TOTP verification and backup code verification, ignoring the user's actual role. This caused `super_admin` and `clinic_admin` users to land on `/doctor/dashboard/` instead of their respective dashboards.

Fixed by calling the `getUserProfile()` server action after MFA/backup verification and looking up `ROLE_DASHBOARD_MAP[profile.role]` — the same pattern already used by `signInWithPassword`, `verifyOTP`, and `verifyEmailOTP`.

```diff
- window.location.href = "/doctor/dashboard";
+ const mfaProfile = await getUserProfile();
+ window.location.href = (mfaProfile && ROLE_DASHBOARD_MAP[mfaProfile.role]) || "/doctor/dashboard";
```

The middleware (`src/middleware.ts`) already had correct role-based routing — no changes needed there.