### PR TITLE
feat: add AI multi-model routing infrastructure with smart fallback

### DIFF
--- a/scripts/check-tenant-scoping.mjs
+++ b/scripts/check-tenant-scoping.mjs
@@ -47,6 +47,10 @@ const ALLOWLIST = new Set([
   "src/app/api/admin/revenue-forecast/route.ts",
   // Admin team — super_admin cross-tenant user management (role updates, member removal)
   "src/app/api/admin/team/route.ts",
+  // Admin AI config — super_admin cross-tenant AI provider management
+  "src/app/api/admin/ai-config/route.ts",
+  // AI route — unified AI endpoint with cross-tenant usage logging
+  "src/app/api/ai/route.ts",
 ]);
 
 const MUTATION_RE = /\.from\(["'][a-z_]+["']\)\.(insert|update|delete|upsert)/;

--- a/src/app/(super-admin)/super-admin/settings/ai/page.tsx
+++ b/src/app/(super-admin)/super-admin/settings/ai/page.tsx
@@ -1,0 +1,737 @@
+/* eslint-disable i18next/no-literal-string */
+"use client";
+
+import {
+  Bot,
+  Check,
+  Eye,
+  EyeOff,
+  Key,
+  Loader2,
+  RefreshCw,
+  Shield,
+  Zap,
+  AlertTriangle,
+  DollarSign,
+  Activity,
+  Settings,
+  Power,
+  PowerOff,
+} from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/components/ui/toast";
+import { logger } from "@/lib/logger";
+
+// ── Types ──
+
+interface ProviderRow {
+  id: string;
+  provider: string;
+  display_name: string;
+  is_active: boolean;
+  has_api_key: boolean;
+  routing_tier: number;
+  monthly_budget_cents: number;
+  requests_this_month: number;
+  tokens_this_month: number;
+  last_error: string | null;
+  last_used_at: string | null;
+}
+
+interface FeatureToggle {
+  id: string;
+  feature_key: string;
+  display_name: string;
+  description: string | null;
+  is_enabled: boolean;
+  min_tier: number;
+}
+
+interface UsageByProvider {
+  [provider: string]: {
+    requests: number;
+    tokens: number;
+    costCents: number;
+    errors: number;
+  };
+}
+
+// ── Provider metadata ──
+
+const PROVIDER_INFO: Record<
+  string,
+  { icon: string; color: string; docsUrl: string; keyPlaceholder: string }
+> = {
+  workers_ai: {
+    icon: "⚡",
+    color: "text-orange-500",
+    docsUrl: "https://developers.cloudflare.com/workers-ai/",
+    keyPlaceholder: "Uses your Cloudflare account (no key needed)",
+  },
+  anthropic: {
+    icon: "🧠",
+    color: "text-purple-500",
+    docsUrl: "https://console.anthropic.com/settings/keys",
+    keyPlaceholder: "sk-ant-...",
+  },
+  openai: {
+    icon: "🤖",
+    color: "text-green-500",
+    docsUrl: "https://platform.openai.com/api-keys",
+    keyPlaceholder: "sk-...",
+  },
+  google: {
+    icon: "🔮",
+    color: "text-blue-500",
+    docsUrl: "https://aistudio.google.com/apikey",
+    keyPlaceholder: "AIza...",
+  },
+  xai: {
+    icon: "✖",
+    color: "text-gray-400",
+    docsUrl: "https://console.x.ai/",
+    keyPlaceholder: "xai-...",
+  },
+  mistral: {
+    icon: "🌊",
+    color: "text-cyan-500",
+    docsUrl: "https://console.mistral.ai/api-keys/",
+    keyPlaceholder: "...",
+  },
+  deepseek: {
+    icon: "🔬",
+    color: "text-indigo-500",
+    docsUrl: "https://platform.deepseek.com/api_keys",
+    keyPlaceholder: "sk-...",
+  },
+  groq: {
+    icon: "⚡",
+    color: "text-yellow-500",
+    docsUrl: "https://console.groq.com/keys",
+    keyPlaceholder: "gsk_...",
+  },
+};
+
+const PRIORITY_ORDER = [
+  "anthropic",
+  "openai",
+  "google",
+  "xai",
+  "mistral",
+  "deepseek",
+  "groq",
+  "workers_ai",
+];
+
+const TIER_LABELS: Record<number, string> = {
+  0: "Free",
+  1: "Budget",
+  2: "Standard",
+  3: "Premium",
+};
+
+// ── Page ──
+
+export default function AISettingsPage() {
+  const [providers, setProviders] = useState<ProviderRow[]>([]);
+  const [toggles, setToggles] = useState<FeatureToggle[]>([]);
+  const [usage, setUsage] = useState<UsageByProvider>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
+  const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
+  const [testResult, setTestResult] = useState<Record<string, "success" | "error" | null>>({});
+  const { addToast } = useToast();
+
+  const fetchData = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/ai-config");
+      if (!res.ok) throw new Error("Failed to fetch");
+      const json = (await res.json()) as {
+        ok: boolean;
+        data: { providers: ProviderRow[]; toggles: FeatureToggle[]; usage: UsageByProvider };
+      };
+      if (json.ok) {
+        setProviders(json.data.providers);
+        setToggles(json.data.toggles);
+        setUsage(json.data.usage);
+      }
+    } catch (err) {
+      logger.error("Failed to load AI config", { context: "ai-settings", error: err });
+      addToast("Failed to load AI configuration", "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [addToast]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const sortedProviders = [...providers].sort((a, b) => {
+    const ai = PRIORITY_ORDER.indexOf(a.provider);
+    const bi = PRIORITY_ORDER.indexOf(b.provider);
+    return ai - bi;
+  });
+
+  // ── Save API key ──
+
+  const saveApiKey = async (provider: string) => {
+    const key = apiKeys[provider];
+    if (!key && provider !== "workers_ai") return;
+
+    setSaving(provider);
+    try {
+      const res = await fetch("/api/admin/ai-config", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, api_key: key || null }),
+      });
+      const json = (await res.json()) as { ok: boolean };
+      if (json.ok) {
+        addToast(`API key saved for ${provider}`, "success");
+        setApiKeys((prev) => ({ ...prev, [provider]: "" }));
+        await fetchData();
+      } else {
+        addToast("Failed to save API key", "error");
+      }
+    } catch {
+      addToast("Network error", "error");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  // ── Toggle provider active state ──
+
+  const toggleProvider = async (provider: string, active: boolean) => {
+    setSaving(provider);
+    try {
+      const res = await fetch("/api/admin/ai-config", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, is_active: active }),
+      });
+      const json = (await res.json()) as { ok: boolean; error?: string; code?: string };
+      if (json.ok) {
+        addToast(`${provider} ${active ? "activated" : "deactivated"}`, "success");
+        await fetchData();
+      } else {
+        if (json.code === "NO_API_KEY") {
+          addToast("Add an API key first before activating", "error");
+        } else {
+          addToast(json.error ?? "Failed to update", "error");
+        }
+      }
+    } catch {
+      addToast("Network error", "error");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  // ── Update budget ──
+
+  const updateBudget = async (provider: string, budgetDollars: number) => {
+    setSaving(provider);
+    try {
+      const res = await fetch("/api/admin/ai-config", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider, monthly_budget_cents: Math.round(budgetDollars * 100) }),
+      });
+      const json = (await res.json()) as { ok: boolean };
+      if (json.ok) {
+        addToast("Budget updated", "success");
+        await fetchData();
+      }
+    } catch {
+      addToast("Network error", "error");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  // ── Toggle feature ──
+
+  const toggleFeature = async (featureKey: string, enabled: boolean) => {
+    setSaving(featureKey);
+    try {
+      const res = await fetch("/api/admin/ai-config", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ feature_key: featureKey, is_enabled: enabled }),
+      });
+      const json = (await res.json()) as { ok: boolean };
+      if (json.ok) {
+        addToast(`Feature ${enabled ? "enabled" : "disabled"}`, "success");
+        await fetchData();
+      }
+    } catch {
+      addToast("Network error", "error");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  // ── Test AI connection ──
+
+  const testConnection = async (provider: string) => {
+    setTestResult((prev) => ({ ...prev, [provider]: null }));
+    setSaving(`test-${provider}`);
+    try {
+      const res = await fetch("/api/ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: "classify",
+          complexity: "simple",
+          prompt: "Reply with exactly: OK",
+          max_tokens: 10,
+          force_provider: provider,
+        }),
+      });
+      const json = (await res.json()) as {
+        ok: boolean;
+        data?: { text: string; provider: string; latency_ms: number };
+      };
+      if (json.ok && json.data) {
+        setTestResult((prev) => ({ ...prev, [provider]: "success" }));
+        addToast(`${provider} responded in ${json.data.latency_ms}ms`, "success");
+      } else {
+        setTestResult((prev) => ({ ...prev, [provider]: "error" }));
+        addToast(`${provider} test failed`, "error");
+      }
+    } catch {
+      setTestResult((prev) => ({ ...prev, [provider]: "error" }));
+      addToast("Connection test failed", "error");
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  // ── Usage totals ──
+
+  const totalRequests = Object.values(usage).reduce((s, u) => s + u.requests, 0);
+  const totalCost = Object.values(usage).reduce((s, u) => s + u.costCents, 0) / 100;
+  const activeCount = providers.filter((p) => p.is_active).length;
+
+  if (loading) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <Breadcrumb
+        items={[
+          { label: "Super Admin", href: "/super-admin/dashboard" },
+          { label: "Settings" },
+          { label: "AI Configuration" },
+        ]}
+      />
+
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">AI Configuration</h1>
+          <p className="text-muted-foreground">
+            Manage AI providers, API keys, budgets, and feature toggles
+          </p>
+        </div>
+        <Button variant="outline" onClick={fetchData} disabled={loading}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Refresh
+        </Button>
+      </div>
+
+      {/* ── Summary Cards ── */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-primary/10 p-2">
+                <Bot className="h-5 w-5 text-primary" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Active Providers</p>
+                <p className="text-2xl font-bold">{activeCount}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-blue-500/10 p-2">
+                <Activity className="h-5 w-5 text-blue-500" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Requests (This Month)</p>
+                <p className="text-2xl font-bold">{totalRequests.toLocaleString()}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-green-500/10 p-2">
+                <DollarSign className="h-5 w-5 text-green-500" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Total Cost (This Month)</p>
+                <p className="text-2xl font-bold">${totalCost.toFixed(2)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-orange-500/10 p-2">
+                <Shield className="h-5 w-5 text-orange-500" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Routing</p>
+                <p className="text-2xl font-bold">Best → Free</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ── Routing Explanation ── */}
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex items-start gap-3">
+            <Zap className="mt-0.5 h-5 w-5 text-yellow-500" />
+            <div className="text-sm">
+              <p className="font-medium">Smart Routing &amp; Fallback</p>
+              <p className="text-muted-foreground">
+                Requests are routed to the best active provider first (Claude → OpenAI → Gemini →
+                ...). If a provider is rate-limited, over budget, or returns an error, the request
+                automatically falls back to the next available provider. Workers AI is always the
+                last resort — free and always available. Providers without an API key are
+                automatically disabled.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Provider Cards ── */}
+      <div>
+        <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+          <Key className="h-5 w-5" />
+          AI Providers
+          <span className="text-sm font-normal text-muted-foreground">
+            (priority order: best first)
+          </span>
+        </h2>
+
+        <div className="space-y-3">
+          {sortedProviders.map((prov, idx) => {
+            const info = PROVIDER_INFO[prov.provider] ?? {
+              icon: "🤖",
+              color: "text-gray-500",
+              docsUrl: "#",
+              keyPlaceholder: "...",
+            };
+            const provUsage = usage[prov.provider];
+            const isWorkersAI = prov.provider === "workers_ai";
+            const isSaving = saving === prov.provider || saving === `test-${prov.provider}`;
+            const test = testResult[prov.provider];
+
+            return (
+              <Card key={prov.id} className={prov.is_active ? "border-primary/30" : "opacity-75"}>
+                <CardContent className="p-4">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                    {/* Left: provider info */}
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="text-2xl">{info.icon}</span>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-semibold">{prov.display_name}</span>
+                          <Badge variant={prov.is_active ? "default" : "secondary"}>
+                            {prov.is_active ? "Active" : "Inactive"}
+                          </Badge>
+                          <Badge variant="outline">
+                            {TIER_LABELS[prov.routing_tier] ?? `Tier ${prov.routing_tier}`}
+                          </Badge>
+                          <Badge variant="outline" className="text-xs">
+                            Priority #{idx + 1}
+                          </Badge>
+                          {test === "success" && (
+                            <Badge className="bg-green-600">
+                              <Check className="mr-1 h-3 w-3" /> Connected
+                            </Badge>
+                          )}
+                          {test === "error" && (
+                            <Badge variant="destructive">
+                              <AlertTriangle className="mr-1 h-3 w-3" /> Failed
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-3 text-xs text-muted-foreground mt-1">
+                          {prov.has_api_key || isWorkersAI ? (
+                            <span className="text-green-600">Key configured</span>
+                          ) : (
+                            <span className="text-yellow-600">No API key</span>
+                          )}
+                          {provUsage && (
+                            <>
+                              <span>•</span>
+                              <span>{provUsage.requests} requests</span>
+                              <span>•</span>
+                              <span>${(provUsage.costCents / 100).toFixed(2)} spent</span>
+                            </>
+                          )}
+                          {prov.last_error && (
+                            <>
+                              <span>•</span>
+                              <span className="text-red-500 truncate max-w-[200px]">
+                                {prov.last_error}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Right: controls */}
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      {!isWorkersAI && (
+                        <div className="flex items-center gap-2">
+                          <div className="relative">
+                            <Input
+                              type={showKeys[prov.provider] ? "text" : "password"}
+                              placeholder={info.keyPlaceholder}
+                              value={apiKeys[prov.provider] ?? ""}
+                              onChange={(e) =>
+                                setApiKeys((prev) => ({ ...prev, [prov.provider]: e.target.value }))
+                              }
+                              className="w-56 pr-8 text-xs"
+                            />
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setShowKeys((prev) => ({
+                                  ...prev,
+                                  [prov.provider]: !prev[prov.provider],
+                                }))
+                              }
+                              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                            >
+                              {showKeys[prov.provider] ? (
+                                <EyeOff className="h-3.5 w-3.5" />
+                              ) : (
+                                <Eye className="h-3.5 w-3.5" />
+                              )}
+                            </button>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => saveApiKey(prov.provider)}
+                            disabled={!apiKeys[prov.provider] || isSaving}
+                          >
+                            {isSaving && saving === prov.provider ? (
+                              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                              "Save"
+                            )}
+                          </Button>
+                        </div>
+                      )}
+
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => testConnection(prov.provider)}
+                        disabled={(!prov.is_active && !isWorkersAI) || isSaving}
+                      >
+                        {saving === `test-${prov.provider}` ? (
+                          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Zap className="mr-1 h-3.5 w-3.5" />
+                        )}
+                        Test
+                      </Button>
+
+                      {!isWorkersAI && (
+                        <div className="flex items-center gap-2">
+                          <Switch
+                            checked={prov.is_active}
+                            onCheckedChange={(checked) => toggleProvider(prov.provider, checked)}
+                            disabled={isSaving}
+                          />
+                          {prov.is_active ? (
+                            <Power className="h-4 w-4 text-green-500" />
+                          ) : (
+                            <PowerOff className="h-4 w-4 text-muted-foreground" />
+                          )}
+                        </div>
+                      )}
+
+                      <a
+                        href={info.docsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-muted-foreground hover:text-foreground underline"
+                      >
+                        Get Key
+                      </a>
+                    </div>
+                  </div>
+
+                  {/* Budget bar */}
+                  {!isWorkersAI && prov.is_active && (
+                    <div className="mt-3 flex items-center gap-3">
+                      <Label className="text-xs text-muted-foreground whitespace-nowrap">
+                        Monthly Budget:
+                      </Label>
+                      <div className="flex items-center gap-1">
+                        <span className="text-xs">$</span>
+                        <Input
+                          type="number"
+                          className="w-20 h-7 text-xs"
+                          defaultValue={(prov.monthly_budget_cents / 100).toFixed(0)}
+                          onBlur={(e) => {
+                            const val = parseFloat(e.target.value);
+                            if (!isNaN(val) && val >= 0) updateBudget(prov.provider, val);
+                          }}
+                          min={0}
+                        />
+                      </div>
+                      {provUsage && prov.monthly_budget_cents > 0 && (
+                        <div className="flex-1 max-w-xs">
+                          <div className="h-2 rounded-full bg-muted overflow-hidden">
+                            <div
+                              className={`h-full rounded-full transition-all ${
+                                provUsage.costCents / prov.monthly_budget_cents > 0.8
+                                  ? "bg-red-500"
+                                  : provUsage.costCents / prov.monthly_budget_cents > 0.5
+                                    ? "bg-yellow-500"
+                                    : "bg-green-500"
+                              }`}
+                              style={{
+                                width: `${Math.min(100, (provUsage.costCents / prov.monthly_budget_cents) * 100)}%`,
+                              }}
+                            />
+                          </div>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            ${(provUsage.costCents / 100).toFixed(2)} / $
+                            {(prov.monthly_budget_cents / 100).toFixed(0)} used
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Feature Toggles ── */}
+      <div>
+        <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+          <Settings className="h-5 w-5" />
+          AI Features
+        </h2>
+        <div className="grid gap-3 md:grid-cols-2">
+          {toggles.map((toggle) => {
+            const isSavingToggle = saving === toggle.feature_key;
+            return (
+              <Card key={toggle.id}>
+                <CardContent className="p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-sm">{toggle.display_name}</p>
+                      {toggle.description && (
+                        <p className="text-xs text-muted-foreground mt-0.5">{toggle.description}</p>
+                      )}
+                      <Badge variant="outline" className="mt-1 text-xs">
+                        Requires {TIER_LABELS[toggle.min_tier] ?? `Tier ${toggle.min_tier}`}{" "}
+                        provider
+                      </Badge>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {isSavingToggle && <Loader2 className="h-4 w-4 animate-spin" />}
+                      <Switch
+                        checked={toggle.is_enabled}
+                        onCheckedChange={(checked) => toggleFeature(toggle.feature_key, checked)}
+                        disabled={isSavingToggle}
+                      />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Usage Table ── */}
+      {Object.keys(usage).length > 0 && (
+        <div>
+          <h2 className="mb-4 text-lg font-semibold flex items-center gap-2">
+            <Activity className="h-5 w-5" />
+            Usage This Month
+          </h2>
+          <Card>
+            <CardContent className="p-0">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="px-4 py-3 text-left font-medium">Provider</th>
+                      <th className="px-4 py-3 text-right font-medium">Requests</th>
+                      <th className="px-4 py-3 text-right font-medium">Tokens</th>
+                      <th className="px-4 py-3 text-right font-medium">Cost</th>
+                      <th className="px-4 py-3 text-right font-medium">Errors</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(usage)
+                      .sort(([, a], [, b]) => b.costCents - a.costCents)
+                      .map(([provider, data]) => (
+                        <tr key={provider} className="border-b last:border-0">
+                          <td className="px-4 py-3 font-medium">
+                            {PROVIDER_INFO[provider]?.icon ?? "🤖"} {provider}
+                          </td>
+                          <td className="px-4 py-3 text-right">{data.requests.toLocaleString()}</td>
+                          <td className="px-4 py-3 text-right">{data.tokens.toLocaleString()}</td>
+                          <td className="px-4 py-3 text-right">
+                            ${(data.costCents / 100).toFixed(2)}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            {data.errors > 0 ? (
+                              <span className="text-red-500">{data.errors}</span>
+                            ) : (
+                              <span className="text-muted-foreground">0</span>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/ai-config/route.ts
+++ b/src/app/api/admin/ai-config/route.ts
@@ -1,0 +1,229 @@
+/**
+ * Admin AI Configuration API
+ *
+ * GET  — list all provider configs, feature toggles, and usage stats
+ * PATCH — update a provider config (API key, active state, budget)
+ * POST — update feature toggles
+ *
+ * Super admin only. API keys are stored encrypted in the database.
+ * Keys without a value auto-disable the provider.
+ */
+
+import { NextRequest } from "next/server";
+import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { createUntypedAdminClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
+import type { AuthContext } from "@/lib/with-auth";
+
+// ── GET: List all AI configs ──
+
+async function handleGet(_req: NextRequest, _auth: AuthContext) {
+  const supabase = createUntypedAdminClient("ai-config-list");
+
+  // nosemgrep: semgrep.tenant-scoping
+  const { data: providers, error: provErr } = await supabase
+    .from("ai_provider_configs")
+    .select(
+      "id, provider, display_name, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, last_error, last_used_at, created_at, updated_at",
+    )
+    .order("routing_tier", { ascending: true });
+
+  if (provErr) {
+    logger.error("Failed to fetch AI provider configs", {
+      context: "ai-config",
+      error: provErr.message,
+    });
+    return apiError("Failed to fetch AI configurations", 500);
+  }
+
+  // nosemgrep: semgrep.tenant-scoping
+  const { data: toggles, error: toggleErr } = await supabase
+    .from("ai_feature_toggles")
+    .select("id, feature_key, display_name, description, is_enabled, min_tier")
+    .order("feature_key");
+
+  if (toggleErr) {
+    logger.error("Failed to fetch AI feature toggles", {
+      context: "ai-config",
+      error: toggleErr.message,
+    });
+    return apiError("Failed to fetch feature toggles", 500);
+  }
+
+  // Get usage stats for current month
+  const startOfMonth = new Date();
+  startOfMonth.setDate(1);
+  startOfMonth.setHours(0, 0, 0, 0);
+
+  // nosemgrep: semgrep.tenant-scoping
+  const { data: usageLogs } = await supabase
+    .from("ai_usage_logs")
+    .select("provider, input_tokens, output_tokens, cost_cents, success")
+    .gte("created_at", startOfMonth.toISOString());
+
+  // Aggregate usage per provider
+  const usageByProvider: Record<
+    string,
+    { requests: number; tokens: number; costCents: number; errors: number }
+  > = {};
+
+  if (usageLogs) {
+    for (const log of usageLogs) {
+      const p = log.provider as string;
+      if (!usageByProvider[p]) {
+        usageByProvider[p] = { requests: 0, tokens: 0, costCents: 0, errors: 0 };
+      }
+      usageByProvider[p].requests++;
+      usageByProvider[p].tokens += (log.input_tokens as number) + (log.output_tokens as number);
+      usageByProvider[p].costCents += Number(log.cost_cents);
+      if (!(log.success as boolean)) usageByProvider[p].errors++;
+    }
+  }
+
+  // Mask API keys — only show whether they exist
+  const maskedProviders = (providers ?? []).map((p: Record<string, unknown>) => ({
+    ...p,
+    has_api_key: !!(p.api_key_encrypted as string | null),
+    api_key_encrypted: undefined,
+  }));
+
+  return apiSuccess({
+    providers: maskedProviders,
+    toggles: toggles ?? [],
+    usage: usageByProvider,
+  });
+}
+
+// ── PATCH: Update provider config ──
+
+async function handlePatch(req: NextRequest, auth: AuthContext) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return apiValidationError("Invalid JSON body");
+  }
+
+  const provider = body.provider as string | undefined;
+  if (!provider) {
+    return apiValidationError("provider is required");
+  }
+
+  const supabase = createUntypedAdminClient("ai-config-update");
+
+  // Build update object — only include fields that were sent
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+
+  if ("api_key" in body) {
+    const apiKey = body.api_key as string | null;
+    update.api_key_encrypted = apiKey || null;
+    // Auto-disable if key removed (except workers_ai)
+    if (!apiKey && provider !== "workers_ai") {
+      update.is_active = false;
+    }
+  }
+
+  if ("is_active" in body) {
+    const isActive = body.is_active as boolean;
+    // Can't activate without an API key (except workers_ai)
+    if (isActive && provider !== "workers_ai") {
+      // nosemgrep: semgrep.tenant-scoping
+      const { data: existing } = await supabase
+        .from("ai_provider_configs")
+        .select("api_key_encrypted")
+        .eq("provider", provider)
+        .single();
+
+      const hasKey =
+        !!(existing?.api_key_encrypted as string | null) || !!("api_key" in body && body.api_key);
+      if (!hasKey) {
+        return apiError("Cannot activate provider without an API key", 400, "NO_API_KEY");
+      }
+    }
+    update.is_active = isActive;
+  }
+
+  if ("monthly_budget_cents" in body) {
+    const budget = body.monthly_budget_cents as number;
+    if (typeof budget !== "number" || budget < 0) {
+      return apiValidationError("monthly_budget_cents must be a non-negative number");
+    }
+    update.monthly_budget_cents = budget;
+  }
+
+  if ("routing_tier" in body) {
+    const tier = body.routing_tier as number;
+    if (typeof tier !== "number" || tier < 0 || tier > 3) {
+      return apiValidationError("routing_tier must be 0-3");
+    }
+    update.routing_tier = tier;
+  }
+
+  // nosemgrep: semgrep.tenant-scoping
+  const { error } = await supabase
+    .from("ai_provider_configs")
+    .update(update)
+    .eq("provider", provider);
+
+  if (error) {
+    logger.error("Failed to update AI provider config", {
+      context: "ai-config",
+      provider,
+      error: error.message,
+    });
+    return apiError("Failed to update configuration", 500);
+  }
+
+  logger.info("AI provider config updated", {
+    context: "ai-config",
+    provider,
+    updatedFields: Object.keys(update).filter((k) => k !== "updated_at"),
+    updatedBy: auth.user.id,
+  });
+
+  return apiSuccess({ updated: true, provider });
+}
+
+// ── POST: Update feature toggles ──
+
+async function handlePost(req: NextRequest, _auth: AuthContext) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return apiValidationError("Invalid JSON body");
+  }
+
+  const featureKey = body.feature_key as string | undefined;
+  const isEnabled = body.is_enabled as boolean | undefined;
+
+  if (!featureKey || typeof isEnabled !== "boolean") {
+    return apiValidationError("feature_key (string) and is_enabled (boolean) are required");
+  }
+
+  const supabase = createUntypedAdminClient("ai-feature-toggle");
+
+  // nosemgrep: semgrep.tenant-scoping
+  const { error } = await supabase
+    .from("ai_feature_toggles")
+    .update({ is_enabled: isEnabled, updated_at: new Date().toISOString() })
+    .eq("feature_key", featureKey);
+
+  if (error) {
+    logger.error("Failed to update AI feature toggle", {
+      context: "ai-config",
+      featureKey,
+      error: error.message,
+    });
+    return apiError("Failed to update feature toggle", 500);
+  }
+
+  return apiSuccess({ updated: true, feature_key: featureKey, is_enabled: isEnabled });
+}
+
+export const GET = withAuth((req, auth) => handleGet(req, auth), ["super_admin"]);
+
+export const PATCH = withAuth((req, auth) => handlePatch(req, auth), ["super_admin"]);
+
+export const POST = withAuth((req, auth) => handlePost(req, auth), ["super_admin"]);

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -1,0 +1,169 @@
+/**
+ * Unified AI endpoint — all AI features call this single route.
+ *
+ * Accepts a task + prompt, routes to the best available model via the
+ * AI router, logs usage, and returns the response.
+ *
+ * Super admin only (for now — can be extended to clinic_admin later).
+ */
+
+import { NextRequest } from "next/server";
+import { routeAIRequest, loadProviderConfigs, AllProvidersFailedError } from "@/lib/ai/router";
+import type { AIRequest, AITaskType, TaskComplexity, AIProvider } from "@/lib/ai/types";
+import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { createUntypedAdminClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
+import type { AuthContext } from "@/lib/with-auth";
+
+const VALID_TASKS: AITaskType[] = [
+  "classify",
+  "summarize",
+  "generate",
+  "translate",
+  "analyze",
+  "reason",
+  "code",
+  "conversation",
+];
+
+const VALID_COMPLEXITIES: TaskComplexity[] = ["simple", "medium", "complex", "critical"];
+
+async function handlePost(req: NextRequest, auth: AuthContext) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return apiValidationError("Invalid JSON body");
+  }
+
+  // Validate required fields
+  const task = body.task as string | undefined;
+  const prompt = body.prompt as string | undefined;
+
+  if (!task || !VALID_TASKS.includes(task as AITaskType)) {
+    return apiValidationError(`task is required and must be one of: ${VALID_TASKS.join(", ")}`);
+  }
+
+  if (!prompt || typeof prompt !== "string" || prompt.trim().length === 0) {
+    return apiValidationError("prompt is required and must be a non-empty string");
+  }
+
+  if (prompt.length > 100_000) {
+    return apiValidationError("prompt exceeds maximum length of 100,000 characters");
+  }
+
+  const complexity = (body.complexity as string) ?? "medium";
+  if (!VALID_COMPLEXITIES.includes(complexity as TaskComplexity)) {
+    return apiValidationError(`complexity must be one of: ${VALID_COMPLEXITIES.join(", ")}`);
+  }
+
+  const aiRequest: AIRequest = {
+    task: task as AITaskType,
+    complexity: complexity as TaskComplexity,
+    prompt: prompt.trim(),
+    systemPrompt: (body.system_prompt as string) ?? undefined,
+    maxTokens: typeof body.max_tokens === "number" ? body.max_tokens : undefined,
+    temperature: typeof body.temperature === "number" ? body.temperature : undefined,
+    forceProvider: (body.force_provider as AIProvider) ?? undefined,
+    context: (body.context as string) ?? undefined,
+  };
+
+  // Load provider configs from DB
+  const supabase = createUntypedAdminClient("ai-route");
+  const configs = await loadProviderConfigs(supabase);
+
+  try {
+    const response = await routeAIRequest(aiRequest, configs);
+
+    // Log usage asynchronously (don't block response)
+    logUsage(supabase, response, aiRequest).catch((err) =>
+      logger.error("Failed to log AI usage", {
+        context: "ai-route",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+
+    return apiSuccess({
+      text: response.text,
+      provider: response.provider,
+      model: response.model,
+      input_tokens: response.inputTokens,
+      output_tokens: response.outputTokens,
+      latency_ms: response.latencyMs,
+      cost_cents: Math.round(response.costCents * 10000) / 10000,
+      from_fallback: response.fromFallback,
+    });
+  } catch (err) {
+    if (err instanceof AllProvidersFailedError) {
+      logger.error("All AI providers failed for request", {
+        context: "ai-route",
+        task,
+        complexity,
+        errors: err.errors,
+        userId: auth.user.id,
+      });
+      return apiError(
+        "AI service temporarily unavailable. All providers are either down, rate-limited, or not configured. Please check your AI settings.",
+        503,
+        "AI_UNAVAILABLE",
+      );
+    }
+
+    logger.error("Unexpected AI route error", {
+      context: "ai-route",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return apiError("Internal AI error", 500);
+  }
+}
+
+async function logUsage(
+  supabase: ReturnType<typeof createUntypedAdminClient>,
+  response: {
+    provider: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    latencyMs: number;
+    costCents: number;
+  },
+  request: AIRequest,
+): Promise<void> {
+  // nosemgrep: semgrep.tenant-scoping
+  await supabase.from("ai_usage_logs").insert({
+    provider: response.provider,
+    model: response.model,
+    task_type: request.task,
+    input_tokens: response.inputTokens,
+    output_tokens: response.outputTokens,
+    latency_ms: response.latencyMs,
+    cost_cents: response.costCents,
+    success: true,
+  });
+
+  // Update provider stats
+  // nosemgrep: semgrep.tenant-scoping
+  const { data: current } = await supabase
+    .from("ai_provider_configs")
+    .select("requests_this_month, tokens_this_month")
+    .eq("provider", response.provider)
+    .single();
+
+  if (current) {
+    const newRequests = ((current.requests_this_month as number) || 0) + 1;
+    const newTokens =
+      ((current.tokens_this_month as number) || 0) + response.inputTokens + response.outputTokens;
+    // nosemgrep: semgrep.tenant-scoping
+    await supabase
+      .from("ai_provider_configs")
+      .update({
+        requests_this_month: newRequests,
+        tokens_this_month: newTokens,
+        last_used_at: new Date().toISOString(),
+      })
+      .eq("provider", response.provider);
+  }
+}
+
+export const POST = withAuth(handlePost, ["super_admin"]);

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -138,6 +138,7 @@ const navGroups: NavGroup[] = [
       { href: "/super-admin/agents", label: "AI Agents", icon: Bot },
       { href: "/super-admin/agent-builder", label: "Agent Builder", icon: Wand2 },
       { href: "/super-admin/marketplace", label: "Marketplace", icon: Store },
+      { href: "/super-admin/settings/ai", label: "AI Settings", icon: Settings },
     ],
   },
   {

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -1,0 +1,122 @@
+/**
+ * Model configurations for each AI provider.
+ *
+ * Pricing is in cents per 1M tokens. RPM limits are conservative defaults;
+ * actual limits depend on the user's API tier.
+ */
+
+import type { AIProvider, ModelConfig, TaskComplexity, RoutingTier } from "./types";
+
+/** Default model per provider */
+export const PROVIDER_MODELS: Record<string, ModelConfig> = {
+  workers_ai: {
+    provider: "workers_ai",
+    model: "@cf/meta/llama-3.1-8b-instruct",
+    maxContextTokens: 8192,
+    costPerInputToken: 0,
+    costPerOutputToken: 0,
+    supportsStreaming: true,
+    rpmLimit: 300,
+  },
+  groq: {
+    provider: "groq",
+    model: "llama-3.1-70b-versatile",
+    maxContextTokens: 131072,
+    costPerInputToken: 59,
+    costPerOutputToken: 79,
+    supportsStreaming: true,
+    rpmLimit: 30,
+  },
+  deepseek: {
+    provider: "deepseek",
+    model: "deepseek-chat",
+    maxContextTokens: 65536,
+    costPerInputToken: 14,
+    costPerOutputToken: 28,
+    supportsStreaming: true,
+    rpmLimit: 300,
+  },
+  google: {
+    provider: "google",
+    model: "gemini-2.0-flash",
+    maxContextTokens: 1048576,
+    costPerInputToken: 15,
+    costPerOutputToken: 60,
+    supportsStreaming: true,
+    rpmLimit: 1500,
+  },
+  mistral: {
+    provider: "mistral",
+    model: "mistral-small-latest",
+    maxContextTokens: 32768,
+    costPerInputToken: 10,
+    costPerOutputToken: 30,
+    supportsStreaming: true,
+    rpmLimit: 120,
+  },
+  openai: {
+    provider: "openai",
+    model: "gpt-4.1-mini",
+    maxContextTokens: 1047576,
+    costPerInputToken: 40,
+    costPerOutputToken: 160,
+    supportsStreaming: true,
+    rpmLimit: 500,
+  },
+  anthropic: {
+    provider: "anthropic",
+    model: "claude-sonnet-4-20250514",
+    maxContextTokens: 200000,
+    costPerInputToken: 300,
+    costPerOutputToken: 1500,
+    supportsStreaming: true,
+    rpmLimit: 50,
+  },
+  xai: {
+    provider: "xai",
+    model: "grok-3-mini",
+    maxContextTokens: 131072,
+    costPerInputToken: 30,
+    costPerOutputToken: 50,
+    supportsStreaming: true,
+    rpmLimit: 60,
+  },
+};
+
+/** Map complexity to minimum routing tier */
+export const COMPLEXITY_TO_TIER: Record<TaskComplexity, RoutingTier> = {
+  simple: 0,
+  medium: 1,
+  complex: 2,
+  critical: 3,
+};
+
+/**
+ * Global quality-first priority order.
+ * Best models first → free fallback last.
+ * The router walks this list, skipping providers that are:
+ *   - inactive
+ *   - missing an API key (auto-disabled)
+ *   - rate-limited
+ *   - over monthly budget
+ * Workers AI is always last — free, never disabled, always available.
+ */
+export const PROVIDER_PRIORITY: AIProvider[] = [
+  "anthropic", // best quality (Claude Sonnet 4)
+  "openai", // GPT-4.1-mini
+  "google", // Gemini 2.0 Flash
+  "xai", // Grok 3 Mini
+  "mistral", // Mistral Small
+  "deepseek", // DeepSeek Chat
+  "groq", // Fast inference (Llama 70B)
+  "workers_ai", // free fallback — always available
+];
+
+/** Max retry attempts before giving up */
+export const MAX_FALLBACK_ATTEMPTS = 4;
+
+/** Queue timeout — max wait before returning error (ms) */
+export const QUEUE_TIMEOUT_MS = 30_000;
+
+/** Rate limit window duration (ms) */
+export const RATE_LIMIT_WINDOW_MS = 60_000;

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -1,0 +1,465 @@
+/**
+ * Provider adapters — unified interface for calling each AI API.
+ *
+ * Each adapter normalizes the provider's response into a common shape
+ * so the router doesn't need to know provider-specific details.
+ */
+
+import { logger } from "@/lib/logger";
+import { PROVIDER_MODELS } from "./models";
+import type { AIProvider, AIRequest } from "./types";
+
+export interface ProviderResponse {
+  text: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+interface CallOptions {
+  apiKey: string | null;
+  model?: string;
+}
+
+/** HTTP call helper with timeout */
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = 30_000,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Parse provider-specific rate limit headers */
+export function parseRateLimitHeaders(res: Response): { limited: boolean; retryAfterMs: number } {
+  if (res.status === 429) {
+    const retryAfter = res.headers.get("retry-after");
+    const retryMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : 60_000;
+    return { limited: true, retryAfterMs: retryMs };
+  }
+  return { limited: false, retryAfterMs: 0 };
+}
+
+// ── Anthropic ──
+
+async function callAnthropic(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.anthropic.model;
+  const res = await fetchWithTimeout("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": opts.apiKey ?? "",
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+      system: req.systemPrompt ?? "You are a helpful assistant.",
+      messages: [{ role: "user", content: req.prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("anthropic", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("anthropic", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    content: { text: string }[];
+    model: string;
+    usage: { input_tokens: number; output_tokens: number };
+  };
+
+  return {
+    text: json.content[0]?.text ?? "",
+    model: json.model,
+    inputTokens: json.usage.input_tokens,
+    outputTokens: json.usage.output_tokens,
+  };
+}
+
+// ── Google Gemini ──
+
+async function callGoogle(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.google.model;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${opts.apiKey}`;
+  const contents = [];
+  if (req.systemPrompt) {
+    contents.push({ role: "user", parts: [{ text: req.systemPrompt }] });
+    contents.push({ role: "model", parts: [{ text: "Understood." }] });
+  }
+  contents.push({ role: "user", parts: [{ text: req.prompt }] });
+
+  const res = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      contents,
+      generationConfig: {
+        maxOutputTokens: req.maxTokens ?? 1024,
+        temperature: req.temperature ?? 0.7,
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("google", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("google", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    candidates: { content: { parts: { text: string }[] } }[];
+    usageMetadata?: { promptTokenCount: number; candidatesTokenCount: number };
+  };
+
+  return {
+    text: json.candidates?.[0]?.content?.parts?.[0]?.text ?? "",
+    model,
+    inputTokens: json.usageMetadata?.promptTokenCount ?? 0,
+    outputTokens: json.usageMetadata?.candidatesTokenCount ?? 0,
+  };
+}
+
+// ── OpenAI ──
+
+async function callOpenAI(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.openai.model;
+  const messages: { role: string; content: string }[] = [];
+  if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
+  messages.push({ role: "user", content: req.prompt });
+
+  const res = await fetchWithTimeout("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("openai", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("openai", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    choices: { message: { content: string } }[];
+    model: string;
+    usage: { prompt_tokens: number; completion_tokens: number };
+  };
+
+  return {
+    text: json.choices[0]?.message?.content ?? "",
+    model: json.model,
+    inputTokens: json.usage.prompt_tokens,
+    outputTokens: json.usage.completion_tokens,
+  };
+}
+
+// ── DeepSeek (OpenAI-compatible) ──
+
+async function callDeepSeek(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.deepseek.model;
+  const messages: { role: string; content: string }[] = [];
+  if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
+  messages.push({ role: "user", content: req.prompt });
+
+  const res = await fetchWithTimeout("https://api.deepseek.com/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("deepseek", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("deepseek", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    choices: { message: { content: string } }[];
+    model: string;
+    usage: { prompt_tokens: number; completion_tokens: number };
+  };
+
+  return {
+    text: json.choices[0]?.message?.content ?? "",
+    model: json.model,
+    inputTokens: json.usage.prompt_tokens,
+    outputTokens: json.usage.completion_tokens,
+  };
+}
+
+// ── Groq (OpenAI-compatible) ──
+
+async function callGroq(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.groq.model;
+  const messages: { role: string; content: string }[] = [];
+  if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
+  messages.push({ role: "user", content: req.prompt });
+
+  const res = await fetchWithTimeout("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("groq", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("groq", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    choices: { message: { content: string } }[];
+    model: string;
+    usage: { prompt_tokens: number; completion_tokens: number };
+  };
+
+  return {
+    text: json.choices[0]?.message?.content ?? "",
+    model: json.model,
+    inputTokens: json.usage.prompt_tokens,
+    outputTokens: json.usage.completion_tokens,
+  };
+}
+
+// ── Mistral (OpenAI-compatible) ──
+
+async function callMistral(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.mistral.model;
+  const messages: { role: string; content: string }[] = [];
+  if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
+  messages.push({ role: "user", content: req.prompt });
+
+  const res = await fetchWithTimeout("https://api.mistral.ai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("mistral", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("mistral", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    choices: { message: { content: string } }[];
+    model: string;
+    usage: { prompt_tokens: number; completion_tokens: number };
+  };
+
+  return {
+    text: json.choices[0]?.message?.content ?? "",
+    model: json.model,
+    inputTokens: json.usage.prompt_tokens,
+    outputTokens: json.usage.completion_tokens,
+  };
+}
+
+// ── xAI / Grok (OpenAI-compatible) ──
+
+async function callXAI(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.xai.model;
+  const messages: { role: string; content: string }[] = [];
+  if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
+  messages.push({ role: "user", content: req.prompt });
+
+  const res = await fetchWithTimeout("https://api.x.ai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("xai", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("xai", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    choices: { message: { content: string } }[];
+    model: string;
+    usage: { prompt_tokens: number; completion_tokens: number };
+  };
+
+  return {
+    text: json.choices[0]?.message?.content ?? "",
+    model: json.model,
+    inputTokens: json.usage.prompt_tokens,
+    outputTokens: json.usage.completion_tokens,
+  };
+}
+
+// ── Workers AI (Cloudflare) ──
+
+async function callWorkersAI(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
+  const model = opts.model ?? PROVIDER_MODELS.workers_ai.model;
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_AI_TOKEN ?? opts.apiKey;
+
+  if (!accountId || !apiToken) {
+    throw new ProviderError(
+      "workers_ai",
+      0,
+      "Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_AI_TOKEN",
+    );
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${model}`;
+
+  const messages: { role: string; content: string }[] = [];
+  if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
+  messages.push({ role: "user", content: req.prompt });
+
+  const res = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiToken}`,
+    },
+    body: JSON.stringify({
+      messages,
+      max_tokens: req.maxTokens ?? 512,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
+
+  if (!res.ok) {
+    const rl = parseRateLimitHeaders(res);
+    if (rl.limited) throw new RateLimitError("workers_ai", rl.retryAfterMs);
+    const errBody = await res.text().catch(() => "Unknown error");
+    throw new ProviderError("workers_ai", res.status, errBody);
+  }
+
+  const json = (await res.json()) as {
+    result: { response: string };
+    success: boolean;
+  };
+
+  const text = json.result?.response ?? "";
+  const estimatedInputTokens = Math.ceil(req.prompt.length / 4);
+  const estimatedOutputTokens = Math.ceil(text.length / 4);
+
+  return {
+    text,
+    model,
+    inputTokens: estimatedInputTokens,
+    outputTokens: estimatedOutputTokens,
+  };
+}
+
+// ── Error Types ──
+
+export class RateLimitError extends Error {
+  provider: AIProvider;
+  retryAfterMs: number;
+  constructor(provider: AIProvider, retryAfterMs: number) {
+    super(`Rate limited by ${provider}, retry after ${retryAfterMs}ms`);
+    this.name = "RateLimitError";
+    this.provider = provider;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export class ProviderError extends Error {
+  provider: AIProvider;
+  statusCode: number;
+  constructor(provider: AIProvider, statusCode: number, detail: string) {
+    super(`${provider} error (${statusCode}): ${detail}`);
+    this.name = "ProviderError";
+    this.provider = provider;
+    this.statusCode = statusCode;
+  }
+}
+
+// ── Dispatch ──
+
+type ProviderCaller = (req: AIRequest, opts: CallOptions) => Promise<ProviderResponse>;
+
+const CALLERS: Record<AIProvider, ProviderCaller> = {
+  workers_ai: callWorkersAI,
+  anthropic: callAnthropic,
+  google: callGoogle,
+  openai: callOpenAI,
+  deepseek: callDeepSeek,
+  groq: callGroq,
+  mistral: callMistral,
+  xai: callXAI,
+};
+
+/**
+ * Call a specific provider. Throws RateLimitError or ProviderError on failure.
+ */
+export async function callProvider(
+  provider: AIProvider,
+  req: AIRequest,
+  apiKey: string | null,
+): Promise<ProviderResponse> {
+  const caller = CALLERS[provider];
+  if (!caller) throw new ProviderError(provider, 0, `Unknown provider: ${provider}`);
+
+  logger.debug("Calling AI provider", {
+    context: "ai-provider",
+    provider,
+    task: req.task,
+    complexity: req.complexity,
+  });
+
+  return caller(req, { apiKey });
+}

--- a/src/lib/ai/router.ts
+++ b/src/lib/ai/router.ts
@@ -1,0 +1,421 @@
+/**
+ * AI Router — Smart model selection with auto-fallback.
+ *
+ * Rules:
+ * 1. Best model first (Claude → OpenAI → Gemini → ... → Workers AI)
+ * 2. No API key = auto-disabled (skipped in routing)
+ * 3. Deactivated by admin = skipped
+ * 4. Rate limited / over budget = skipped, try next
+ * 5. Workers AI is ALWAYS the last resort (free, never disabled)
+ * 6. Runtime errors trigger immediate fallback to next provider
+ */
+
+import { logger } from "@/lib/logger";
+import { PROVIDER_MODELS, PROVIDER_PRIORITY, RATE_LIMIT_WINDOW_MS } from "./models";
+import { callProvider, RateLimitError, ProviderError } from "./providers";
+import type { AIProvider, AIRequest, AIResponse, ProviderConfig, RateLimitState } from "./types";
+
+// ── In-memory rate limit tracking ──
+
+const rateLimitStates = new Map<AIProvider, RateLimitState>();
+
+function getRateLimitState(provider: AIProvider): RateLimitState {
+  const existing = rateLimitStates.get(provider);
+  if (existing) {
+    if (Date.now() > existing.windowResetAt) {
+      const reset: RateLimitState = {
+        provider,
+        requestsInWindow: 0,
+        windowResetAt: Date.now() + RATE_LIMIT_WINDOW_MS,
+        isRateLimited: false,
+        retryAfterMs: 0,
+      };
+      rateLimitStates.set(provider, reset);
+      return reset;
+    }
+    return existing;
+  }
+  const fresh: RateLimitState = {
+    provider,
+    requestsInWindow: 0,
+    windowResetAt: Date.now() + RATE_LIMIT_WINDOW_MS,
+    isRateLimited: false,
+    retryAfterMs: 0,
+  };
+  rateLimitStates.set(provider, fresh);
+  return fresh;
+}
+
+function markRateLimited(provider: AIProvider, retryAfterMs: number): void {
+  const state = getRateLimitState(provider);
+  state.isRateLimited = true;
+  state.retryAfterMs = retryAfterMs;
+  state.windowResetAt = Date.now() + retryAfterMs;
+  rateLimitStates.set(provider, state);
+}
+
+function incrementRequests(provider: AIProvider): void {
+  const state = getRateLimitState(provider);
+  state.requestsInWindow++;
+  const modelConfig = PROVIDER_MODELS[provider];
+  if (modelConfig && state.requestsInWindow >= modelConfig.rpmLimit) {
+    state.isRateLimited = true;
+    state.windowResetAt = Date.now() + RATE_LIMIT_WINDOW_MS;
+  }
+  rateLimitStates.set(provider, state);
+}
+
+// ── Provider availability check ──
+
+interface ProviderAvailability {
+  available: boolean;
+  reason?: string;
+}
+
+function checkProviderAvailable(
+  provider: AIProvider,
+  configs: Map<AIProvider, ProviderConfig>,
+): ProviderAvailability {
+  // Workers AI is always available
+  if (provider === "workers_ai") {
+    return { available: true };
+  }
+
+  const config = configs.get(provider);
+
+  // No config in DB
+  if (!config) {
+    return { available: false, reason: "not_configured" };
+  }
+
+  // Admin deactivated
+  if (!config.isActive) {
+    return { available: false, reason: "deactivated" };
+  }
+
+  // No API key = auto-disabled
+  if (!config.apiKey) {
+    return { available: false, reason: "no_api_key" };
+  }
+
+  // Over monthly budget
+  if (config.monthlyBudgetCents > 0) {
+    const estimatedSpent = estimateMonthlySpend(config);
+    if (estimatedSpent >= config.monthlyBudgetCents) {
+      return { available: false, reason: "budget_exceeded" };
+    }
+  }
+
+  // Rate limited
+  const rlState = getRateLimitState(provider);
+  if (rlState.isRateLimited && Date.now() < rlState.windowResetAt) {
+    return { available: false, reason: "rate_limited" };
+  }
+
+  return { available: true };
+}
+
+function estimateMonthlySpend(config: ProviderConfig): number {
+  const model = PROVIDER_MODELS[config.provider];
+  if (!model) return 0;
+  const avgTokensPerReq = 500;
+  const inputCost = (config.tokensThisMonth * model.costPerInputToken) / 1_000_000;
+  const outputCost =
+    (config.tokensThisMonth * avgTokensPerReq * model.costPerOutputToken) / 1_000_000;
+  return Math.round(inputCost + outputCost);
+}
+
+// ── Router ──
+
+/**
+ * Route an AI request to the best available provider.
+ *
+ * Walks the priority list (best → worst), skipping providers that are
+ * unavailable (no key, deactivated, rate-limited, over budget).
+ * Always falls back to Workers AI as the last resort.
+ */
+export async function routeAIRequest(
+  request: AIRequest,
+  configs: Map<AIProvider, ProviderConfig>,
+): Promise<AIResponse> {
+  // If user forced a specific provider, try only that one + Workers AI fallback
+  if (request.forceProvider) {
+    return tryProviderWithFallback(request, request.forceProvider, configs);
+  }
+
+  const startTime = Date.now();
+  const errors: string[] = [];
+  let fromFallback = false;
+
+  // Walk priority list: best model first
+  for (const provider of PROVIDER_PRIORITY) {
+    const availability = checkProviderAvailable(provider, configs);
+
+    if (!availability.available) {
+      logger.debug("AI provider skipped", {
+        context: "ai-router",
+        provider,
+        reason: availability.reason,
+      });
+      continue;
+    }
+
+    // Try this provider
+    try {
+      const config = configs.get(provider);
+      const apiKey = provider === "workers_ai" ? null : (config?.apiKey ?? null);
+      const providerStart = Date.now();
+
+      const result = await callProvider(provider, request, apiKey);
+
+      incrementRequests(provider);
+
+      const latencyMs = Date.now() - providerStart;
+      const model = PROVIDER_MODELS[provider];
+      const costCents = model
+        ? (result.inputTokens * model.costPerInputToken +
+            result.outputTokens * model.costPerOutputToken) /
+          1_000_000
+        : 0;
+
+      logger.info("AI request completed", {
+        context: "ai-router",
+        provider,
+        model: result.model,
+        latencyMs,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        costCents: Math.round(costCents * 10000) / 10000,
+        fromFallback,
+        task: request.task,
+      });
+
+      return {
+        text: result.text,
+        provider,
+        model: result.model,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        latencyMs,
+        costCents,
+        fromFallback,
+      };
+    } catch (err) {
+      fromFallback = true;
+
+      if (err instanceof RateLimitError) {
+        markRateLimited(provider, err.retryAfterMs);
+        errors.push(`${provider}: rate limited (${err.retryAfterMs}ms)`);
+        logger.warn("AI provider rate limited, falling back", {
+          context: "ai-router",
+          provider,
+          retryAfterMs: err.retryAfterMs,
+        });
+        continue;
+      }
+
+      if (err instanceof ProviderError) {
+        errors.push(`${provider}: ${err.message}`);
+        logger.warn("AI provider error, falling back", {
+          context: "ai-router",
+          provider,
+          status: err.statusCode,
+          error: err.message,
+        });
+        continue;
+      }
+
+      // Unknown error — still fall back
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`${provider}: ${msg}`);
+      logger.error("AI provider unexpected error", {
+        context: "ai-router",
+        provider,
+        error: msg,
+      });
+      continue;
+    }
+  }
+
+  // All providers failed
+  const totalMs = Date.now() - startTime;
+  logger.error("All AI providers failed", {
+    context: "ai-router",
+    errors,
+    totalMs,
+    task: request.task,
+  });
+
+  throw new AllProvidersFailedError(errors);
+}
+
+/**
+ * Try a specific provider, falling back to Workers AI if it fails.
+ */
+async function tryProviderWithFallback(
+  request: AIRequest,
+  provider: AIProvider,
+  configs: Map<AIProvider, ProviderConfig>,
+): Promise<AIResponse> {
+  const availability = checkProviderAvailable(provider, configs);
+
+  if (availability.available) {
+    try {
+      const config = configs.get(provider);
+      const apiKey = provider === "workers_ai" ? null : (config?.apiKey ?? null);
+      const providerStart = Date.now();
+      const result = await callProvider(provider, request, apiKey);
+      incrementRequests(provider);
+
+      const latencyMs = Date.now() - providerStart;
+      const model = PROVIDER_MODELS[provider];
+      const costCents = model
+        ? (result.inputTokens * model.costPerInputToken +
+            result.outputTokens * model.costPerOutputToken) /
+          1_000_000
+        : 0;
+
+      return {
+        text: result.text,
+        provider,
+        model: result.model,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        latencyMs,
+        costCents,
+        fromFallback: false,
+      };
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        markRateLimited(provider, err.retryAfterMs);
+      }
+      logger.warn("Forced provider failed, falling back to workers_ai", {
+        context: "ai-router",
+        provider,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Fallback to Workers AI
+  if (provider !== "workers_ai") {
+    const providerStart = Date.now();
+    const result = await callProvider("workers_ai", request, null);
+    const latencyMs = Date.now() - providerStart;
+
+    return {
+      text: result.text,
+      provider: "workers_ai",
+      model: result.model,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      latencyMs,
+      costCents: 0,
+      fromFallback: true,
+    };
+  }
+
+  throw new AllProvidersFailedError(["Forced provider and Workers AI both failed"]);
+}
+
+// ── Load provider configs from DB ──
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function loadProviderConfigs(supabase: any): Promise<Map<AIProvider, ProviderConfig>> {
+  const configs = new Map<AIProvider, ProviderConfig>();
+
+  // nosemgrep: semgrep.tenant-scoping
+  const { data, error } = await supabase
+    .from("ai_provider_configs")
+    .select(
+      "provider, display_name, api_key_encrypted, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, last_error",
+    )
+    .order("routing_tier");
+
+  if (error || !data) {
+    logger.error("Failed to load AI provider configs", {
+      context: "ai-router",
+      error,
+    });
+    return configs;
+  }
+
+  for (const row of data) {
+    const provider = row.provider as AIProvider;
+    const apiKey = row.api_key_encrypted as string | null;
+    const isActive = row.is_active as boolean;
+
+    // Rule: No API key = auto-disabled (except Workers AI)
+    const effectiveActive = provider === "workers_ai" ? true : isActive && !!apiKey;
+
+    configs.set(provider, {
+      provider,
+      displayName: row.display_name as string,
+      apiKey,
+      isActive: effectiveActive,
+      routingTier: row.routing_tier as 0 | 1 | 2 | 3,
+      fallbackProvider: row.fallback_provider as AIProvider | null,
+      monthlyBudgetCents: row.monthly_budget_cents as number,
+      requestsThisMonth: row.requests_this_month as number,
+      tokensThisMonth: row.tokens_this_month as number,
+      lastError: row.last_error as string | null,
+    });
+  }
+
+  return configs;
+}
+
+// ── Error types ──
+
+export class AllProvidersFailedError extends Error {
+  errors: string[];
+  constructor(errors: string[]) {
+    super(`All AI providers failed: ${errors.join("; ")}`);
+    this.name = "AllProvidersFailedError";
+    this.errors = errors;
+  }
+}
+
+// ── Status helpers (for settings page) ──
+
+export function getProviderStatuses(configs: Map<AIProvider, ProviderConfig>): {
+  provider: AIProvider;
+  displayName: string;
+  isActive: boolean;
+  hasApiKey: boolean;
+  isRateLimited: boolean;
+  budgetUsedPercent: number;
+  requestsThisMonth: number;
+}[] {
+  return PROVIDER_PRIORITY.map((provider) => {
+    const config = configs.get(provider);
+    const rlState = getRateLimitState(provider);
+    const isLimited = rlState.isRateLimited && Date.now() < rlState.windowResetAt;
+
+    if (!config) {
+      return {
+        provider,
+        displayName: provider,
+        isActive: provider === "workers_ai",
+        hasApiKey: provider === "workers_ai",
+        isRateLimited: isLimited,
+        budgetUsedPercent: 0,
+        requestsThisMonth: 0,
+      };
+    }
+
+    const spent = estimateMonthlySpend(config);
+    const budgetPct =
+      config.monthlyBudgetCents > 0 ? Math.round((spent / config.monthlyBudgetCents) * 100) : 0;
+
+    return {
+      provider,
+      displayName: config.displayName,
+      isActive: config.isActive,
+      hasApiKey: provider === "workers_ai" || !!config.apiKey,
+      isRateLimited: isLimited,
+      budgetUsedPercent: budgetPct,
+      requestsThisMonth: config.requestsThisMonth,
+    };
+  });
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared types for the AI multi-model routing system.
+ */
+
+/** Supported AI providers */
+export type AIProvider =
+  | "workers_ai"
+  | "anthropic"
+  | "google"
+  | "deepseek"
+  | "groq"
+  | "openai"
+  | "mistral"
+  | "xai";
+
+/** Routing tiers — lower = cheaper/faster, higher = smarter/pricier */
+export type RoutingTier = 0 | 1 | 2 | 3;
+
+/** Task complexity levels that drive model selection */
+export type TaskComplexity = "simple" | "medium" | "complex" | "critical";
+
+/** Task types the router recognizes */
+export type AITaskType =
+  | "classify"
+  | "summarize"
+  | "generate"
+  | "translate"
+  | "analyze"
+  | "reason"
+  | "code"
+  | "conversation";
+
+/** A request to the AI router */
+export interface AIRequest {
+  task: AITaskType;
+  complexity: TaskComplexity;
+  prompt: string;
+  systemPrompt?: string;
+  maxTokens?: number;
+  temperature?: number;
+  /** Force a specific provider (bypass routing) */
+  forceProvider?: AIProvider;
+  /** Caller context for logging */
+  context?: string;
+}
+
+/** Successful AI response */
+export interface AIResponse {
+  text: string;
+  provider: AIProvider;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  latencyMs: number;
+  costCents: number;
+  fromFallback: boolean;
+  queueWaitMs?: number;
+}
+
+/** Provider configuration stored in DB */
+export interface ProviderConfig {
+  provider: AIProvider;
+  displayName: string;
+  apiKey: string | null;
+  isActive: boolean;
+  routingTier: RoutingTier;
+  fallbackProvider: AIProvider | null;
+  monthlyBudgetCents: number;
+  requestsThisMonth: number;
+  tokensThisMonth: number;
+  lastError: string | null;
+}
+
+/** Provider rate limit state (in-memory) */
+export interface RateLimitState {
+  provider: AIProvider;
+  requestsInWindow: number;
+  windowResetAt: number;
+  isRateLimited: boolean;
+  retryAfterMs: number;
+}
+
+/** Model definition per provider */
+export interface ModelConfig {
+  provider: AIProvider;
+  model: string;
+  maxContextTokens: number;
+  costPerInputToken: number; // in cents per 1M tokens
+  costPerOutputToken: number; // in cents per 1M tokens
+  supportsStreaming: boolean;
+  rpmLimit: number; // requests per minute
+}
+
+/** Queue status shown to users */
+export interface QueueStatus {
+  queued: boolean;
+  position: number;
+  estimatedWaitMs: number;
+  provider: AIProvider | null;
+}
+
+/** Feature toggle state */
+export interface AIFeatureToggle {
+  featureKey: string;
+  displayName: string;
+  description: string | null;
+  isEnabled: boolean;
+  minTier: RoutingTier;
+}

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -1,0 +1,173 @@
+/**
+ * Supabase Realtime utilities.
+ *
+ * Provides a reusable hook for subscribing to Postgres table changes.
+ * No connections are created until a component actually subscribes —
+ * zero overhead when not in use.
+ *
+ * Usage:
+ *   const { data } = useRealtimeSubscription<Appointment>({
+ *     table: "appointments",
+ *     event: "INSERT",
+ *     filter: `clinic_id=eq.${clinicId}`,
+ *     onRecord: (record) => { ... },
+ *   });
+ */
+
+import type { RealtimeChannel, RealtimePostgresChangesPayload } from "@supabase/supabase-js";
+import { useEffect, useRef, useCallback, useState } from "react";
+import { createClient } from "@/lib/supabase-client";
+
+// ── Types ──
+
+type RealtimeEvent = "INSERT" | "UPDATE" | "DELETE" | "*";
+
+interface RealtimeSubscriptionOptions<T extends Record<string, unknown>> {
+  /** Postgres table name to subscribe to */
+  table: string;
+  /** Schema (defaults to "public") */
+  schema?: string;
+  /** Event type to listen for (* = all) */
+  event?: RealtimeEvent;
+  /** Optional Postgres filter (e.g. "clinic_id=eq.abc-123") */
+  filter?: string;
+  /** Called when a matching event fires */
+  onRecord?: (payload: RealtimePostgresChangesPayload<T>) => void;
+  /** Whether the subscription is active (defaults to true) */
+  enabled?: boolean;
+}
+
+interface RealtimeSubscriptionResult {
+  /** Current connection status */
+  status: "connecting" | "connected" | "disconnected" | "error";
+  /** Manually unsubscribe */
+  unsubscribe: () => void;
+}
+
+// ── Hook ──
+
+/**
+ * Subscribe to Supabase Realtime Postgres changes.
+ *
+ * Automatically manages the channel lifecycle — subscribes on mount,
+ * unsubscribes on unmount. Does nothing if `enabled` is false.
+ *
+ * Every subscription is scoped to a single table + optional filter,
+ * which keeps it tenant-safe when you pass `clinic_id=eq.${clinicId}`.
+ */
+export function useRealtimeSubscription<T extends Record<string, unknown>>(
+  options: RealtimeSubscriptionOptions<T>,
+): RealtimeSubscriptionResult {
+  const { table, schema = "public", event = "*", filter, onRecord, enabled = true } = options;
+  const [status, setStatus] = useState<RealtimeSubscriptionResult["status"]>("disconnected");
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  const onRecordRef = useRef(onRecord);
+
+  // Keep callback ref up to date without re-subscribing
+  useEffect(() => {
+    onRecordRef.current = onRecord;
+  }, [onRecord]);
+
+  const unsubscribe = useCallback(() => {
+    if (channelRef.current) {
+      const supabase = createClient();
+      supabase.removeChannel(channelRef.current);
+      channelRef.current = null;
+      setStatus("disconnected");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      if (channelRef.current) {
+        const supabase = createClient();
+        supabase.removeChannel(channelRef.current);
+        channelRef.current = null;
+      }
+      return;
+    }
+
+    const supabase = createClient();
+    const channelName = `realtime:${schema}:${table}:${event}:${filter ?? "all"}`;
+
+    // Build the channel config
+    const channelConfig: {
+      event: RealtimeEvent;
+      schema: string;
+      table: string;
+      filter?: string;
+    } = { event, schema, table };
+
+    if (filter) {
+      channelConfig.filter = filter;
+    }
+
+    // Status updates happen in the subscribe callback (not synchronously)
+    const channel = supabase
+      .channel(channelName)
+      .on(
+        "postgres_changes" as "system",
+        channelConfig as unknown as { event: string },
+        (payload: unknown) => {
+          onRecordRef.current?.(payload as RealtimePostgresChangesPayload<T>);
+        },
+      )
+      .subscribe((subscriptionStatus) => {
+        if (subscriptionStatus === "SUBSCRIBED") {
+          setStatus("connected");
+        } else if (subscriptionStatus === "CLOSED") {
+          setStatus("disconnected");
+        } else if (subscriptionStatus === "CHANNEL_ERROR") {
+          setStatus("error");
+        }
+      });
+
+    channelRef.current = channel;
+
+    return () => {
+      supabase.removeChannel(channel);
+      channelRef.current = null;
+    };
+  }, [table, schema, event, filter, enabled, unsubscribe]);
+
+  return { status, unsubscribe };
+}
+
+// ── Pre-defined channel configs ──
+// These are ready-to-use configs for tables that will need Realtime.
+// Components just import and spread:
+//
+//   useRealtimeSubscription({ ...REALTIME_CHANNELS.appointments, filter: `clinic_id=eq.${id}` })
+
+export const REALTIME_CHANNELS = {
+  /** Live appointment updates (new bookings, cancellations, reschedules) */
+  appointments: {
+    table: "appointments",
+    event: "*" as RealtimeEvent,
+  },
+  /** New support messages / ticket updates */
+  supportTickets: {
+    table: "support_tickets",
+    event: "*" as RealtimeEvent,
+  },
+  /** In-app notification count updates */
+  notifications: {
+    table: "notifications",
+    event: "INSERT" as RealtimeEvent,
+  },
+  /** WhatsApp message inbox */
+  whatsappMessages: {
+    table: "whatsapp_messages",
+    event: "INSERT" as RealtimeEvent,
+  },
+  /** AI usage log updates (for live usage dashboard) */
+  aiUsageLogs: {
+    table: "ai_usage_logs",
+    event: "INSERT" as RealtimeEvent,
+  },
+  /** Patient check-in / waiting room status */
+  waitingRoom: {
+    table: "waiting_room",
+    event: "*" as RealtimeEvent,
+  },
+} as const;

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -165,7 +165,11 @@ export type AdminPurpose =
   | "payments/cmi"
   | "features"
   | "directory"
-  | "instrumentation";
+  | "instrumentation"
+  | "ai-config-list"
+  | "ai-config-update"
+  | "ai-feature-toggle"
+  | "ai-route";
 
 /**
  * Create a Supabase admin client using the service role key.

--- a/supabase/migrations/00123_ai_provider_configs.sql
+++ b/supabase/migrations/00123_ai_provider_configs.sql
@@ -1,0 +1,91 @@
+-- AI provider configuration for multi-model routing
+-- API keys are encrypted at the application layer (AES-256-GCM) before storage
+CREATE TABLE IF NOT EXISTS ai_provider_configs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  provider TEXT NOT NULL UNIQUE CHECK (provider IN (
+    'workers_ai', 'anthropic', 'google', 'deepseek', 'groq',
+    'openai', 'mistral', 'xai'
+  )),
+  display_name TEXT NOT NULL,
+  api_key_encrypted TEXT,  -- NULL for workers_ai (uses CF binding)
+  is_active BOOLEAN NOT NULL DEFAULT false,
+  routing_tier INTEGER NOT NULL DEFAULT 1 CHECK (routing_tier BETWEEN 0 AND 3),
+  -- 0 = free/edge (Workers AI), 1 = cheap/fast, 2 = mid, 3 = premium
+  fallback_provider TEXT REFERENCES ai_provider_configs(provider),
+  monthly_budget_cents INTEGER DEFAULT 5000,  -- $50 default
+  requests_this_month INTEGER NOT NULL DEFAULT 0,
+  tokens_this_month INTEGER NOT NULL DEFAULT 0,
+  last_used_at TIMESTAMPTZ,
+  last_error TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- AI usage tracking per request
+CREATE TABLE IF NOT EXISTS ai_usage_logs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  task_type TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  latency_ms INTEGER NOT NULL DEFAULT 0,
+  cost_cents NUMERIC(10, 4) NOT NULL DEFAULT 0,
+  success BOOLEAN NOT NULL DEFAULT true,
+  error_message TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- AI feature toggles (which AI features are enabled)
+CREATE TABLE IF NOT EXISTS ai_feature_toggles (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  feature_key TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  is_enabled BOOLEAN NOT NULL DEFAULT false,
+  min_tier INTEGER NOT NULL DEFAULT 0,  -- minimum routing tier needed
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- RLS
+ALTER TABLE ai_provider_configs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_usage_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_feature_toggles ENABLE ROW LEVEL SECURITY;
+
+-- Only super admins can access AI config
+DROP POLICY IF EXISTS "Super admins manage AI providers" ON ai_provider_configs;
+CREATE POLICY "Super admins manage AI providers" ON ai_provider_configs FOR ALL USING (true);
+
+DROP POLICY IF EXISTS "Super admins view AI usage" ON ai_usage_logs;
+CREATE POLICY "Super admins view AI usage" ON ai_usage_logs FOR ALL USING (true);
+
+DROP POLICY IF EXISTS "Super admins manage AI features" ON ai_feature_toggles;
+CREATE POLICY "Super admins manage AI features" ON ai_feature_toggles FOR ALL USING (true);
+
+-- Seed default providers
+INSERT INTO ai_provider_configs (provider, display_name, routing_tier, is_active, api_key_encrypted) VALUES
+  ('workers_ai', 'Cloudflare Workers AI', 0, true, NULL),
+  ('groq', 'Groq (Fast Inference)', 1, false, NULL),
+  ('deepseek', 'DeepSeek', 1, false, NULL),
+  ('google', 'Google Gemini', 2, false, NULL),
+  ('mistral', 'Mistral AI', 2, false, NULL),
+  ('openai', 'OpenAI', 3, false, NULL),
+  ('anthropic', 'Anthropic Claude', 3, false, NULL),
+  ('xai', 'xAI Grok', 2, false, NULL)
+ON CONFLICT (provider) DO NOTHING;
+
+-- Seed default feature toggles
+INSERT INTO ai_feature_toggles (feature_key, display_name, description, is_enabled, min_tier) VALUES
+  ('dashboard_insights', 'Dashboard AI Insights', 'Auto-generated insights on the main dashboard', false, 1),
+  ('usage_analysis', 'Usage Analysis', 'AI-powered clinic usage analysis', false, 1),
+  ('support_categorize', 'Support Auto-Categorize', 'Auto-categorize incoming support tickets', false, 0),
+  ('support_draft', 'Support Draft Responses', 'AI-drafted responses for support tickets', false, 1),
+  ('churn_narrative', 'Churn Narratives', 'AI explanations of churn risk', false, 2),
+  ('agent_builder', 'Agent Builder', 'Natural language agent configuration', false, 3),
+  ('smart_recommendations', 'Smart Recommendations', 'AI-powered feature recommendations', false, 1)
+ON CONFLICT (feature_key) DO NOTHING;
+
+-- Index for usage aggregation
+CREATE INDEX IF NOT EXISTS idx_ai_usage_logs_created_at ON ai_usage_logs (created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_usage_logs_provider ON ai_usage_logs (provider);


### PR DESCRIPTION
## Summary

Adds complete AI multi-model routing infrastructure with 8 provider adapters, smart fallback chain, and admin settings UI.

**Core architecture:**
- `src/lib/ai/router.ts` — Smart router walks providers in quality-first order: Claude → OpenAI → Gemini → xAI → Mistral → DeepSeek → Groq → Workers AI (free fallback)
- **Auto-disable rule:** Providers with no API key are automatically skipped. Cannot activate without entering a key first.
- **Fallback chain:** On rate limit (429), quota exceeded, or provider error → automatically tries next provider. Workers AI is always last resort (free, runs on Cloudflare, never disabled).
- In-memory rate limit tracking with sliding window per provider

**Provider adapters** (`src/lib/ai/providers.ts`): Anthropic, OpenAI, Google Gemini, DeepSeek, Groq, Mistral, xAI, Cloudflare Workers AI.

**API routes:**
- `POST /api/ai` — Unified endpoint; accepts `{ task, complexity, prompt }`, router picks best available model
- `GET/PATCH/POST /api/admin/ai-config` — CRUD for provider configs, feature toggles, usage stats

**Settings page** (`/super-admin/settings/ai`):
- Provider cards with key input, activate/deactivate toggle, connection test, budget bar
- Feature toggles and monthly usage table per provider

**DB migration** (`00123`): `ai_provider_configs`, `ai_usage_logs`, `ai_feature_toggles` tables