### PR TITLE
feat: dual-control approval workflow for refunds >5000 MAD (Issue #673)

### DIFF
--- a/src/app/api/booking/payment/refund/approve/route.ts
+++ b/src/app/api/booking/payment/refund/approve/route.ts
@@ -41,12 +41,12 @@ export const POST = withAuthValidation(
       amount: number;
       status: string;
     };
-    const { data: refundReq, error: fetchErr } = await supabase
+    const { data: refundReq, error: fetchErr } = (await supabase
       .from("refund_requests" as never)
       .select("id, clinic_id, payment_id, initiator_id, amount, status")
       .eq("id", body.refundRequestId)
       .eq("clinic_id", clinicId)
-      .single() as { data: RefundRequestRow | null; error: unknown };
+      .single()) as { data: RefundRequestRow | null; error: unknown };
 
     if (fetchErr || !refundReq) {
       return apiNotFound("Refund request not found");
@@ -73,11 +73,15 @@ export const POST = withAuthValidation(
           approver_id: profile.id,
           rejection_reason: body.rejectionReason ?? "No reason provided",
           approved_at: new Date().toISOString(),
-        })
+        } as never)
         .eq("id", body.refundRequestId);
 
       if (rejectErr) {
-        logger.error("Failed to reject refund request", { context: "refund/approve", clinicId, error: rejectErr });
+        logger.error("Failed to reject refund request", {
+          context: "refund/approve",
+          clinicId,
+          error: rejectErr,
+        });
         return apiInternalError("Failed to reject refund request");
       }
 
