### PR TITLE
fix: handle duplicate SBOM release tags on deploy re-runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -491,8 +491,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="deploy-$(date +%Y%m%d)-${GITHUB_SHA::7}"
-          gh release create "$TAG" \
-            --title "Deploy ${TAG}" \
-            --notes "Production deploy — SBOM and cosign bundle attached per A174." \
-            --target "$GITHUB_SHA" \
-            bom.json bom.json.bundle
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — uploading SBOM as additional assets"
+            gh release upload "$TAG" bom.json bom.json.bundle --clobber
+          else
+            gh release create "$TAG" \
+              --title "Deploy ${TAG}" \
+              --notes "Production deploy — SBOM and cosign bundle attached per A174." \
+              --target "$GITHUB_SHA" \
+              bom.json bom.json.bundle
+          fi


### PR DESCRIPTION
## Summary

Fixes the SBOM release step in the deploy workflow that fails with `a release with the same tag name already exists` when the deploy is re-triggered on the same commit (e.g. via `workflow_dispatch`).

Now checks if the release already exists before creating it. If it does, uploads the SBOM assets with `--clobber` to update them. If not, creates a new release as before.