### PR TITLE
fix(register-clinic): graceful 'contact us' panel when self-service is disabled (audit R-12 UX)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@ NEXT_PUBLIC_PHONE_AUTH_ENABLED=false
 # Turnstile + DNS-TXT ownership verification, so flipping this widens the
 # attack surface significantly.
 SELF_SERVICE_REGISTRATION_ENABLED=false
+# ---- Self-Service Registration (Frontend mirror) [Optional] ----
+# MUST mirror SELF_SERVICE_REGISTRATION_ENABLED above. Read by the
+# clinic registration form (src/components/onboarding/register-form.tsx)
+# to render the form vs. the "contact us" panel — without this mirror,
+# the form lets users fill 6 fields and then 403s on submit, which is
+# a confusing UX. Keep the two in sync at deploy time.
+NEXT_PUBLIC_SELF_SERVICE_REGISTRATION_ENABLED=false
 
 # ---- Subdomain Routing [Optional] ----
 # Set to your root domain (e.g., "yourdomain.com") to enable

--- a/src/components/onboarding/register-form.tsx
+++ b/src/components/onboarding/register-form.tsx
@@ -4,11 +4,11 @@ import { Stethoscope, Loader2, CheckCircle2, Mail, ShieldAlert } from "lucide-re
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MOROCCAN_CITIES } from "@/lib/morocco";
+import { cn } from "@/lib/utils";
 
 // Mirrors the server-side SELF_SERVICE_REGISTRATION_ENABLED gate in
 // /api/v1/register-clinic. The server flag is the source of truth; this

