### PR TITLE
feat(doctor): add between-patients micro-dashboard

### DIFF
--- a/src/app/(doctor)/doctor/micro-dashboard/page.tsx
+++ b/src/app/(doctor)/doctor/micro-dashboard/page.tsx
@@ -1,0 +1,7 @@
+import { MicroDashboardView } from "@/components/doctor/micro-dashboard-view";
+import { requireRole } from "@/lib/auth";
+
+export default async function MicroDashboardPage() {
+  await requireRole("doctor", "clinic_admin");
+  return <MicroDashboardView />;
+}

--- a/src/app/api/doctor/micro-dashboard/route.ts
+++ b/src/app/api/doctor/micro-dashboard/route.ts
@@ -1,0 +1,212 @@
+import { type NextRequest } from "next/server";
+import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { getLocalDateStr } from "@/lib/utils";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SupabaseUntyped = { from(table: string): any };
+
+/**
+ * GET /api/doctor/micro-dashboard
+ *
+ * Returns a compact snapshot for the between-patients micro-dashboard:
+ * - Next patient (name, appointment time, history highlights)
+ * - Pending tasks count
+ * - One urgent alert (if any)
+ * - Remaining appointments today
+ *
+ * Designed to be consumed in <30 seconds between consultations.
+ */
+async function handler(_request: NextRequest, auth: AuthContext) {
+  const clinicId = auth.profile.clinic_id;
+  const doctorId = auth.profile.id;
+
+  if (!clinicId) {
+    return apiError("Clinic context required — use a clinic subdomain", 400);
+  }
+
+  try {
+    const untypedSupabase = auth.supabase as unknown as SupabaseUntyped;
+    const today = getLocalDateStr();
+    const now = new Date();
+    const currentTime = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+
+    // Fetch today's upcoming appointments for this doctor
+    const { data: upcomingApptsRaw, error: apptsError } = await untypedSupabase
+      .from("appointments")
+      .select(
+        "id, patient_id, service_id, appointment_date, start_time, status, is_first_visit, is_emergency, notes",
+      )
+      .eq("clinic_id", clinicId)
+      .eq("doctor_id", doctorId)
+      .eq("appointment_date", today)
+      .in("status", ["confirmed", "checked_in", "checked-in", "scheduled"])
+      .gte("start_time", currentTime)
+      .order("start_time", { ascending: true })
+      .limit(10);
+
+    if (apptsError) {
+      logger.error("Failed to fetch micro-dashboard appointments", {
+        context: "api/doctor/micro-dashboard",
+        error: apptsError,
+      });
+      return apiInternalError("Failed to load micro-dashboard data");
+    }
+
+    type ApptRow = {
+      id: string;
+      patient_id: string;
+      service_id: string | null;
+      appointment_date: string;
+      start_time: string;
+      status: string;
+      is_first_visit: boolean;
+      is_emergency: boolean;
+      notes: string | null;
+    };
+    const upcomingAppts = (upcomingApptsRaw ?? []) as ApptRow[];
+
+    // Get patient details for next patient
+    let nextPatient: {
+      id: string;
+      name: string;
+      phone: string | null;
+      appointmentTime: string;
+      isFirstVisit: boolean;
+      isEmergency: boolean;
+      notes: string | null;
+      pastVisitCount: number;
+      lastVisitDate: string | null;
+    } | null = null;
+
+    if (upcomingAppts.length > 0) {
+      const next = upcomingAppts[0];
+
+      // Get patient name
+      const { data: patientData } = await untypedSupabase
+        .from("users")
+        .select("id, name, phone")
+        .eq("clinic_id", clinicId)
+        .eq("id", next.patient_id)
+        .single();
+
+      type PatientRow = { id: string; name: string; phone: string | null };
+      const patient = patientData as PatientRow | null;
+
+      // Get past visit count for this patient with this doctor
+      const { count: pastVisits } = await untypedSupabase
+        .from("appointments")
+        .select("id", { count: "exact", head: true })
+        .eq("clinic_id", clinicId)
+        .eq("patient_id", next.patient_id)
+        .eq("doctor_id", doctorId)
+        .in("status", ["completed", "done"])
+        .lt("appointment_date", today);
+
+      // Get last visit date
+      const { data: lastVisitData } = await untypedSupabase
+        .from("appointments")
+        .select("appointment_date")
+        .eq("clinic_id", clinicId)
+        .eq("patient_id", next.patient_id)
+        .eq("doctor_id", doctorId)
+        .in("status", ["completed", "done"])
+        .order("appointment_date", { ascending: false })
+        .limit(1);
+
+      type LastVisitRow = { appointment_date: string };
+      const lastVisitRows = (lastVisitData ?? []) as LastVisitRow[];
+
+      nextPatient = {
+        id: next.patient_id,
+        name: patient?.name ?? "Patient inconnu",
+        phone: patient?.phone ?? null,
+        appointmentTime: next.start_time,
+        isFirstVisit: next.is_first_visit,
+        isEmergency: next.is_emergency,
+        notes: next.notes,
+        pastVisitCount: pastVisits ?? 0,
+        lastVisitDate: lastVisitRows[0]?.appointment_date ?? null,
+      };
+    }
+
+    // Count pending tasks: unsigned prescriptions, unread lab results
+    const { count: pendingPrescriptions } = await untypedSupabase
+      .from("prescriptions")
+      .select("id", { count: "exact", head: true })
+      .eq("clinic_id", clinicId)
+      .eq("doctor_id", doctorId)
+      .eq("status", "draft");
+
+    const { count: pendingLabOrders } = await untypedSupabase
+      .from("lab_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("clinic_id", clinicId)
+      .eq("doctor_id", doctorId)
+      .eq("status", "results_ready");
+
+    // Check for urgent alerts: emergency patients in waiting room
+    const { data: emergencyPatientsRaw } = await untypedSupabase
+      .from("appointments")
+      .select("id, patient_id, start_time")
+      .eq("clinic_id", clinicId)
+      .eq("doctor_id", doctorId)
+      .eq("appointment_date", today)
+      .eq("is_emergency", true)
+      .in("status", ["confirmed", "checked_in", "checked-in", "scheduled"])
+      .order("start_time", { ascending: true })
+      .limit(1);
+
+    type EmergencyRow = { id: string; patient_id: string; start_time: string };
+    const emergencyPatients = (emergencyPatientsRaw ?? []) as EmergencyRow[];
+
+    let urgentAlert: { type: string; message: string } | null = null;
+    if (emergencyPatients.length > 0) {
+      const { data: emergencyPatientData } = await untypedSupabase
+        .from("users")
+        .select("name")
+        .eq("clinic_id", clinicId)
+        .eq("id", emergencyPatients[0].patient_id)
+        .single();
+
+      type NameRow = { name: string };
+      const emergencyPatient = emergencyPatientData as NameRow | null;
+
+      urgentAlert = {
+        type: "emergency",
+        message: `Urgence: ${emergencyPatient?.name ?? "Patient"} — ${emergencyPatients[0].start_time}`,
+      };
+    }
+
+    // Count completed today for progress tracking
+    const { count: completedToday } = await untypedSupabase
+      .from("appointments")
+      .select("id", { count: "exact", head: true })
+      .eq("clinic_id", clinicId)
+      .eq("doctor_id", doctorId)
+      .eq("appointment_date", today)
+      .in("status", ["completed", "done"]);
+
+    return apiSuccess({
+      nextPatient,
+      remainingCount: upcomingAppts.length,
+      completedToday: completedToday ?? 0,
+      pendingTasks: {
+        prescriptions: pendingPrescriptions ?? 0,
+        labResults: pendingLabOrders ?? 0,
+        total: (pendingPrescriptions ?? 0) + (pendingLabOrders ?? 0),
+      },
+      urgentAlert,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.error("Micro-dashboard error", {
+      context: "api/doctor/micro-dashboard",
+      error: err,
+    });
+    return apiInternalError("Failed to load micro-dashboard");
+  }
+}
+
+export const GET = withAuth(handler, ["doctor", "clinic_admin"]);

--- a/src/components/doctor/micro-dashboard-view.tsx
+++ b/src/components/doctor/micro-dashboard-view.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import {
+  Clock,
+  AlertTriangle,
+  User,
+  FileText,
+  FlaskConical,
+  ChevronRight,
+  RefreshCw,
+  Stethoscope,
+  CalendarCheck,
+  Phone,
+} from "lucide-react";
+import Link from "next/link";
+import { useState, useEffect, useCallback } from "react";
+import { useLocale } from "@/components/locale-switcher";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface MicroDashboardData {
+  nextPatient: {
+    id: string;
+    name: string;
+    phone: string | null;
+    appointmentTime: string;
+    isFirstVisit: boolean;
+    isEmergency: boolean;
+    notes: string | null;
+    pastVisitCount: number;
+    lastVisitDate: string | null;
+  } | null;
+  remainingCount: number;
+  completedToday: number;
+  pendingTasks: {
+    prescriptions: number;
+    labResults: number;
+    total: number;
+  };
+  urgentAlert: {
+    type: string;
+    message: string;
+  } | null;
+  timestamp: string;
+}
+
+function formatTime(time: string): string {
+  const [h, m] = time.split(":");
+  return `${h}:${m}`;
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("fr-MA", { day: "numeric", month: "short", year: "numeric" });
+}
+
+export function MicroDashboardView() {
+  const [locale] = useLocale();
+  const [data, setData] = useState<MicroDashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await fetch("/api/doctor/micro-dashboard");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const json = await res.json();
+      if (json.ok) {
+        setData(json.data);
+      } else {
+        setError(json.error ?? "Failed to load");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Erreur de connexion");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchData();
+    // Auto-refresh every 60 seconds
+    const interval = setInterval(() => void fetchData(), 60_000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  if (loading && !data) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <RefreshCw className="text-muted-foreground h-8 w-8 animate-spin" />
+          <p className="text-muted-foreground text-sm">
+            {locale === "ar" ? "جاري التحميل..." : "Chargement..."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Card className="max-w-sm">
+          <CardContent className="pt-6 text-center">
+            <AlertTriangle className="text-destructive mx-auto mb-3 h-8 w-8" />
+            <p className="text-sm">{error}</p>
+            <Button onClick={() => void fetchData()} className="mt-4" size="sm" variant="outline">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Réessayer
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">Micro-Dashboard</h1>
+          <p className="text-muted-foreground text-xs">
+            {data.completedToday} consultations terminées · {data.remainingCount} restantes
+          </p>
+        </div>
+        <Button onClick={() => void fetchData()} size="sm" variant="ghost" disabled={loading}>
+          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+        </Button>
+      </div>
+
+      {/* Urgent Alert */}
+      {data.urgentAlert && (
+        <Card className="border-destructive bg-destructive/5">
+          <CardContent className="flex items-center gap-3 py-3">
+            <AlertTriangle className="text-destructive h-5 w-5 shrink-0" />
+            <p className="text-destructive text-sm font-medium">{data.urgentAlert.message}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Next Patient */}
+      {data.nextPatient ? (
+        <Card className="border-[var(--oltigo-green)]/30 bg-[var(--oltigo-green)]/5">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Stethoscope className="h-5 w-5 text-[var(--oltigo-green)]" />
+              Patient suivant
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex items-start justify-between">
+              <div className="flex items-center gap-3">
+                <div className="bg-muted flex h-10 w-10 items-center justify-center rounded-full">
+                  <User className="text-muted-foreground h-5 w-5" />
+                </div>
+                <div>
+                  <p className="font-semibold">{data.nextPatient.name}</p>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Clock className="h-3 w-3" />
+                    {formatTime(data.nextPatient.appointmentTime)}
+                    {data.nextPatient.phone && (
+                      <>
+                        <Phone className="ml-1 h-3 w-3" />
+                        {data.nextPatient.phone}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="flex gap-1">
+                {data.nextPatient.isFirstVisit && (
+                  <Badge variant="outline" className="text-xs">
+                    1ère visite
+                  </Badge>
+                )}
+                {data.nextPatient.isEmergency && (
+                  <Badge variant="destructive" className="text-xs">
+                    Urgence
+                  </Badge>
+                )}
+              </div>
+            </div>
+
+            {/* History highlight */}
+            <div className="bg-muted/50 rounded-md p-2 text-xs">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Visites précédentes:</span>
+                <span className="font-medium">{data.nextPatient.pastVisitCount}</span>
+              </div>
+              {data.nextPatient.lastVisitDate && (
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Dernière visite:</span>
+                  <span className="font-medium">{formatDate(data.nextPatient.lastVisitDate)}</span>
+                </div>
+              )}
+              {data.nextPatient.notes && (
+                <div className="mt-1 border-t pt-1">
+                  <span className="text-muted-foreground">Notes:</span>
+                  <p className="mt-0.5 font-medium">
+                    {data.nextPatient.notes.length > 120
+                      ? data.nextPatient.notes.slice(0, 120) + "…"
+                      : data.nextPatient.notes}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <Link href={`/doctor/patients/${data.nextPatient.id}/timeline`}>
+              <Button size="sm" variant="outline" className="w-full">
+                Voir le dossier patient
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <CalendarCheck className="text-muted-foreground mx-auto mb-2 h-8 w-8" />
+            <p className="text-muted-foreground text-sm">
+              Plus de patients prévus pour aujourd&apos;hui
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Pending Tasks */}
+      {data.pendingTasks.total > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">Tâches en attente</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {data.pendingTasks.prescriptions > 0 && (
+              <Link
+                href="/doctor/prescriptions"
+                className="flex items-center justify-between rounded-md p-2 hover:bg-muted/50"
+              >
+                <div className="flex items-center gap-2">
+                  <FileText className="h-4 w-4 text-[var(--signal-amber)]" />
+                  <span className="text-sm">Ordonnances en brouillon</span>
+                </div>
+                <Badge variant="secondary">{data.pendingTasks.prescriptions}</Badge>
+              </Link>
+            )}
+            {data.pendingTasks.labResults > 0 && (
+              <Link
+                href="/doctor/lab-orders"
+                className="flex items-center justify-between rounded-md p-2 hover:bg-muted/50"
+              >
+                <div className="flex items-center gap-2">
+                  <FlaskConical className="h-4 w-4 text-[var(--signal-amber)]" />
+                  <span className="text-sm">Résultats de laboratoire</span>
+                </div>
+                <Badge variant="secondary">{data.pendingTasks.labResults}</Badge>
+              </Link>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Quick navigation */}
+      <div className="grid grid-cols-2 gap-2">
+        <Link href="/doctor/dashboard">
+          <Button variant="outline" className="w-full text-sm" size="sm">
+            Dashboard complet
+          </Button>
+        </Link>
+        <Link href="/doctor/waiting-room">
+          <Button variant="outline" className="w-full text-sm" size="sm">
+            Salle d&apos;attente
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a 30-second glanceable micro-dashboard at `/doctor/micro-dashboard` for the 5-minute gap between consultations (5 min × 20 consultations = 100 min/day recoverable).

**What it shows:**
- Next patient: name, appointment time, visit history count, last visit date, notes
- Pending tasks: draft prescriptions, ready lab results
- Urgent alerts: emergency patients in queue
- Progress: completed/remaining appointments today
- Auto-refreshes every 60s

**New files:**
- `GET /api/doctor/micro-dashboard` — `withAuth(handler, ["doctor", "clinic_admin"])`, uses tenant-scoped `auth.supabase` from `AuthContext`
- `/doctor/micro-dashboard` page + `MicroDashboardView` client component

All DB queries scoped by `clinic_id` + `doctor_id`. No new migrations needed — reads from existing `appointments`, `users`, `prescriptions`, `lab_orders` tables.