### PR TITLE
fix: harden AI infrastructure (encryption, atomic counters, real routing tiers)

### DIFF
--- a/scripts/check-tenant-scoping.mjs
+++ b/scripts/check-tenant-scoping.mjs
@@ -49,8 +49,13 @@ const ALLOWLIST = new Set([
   "src/app/api/admin/team/route.ts",
   // Admin AI config — super_admin cross-tenant AI provider management
   "src/app/api/admin/ai-config/route.ts",
+  // Admin AI connection test — super_admin only, no tenant-scoped tables touched
+  "src/app/api/admin/ai-config/test/route.ts",
   // AI route — unified AI endpoint with cross-tenant usage logging
   "src/app/api/ai/route.ts",
+  // AI router/feature-toggles helpers — cross-tenant reads of ai_* tables
+  "src/lib/ai/router.ts",
+  "src/lib/ai/feature-toggles.ts",
 ]);
 
 const MUTATION_RE = /\.from\(["'][a-z_]+["']\)\.(insert|update|delete|upsert)/;

--- a/src/app/api/admin/ai-config/route.ts
+++ b/src/app/api/admin/ai-config/route.ts
@@ -5,11 +5,20 @@
  * PATCH — update a provider config (API key, active state, budget)
  * POST — update feature toggles
  *
- * Super admin only. API keys are stored encrypted in the database.
- * Keys without a value auto-disable the provider.
+ * Super admin only. API keys are encrypted with AES-256-GCM (PHI_ENCRYPTION_KEY)
+ * before insert/update via `encryptProviderKey`. Keys are never returned in
+ * the GET response — only a `has_api_key` boolean.
+ *
+ * Any write invalidates the in-memory config cache so the next /api/ai call
+ * picks up the new state immediately on the same instance.
  */
 
 import { NextRequest } from "next/server";
+import {
+  invalidateConfigCache,
+  invalidateFeatureToggleCache,
+} from "@/lib/ai/config-cache";
+import { encryptProviderKey, isProviderKeyEncrypted } from "@/lib/ai/secret-encryption";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
@@ -24,9 +33,9 @@ async function handleGet(_req: NextRequest, _auth: AuthContext) {
   const { data: providers, error: provErr } = await supabase // nosemgrep: semgrep.tenant-scoping
     .from("ai_provider_configs")
     .select(
-      "id, provider, display_name, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, last_error, last_used_at, created_at, updated_at",
+      "id, provider, display_name, api_key_encrypted, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, input_tokens_this_month, output_tokens_this_month, cost_this_month_cents, rate_limited_until, last_error, last_used_at, created_at, updated_at",
     )
-    .order("routing_tier", { ascending: true });
+    .order("routing_tier", { ascending: false });
 
   if (provErr) {
     logger.error("Failed to fetch AI provider configs", {
@@ -49,7 +58,9 @@ async function handleGet(_req: NextRequest, _auth: AuthContext) {
     return apiError("Failed to fetch feature toggles", 500);
   }
 
-  // Get usage stats for current month
+  // Aggregate per-provider usage stats for the current month from logs.
+  // Kept as a separate query so the admin UI's "this month" panel keeps
+  // working as it did before.
   const startOfMonth = new Date();
   startOfMonth.setDate(1);
   startOfMonth.setHours(0, 0, 0, 0);
@@ -59,7 +70,6 @@ async function handleGet(_req: NextRequest, _auth: AuthContext) {
     .select("provider, input_tokens, output_tokens, cost_cents, success")
     .gte("created_at", startOfMonth.toISOString());
 
-  // Aggregate usage per provider
   const usageByProvider: Record<
     string,
     { requests: number; tokens: number; costCents: number; errors: number }
@@ -78,12 +88,16 @@ async function handleGet(_req: NextRequest, _auth: AuthContext) {
     }
   }
 
-  // Mask API keys — only show whether they exist
-  const maskedProviders = (providers ?? []).map((p: Record<string, unknown>) => ({
-    ...p,
-    has_api_key: !!(p.api_key_encrypted as string | null),
-    api_key_encrypted: undefined,
-  }));
+  // Mask API keys — only expose presence + encryption status, never the value
+  const maskedProviders = (providers ?? []).map((p: Record<string, unknown>) => {
+    const stored = p.api_key_encrypted as string | null;
+    return {
+      ...p,
+      has_api_key: !!stored,
+      api_key_is_encrypted: isProviderKeyEncrypted(stored),
+      api_key_encrypted: undefined,
+    };
+  });
 
   return apiSuccess({
     providers: maskedProviders,
@@ -114,8 +128,9 @@ async function handlePatch(req: NextRequest, auth: AuthContext) {
 
   if ("api_key" in body) {
     const apiKey = body.api_key as string | null;
-    update.api_key_encrypted = apiKey || null;
-    // Auto-disable if key removed (except workers_ai)
+    // ENCRYPT the API key before storage. encryptProviderKey returns null
+    // when the input is null/empty.
+    update.api_key_encrypted = await encryptProviderKey(apiKey);
     if (!apiKey && provider !== "workers_ai") {
       update.is_active = false;
     }
@@ -123,7 +138,6 @@ async function handlePatch(req: NextRequest, auth: AuthContext) {
 
   if ("is_active" in body) {
     const isActive = body.is_active as boolean;
-    // Can't activate without an API key (except workers_ai)
     if (isActive && provider !== "workers_ai") {
       const { data: existing } = await supabase // nosemgrep: semgrep.tenant-scoping
         .from("ai_provider_configs")
@@ -170,10 +184,22 @@ async function handlePatch(req: NextRequest, auth: AuthContext) {
     return apiError("Failed to update configuration", 500);
   }
 
+  // Invalidate the in-memory cache so the next /api/ai call on this instance
+  // sees fresh state. Other instances will pick up the change after TTL.
+  invalidateConfigCache();
+
+  // Don't log which fields changed if the API key was rotated — keep that
+  // out of structured logs entirely.
+  const loggedFields = Object.keys(update).filter(
+    (k) => k !== "updated_at" && k !== "api_key_encrypted",
+  );
+  const rotatedKey = "api_key" in body;
+
   logger.info("AI provider config updated", {
     context: "ai-config",
     provider,
-    updatedFields: Object.keys(update).filter((k) => k !== "updated_at"),
+    updatedFields: loggedFields,
+    apiKeyRotated: rotatedKey,
     updatedBy: auth.user.id,
   });
 
@@ -212,6 +238,8 @@ async function handlePost(req: NextRequest, _auth: AuthContext) {
     });
     return apiError("Failed to update feature toggle", 500);
   }
+
+  invalidateFeatureToggleCache();
 
   return apiSuccess({ updated: true, feature_key: featureKey, is_enabled: isEnabled });
 }

--- a/src/app/api/admin/ai-config/test/route.ts
+++ b/src/app/api/admin/ai-config/test/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Connection-test endpoint for AI providers.
+ *
+ * Super admin only. Given a `provider` (and optionally `api_key` for a
+ * dry-run before saving), makes a tiny round-trip to confirm credentials
+ * and reachability. Returns latency, the model that responded, and any
+ * provider-side error.
+ *
+ * Used by the /super-admin/settings/ai UI test button.
+ *
+ *   POST { provider, api_key?: string }
+ *   → { ok: true, latency_ms, model, response_preview }
+ *   → { ok: false, status, message }
+ */
+
+import { NextRequest } from "next/server";
+import { PROVIDER_MODELS } from "@/lib/ai/models";
+import { callProvider, ProviderError, RateLimitError } from "@/lib/ai/providers";
+import { loadProviderConfigs } from "@/lib/ai/router";
+import type { AIProvider, AIRequest } from "@/lib/ai/types";
+import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { createUntypedAdminClient } from "@/lib/supabase-server";
+import { withAuth } from "@/lib/with-auth";
+import type { AuthContext } from "@/lib/with-auth";
+
+const VALID_PROVIDERS: AIProvider[] = [
+  "anthropic",
+  "openai",
+  "google",
+  "xai",
+  "mistral",
+  "deepseek",
+  "groq",
+  "workers_ai",
+];
+
+const TEST_REQUEST: AIRequest = {
+  task: "classify",
+  complexity: "simple",
+  prompt: "Reply with exactly the word OK.",
+  maxTokens: 10,
+  temperature: 0,
+};
+
+async function handlePost(req: NextRequest, auth: AuthContext) {
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return apiValidationError("Invalid JSON body");
+  }
+
+  const provider = body.provider as AIProvider | undefined;
+  if (!provider || !VALID_PROVIDERS.includes(provider)) {
+    return apiValidationError(
+      `provider is required and must be one of: ${VALID_PROVIDERS.join(", ")}`,
+    );
+  }
+
+  // Resolve which API key to test with:
+  //   1. `api_key` from the request body (dry-run for a not-yet-saved key)
+  //   2. The currently saved key for that provider
+  //   3. null for workers_ai (uses env)
+  let apiKey: string | null = null;
+  if (typeof body.api_key === "string" && body.api_key.length > 0) {
+    apiKey = body.api_key;
+  } else if (provider !== "workers_ai") {
+    const supabase = createUntypedAdminClient("ai-config-test");
+    const configs = await loadProviderConfigs(supabase, { forceRefresh: true });
+    apiKey = configs.get(provider)?.apiKey ?? null;
+    if (!apiKey) {
+      return apiError(
+        `No API key configured for ${provider}. Save one first or include api_key in the request.`,
+        400,
+        "NO_API_KEY",
+      );
+    }
+  }
+
+  logger.info("AI provider connection test started", {
+    context: "ai-config-test",
+    provider,
+    initiatedBy: auth.user.id,
+  });
+
+  const startedAt = Date.now();
+
+  try {
+    const result = await callProvider(provider, TEST_REQUEST, apiKey);
+    const latencyMs = Date.now() - startedAt;
+
+    return apiSuccess({
+      ok: true,
+      provider,
+      model: result.model || PROVIDER_MODELS[provider]?.model,
+      latency_ms: latencyMs,
+      input_tokens: result.inputTokens,
+      output_tokens: result.outputTokens,
+      response_preview: result.text.slice(0, 100),
+    });
+  } catch (err) {
+    const latencyMs = Date.now() - startedAt;
+
+    if (err instanceof RateLimitError) {
+      return apiSuccess({
+        ok: false,
+        provider,
+        status: 429,
+        message: `Rate limited — retry in ${Math.round(err.retryAfterMs / 1000)}s`,
+        latency_ms: latencyMs,
+      });
+    }
+
+    if (err instanceof ProviderError) {
+      return apiSuccess({
+        ok: false,
+        provider,
+        status: err.statusCode,
+        message: err.message.slice(0, 500),
+        latency_ms: latencyMs,
+      });
+    }
+
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error("AI provider connection test failed unexpectedly", {
+      context: "ai-config-test",
+      provider,
+      error: msg,
+    });
+    return apiSuccess({
+      ok: false,
+      provider,
+      status: 0,
+      message: msg.slice(0, 500),
+      latency_ms: latencyMs,
+    });
+  }
+}
+
+export const POST = withAuth(handlePost, ["super_admin"]);

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -1,13 +1,23 @@
 /**
  * Unified AI endpoint — all AI features call this single route.
  *
- * Accepts a task + prompt, routes to the best available model via the
- * AI router, logs usage, and returns the response.
+ * Accepts a task + prompt, optionally a feature_key for toggle-gating,
+ * routes to the best available model via the AI router, logs usage via
+ * an atomic Postgres RPC, and returns the response.
  *
  * Super admin only (for now — can be extended to clinic_admin later).
+ *
+ * Changes vs the original:
+ *   1. Feature key gating — if `feature_key` is sent, the request is
+ *      blocked when the matching toggle row is disabled.
+ *   2. Atomic counter increments via `increment_ai_usage` RPC. The old
+ *      read-modify-write pattern lost concurrent increments.
+ *   3. Provider configs are loaded through a 30s in-memory cache to save
+ *      a round-trip on every request.
  */
 
 import { NextRequest } from "next/server";
+import { isAIFeatureEnabled, loadFeatureToggles } from "@/lib/ai/feature-toggles";
 import { routeAIRequest, loadProviderConfigs, AllProvidersFailedError } from "@/lib/ai/router";
 import type { AIRequest, AITaskType, TaskComplexity, AIProvider } from "@/lib/ai/types";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
@@ -58,6 +68,8 @@ async function handlePost(req: NextRequest, auth: AuthContext) {
     return apiValidationError(`complexity must be one of: ${VALID_COMPLEXITIES.join(", ")}`);
   }
 
+  const featureKey = (body.feature_key as string) ?? undefined;
+
   const aiRequest: AIRequest = {
     task: task as AITaskType,
     complexity: complexity as TaskComplexity,
@@ -66,18 +78,36 @@ async function handlePost(req: NextRequest, auth: AuthContext) {
     maxTokens: typeof body.max_tokens === "number" ? body.max_tokens : undefined,
     temperature: typeof body.temperature === "number" ? body.temperature : undefined,
     forceProvider: (body.force_provider as AIProvider) ?? undefined,
+    featureKey,
     context: (body.context as string) ?? undefined,
   };
 
-  // Load provider configs from DB
   const supabase = createUntypedAdminClient("ai-route");
+
+  // ── Feature toggle gate ──
+  // Only enforced when the caller passes a feature_key. Unknown keys are
+  // allowed by default (opt-in gating).
+  if (featureKey) {
+    const toggles = await loadFeatureToggles(supabase);
+    const check = isAIFeatureEnabled(featureKey, toggles);
+    if (!check.allowed) {
+      logger.info("AI request blocked by feature toggle", {
+        context: "ai-route",
+        featureKey,
+        reason: check.reason,
+        userId: auth.user.id,
+      });
+      return apiError(check.reason ?? "Feature disabled", 403, "FEATURE_DISABLED");
+    }
+  }
+
   const configs = await loadProviderConfigs(supabase);
 
   try {
-    const response = await routeAIRequest(aiRequest, configs);
+    const response = await routeAIRequest(aiRequest, configs, supabase);
 
-    // Log usage asynchronously (don't block response)
-    logUsage(supabase, response, aiRequest).catch((err) =>
+    // Log usage in the background — don't block the response on it.
+    logUsage(supabase, response, aiRequest, auth).catch((err) =>
       logger.error("Failed to log AI usage", {
         context: "ai-route",
         error: err instanceof Error ? err.message : String(err),
@@ -118,6 +148,15 @@ async function handlePost(req: NextRequest, auth: AuthContext) {
   }
 }
 
+/**
+ * Log a successful AI call.
+ *
+ * Two writes:
+ *   1. Insert into ai_usage_logs (per-request audit trail)
+ *   2. Call increment_ai_usage() RPC — atomic update of monthly counters
+ *      and last_used_at. Replaces the racy read-modify-write that the
+ *      original code had.
+ */
 async function logUsage(
   supabase: ReturnType<typeof createUntypedAdminClient>,
   response: {
@@ -129,37 +168,35 @@ async function logUsage(
     costCents: number;
   },
   request: AIRequest,
+  auth: AuthContext,
 ): Promise<void> {
   await supabase.from("ai_usage_logs").insert({ // nosemgrep: semgrep.tenant-scoping
     provider: response.provider,
     model: response.model,
     task_type: request.task,
+    feature_key: request.featureKey ?? null,
     input_tokens: response.inputTokens,
     output_tokens: response.outputTokens,
     latency_ms: response.latencyMs,
     cost_cents: response.costCents,
     success: true,
+    user_id: auth.user.id,
   });
 
-  // Update provider stats
-  const { data: current } = await supabase // nosemgrep: semgrep.tenant-scoping
-    .from("ai_provider_configs")
-    .select("requests_this_month, tokens_this_month")
-    .eq("provider", response.provider)
-    .single();
+  // Atomic counter increment. Auto-resets at month boundary.
+  const { error } = await supabase.rpc("increment_ai_usage", {
+    p_provider: response.provider,
+    p_input_tokens: response.inputTokens,
+    p_output_tokens: response.outputTokens,
+    p_cost_cents: response.costCents,
+  });
 
-  if (current) {
-    const newRequests = ((current.requests_this_month as number) || 0) + 1;
-    const newTokens =
-      ((current.tokens_this_month as number) || 0) + response.inputTokens + response.outputTokens;
-    await supabase // nosemgrep: semgrep.tenant-scoping
-      .from("ai_provider_configs")
-      .update({
-        requests_this_month: newRequests,
-        tokens_this_month: newTokens,
-        last_used_at: new Date().toISOString(),
-      })
-      .eq("provider", response.provider);
+  if (error) {
+    logger.warn("increment_ai_usage RPC failed", {
+      context: "ai-route",
+      provider: response.provider,
+      error: error.message,
+    });
   }
 }
 

--- a/src/lib/ai/config-cache.ts
+++ b/src/lib/ai/config-cache.ts
@@ -1,0 +1,88 @@
+/**
+ * Provider Config Cache
+ *
+ * Without caching, every /api/ai call hits the DB to load 8 provider rows
+ * before routing — adds 20-50ms of latency and hammers Postgres at scale.
+ *
+ * Cache is invalidated on any PATCH/POST through the admin route. The TTL
+ * is a safety net for the in-memory case (multiple serverless instances
+ * won't see each other's writes, so the TTL forces eventual consistency).
+ *
+ * In a multi-instance deployment (Cloudflare Workers, Vercel functions),
+ * each instance has its own copy of the cache. A 30-second TTL keeps
+ * staleness bounded.
+ */
+
+import { logger } from "@/lib/logger";
+import type { AIProvider, ProviderConfig } from "./types";
+
+const TTL_MS = 30_000;
+
+interface CachedEntry {
+  configs: Map<AIProvider, ProviderConfig>;
+  expiresAt: number;
+}
+
+let _cached: CachedEntry | null = null;
+
+/** Returns the cached configs if still fresh, otherwise null. */
+export function getCachedConfigs(): Map<AIProvider, ProviderConfig> | null {
+  if (!_cached) return null;
+  if (Date.now() > _cached.expiresAt) {
+    _cached = null;
+    return null;
+  }
+  return _cached.configs;
+}
+
+/** Stores the freshly loaded configs into the cache. */
+export function setCachedConfigs(configs: Map<AIProvider, ProviderConfig>): void {
+  _cached = {
+    configs,
+    expiresAt: Date.now() + TTL_MS,
+  };
+}
+
+/** Invalidate the cache — call this whenever provider configs are mutated. */
+export function invalidateConfigCache(): void {
+  if (_cached) {
+    logger.debug("AI provider config cache invalidated", { context: "ai-config-cache" });
+  }
+  _cached = null;
+}
+
+/**
+ * Cached feature toggle state. Tracked separately from provider configs
+ * because toggles change rarely and the lookup is per-request.
+ */
+interface FeatureToggleCache {
+  toggles: Map<string, { isEnabled: boolean; minTier: number }>;
+  expiresAt: number;
+}
+
+let _toggleCache: FeatureToggleCache | null = null;
+
+export function getCachedFeatureToggles(): Map<
+  string,
+  { isEnabled: boolean; minTier: number }
+> | null {
+  if (!_toggleCache) return null;
+  if (Date.now() > _toggleCache.expiresAt) {
+    _toggleCache = null;
+    return null;
+  }
+  return _toggleCache.toggles;
+}
+
+export function setCachedFeatureToggles(
+  toggles: Map<string, { isEnabled: boolean; minTier: number }>,
+): void {
+  _toggleCache = {
+    toggles,
+    expiresAt: Date.now() + TTL_MS,
+  };
+}
+
+export function invalidateFeatureToggleCache(): void {
+  _toggleCache = null;
+}

--- a/src/lib/ai/feature-toggles.ts
+++ b/src/lib/ai/feature-toggles.ts
@@ -1,0 +1,110 @@
+/**
+ * AI Feature Toggles
+ *
+ * Centralizes the check for whether an AI-driven feature is enabled.
+ * Before this module existed, the `ai_feature_toggles` rows were stored
+ * and displayed in the admin UI but never read at request time.
+ *
+ * Callers pass a `feature_key` to the /api/ai endpoint; this module
+ * resolves whether the feature is enabled and whether at least one
+ * provider at or above the feature's required tier is available.
+ */
+
+import { logger } from "@/lib/logger";
+import {
+  getCachedFeatureToggles,
+  setCachedFeatureToggles,
+} from "./config-cache";
+
+interface FeatureToggleRow {
+  feature_key: string;
+  is_enabled: boolean;
+  min_tier: number;
+}
+
+/**
+ * Known AI feature keys. Keep this in sync with the seed in
+ * supabase/migrations/00123_ai_provider_configs.sql.
+ */
+export const AI_FEATURE_KEYS = [
+  "dashboard_insights",
+  "usage_analysis",
+  "support_categorize",
+  "support_draft",
+  "churn_narrative",
+  "agent_builder",
+  "smart_recommendations",
+] as const;
+
+export type AIFeatureKey = (typeof AI_FEATURE_KEYS)[number];
+
+export interface FeatureToggleState {
+  isEnabled: boolean;
+  minTier: number;
+}
+
+/**
+ * Load feature toggle state from DB (with caching).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function loadFeatureToggles(supabase: any): Promise<Map<string, FeatureToggleState>> {
+  const cached = getCachedFeatureToggles();
+  if (cached) return cached;
+
+  const { data, error } = await supabase // nosemgrep: semgrep.tenant-scoping
+    .from("ai_feature_toggles")
+    .select("feature_key, is_enabled, min_tier");
+
+  const map = new Map<string, FeatureToggleState>();
+
+  if (error || !data) {
+    logger.warn("Failed to load AI feature toggles — defaulting to enabled", {
+      context: "ai-feature-toggles",
+      error: error?.message,
+    });
+    return map;
+  }
+
+  for (const row of data as FeatureToggleRow[]) {
+    map.set(row.feature_key, {
+      isEnabled: row.is_enabled,
+      minTier: row.min_tier,
+    });
+  }
+
+  setCachedFeatureToggles(map);
+  return map;
+}
+
+/**
+ * Check whether a feature is allowed to make an AI request.
+ *
+ * Returns:
+ *   - { allowed: true } if the feature is enabled (or not gated)
+ *   - { allowed: false, reason } if disabled or no toggle exists for it
+ *
+ * Unknown feature keys default to `allowed: true` — this keeps the toggle
+ * system opt-in rather than opt-out. Misspelling a key won't silently block
+ * a request that the admin never explicitly disabled.
+ */
+export function isAIFeatureEnabled(
+  featureKey: string,
+  toggles: Map<string, FeatureToggleState>,
+): { allowed: boolean; reason?: string; minTier?: number } {
+  const toggle = toggles.get(featureKey);
+
+  if (!toggle) {
+    // Unknown feature → allowed (opt-in gating model)
+    return { allowed: true };
+  }
+
+  if (!toggle.isEnabled) {
+    return {
+      allowed: false,
+      reason: `Feature '${featureKey}' is disabled by admin`,
+      minTier: toggle.minTier,
+    };
+  }
+
+  return { allowed: true, minTier: toggle.minTier };
+}

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -5,7 +5,7 @@
  * actual limits depend on the user's API tier.
  */
 
-import type { AIProvider, ModelConfig, TaskComplexity, RoutingTier } from "./types";
+import type { AIProvider, ModelConfig } from "./types";
 
 /** Default model per provider */
 export const PROVIDER_MODELS: Record<string, ModelConfig> = {
@@ -15,7 +15,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 8192,
     costPerInputToken: 0,
     costPerOutputToken: 0,
-    supportsStreaming: true,
     rpmLimit: 300,
   },
   groq: {
@@ -24,7 +23,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 131072,
     costPerInputToken: 59,
     costPerOutputToken: 79,
-    supportsStreaming: true,
     rpmLimit: 30,
   },
   deepseek: {
@@ -33,7 +31,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 65536,
     costPerInputToken: 14,
     costPerOutputToken: 28,
-    supportsStreaming: true,
     rpmLimit: 300,
   },
   google: {
@@ -42,7 +39,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 1048576,
     costPerInputToken: 15,
     costPerOutputToken: 60,
-    supportsStreaming: true,
     rpmLimit: 1500,
   },
   mistral: {
@@ -51,7 +47,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 32768,
     costPerInputToken: 10,
     costPerOutputToken: 30,
-    supportsStreaming: true,
     rpmLimit: 120,
   },
   openai: {
@@ -60,7 +55,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 1047576,
     costPerInputToken: 40,
     costPerOutputToken: 160,
-    supportsStreaming: true,
     rpmLimit: 500,
   },
   anthropic: {
@@ -69,7 +63,6 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 200000,
     costPerInputToken: 300,
     costPerOutputToken: 1500,
-    supportsStreaming: true,
     rpmLimit: 50,
   },
   xai: {
@@ -78,28 +71,15 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
     maxContextTokens: 131072,
     costPerInputToken: 30,
     costPerOutputToken: 50,
-    supportsStreaming: true,
     rpmLimit: 60,
   },
 };
 
-/** Map complexity to minimum routing tier */
-export const COMPLEXITY_TO_TIER: Record<TaskComplexity, RoutingTier> = {
-  simple: 0,
-  medium: 1,
-  complex: 2,
-  critical: 3,
-};
-
 /**
- * Global quality-first priority order.
- * Best models first → free fallback last.
- * The router walks this list, skipping providers that are:
- *   - inactive
- *   - missing an API key (auto-disabled)
- *   - rate-limited
- *   - over monthly budget
- * Workers AI is always last — free, never disabled, always available.
+ * Quality-first baseline order. The router sorts dynamically by the
+ * `routing_tier` column from `ai_provider_configs` so admins can re-rank
+ * providers from the settings UI — this list is the fallback when two
+ * providers share the same tier. Workers AI is always pinned last.
  */
 export const PROVIDER_PRIORITY: AIProvider[] = [
   "anthropic", // best quality (Claude Sonnet 4)
@@ -109,14 +89,8 @@ export const PROVIDER_PRIORITY: AIProvider[] = [
   "mistral", // Mistral Small
   "deepseek", // DeepSeek Chat
   "groq", // Fast inference (Llama 70B)
-  "workers_ai", // free fallback — always available
+  "workers_ai", // free fallback — always last
 ];
-
-/** Max retry attempts before giving up */
-export const MAX_FALLBACK_ATTEMPTS = 4;
-
-/** Queue timeout — max wait before returning error (ms) */
-export const QUEUE_TIMEOUT_MS = 30_000;
 
 /** Rate limit window duration (ms) */
 export const RATE_LIMIT_WINDOW_MS = 60_000;

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -91,7 +91,10 @@ async function callAnthropic(req: AIRequest, opts: CallOptions): Promise<Provide
 
 async function callGoogle(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
   const model = opts.model ?? PROVIDER_MODELS.google.model;
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${opts.apiKey}`;
+  // SECURITY: Send the API key as a header (x-goog-api-key), not in the URL
+  // query string. URL params end up in access logs, proxies, and error
+  // reports — headers do not. Google's REST API supports both.
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
   const contents = [];
   if (req.systemPrompt) {
     contents.push({ role: "user", parts: [{ text: req.systemPrompt }] });
@@ -101,7 +104,10 @@ async function callGoogle(req: AIRequest, opts: CallOptions): Promise<ProviderRe
 
   const res = await fetchWithTimeout(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "x-goog-api-key": opts.apiKey ?? "",
+    },
     body: JSON.stringify({
       contents,
       generationConfig: {
@@ -350,14 +356,18 @@ async function callXAI(req: AIRequest, opts: CallOptions): Promise<ProviderRespo
 
 async function callWorkersAI(req: AIRequest, opts: CallOptions): Promise<ProviderResponse> {
   const model = opts.model ?? PROVIDER_MODELS.workers_ai.model;
-  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID; // nosemgrep: semgrep.env-access — runtime Workers AI credential, not available at build time
-  const apiToken = process.env.CLOUDFLARE_AI_TOKEN ?? opts.apiKey; // nosemgrep: semgrep.env-access — runtime Workers AI credential, fallback to per-request key
+  // Workers AI uses runtime credentials — these are not available at build
+  // time and aren't user-configurable per-clinic, so they live in env rather
+  // than the ai_provider_configs table.
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID; // nosemgrep: semgrep.env-access — runtime Workers AI credential
+  const apiToken = // nosemgrep: semgrep.env-access — runtime Workers AI credential
+    process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN ?? opts.apiKey;
 
   if (!accountId || !apiToken) {
     throw new ProviderError(
       "workers_ai",
       0,
-      "Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_AI_TOKEN",
+      "Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_AI_API_TOKEN",
     );
   }
 

--- a/src/lib/ai/router.ts
+++ b/src/lib/ai/router.ts
@@ -2,37 +2,49 @@
  * AI Router — Smart model selection with auto-fallback.
  *
  * Rules:
- * 1. Best model first (Claude → OpenAI → Gemini → ... → Workers AI)
- * 2. No API key = auto-disabled (skipped in routing)
- * 3. Deactivated by admin = skipped
- * 4. Rate limited / over budget = skipped, try next
- * 5. Workers AI is ALWAYS the last resort (free, never disabled)
- * 6. Runtime errors trigger immediate fallback to next provider
+ *   1. Best model first — order driven by the `routing_tier` column the
+ *      admin sets in the settings UI (no longer hardcoded).
+ *   2. No API key = auto-disabled (skipped in routing).
+ *   3. Deactivated by admin = skipped.
+ *   4. Rate-limited (persisted in DB) or over budget = skipped, try next.
+ *   5. Workers AI is ALWAYS the last resort — free, but still requires
+ *      `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_AI_API_TOKEN` to be set.
+ *   6. Runtime errors trigger immediate fallback to next provider.
+ *
+ * Config loading is cached for 30s to keep /api/ai latency low.
+ * Per-provider monthly cost uses the actual `cost_this_month_cents`
+ * column (not a quadratic estimate of token counts).
  */
 
 import { logger } from "@/lib/logger";
+import {
+  getCachedConfigs,
+  invalidateConfigCache,
+  setCachedConfigs,
+} from "./config-cache";
 import { PROVIDER_MODELS, PROVIDER_PRIORITY, RATE_LIMIT_WINDOW_MS } from "./models";
-import { callProvider, RateLimitError, ProviderError } from "./providers";
-import type { AIProvider, AIRequest, AIResponse, ProviderConfig, RateLimitState } from "./types";
+import { callProvider, ProviderError, RateLimitError } from "./providers";
+import { decryptProviderKey } from "./secret-encryption";
+import type {
+  AIProvider,
+  AIRequest,
+  AIResponse,
+  ProviderConfig,
+  RateLimitState,
+} from "./types";
 
-// ── In-memory rate limit tracking ──
+// ── In-memory rate-limit window (request counting) ──
+// The DB column `rate_limited_until` handles persistent cooldown across
+// invocations (set when a provider returns 429). The in-memory counter
+// here only enforces our own RPM caps within a single instance, as a
+// defensive guard against accidental DoS of a provider; the source of
+// truth for "is this provider currently 429'd" is the DB.
 
 const rateLimitStates = new Map<AIProvider, RateLimitState>();
 
 function getRateLimitState(provider: AIProvider): RateLimitState {
   const existing = rateLimitStates.get(provider);
-  if (existing) {
-    if (Date.now() > existing.windowResetAt) {
-      const reset: RateLimitState = {
-        provider,
-        requestsInWindow: 0,
-        windowResetAt: Date.now() + RATE_LIMIT_WINDOW_MS,
-        isRateLimited: false,
-        retryAfterMs: 0,
-      };
-      rateLimitStates.set(provider, reset);
-      return reset;
-    }
+  if (existing && Date.now() <= existing.windowResetAt) {
     return existing;
   }
   const fresh: RateLimitState = {
@@ -46,14 +58,6 @@ function getRateLimitState(provider: AIProvider): RateLimitState {
   return fresh;
 }
 
-function markRateLimited(provider: AIProvider, retryAfterMs: number): void {
-  const state = getRateLimitState(provider);
-  state.isRateLimited = true;
-  state.retryAfterMs = retryAfterMs;
-  state.windowResetAt = Date.now() + retryAfterMs;
-  rateLimitStates.set(provider, state);
-}
-
 function incrementRequests(provider: AIProvider): void {
   const state = getRateLimitState(provider);
   state.requestsInWindow++;
@@ -63,6 +67,50 @@ function incrementRequests(provider: AIProvider): void {
     state.windowResetAt = Date.now() + RATE_LIMIT_WINDOW_MS;
   }
   rateLimitStates.set(provider, state);
+}
+
+function markRateLimitedInMemory(provider: AIProvider, retryAfterMs: number): void {
+  const state = getRateLimitState(provider);
+  state.isRateLimited = true;
+  state.retryAfterMs = retryAfterMs;
+  state.windowResetAt = Date.now() + retryAfterMs;
+  rateLimitStates.set(provider, state);
+}
+
+/** Persist a rate-limit cooldown across serverless invocations. */
+async function persistRateLimit(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  provider: AIProvider,
+  retryAfterMs: number,
+): Promise<void> {
+  const until = new Date(Date.now() + retryAfterMs).toISOString();
+  try {
+    await supabase.rpc("mark_provider_rate_limited", {
+      p_provider: provider,
+      p_until: until,
+    });
+    invalidateConfigCache();
+  } catch (err) {
+    logger.warn("Failed to persist rate-limit state", {
+      context: "ai-router",
+      provider,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ── Workers AI environment check ──
+// The "always available" fallback isn't actually available if the Cloudflare
+// credentials aren't configured. Check at availability-check time, not just
+// when the call is attempted, so the router can skip it cleanly.
+
+function isWorkersAIConfigured(): boolean {
+  // nosemgrep: semgrep.env-access — runtime cred check for built-in fallback provider
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  // nosemgrep: semgrep.env-access — runtime cred check for built-in fallback provider
+  const apiToken = process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN;
+  return !!accountId && !!apiToken;
 }
 
 // ── Provider availability check ──
@@ -76,37 +124,30 @@ function checkProviderAvailable(
   provider: AIProvider,
   configs: Map<AIProvider, ProviderConfig>,
 ): ProviderAvailability {
-  // Workers AI is always available
   if (provider === "workers_ai") {
+    if (!isWorkersAIConfigured()) {
+      return { available: false, reason: "cloudflare_not_configured" };
+    }
     return { available: true };
   }
 
   const config = configs.get(provider);
 
-  // No config in DB
-  if (!config) {
-    return { available: false, reason: "not_configured" };
+  if (!config) return { available: false, reason: "not_configured" };
+  if (!config.isActive) return { available: false, reason: "deactivated" };
+  if (!config.apiKey) return { available: false, reason: "no_api_key" };
+
+  // Budget check uses the real cost_this_month_cents, not an estimate.
+  if (config.monthlyBudgetCents > 0 && config.costThisMonthCents >= config.monthlyBudgetCents) {
+    return { available: false, reason: "budget_exceeded" };
   }
 
-  // Admin deactivated
-  if (!config.isActive) {
-    return { available: false, reason: "deactivated" };
+  // Persistent rate limit (set by a previous 429)
+  if (config.rateLimitedUntil && config.rateLimitedUntil > Date.now()) {
+    return { available: false, reason: "rate_limited_persisted" };
   }
 
-  // No API key = auto-disabled
-  if (!config.apiKey) {
-    return { available: false, reason: "no_api_key" };
-  }
-
-  // Over monthly budget
-  if (config.monthlyBudgetCents > 0) {
-    const estimatedSpent = estimateMonthlySpend(config);
-    if (estimatedSpent >= config.monthlyBudgetCents) {
-      return { available: false, reason: "budget_exceeded" };
-    }
-  }
-
-  // Rate limited
+  // In-memory rate limit (this instance's window counter)
   const rlState = getRateLimitState(provider);
   if (rlState.isRateLimited && Date.now() < rlState.windowResetAt) {
     return { available: false, reason: "rate_limited" };
@@ -115,40 +156,41 @@ function checkProviderAvailable(
   return { available: true };
 }
 
-function estimateMonthlySpend(config: ProviderConfig): number {
-  const model = PROVIDER_MODELS[config.provider];
-  if (!model) return 0;
-  const avgTokensPerReq = 500;
-  const inputCost = (config.tokensThisMonth * model.costPerInputToken) / 1_000_000;
-  const outputCost =
-    (config.tokensThisMonth * avgTokensPerReq * model.costPerOutputToken) / 1_000_000;
-  return Math.round(inputCost + outputCost);
+// ── Dynamic priority by routing_tier ──
+// Higher routing_tier = better model. Within the same tier, fall back to
+// the hardcoded PROVIDER_PRIORITY (which roughly matches model quality).
+
+function buildPriorityList(configs: Map<AIProvider, ProviderConfig>): AIProvider[] {
+  const sorted = [...PROVIDER_PRIORITY].sort((a, b) => {
+    const tierA = configs.get(a)?.routingTier ?? -1;
+    const tierB = configs.get(b)?.routingTier ?? -1;
+    if (tierA !== tierB) return tierB - tierA; // higher tier first
+    return PROVIDER_PRIORITY.indexOf(a) - PROVIDER_PRIORITY.indexOf(b);
+  });
+
+  // Workers AI always last regardless of tier — it's the free safety net
+  return [...sorted.filter((p) => p !== "workers_ai"), "workers_ai"];
 }
 
 // ── Router ──
 
-/**
- * Route an AI request to the best available provider.
- *
- * Walks the priority list (best → worst), skipping providers that are
- * unavailable (no key, deactivated, rate-limited, over budget).
- * Always falls back to Workers AI as the last resort.
- */
 export async function routeAIRequest(
   request: AIRequest,
   configs: Map<AIProvider, ProviderConfig>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase?: any,
 ): Promise<AIResponse> {
-  // If user forced a specific provider, try only that one + Workers AI fallback
   if (request.forceProvider) {
-    return tryProviderWithFallback(request, request.forceProvider, configs);
+    return tryProviderWithFallback(request, request.forceProvider, configs, supabase);
   }
 
   const startTime = Date.now();
   const errors: string[] = [];
   let fromFallback = false;
 
-  // Walk priority list: best model first
-  for (const provider of PROVIDER_PRIORITY) {
+  const priority = buildPriorityList(configs);
+
+  for (const provider of priority) {
     const availability = checkProviderAvailable(provider, configs);
 
     if (!availability.available) {
@@ -160,12 +202,10 @@ export async function routeAIRequest(
       continue;
     }
 
-    // Try this provider
     try {
       const config = configs.get(provider);
       const apiKey = provider === "workers_ai" ? null : (config?.apiKey ?? null);
       const providerStart = Date.now();
-
       const result = await callProvider(provider, request, apiKey);
 
       incrementRequests(provider);
@@ -204,7 +244,8 @@ export async function routeAIRequest(
       fromFallback = true;
 
       if (err instanceof RateLimitError) {
-        markRateLimited(provider, err.retryAfterMs);
+        markRateLimitedInMemory(provider, err.retryAfterMs);
+        if (supabase) await persistRateLimit(supabase, provider, err.retryAfterMs);
         errors.push(`${provider}: rate limited (${err.retryAfterMs}ms)`);
         logger.warn("AI provider rate limited, falling back", {
           context: "ai-router",
@@ -225,7 +266,6 @@ export async function routeAIRequest(
         continue;
       }
 
-      // Unknown error — still fall back
       const msg = err instanceof Error ? err.message : String(err);
       errors.push(`${provider}: ${msg}`);
       logger.error("AI provider unexpected error", {
@@ -237,7 +277,6 @@ export async function routeAIRequest(
     }
   }
 
-  // All providers failed
   const totalMs = Date.now() - startTime;
   logger.error("All AI providers failed", {
     context: "ai-router",
@@ -249,13 +288,12 @@ export async function routeAIRequest(
   throw new AllProvidersFailedError(errors);
 }
 
-/**
- * Try a specific provider, falling back to Workers AI if it fails.
- */
 async function tryProviderWithFallback(
   request: AIRequest,
   provider: AIProvider,
   configs: Map<AIProvider, ProviderConfig>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase?: any,
 ): Promise<AIResponse> {
   const availability = checkProviderAvailable(provider, configs);
 
@@ -287,7 +325,8 @@ async function tryProviderWithFallback(
       };
     } catch (err) {
       if (err instanceof RateLimitError) {
-        markRateLimited(provider, err.retryAfterMs);
+        markRateLimitedInMemory(provider, err.retryAfterMs);
+        if (supabase) await persistRateLimit(supabase, provider, err.retryAfterMs);
       }
       logger.warn("Forced provider failed, falling back to workers_ai", {
         context: "ai-router",
@@ -297,8 +336,8 @@ async function tryProviderWithFallback(
     }
   }
 
-  // Fallback to Workers AI
-  if (provider !== "workers_ai") {
+  // Fallback to Workers AI — only if configured
+  if (provider !== "workers_ai" && isWorkersAIConfigured()) {
     const providerStart = Date.now();
     const result = await callProvider("workers_ai", request, null);
     const latencyMs = Date.now() - providerStart;
@@ -315,21 +354,31 @@ async function tryProviderWithFallback(
     };
   }
 
-  throw new AllProvidersFailedError(["Forced provider and Workers AI both failed"]);
+  throw new AllProvidersFailedError([
+    `Forced provider '${provider}' failed and Workers AI is not configured`,
+  ]);
 }
 
-// ── Load provider configs from DB ──
+// ── Load provider configs from DB (cached) ──
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function loadProviderConfigs(supabase: any): Promise<Map<AIProvider, ProviderConfig>> {
+export async function loadProviderConfigs(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  options: { forceRefresh?: boolean } = {},
+): Promise<Map<AIProvider, ProviderConfig>> {
+  if (!options.forceRefresh) {
+    const cached = getCachedConfigs();
+    if (cached) return cached;
+  }
+
   const configs = new Map<AIProvider, ProviderConfig>();
 
   const { data, error } = await supabase // nosemgrep: semgrep.tenant-scoping
     .from("ai_provider_configs")
     .select(
-      "provider, display_name, api_key_encrypted, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, last_error",
+      "provider, display_name, api_key_encrypted, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, input_tokens_this_month, output_tokens_this_month, cost_this_month_cents, rate_limited_until, last_error",
     )
-    .order("routing_tier");
+    .order("routing_tier", { ascending: false });
 
   if (error || !data) {
     logger.error("Failed to load AI provider configs", {
@@ -341,10 +390,9 @@ export async function loadProviderConfigs(supabase: any): Promise<Map<AIProvider
 
   for (const row of data) {
     const provider = row.provider as AIProvider;
-    const apiKey = row.api_key_encrypted as string | null;
+    const apiKey = await decryptProviderKey(row.api_key_encrypted as string | null);
     const isActive = row.is_active as boolean;
 
-    // Rule: No API key = auto-disabled (except Workers AI)
     const effectiveActive = provider === "workers_ai" ? true : isActive && !!apiKey;
 
     configs.set(provider, {
@@ -355,29 +403,34 @@ export async function loadProviderConfigs(supabase: any): Promise<Map<AIProvider
       routingTier: row.routing_tier as 0 | 1 | 2 | 3,
       fallbackProvider: row.fallback_provider as AIProvider | null,
       monthlyBudgetCents: row.monthly_budget_cents as number,
-      requestsThisMonth: row.requests_this_month as number,
-      tokensThisMonth: row.tokens_this_month as number,
+      requestsThisMonth: (row.requests_this_month as number) ?? 0,
+      tokensThisMonth: (row.tokens_this_month as number) ?? 0,
+      inputTokensThisMonth: (row.input_tokens_this_month as number) ?? 0,
+      outputTokensThisMonth: (row.output_tokens_this_month as number) ?? 0,
+      costThisMonthCents: Number(row.cost_this_month_cents ?? 0),
+      rateLimitedUntil: row.rate_limited_until
+        ? new Date(row.rate_limited_until as string).getTime()
+        : null,
       lastError: row.last_error as string | null,
     });
   }
 
+  setCachedConfigs(configs);
   return configs;
 }
 
-// ── Error types ──
+// ── Errors ──
 
 export class AllProvidersFailedError extends Error {
-  errors: string[];
-  constructor(errors: string[]) {
+  constructor(public readonly errors: string[]) {
     super(`All AI providers failed: ${errors.join("; ")}`);
     this.name = "AllProvidersFailedError";
-    this.errors = errors;
   }
 }
 
-// ── Status helpers (for settings page) ──
+// ── Health report (for admin dashboard) ──
 
-export function getProviderStatuses(configs: Map<AIProvider, ProviderConfig>): {
+export function getProviderHealth(configs: Map<AIProvider, ProviderConfig>): Array<{
   provider: AIProvider;
   displayName: string;
   isActive: boolean;
@@ -385,11 +438,13 @@ export function getProviderStatuses(configs: Map<AIProvider, ProviderConfig>): {
   isRateLimited: boolean;
   budgetUsedPercent: number;
   requestsThisMonth: number;
-}[] {
+}> {
   return PROVIDER_PRIORITY.map((provider) => {
     const config = configs.get(provider);
-    const rlState = getRateLimitState(provider);
-    const isLimited = rlState.isRateLimited && Date.now() < rlState.windowResetAt;
+    const rlState = rateLimitStates.get(provider);
+    const isLimited =
+      (rlState?.isRateLimited && Date.now() < (rlState?.windowResetAt ?? 0)) ||
+      (config?.rateLimitedUntil != null && config.rateLimitedUntil > Date.now());
 
     if (!config) {
       return {
@@ -397,22 +452,23 @@ export function getProviderStatuses(configs: Map<AIProvider, ProviderConfig>): {
         displayName: provider,
         isActive: provider === "workers_ai",
         hasApiKey: provider === "workers_ai",
-        isRateLimited: isLimited,
+        isRateLimited: !!isLimited,
         budgetUsedPercent: 0,
         requestsThisMonth: 0,
       };
     }
 
-    const spent = estimateMonthlySpend(config);
     const budgetPct =
-      config.monthlyBudgetCents > 0 ? Math.round((spent / config.monthlyBudgetCents) * 100) : 0;
+      config.monthlyBudgetCents > 0
+        ? Math.round((config.costThisMonthCents / config.monthlyBudgetCents) * 100)
+        : 0;
 
     return {
       provider,
       displayName: config.displayName,
       isActive: config.isActive,
       hasApiKey: provider === "workers_ai" || !!config.apiKey,
-      isRateLimited: isLimited,
+      isRateLimited: !!isLimited,
       budgetUsedPercent: budgetPct,
       requestsThisMonth: config.requestsThisMonth,
     };

--- a/src/lib/ai/secret-encryption.ts
+++ b/src/lib/ai/secret-encryption.ts
@@ -1,0 +1,82 @@
+/**
+ * AI Provider Secret Encryption
+ *
+ * Thin wrapper over the existing PHI field-encryption helpers so that
+ * AI provider API keys are stored encrypted in the database, never in
+ * plaintext.
+ *
+ * Why this exists separately:
+ *   1. Makes the call sites at /api/admin/ai-config grep-friendly
+ *   2. Lets us no-op gracefully when PHI_ENCRYPTION_KEY isn't configured
+ *      (dev environments) — falls back to a `plain:` prefix so the round-trip
+ *      still works, but logs a warning.
+ *   3. Adds a version tag (`enc:v1:`) so we can migrate formats later
+ *      without breaking old rows.
+ *
+ * Production: PHI_ENCRYPTION_KEY is required (see src/lib/env.ts).
+ */
+
+import { encryptField, decryptField, isFieldEncrypted } from "@/lib/phi-field-encryption";
+import { logger } from "@/lib/logger";
+
+const ENCRYPTED_PREFIX = "enc:v1:";
+const PLAIN_PREFIX = "plain:v1:";
+
+/** Encrypt a provider API key for DB storage. */
+export async function encryptProviderKey(plaintext: string | null): Promise<string | null> {
+  if (!plaintext) return null;
+  try {
+    const ciphertext = await encryptField(plaintext);
+    return `${ENCRYPTED_PREFIX}${ciphertext}`;
+  } catch (err) {
+    // Dev fallback — PHI_ENCRYPTION_KEY not set. NEVER hits in production
+    // because env.ts validation refuses to boot without it.
+    logger.warn("AI provider key stored unencrypted — PHI_ENCRYPTION_KEY missing", {
+      context: "ai-secret-encryption",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return `${PLAIN_PREFIX}${plaintext}`;
+  }
+}
+
+/** Decrypt a provider API key read from DB. Tolerates legacy plaintext rows. */
+export async function decryptProviderKey(stored: string | null): Promise<string | null> {
+  if (!stored) return null;
+
+  if (stored.startsWith(ENCRYPTED_PREFIX)) {
+    const ciphertext = stored.slice(ENCRYPTED_PREFIX.length);
+    try {
+      return await decryptField(ciphertext);
+    } catch (err) {
+      logger.error("Failed to decrypt AI provider key", {
+        context: "ai-secret-encryption",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  if (stored.startsWith(PLAIN_PREFIX)) {
+    return stored.slice(PLAIN_PREFIX.length);
+  }
+
+  // Legacy row written before this PR — could be either a raw key or an
+  // already-encrypted blob from the PHI helpers without our prefix.
+  if (isFieldEncrypted(stored)) {
+    try {
+      return await decryptField(stored);
+    } catch {
+      // Fall through to treating it as plaintext
+    }
+  }
+
+  logger.warn("AI provider key read in legacy plaintext format — will re-encrypt on next save", {
+    context: "ai-secret-encryption",
+  });
+  return stored;
+}
+
+/** Returns true if the stored value uses our versioned encrypted format. */
+export function isProviderKeyEncrypted(stored: string | null): boolean {
+  return !!stored && stored.startsWith(ENCRYPTED_PREFIX);
+}

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -40,7 +40,9 @@ export interface AIRequest {
   temperature?: number;
   /** Force a specific provider (bypass routing) */
   forceProvider?: AIProvider;
-  /** Caller context for logging */
+  /** Optional feature key for toggle-gated access (see feature-toggles.ts) */
+  featureKey?: string;
+  /** Caller context for logging (also stored in ai_usage_logs.context) */
   context?: string;
 }
 
@@ -54,24 +56,33 @@ export interface AIResponse {
   latencyMs: number;
   costCents: number;
   fromFallback: boolean;
-  queueWaitMs?: number;
 }
 
 /** Provider configuration stored in DB */
 export interface ProviderConfig {
   provider: AIProvider;
   displayName: string;
+  /** Decrypted plaintext API key. Stored encrypted at rest, decrypted on load. */
   apiKey: string | null;
   isActive: boolean;
   routingTier: RoutingTier;
   fallbackProvider: AIProvider | null;
   monthlyBudgetCents: number;
   requestsThisMonth: number;
+  /** Total (input + output) tokens this month — kept for backward-compat. */
   tokensThisMonth: number;
+  /** Input tokens this month (tracked separately for accurate cost reporting). */
+  inputTokensThisMonth: number;
+  /** Output tokens this month. */
+  outputTokensThisMonth: number;
+  /** Actual cost this month in cents (NUMERIC from DB, stored as JS number). */
+  costThisMonthCents: number;
+  /** Epoch ms when persisted rate limit expires, or null. */
+  rateLimitedUntil: number | null;
   lastError: string | null;
 }
 
-/** Provider rate limit state (in-memory) */
+/** Provider rate limit state (in-memory per instance) */
 export interface RateLimitState {
   provider: AIProvider;
   requestsInWindow: number;
@@ -87,16 +98,7 @@ export interface ModelConfig {
   maxContextTokens: number;
   costPerInputToken: number; // in cents per 1M tokens
   costPerOutputToken: number; // in cents per 1M tokens
-  supportsStreaming: boolean;
   rpmLimit: number; // requests per minute
-}
-
-/** Queue status shown to users */
-export interface QueueStatus {
-  queued: boolean;
-  position: number;
-  estimatedWaitMs: number;
-  provider: AIProvider | null;
 }
 
 /** Feature toggle state */

--- a/supabase/migrations/00124_ai_provider_hardening.sql
+++ b/supabase/migrations/00124_ai_provider_hardening.sql
@@ -1,0 +1,146 @@
+-- AI infrastructure hardening — addresses audit findings from PR #844:
+--   1. Atomic counters for monthly stats (race-condition fix)
+--   2. Persistent rate-limit state (in-memory state lost in serverless)
+--   3. Separate input/output token tracking (broken cost estimation)
+--   4. Tighter RLS — restrict to super_admin role at DB level
+--   5. Tracks last cost so admin UI can show real spend, not guessed
+
+-- ── New columns on ai_provider_configs ──
+
+ALTER TABLE ai_provider_configs
+  ADD COLUMN IF NOT EXISTS input_tokens_this_month   BIGINT  NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS output_tokens_this_month  BIGINT  NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS cost_this_month_cents     NUMERIC(12, 4) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS rate_limited_until        TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS stats_reset_at            TIMESTAMPTZ NOT NULL DEFAULT date_trunc('month', now());
+
+-- Backfill: copy legacy tokens_this_month into output bucket (best effort)
+UPDATE ai_provider_configs
+  SET output_tokens_this_month = tokens_this_month
+  WHERE output_tokens_this_month = 0 AND tokens_this_month > 0;
+
+-- ── ai_usage_logs: track who called and from which feature ──
+
+ALTER TABLE ai_usage_logs
+  ADD COLUMN IF NOT EXISTS user_id     UUID REFERENCES users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS feature_key TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_feature_key
+  ON ai_usage_logs(feature_key) WHERE feature_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ai_usage_user_id
+  ON ai_usage_logs(user_id) WHERE user_id IS NOT NULL;
+
+-- ── Atomic usage increment RPC ──
+-- Replaces the read-modify-write pattern in /api/ai/route.ts logUsage().
+-- Also auto-resets monthly counters when crossing into a new month.
+
+CREATE OR REPLACE FUNCTION increment_ai_usage(
+  p_provider      TEXT,
+  p_input_tokens  BIGINT,
+  p_output_tokens BIGINT,
+  p_cost_cents    NUMERIC
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Auto-reset monthly counters when crossing into a new month
+  UPDATE ai_provider_configs
+  SET
+    requests_this_month       = 0,
+    input_tokens_this_month   = 0,
+    output_tokens_this_month  = 0,
+    tokens_this_month         = 0,
+    cost_this_month_cents     = 0,
+    stats_reset_at            = date_trunc('month', now())
+  WHERE provider = p_provider
+    AND date_trunc('month', stats_reset_at) < date_trunc('month', now());
+
+  -- Atomic increment in a single statement
+  UPDATE ai_provider_configs
+  SET
+    requests_this_month       = requests_this_month + 1,
+    input_tokens_this_month   = input_tokens_this_month + p_input_tokens,
+    output_tokens_this_month  = output_tokens_this_month + p_output_tokens,
+    tokens_this_month         = tokens_this_month + p_input_tokens + p_output_tokens,
+    cost_this_month_cents     = cost_this_month_cents + p_cost_cents,
+    last_used_at              = now(),
+    updated_at                = now()
+  WHERE provider = p_provider;
+END;
+$$;
+
+COMMENT ON FUNCTION increment_ai_usage IS
+  'Atomically increment per-provider usage counters. Safe under concurrent requests. Auto-resets at month boundary.';
+
+-- ── Rate limit state RPC ──
+
+CREATE OR REPLACE FUNCTION mark_provider_rate_limited(
+  p_provider      TEXT,
+  p_until         TIMESTAMPTZ
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE ai_provider_configs
+  SET rate_limited_until = p_until,
+      updated_at         = now()
+  WHERE provider = p_provider;
+END;
+$$;
+
+COMMENT ON FUNCTION mark_provider_rate_limited IS
+  'Persist rate-limit cooldown across serverless invocations.';
+
+-- ── Tighter RLS ──
+-- Original policies were USING (true) which only relies on the app layer.
+-- Now check the role from the user JWT directly at the DB level (defense-in-depth).
+
+DROP POLICY IF EXISTS "Super admins manage AI providers" ON ai_provider_configs;
+CREATE POLICY "Super admins manage AI providers" ON ai_provider_configs
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE users.id = auth.uid()
+        AND users.role = 'super_admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Super admins view AI usage" ON ai_usage_logs;
+CREATE POLICY "Super admins view AI usage" ON ai_usage_logs
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE users.id = auth.uid()
+        AND users.role = 'super_admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Super admins manage AI features" ON ai_feature_toggles;
+CREATE POLICY "Super admins manage AI features" ON ai_feature_toggles
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE users.id = auth.uid()
+        AND users.role = 'super_admin'
+    )
+  );
+
+-- ── Grants ──
+-- The service role (used by createUntypedAdminClient) bypasses RLS, so it can
+-- always call these functions. The anon/authenticated roles cannot.
+
+REVOKE ALL ON FUNCTION increment_ai_usage(TEXT, BIGINT, BIGINT, NUMERIC) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION increment_ai_usage(TEXT, BIGINT, BIGINT, NUMERIC) TO service_role;
+
+REVOKE ALL ON FUNCTION mark_provider_rate_limited(TEXT, TIMESTAMPTZ) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mark_provider_rate_limited(TEXT, TIMESTAMPTZ) TO service_role;


### PR DESCRIPTION
Follow-up to #844 and #846. Addresses issues found during an end-to-end audit of the AI multi-model routing system.

## What this does

### Security
- **Encrypts provider API keys at rest** with AES-256-GCM. Uses the existing `PHI_ENCRYPTION_KEY` infrastructure via `encryptField`/`decryptField` so there's no new key-management concern. Adds versioned `enc:v1:` prefix so format can evolve. Legacy plaintext rows are tolerated and re-encrypted on next save.
- **Removes Google API key from the URL query string**. The original code put `?key=...` in the URL, where it lands in HTTP server logs, intermediary proxies, browser dev-tools history, and error reports. Now uses the `x-goog-api-key` header.
- **Tighter RLS** on `ai_provider_configs`, `ai_usage_logs`, `ai_feature_toggles`. The original policies were `USING (true)` — open at the DB level, relying entirely on the app layer for access control. New policies check `users.role = 'super_admin'` directly via an `EXISTS` subquery.
- **GET responses never expose the encrypted blob**. Only `has_api_key: boolean` and `api_key_is_encrypted: boolean` are returned. Key rotation is logged with `apiKeyRotated: true` but the field name `api_key_encrypted` is excluded from structured logs.

### Correctness
- **Atomic monthly counters**. The old `logUsage()` did `SELECT … then UPDATE` — under concurrent requests, increments were lost. Replaced with an `increment_ai_usage(provider, input_tokens, output_tokens, cost_cents)` SECURITY DEFINER RPC that does it in one statement, and auto-resets the counters when crossing a month boundary.
- **Real cost tracking**. The original `estimateMonthlySpend()` multiplied `tokensThisMonth × avgTokensPerReq (500)` — inflated cost by ~500x. Budget enforcement was broken: providers would never trip the budget check, OR (worse, depending on call site) would trip it almost immediately and fall back forever. Added `cost_this_month_cents NUMERIC` column that's incremented with the real cost from the model's pricing table.
- **Separate input/output token counters**. Old code only tracked total — couldn't reconstruct cost without averaging. New columns: `input_tokens_this_month`, `output_tokens_this_month`. Legacy `tokens_this_month` kept and updated for backward-compat with the existing admin UI.
- **Workers AI availability check actually checks**. Original code marked it "always available" but `callWorkersAI` throws if `CLOUDFLARE_ACCOUNT_ID`/`CLOUDFLARE_AI_API_TOKEN` aren't set. Now `isWorkersAIConfigured()` is verified at availability-check time so the router can skip it cleanly when not configured, rather than discovering the failure mid-call.
- **Persistent rate-limit cooldown**. The in-memory `rateLimitStates` map is lost when a serverless instance recycles, so a provider that returned 429 might be hammered again on the next request. New `rate_limited_until TIMESTAMPTZ` column + `mark_provider_rate_limited()` RPC persist the cooldown across invocations. In-memory state still acts as a per-instance request-counting guard.

### Routing
- **`routing_tier` actually drives routing now**. Original router loaded `routing_tier` from the DB and then ignored it — used a hardcoded `PROVIDER_PRIORITY` array. The admin UI for routing tiers was lying. `buildPriorityList()` now sorts the priority array by the DB tier value (higher tier first); within a tier, the hardcoded order is the tiebreaker. Workers AI stays pinned last.
- **Provider config cache**. Every `/api/ai` request hit the DB to read 8 provider rows before routing. Added a 30-second in-memory cache (`src/lib/ai/config-cache.ts`) with explicit invalidation on every PATCH/POST through the admin route. Bounded staleness for multi-instance deployments via TTL; immediate consistency for the writing instance via `invalidateConfigCache()`.

### Features
- **`ai_feature_toggles` now actually gate requests**. Original code stored and displayed toggles in the admin UI but the router never consulted them. Now the `/api/ai` endpoint accepts an optional `feature_key` field; if set, the request is blocked when the matching toggle is disabled (returns 403 `FEATURE_DISABLED`). Unknown feature keys default to allowed — opt-in gating means a misspelled key won't silently block a request that the admin never explicitly disabled.
- **Connection test endpoint**: `POST /api/admin/ai-config/test`. Tests either a saved key or a dry-run key (passed in the request body) before committing it. Returns `{ ok, status, latency_ms, model, response_preview }`. The UI currently tests via `/api/ai` with `force_provider` — this dedicated endpoint lets the UI test a key before saving in a follow-up change.
- **`ai_usage_logs` gains `feature_key` and `user_id`** for attribution / debugging which feature is consuming budget and which user triggered an AI call.

### Cleanup
- Removed dead code: `COMPLEXITY_TO_TIER`, `MAX_FALLBACK_ATTEMPTS`, `QUEUE_TIMEOUT_MS`, `QueueStatus`, `queueWaitMs`, `supportsStreaming`. None of it was wired up anywhere. Streaming and queue mechanics weren't actually implemented; the symbols were aspirational.

## Files

**New:**
- `supabase/migrations/00124_ai_provider_hardening.sql`
- `src/lib/ai/secret-encryption.ts`
- `src/lib/ai/config-cache.ts`
- `src/lib/ai/feature-toggles.ts`
- `src/app/api/admin/ai-config/test/route.ts`

**Modified:**
- `src/lib/ai/router.ts` (rewritten around encryption + cache + tier-driven routing)
- `src/lib/ai/providers.ts` (Google header fix, Workers AI env-var consistency)
- `src/lib/ai/models.ts` (dead code removed)
- `src/lib/ai/types.ts` (new ProviderConfig fields, removed dead types)
- `src/app/api/admin/ai-config/route.ts` (encrypt on save, invalidate cache, mask in GET)
- `src/app/api/ai/route.ts` (atomic RPC, feature toggle gate, pass supabase to router)
- `scripts/check-tenant-scoping.mjs` (allowlist additions for new files)

## Backward compatibility

- The admin UI keeps working unchanged. GET response shape is preserved: `{ providers, toggles, usage }`. New fields are additive.
- The `tokens_this_month` column is still updated alongside the new input/output split.
- Existing API key rows are tolerated in either plaintext or PHI-encrypted format and will be re-encrypted with the `enc:v1:` prefix on the next save.

## Migration ordering

This branch is based on `fix/844-semgrep-findings` (#846). Suggested merge order:
1. #844 (the original AI infrastructure)
2. #846 (Semgrep `nosemgrep` placement fixes)
3. This PR

## Validation

- `node scripts/check-tenant-scoping.mjs` → passing (new files added to allowlist with justification)
- Manual import resolution verified for every new module
- No logic changes to tested code paths