@@ -144,7 +148,11 @@ export const POST = withAuthValidation(
       .maybeSingle();
 
     if (updateErr) {
-      logger.error("Approved refund execution failed", { context: "refund/approve", clinicId, error: updateErr });
+      logger.error("Approved refund execution failed", {
+        context: "refund/approve",
+        clinicId,
+        error: updateErr,
+      });
       return apiInternalError("Failed to execute approved refund");
     }
 
@@ -161,7 +169,7 @@ export const POST = withAuthValidation(
         approved_at: new Date().toISOString(),
         executed_at: new Date().toISOString(),
         executed_by: profile.id,
-      })
+      } as never)
       .eq("id", body.refundRequestId);
 
     await logAuditEvent({

--- a/src/app/api/booking/payment/refund/approve/route.ts
+++ b/src/app/api/booking/payment/refund/approve/route.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+import { apiError, apiInternalError, apiNotFound, apiSuccess } from "@/lib/api-response";
+import { withAuthValidation } from "@/lib/api-validate";
+import { logAuditEvent } from "@/lib/audit-log";
+import { logger } from "@/lib/logger";
+import { requireTenant } from "@/lib/tenant";
+import type { UserRole } from "@/lib/types/database";
+
+const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
+
+const approveRefundSchema = z.object({
+  refundRequestId: z.string().uuid("refundRequestId must be a valid UUID"),
+  action: z.enum(["approve", "reject"]),
+  rejectionReason: z.string().min(1).max(500).optional(),
+});
+
+/**
+ * POST /api/booking/payment/refund/approve
+ *
+ * Second-admin approval or rejection of a pending refund_request.
+ *
+ * - The approver MUST be a different user than the initiator.
+ * - On approval: executes the actual payment refund atomically.
+ * - On rejection: marks the request as rejected; initiator may re-initiate.
+ *
+ * Auth: clinic_admin + super_admin.
+ * Issue #673 / Audit A169-02.
+ */
+export const POST = withAuthValidation(
+  approveRefundSchema,
+  async (body, request, { supabase, profile }) => {
+    const tenant = await requireTenant();
+    const clinicId = tenant.clinicId;
+
+    // Fetch the pending request (RLS ensures it belongs to this clinic)
+    type RefundRequestRow = {
+      id: string;
+      clinic_id: string;
+      payment_id: string;
+      initiator_id: string;
+      amount: number;
+      status: string;
+    };
+    const { data: refundReq, error: fetchErr } = await supabase
+      .from("refund_requests" as never)
+      .select("id, clinic_id, payment_id, initiator_id, amount, status")
+      .eq("id", body.refundRequestId)
+      .eq("clinic_id", clinicId)
+      .single() as { data: RefundRequestRow | null; error: unknown };
+
+    if (fetchErr || !refundReq) {
+      return apiNotFound("Refund request not found");
+    }
+
+    if (refundReq.status !== "pending") {
+      return apiError(`Refund request is already ${refundReq.status} — cannot ${body.action}`);
+    }
+
+    // Enforce dual-control: approver must differ from initiator
+    if (profile.id === refundReq.initiator_id) {
+      return apiError(
+        "Dual-control violation: the approver must be a different admin than the initiator.",
+        403,
+      );
+    }
+
+    // ── Rejection path ──────────────────────────────────────────────────
+    if (body.action === "reject") {
+      const { error: rejectErr } = await supabase
+        .from("refund_requests" as never)
+        .update({
+          status: "rejected",
+          approver_id: profile.id,
+          rejection_reason: body.rejectionReason ?? "No reason provided",
+          approved_at: new Date().toISOString(),
+        })
+        .eq("id", body.refundRequestId);
+
+      if (rejectErr) {
+        logger.error("Failed to reject refund request", { context: "refund/approve", clinicId, error: rejectErr });
+        return apiInternalError("Failed to reject refund request");
+      }
+
+      await logAuditEvent({
+        supabase,
+        action: "refund_request_rejected",
+        type: "payment",
+        actor: profile.id,
+        clinicId,
+        description:
+          `Refund request ${body.refundRequestId} rejected by ${profile.id}. ` +
+          `Reason: ${body.rejectionReason ?? "none"}`,
+        metadata: {
+          refund_request_id: body.refundRequestId,
+          payment_id: refundReq.payment_id,
+          amount: refundReq.amount,
+          rejection_reason: body.rejectionReason,
+        },
+      });
+
+      return apiSuccess({ status: "rejected", message: "Refund request rejected" });
+    }
+
+    // ── Approval + execution path ────────────────────────────────────────
+    // Fetch the payment to apply the refund with optimistic concurrency
+    const { data: payment, error: payFetchErr } = await supabase
+      .from("payments")
+      .select("id, status, amount, refunded_amount")
+      .eq("id", refundReq.payment_id)
+      .eq("clinic_id", clinicId)
+      .single();
+
+    if (payFetchErr || !payment) {
+      return apiNotFound("Payment no longer exists");
+    }
+
+    if (payment.status !== "completed" && payment.status !== "partially_refunded") {
+      return apiError("Payment is no longer in a refundable state");
+    }
+
+    const alreadyRefunded = (payment.refunded_amount as number) ?? 0;
+    const remaining = payment.amount - alreadyRefunded;
+
+    if (refundReq.amount > remaining) {
+      return apiError(
+        `Refund amount (${refundReq.amount}) exceeds remaining refundable amount (${remaining})`,
+      );
+    }
+
+    const newRefundedTotal = alreadyRefunded + refundReq.amount;
+    const isFullyRefunded = newRefundedTotal >= payment.amount;
+
+    // Execute the refund (optimistic concurrency)
+    const { data: updated, error: updateErr } = await supabase
+      .from("payments")
+      .update({
+        status: isFullyRefunded ? "refunded" : "partially_refunded",
+        refunded_amount: newRefundedTotal,
+      })
+      .eq("id", refundReq.payment_id)
+      .eq("clinic_id", clinicId)
+      .eq("refunded_amount", alreadyRefunded)
+      .select("id")
+      .maybeSingle();
+
+    if (updateErr) {
+      logger.error("Approved refund execution failed", { context: "refund/approve", clinicId, error: updateErr });
+      return apiInternalError("Failed to execute approved refund");
+    }
+
+    if (!updated) {
+      return apiError("Concurrent refund detected — please retry", 409, "CONCURRENT_REFUND");
+    }
+
+    // Mark the request as executed
+    await supabase
+      .from("refund_requests" as never)
+      .update({
+        status: "executed",
+        approver_id: profile.id,
+        approved_at: new Date().toISOString(),
+        executed_at: new Date().toISOString(),
+        executed_by: profile.id,
+      })
+      .eq("id", body.refundRequestId);
+
+    await logAuditEvent({
+      supabase,
+      action: "refund_request_approved_and_executed",
+      type: "payment",
+      actor: profile.id,
+      clinicId,
+      description:
+        `Refund request ${body.refundRequestId} approved and executed by ${profile.id}. ` +
+        `Amount: ${refundReq.amount} MAD refunded from payment ${refundReq.payment_id}.`,
+      metadata: {
+        refund_request_id: body.refundRequestId,
+        payment_id: refundReq.payment_id,
+        amount: refundReq.amount,
+        approver_id: profile.id,
+      },
+    });
+
+    return apiSuccess({
+      status: "executed",
+      message: `Refund of ${refundReq.amount} MAD approved and executed`,
+    });
+  },
+  ADMIN_ROLES,
+);

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -70,12 +70,12 @@ export const POST = withAuthValidation(
     // ── Dual-control gate ─────────────────────────────────────────────────
     if (refundAmount > DUAL_CONTROL_THRESHOLD_MAD) {
       // Check for an existing pending request to prevent duplicates
-      const { data: existing } = await supabase
+      const { data: existing } = (await supabase
         .from("refund_requests" as never)
         .select("id, status")
         .eq("payment_id", body.paymentId)
         .eq("status", "pending")
-        .maybeSingle() as { data: { id: string; status: string } | null };
+        .maybeSingle()) as { data: { id: string; status: string } | null };
 
       if (existing) {
         return apiError(
@@ -86,7 +86,7 @@ export const POST = withAuthValidation(
       }
 
       // Create the pending approval request
-      const { data: refundRequest, error: reqError } = await supabase
+      const { data: refundRequest, error: reqError } = (await supabase
         .from("refund_requests" as never)
         .insert({
           clinic_id: clinicId,
@@ -96,10 +96,14 @@ export const POST = withAuthValidation(
           reason: body.reason ?? null,
         })
         .select("id")
-        .single() as { data: { id: string } | null; error: unknown };
+        .single()) as { data: { id: string } | null; error: unknown };
 
       if (reqError || !refundRequest) {
-        logger.error("Failed to create refund_request", { context: "refund", clinicId, error: reqError });
+        logger.error("Failed to create refund_request", {
+          context: "refund",
+          clinicId,
+          error: reqError,
+        });
         return apiInternalError("Failed to create refund approval request");
       }
 

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -5,27 +5,38 @@ import { logger } from "@/lib/logger";
 import { requireTenant } from "@/lib/tenant";
 import type { UserRole } from "@/lib/types/database";
 import { paymentRefundSchema } from "@/lib/validations";
+
 const ADMIN_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
+
+/**
+ * Refunds above this threshold (in MAD) require a two-person approval
+ * workflow. The initiating admin creates a refund_request; a second admin
+ * must approve it before the payment status is actually updated.
+ *
+ * Issue #673 / Audit A169-02.
+ */
+const DUAL_CONTROL_THRESHOLD_MAD = 5_000;
 
 /**
  * POST /api/booking/payment/refund
  *
  * Refund a completed payment (full or partial).
- * Auth: clinic_admin + super_admin only (ADMIN_ROLES).
- * A169-02: For refunds >5 000 MAD consider adding a two-person approval
- * workflow (e.g. a separate `refund_approvals` table requiring a second
- * admin to confirm before the refund executes).
+ * Auth: clinic_admin + super_admin only.
+ *
+ * For refunds ≤ 5 000 MAD: executes immediately (single-admin flow).
+ * For refunds >  5 000 MAD: creates a pending refund_request requiring
+ *   a second admin to approve at POST /api/booking/payment/refund/approve.
+ *   Returns HTTP 202 with a `refund_request_id` for polling/notification.
  */
 export const POST = withAuthValidation(
   paymentRefundSchema,
-  async (body, request, { supabase }) => {
+  async (body, request, { supabase, profile }) => {
     const tenant = await requireTenant();
     const clinicId = tenant.clinicId;
 
     // F-A18-02: Fetch the payment with refunded_amount for optimistic
     // concurrency control. The DB CHECK constraint
-    // (chk_refund_not_exceeds_amount) is the final safety net, but
-    // application-level validation prevents wasted work and clearer errors.
+    // (chk_refund_not_exceeds_amount) is the final safety net.
     const { data: payment, error: fetchError } = await supabase
       .from("payments")
       .select("id, status, amount, refunded_amount")
@@ -43,7 +54,6 @@ export const POST = withAuthValidation(
 
     const refundAmount = body.amount ?? payment.amount;
 
-    // Validate refund amount
     if (typeof refundAmount !== "number" || !Number.isFinite(refundAmount) || refundAmount <= 0) {
       return apiError("Refund amount must be a positive number");
     }
@@ -57,14 +67,79 @@ export const POST = withAuthValidation(
       );
     }
 
+    // ── Dual-control gate ─────────────────────────────────────────────────
+    if (refundAmount > DUAL_CONTROL_THRESHOLD_MAD) {
+      // Check for an existing pending request to prevent duplicates
+      const { data: existing } = await supabase
+        .from("refund_requests" as never)
+        .select("id, status")
+        .eq("payment_id", body.paymentId)
+        .eq("status", "pending")
+        .maybeSingle() as { data: { id: string; status: string } | null };
+
+      if (existing) {
+        return apiError(
+          `A refund request for this payment is already pending approval (id: ${existing.id}). ` +
+            "A second admin must approve it before proceeding.",
+          409,
+        );
+      }
+
+      // Create the pending approval request
+      const { data: refundRequest, error: reqError } = await supabase
+        .from("refund_requests" as never)
+        .insert({
+          clinic_id: clinicId,
+          payment_id: body.paymentId,
+          initiator_id: profile.id,
+          amount: refundAmount,
+          reason: body.reason ?? null,
+        })
+        .select("id")
+        .single() as { data: { id: string } | null; error: unknown };
+
+      if (reqError || !refundRequest) {
+        logger.error("Failed to create refund_request", { context: "refund", clinicId, error: reqError });
+        return apiInternalError("Failed to create refund approval request");
+      }
+
+      await logAuditEvent({
+        supabase,
+        action: "refund_request_initiated",
+        type: "payment",
+        actor: profile.id,
+        clinicId,
+        description:
+          `Refund of ${refundAmount} MAD requested for payment ${body.paymentId} — ` +
+          `exceeds ${DUAL_CONTROL_THRESHOLD_MAD} MAD threshold; awaiting second-admin approval. ` +
+          `Request ID: ${refundRequest.id}`,
+        metadata: {
+          refund_request_id: refundRequest.id,
+          payment_id: body.paymentId,
+          amount: refundAmount,
+          threshold: DUAL_CONTROL_THRESHOLD_MAD,
+        },
+      });
+
+      return new Response(
+        JSON.stringify({
+          status: "pending_approval",
+          message:
+            `Refund of ${refundAmount} MAD exceeds the ${DUAL_CONTROL_THRESHOLD_MAD} MAD ` +
+            "dual-control threshold. A second admin must approve this request.",
+          refund_request_id: refundRequest.id,
+        }),
+        { status: 202, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // ── Immediate execution (≤ 5 000 MAD) ────────────────────────────────
     const newRefundedTotal = alreadyRefunded + refundAmount;
     const isFullyRefunded = newRefundedTotal >= payment.amount;
 
-    // F-A18-02: Optimistic concurrency — include refunded_amount in the
-    // WHERE clause so a concurrent refund that changed the value between
-    // our SELECT and this UPDATE will find zero rows and fail cleanly.
-    // The DB-level CHECK (chk_refund_not_exceeds_amount) is the final
-    // safety net if this CAS guard is somehow bypassed.
+    // F-A18-02: Optimistic concurrency — include refunded_amount in WHERE
+    // so a concurrent refund that changed the value between our SELECT and
+    // this UPDATE will find zero rows and fail cleanly.
     const { data: updated, error: updateError } = await supabase
       .from("payments")
       .update({
@@ -90,8 +165,15 @@ export const POST = withAuthValidation(
       supabase,
       action: "payment_refunded",
       type: "payment",
+      actor: profile.id,
       clinicId,
-      description: `Payment ${body.paymentId} refunded: ${refundAmount} of ${payment.amount}`,
+      description: `Payment ${body.paymentId} refunded: ${refundAmount} MAD of ${payment.amount} MAD (single-admin, below threshold)`,
+      metadata: {
+        payment_id: body.paymentId,
+        refund_amount: refundAmount,
+        payment_amount: payment.amount,
+        threshold: DUAL_CONTROL_THRESHOLD_MAD,
+      },
     });
 
     return apiSuccess({ status: "refunded", message: "Payment refunded" });

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-
 import { apiError, apiInternalError, apiNotFound, apiSuccess } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";

--- a/src/app/api/booking/payment/refund/route.ts
+++ b/src/app/api/booking/payment/refund/route.ts
@@ -1,3 +1,5 @@
+import { NextResponse } from "next/server";
+
 import { apiError, apiInternalError, apiNotFound, apiSuccess } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
@@ -94,7 +96,7 @@ export const POST = withAuthValidation(
           initiator_id: profile.id,
           amount: refundAmount,
           reason: body.reason ?? null,
-        })
+        } as never)
         .select("id")
         .single()) as { data: { id: string } | null; error: unknown };
 
@@ -125,15 +127,15 @@ export const POST = withAuthValidation(
         },
       });
 
-      return new Response(
-        JSON.stringify({
+      return NextResponse.json(
+        {
           status: "pending_approval",
           message:
             `Refund of ${refundAmount} MAD exceeds the ${DUAL_CONTROL_THRESHOLD_MAD} MAD ` +
             "dual-control threshold. A second admin must approve this request.",
           refund_request_id: refundRequest.id,
-        }),
-        { status: 202, headers: { "Content-Type": "application/json" } },
+        },
+        { status: 202 },
       );
     }
 

--- a/src/lib/__tests__/public-api-surface.test.ts
+++ b/src/lib/__tests__/public-api-surface.test.ts
@@ -63,6 +63,7 @@ const EXPECTED_PUBLIC_ROUTES: string[] = [
   "/api/booking/payment/confirm",
   "/api/booking/payment/initiate",
   "/api/booking/payment/refund",
+  "/api/booking/payment/refund/approve",
   "/api/booking/recurring",
   "/api/booking/reminders",
   "/api/booking/reschedule",

--- a/src/lib/validations/payments.ts
+++ b/src/lib/validations/payments.ts
@@ -16,6 +16,8 @@ export const paymentInitiateSchema = z.object({
 export const paymentRefundSchema = z.object({
   paymentId: z.string().min(1),
   amount: z.number().positive().finite().optional(),
+  /** Optional reason — required for audit trail on large refunds */
+  reason: z.string().max(500).optional(),
 });
 
 /**

--- a/supabase/migrations/00124_dual_control_refunds.sql
+++ b/supabase/migrations/00124_dual_control_refunds.sql
@@ -1,0 +1,147 @@
+-- Migration: 00124_dual_control_refunds.sql
+--
+-- Issue #673 (Audit A169-02): Add two-person approval workflow for
+-- refunds exceeding 5 000 MAD. A single admin initiates a refund request;
+-- a second admin of equal or higher privilege approves it. Only after
+-- approval does the actual payment status update execute.
+--
+-- Tables:
+--   refund_requests  — pending / approved / rejected / expired refund records
+--
+-- The existing payments.refunded_amount + CHECK constraint remain the
+-- final financial safety net; this table adds the human-approval layer.
+
+-- ── refund_requests ──────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS refund_requests (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id           UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  payment_id          UUID NOT NULL REFERENCES payments(id) ON DELETE CASCADE,
+
+  -- Who initiated the refund and how much
+  initiator_id        UUID REFERENCES users(id) ON DELETE SET NULL,
+  amount              NUMERIC(12, 2) NOT NULL CHECK (amount > 0),
+  reason              TEXT,
+
+  -- Approval workflow
+  status              TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'approved', 'rejected', 'executed', 'expired')),
+  approver_id         UUID REFERENCES users(id) ON DELETE SET NULL,
+  approved_at         TIMESTAMPTZ,
+  rejection_reason    TEXT,
+
+  -- Execution receipt (populated once the refund is actually applied)
+  executed_at         TIMESTAMPTZ,
+  executed_by         UUID REFERENCES users(id) ON DELETE SET NULL,
+
+  -- Timestamps
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at          TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '24 hours'),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Prevent the same payment from having multiple pending requests at once.
+-- A previously rejected/expired/executed request does not block a new one.
+CREATE UNIQUE INDEX IF NOT EXISTS refund_requests_payment_pending_uniq
+  ON refund_requests (payment_id)
+  WHERE status = 'pending';
+
+-- Performance: look up pending requests by clinic quickly
+CREATE INDEX IF NOT EXISTS refund_requests_clinic_status_idx
+  ON refund_requests (clinic_id, status, created_at DESC);
+
+-- ── updated_at trigger ───────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION update_refund_requests_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_refund_requests_updated_at ON refund_requests;
+CREATE TRIGGER trg_refund_requests_updated_at
+  BEFORE UPDATE ON refund_requests
+  FOR EACH ROW EXECUTE FUNCTION update_refund_requests_updated_at();
+
+-- ── Auto-expire stale pending requests (called by cron) ─────────────────
+CREATE OR REPLACE FUNCTION expire_stale_refund_requests()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  expired_count INTEGER;
+BEGIN
+  UPDATE refund_requests
+     SET status = 'expired', updated_at = NOW()
+   WHERE status = 'pending'
+     AND expires_at < NOW();
+  GET DIAGNOSTICS expired_count = ROW_COUNT;
+  RETURN expired_count;
+END;
+$$;
+
+-- ── RLS ──────────────────────────────────────────────────────────────────
+ALTER TABLE refund_requests ENABLE ROW LEVEL SECURITY;
+
+-- Clinic admins and super_admins can see all requests for their clinic
+CREATE POLICY "Admins can view own clinic refund_requests"
+  ON refund_requests FOR SELECT
+  USING (
+    clinic_id = get_request_clinic_id()
+    AND EXISTS (
+      SELECT 1 FROM users u
+       WHERE u.auth_id = auth.uid()
+         AND u.clinic_id = refund_requests.clinic_id
+         AND u.role IN ('clinic_admin', 'super_admin')
+    )
+  );
+
+-- Only admins can insert (initiate) refund requests for their own clinic
+CREATE POLICY "Admins can initiate refund_requests"
+  ON refund_requests FOR INSERT
+  WITH CHECK (
+    clinic_id = get_request_clinic_id()
+    AND EXISTS (
+      SELECT 1 FROM users u
+       WHERE u.auth_id = auth.uid()
+         AND u.clinic_id = refund_requests.clinic_id
+         AND u.role IN ('clinic_admin', 'super_admin')
+    )
+  );
+
+-- Only a DIFFERENT admin (not the initiator) can approve/reject
+CREATE POLICY "Different admin can approve/reject refund_requests"
+  ON refund_requests FOR UPDATE
+  USING (
+    clinic_id = get_request_clinic_id()
+    AND status = 'pending'
+    AND EXISTS (
+      SELECT 1 FROM users u
+       WHERE u.auth_id = auth.uid()
+         AND u.clinic_id = refund_requests.clinic_id
+         AND u.role IN ('clinic_admin', 'super_admin')
+         AND u.id <> refund_requests.initiator_id -- must be a different person
+    )
+  );
+
+-- Super-admin can see all refund requests across all clinics (override)
+CREATE POLICY "Super admins can manage all refund_requests"
+  ON refund_requests FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM users u
+       WHERE u.auth_id = auth.uid()
+         AND u.role = 'super_admin'
+    )
+  );
+
+-- ── Comments ─────────────────────────────────────────────────────────────
+COMMENT ON TABLE refund_requests IS
+  'Two-person approval workflow for refunds > 5000 MAD (Audit Issue #673). '
+  'Status: pending → approved → executed | rejected | expired. '
+  'Initiator and approver must be different users.';
+
+COMMENT ON COLUMN refund_requests.expires_at IS
+  'Pending requests automatically expire after 24 hours via expire_stale_refund_requests() cron.';

--- a/supabase/migrations/00125_dual_control_refunds.sql
+++ b/supabase/migrations/00125_dual_control_refunds.sql
@@ -1,4 +1,4 @@
--- Migration: 00124_dual_control_refunds.sql
+-- Migration: 00125_dual_control_refunds.sql
 --
 -- Issue #673 (Audit A169-02): Add two-person approval workflow for
 -- refunds exceeding 5 000 MAD. A single admin initiates a refund request;


### PR DESCRIPTION
## Summary\n\nImplements the two-person approval gate recommended in audit A169-02 and Issue #673.\n\n### Changes\n\n**Migration 00124_dual_control_refunds.sql**:\n- New table `refund_requests` (pending/approved/rejected/executed/expired)\n- Unique partial index: one pending request per payment at a time\n- RLS: clinic admins see own-clinic requests; DB-level check that approver ≠ initiator\n- `expire_stale_refund_requests()` SECURITY DEFINER function for cron TTL cleanup\n\n**POST /api/booking/payment/refund (updated)**:\n- Refunds ≤ 5 000 MAD: execute immediately (existing single-admin flow, unchanged)\n- Refunds > 5 000 MAD: create `pending` refund_request → HTTP 202 + `refund_request_id`; does NOT touch the payment record yet\n\n**POST /api/booking/payment/refund/approve (new)**:\n- Accepts `{ refundRequestId, action: 'approve'|'reject', rejectionReason }`\n- Enforces dual-control: `profile.id !== initiator_id` (HTTP 403 otherwise)\n- On approve: executes payment update with optimistic concurrency guard + marks request as `executed`\n- On reject: marks as `rejected`; initiator may re-initiate\n- Both paths emit detailed audit events with full metadata\n\n**paymentRefundSchema**: added optional `reason` field for audit trail.\n\n## Type of change\n- [x] New feature\n- [x] Infrastructure / CI\n\n## Security Impact\n- [x] This PR modifies authentication or authorization logic\n- [x] This PR changes RLS policies or database migrations\n- [x] This PR modifies audit logging\n\n## Migration Safety\n- [x] Migration includes `IF NOT EXISTS` guards\n- [x] New table has RLS with clinic_id scoping\n- [x] Backward-compatible: existing small-refund flow unchanged\n\n⚠️ Do NOT merge until manually reviewed.