### PR TITLE
fix: resolve Semgrep tenant-scoping findings on admin API routes

### DIFF
--- a/src/app/api/admin/marketplace/route.ts
+++ b/src/app/api/admin/marketplace/route.ts
@@ -19,7 +19,7 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
     const supabase = createUntypedAdminClient("super_admin");
 
     const { data, error } = await supabase
-      .from("feature_definitions")
+      .from("feature_definitions") // nosemgrep: semgrep.tenant-scoping
       .select("id, name, description, key, category, available_tiers, global_enabled")
       .order("name");
 
@@ -30,7 +30,7 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
 
     // Count how many clinics have each feature enabled (via feature_overrides)
     const { data: overrides } = await supabase
-      .from("clinic_feature_overrides")
+      .from("clinic_feature_overrides") // nosemgrep: semgrep.tenant-scoping
       .select("feature_key");
 
     const installCounts: Record<string, number> = {};

--- a/src/app/api/admin/referrals/route.ts
+++ b/src/app/api/admin/referrals/route.ts
@@ -19,7 +19,7 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
     const supabase = createUntypedAdminClient("super_admin");
 
     const { data, error } = await supabase
-      .from("referrals")
+      .from("referrals") // nosemgrep: semgrep.tenant-scoping
       .select(
         "id, clinic_id, referring_doctor_id, referred_to_doctor_id, patient_id, reason, status, created_at, clinics(name)",
       )

--- a/src/app/api/admin/team/route.ts
+++ b/src/app/api/admin/team/route.ts
@@ -24,7 +24,7 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
     const supabase = createUntypedAdminClient("super_admin");
 
     const { data, error } = await supabase
-      .from("users")
+      .from("users") // nosemgrep: semgrep.tenant-scoping
       .select("id, auth_id, name, email, role, clinic_id, created_at")
       .in("role", ADMIN_ROLES)
       .order("created_at", { ascending: false });
@@ -94,6 +94,7 @@ async function handlePatch(request: NextRequest, auth: AuthContext) {
         return apiValidationError(`role must be one of: ${ADMIN_ROLES.join(", ")}`);
       }
 
+      // nosemgrep: semgrep.tenant-scoping
       const { error } = await supabase.from("users").update({ role: newRole }).eq("id", userId);
 
       if (error) {
@@ -116,7 +117,7 @@ async function handlePatch(request: NextRequest, auth: AuthContext) {
 
     if (action === "remove") {
       const { error } = await supabase
-        .from("users")
+        .from("users") // nosemgrep: semgrep.tenant-scoping
         .delete()
         .eq("id", userId)
         .in("role", ADMIN_ROLES);

--- a/src/app/api/admin/usage/route.ts
+++ b/src/app/api/admin/usage/route.ts
@@ -20,7 +20,7 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
 
     // Fetch all clinics
     const { data: clinics, error: clinicsErr } = await supabase
-      .from("clinics")
+      .from("clinics") // nosemgrep: semgrep.tenant-scoping
       .select("id, name, type, status, created_at")
       .order("name");
 
@@ -33,9 +33,11 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
     }
 
     // Count appointments per clinic
+    // nosemgrep: semgrep.tenant-scoping
     const { data: apptCounts } = await supabase.from("appointments").select("clinic_id");
 
     // Count users per clinic
+    // nosemgrep: semgrep.tenant-scoping
     const { data: userCounts } = await supabase.from("users").select("clinic_id");
 
     // Build per-clinic counts


### PR DESCRIPTION
## Summary

Addresses all 9 Semgrep `tenant-scoping` review comments from PR #842. Added `// nosemgrep: semgrep.tenant-scoping` inline on every `.from()` call in the 4 admin API routes:

- `src/app/api/admin/team/route.ts` — 3 queries (users select, users update, users delete)
- `src/app/api/admin/usage/route.ts` — 3 queries (clinics, appointments, users)
- `src/app/api/admin/referrals/route.ts` — 1 query (referrals with clinic join)
- `src/app/api/admin/marketplace/route.ts` — 2 queries (feature_definitions, clinic_feature_overrides)

All are verified-safe cross-tenant operations: each route is behind `withAuth(handler, ["super_admin"])` and uses `createUntypedAdminClient()` — cross-tenant visibility is the core purpose of these super-admin endpoints.