--- a/src/components/onboarding/register-form.tsx
+++ b/src/components/onboarding/register-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Stethoscope, Loader2, CheckCircle2 } from "lucide-react";
+import { Stethoscope, Loader2, CheckCircle2, Mail, ShieldAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,20 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MOROCCAN_CITIES } from "@/lib/morocco";
+
+// Mirrors the server-side SELF_SERVICE_REGISTRATION_ENABLED gate in
+// /api/v1/register-clinic. The server flag is the source of truth; this
+// public mirror only exists so we can render the right UI at page load
+// instead of letting the operator fill out the entire form and then hit
+// a 403 "disabled" error from the API.
+//
+// Both flags must be "true" for self-service to actually work in
+// production (see SECURITY_FLAG_ACKNOWLEDGMENTS in src/lib/env.ts —
+// SELF_SERVICE_REGISTRATION_ACK is also required at server startup).
+const SELF_SERVICE_REGISTRATION_ENABLED =
+  process.env.NEXT_PUBLIC_SELF_SERVICE_REGISTRATION_ENABLED === "true";
+
+const CONTACT_EMAIL = "contact@oltigo.com";
 
 const SPECIALTIES = [
   "Médecine générale",
@@ -73,7 +87,17 @@ export function RegisterForm() {
       const data = await res.json();
 
       if (!res.ok || !data.ok) {
-        setError(data.error || "Une erreur est survenue. Veuillez réessayer.");
+        // If the server returns the "disabled" 403, show the French
+        // operator-facing message + contact path rather than echoing
+        // the raw English API string into the red error box.
+        if (res.status === 403 && typeof data.error === "string") {
+          setError(
+            "L'inscription en libre-service est actuellement indisponible. " +
+              `Pour créer votre clinique, contactez-nous à ${CONTACT_EMAIL}.`,
+          );
+        } else {
+          setError(data.error || "Une erreur est survenue. Veuillez réessayer.");
+        }
         return;
       }
 
@@ -91,6 +115,61 @@ export function RegisterForm() {
     } finally {
       setLoading(false);
     }
+  }
+
+  // When self-service is disabled (current default per audit R-12), don't
+  // make the operator fill out 6 fields just to get a 403. Show a clear
+  // "contact us" panel up front with the same visual structure as the form.
+  if (!SELF_SERVICE_REGISTRATION_ENABLED) {
+    const subject = encodeURIComponent("Demande d'inscription clinique");
+    const body = encodeURIComponent(
+      "Bonjour Oltigo,\n\n" +
+        "Je souhaite créer un compte clinique sur la plateforme.\n\n" +
+        "- Nom de la clinique :\n" +
+        "- Nom du docteur :\n" +
+        "- Spécialité :\n" +
+        "- Ville :\n" +
+        "- Téléphone :\n\n" +
+        "Merci.",
+    );
+    return (
+      <Card className="w-full max-w-lg mx-auto">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
+            <ShieldAlert className="h-6 w-6 text-amber-600" />
+          </div>
+          <CardTitle className="text-xl">Inscription par contact</CardTitle>
+          <CardDescription>
+            L&apos;inscription en libre-service est temporairement fermée — chaque clinique est
+            vérifiée manuellement par notre équipe avant activation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+            Pour créer votre clinique, écrivez-nous : nous vous accompagnons dans la mise en
+            service en moins de 24h.
+          </div>
+          <Button asChild className="w-full">
+            <a href={`mailto:${CONTACT_EMAIL}?subject=${subject}&body=${body}`}>
+              <Mail className="mr-2 h-4 w-4" />
+              Nous contacter — {CONTACT_EMAIL}
+            </a>
+          </Button>
+          <p className="text-center text-xs text-muted-foreground">
+            Vous avez déjà un compte ?{" "}
+            <a href="/login" className="text-primary underline">
+              Se connecter
+            </a>
+          </p>
+          <p className="text-center text-xs text-muted-foreground">
+            Vous êtes un patient ?{" "}
+            <a href="/register" className="text-primary underline">
+              Créer un compte patient
+            </a>
+          </p>
+        </CardContent>
+      </Card>
+    );
   }
 
   if (success) {

--- a/src/components/onboarding/register-form.tsx
+++ b/src/components/onboarding/register-form.tsx
@@ -146,8 +146,8 @@ export function RegisterForm() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
-            Pour créer votre clinique, écrivez-nous : nous vous accompagnons dans la mise en
-            service en moins de 24h.
+            Pour créer votre clinique, écrivez-nous : nous vous accompagnons dans la mise en service
+            en moins de 24h.
           </div>
           <Button asChild className="w-full">
             <a href={`mailto:${CONTACT_EMAIL}?subject=${subject}&body=${body}`}>

--- a/src/components/onboarding/register-form.tsx
+++ b/src/components/onboarding/register-form.tsx
@@ -3,7 +3,8 @@
 import { Stethoscope, Loader2, CheckCircle2, Mail, ShieldAlert } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -149,12 +150,13 @@ export function RegisterForm() {
             Pour créer votre clinique, écrivez-nous : nous vous accompagnons dans la mise en service
             en moins de 24h.
           </div>
-          <Button asChild className="w-full">
-            <a href={`mailto:${CONTACT_EMAIL}?subject=${subject}&body=${body}`}>
-              <Mail className="mr-2 h-4 w-4" />
-              Nous contacter — {CONTACT_EMAIL}
-            </a>
-          </Button>
+          <a
+            href={`mailto:${CONTACT_EMAIL}?subject=${subject}&body=${body}`}
+            className={cn(buttonVariants({ variant: "default", size: "default" }), "w-full")}
+          >
+            <Mail className="mr-2 h-4 w-4" />
+            Nous contacter — {CONTACT_EMAIL}
+          </a>
           <p className="text-center text-xs text-muted-foreground">
             Vous avez déjà un compte ?{" "}
             <a href="/login" className="text-primary underline">


### PR DESCRIPTION
## Summary

Fixes the confusing UX where the landing page CTA "Open Account" sends users to `/register-clinic`, they fill out 6 fields, click submit, and get a raw English **"Self-service registration is currently disabled"** 403 — while at the same time `/login` and `/register` (patient signup) both work normally.

## Diagnosis (not a bug, a UX hole)

The 403 is intentional — audit finding **R-12** added a hard gate on `POST /api/v1/register-clinic`:

```ts
if (process.env.SELF_SERVICE_REGISTRATION_ENABLED !== "true") {
  return apiError("Self-service registration is currently disabled.", 403);
}
```

…and `.env.example` ships with `SELF_SERVICE_REGISTRATION_ENABLED=false` because creating a clinic creates an admin user, generates a subdomain, and sends WhatsApp messages. Even when flipped to `true`, production requires a second flag `SELF_SERVICE_REGISTRATION_ACK=true` (see `SECURITY_FLAG_ACKNOWLEDGMENTS` in `src/lib/env.ts`).

What's missing is **frontend awareness of that gate**. The form ignored it, let users fill everything in, and then crashed into the 403 with no recovery path.

`/login` and `/register` (patient signup) are different routes that go through Supabase auth directly — they're not affected by this flag.

## Changes

| Change | File |
|---|---|
| Add public mirror flag `NEXT_PUBLIC_SELF_SERVICE_REGISTRATION_ENABLED` (same pattern already used for `NEXT_PUBLIC_PHONE_AUTH_ENABLED`) | `.env.example`, `src/components/onboarding/register-form.tsx` |
| When the mirror flag is not `"true"`, render a **"Contact us"** panel at page load instead of the form — so users see the situation *before* typing 6 fields | `src/components/onboarding/register-form.tsx` |
| Panel includes a pre-filled `mailto:` to `contact@oltigo.com`, a link back to `/login`, and a link to `/register` for patients (who were never the target of this page anyway) | same |
| As a defensive belt-and-braces: even when the form *is* shown (e.g. flag mismatch between server and client), a 403 response now displays a friendly French message + contact path instead of echoing the raw English API string | same |

## Behavior

| Flag state | Page renders |
|---|---|
| `NEXT_PUBLIC_SELF_SERVICE_REGISTRATION_ENABLED=true` AND server `SELF_SERVICE_REGISTRATION_ENABLED=true` | Full clinic registration form — unchanged from before |
| Either flag not set (default) | "Contact us" panel — clear path forward, no wasted form-fills |
| Flag mismatch (client `true`, server `false`) | Form renders, submit gets 403 → user sees French error + contact email |

## What this does **not** change

- The server-side gate stays intact. This PR does not weaken any security control.
- The landing page CTAs (`/register-clinic` everywhere) stay pointed at the same route — the destination is conceptually right (the landing copy is for clinic owners), it just needed a graceful fallback.
- No translation file changes (form is hardcoded French to match existing style — i18n cleanup is a separate task in the audit roadmap).

## Verification

- TSX brace + paren balance: ✅ verified.
- Component signature unchanged (`export function RegisterForm()`).
- Only one component in the file, three `return` paths (disabled-state, success-state, form-state).
- `.env.example` flag documented with explicit "must mirror server flag" rule.

## For the operator

After this lands, your two real choices are:

1. **Keep self-service closed (recommended for now):** do nothing — landing visitors who click "Open Account" will see the new contact-us panel.
2. **Open self-service:** set in your deploy env:
   ```
   SELF_SERVICE_REGISTRATION_ENABLED=true
   NEXT_PUBLIC_SELF_SERVICE_REGISTRATION_ENABLED=true
   SELF_SERVICE_REGISTRATION_ACK=true         # required in production
   SELF_SERVICE_MANUAL_REVIEW=true            # keep manual approval on
   DNS_VERIFICATION_SECRET=<openssl rand -hex 32>
   ```
   …and ensure the DNS verification endpoint works end-to-end before announcing.

## Rollback

`git revert <merge-sha>` is safe — no migrations, no server-side changes, no behavioral changes to existing users.
