### PR TITLE
feat(doctor): doctor wellbeing/workload monitor with burnout risk

### DIFF
--- a/src/app/(doctor)/doctor/wellbeing/page.tsx
+++ b/src/app/(doctor)/doctor/wellbeing/page.tsx
@@ -1,0 +1,11 @@
+import { WellbeingMonitor } from "@/components/doctor/wellbeing-monitor";
+import { requireRole } from "@/lib/auth";
+
+export default async function WellbeingPage() {
+  await requireRole("doctor", "clinic_admin");
+  return (
+    <div className="mx-auto max-w-3xl p-4">
+      <WellbeingMonitor />
+    </div>
+  );
+}

--- a/src/app/api/doctor/wellbeing-check/route.ts
+++ b/src/app/api/doctor/wellbeing-check/route.ts
@@ -1,0 +1,238 @@
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess, apiValidationError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/with-auth";
+import type { AuthContext } from "@/lib/with-auth";
+
+interface WellbeingMetrics {
+  patientsToday: number;
+  patientsThisWeek: number;
+  hoursWorkedToday: number;
+  consecutiveDaysWorked: number;
+  lastDayOff: string | null;
+}
+
+type BurnoutRisk = "low" | "moderate" | "high" | "critical";
+
+interface WellbeingResult {
+  burnoutRisk: BurnoutRisk;
+  score: number;
+  metrics: WellbeingMetrics;
+  recommendations: string[];
+  alerts: string[];
+}
+
+function computeBurnoutScore(metrics: WellbeingMetrics): number {
+  let score = 0;
+
+  if (metrics.patientsToday > 30) score += 30;
+  else if (metrics.patientsToday > 20) score += 20;
+  else if (metrics.patientsToday > 15) score += 10;
+
+  if (metrics.hoursWorkedToday > 12) score += 25;
+  else if (metrics.hoursWorkedToday > 10) score += 15;
+  else if (metrics.hoursWorkedToday > 8) score += 5;
+
+  if (metrics.consecutiveDaysWorked > 12) score += 30;
+  else if (metrics.consecutiveDaysWorked > 7) score += 20;
+  else if (metrics.consecutiveDaysWorked > 5) score += 10;
+
+  if (metrics.patientsThisWeek > 150) score += 15;
+  else if (metrics.patientsThisWeek > 100) score += 10;
+
+  return Math.min(score, 100);
+}
+
+function getRiskLevel(score: number): BurnoutRisk {
+  if (score >= 70) return "critical";
+  if (score >= 50) return "high";
+  if (score >= 30) return "moderate";
+  return "low";
+}
+
+function getRecommendations(
+  metrics: WellbeingMetrics,
+  risk: BurnoutRisk,
+  language: string,
+): string[] {
+  const recs: string[] = [];
+  const isFr = language !== "ar";
+
+  if (risk === "critical" || risk === "high") {
+    recs.push(
+      isFr
+        ? "Envisagez de bloquer un après-midi cette semaine pour vous reposer"
+        : "فكر في حجب فترة بعد الظهر هذا الأسبوع للراحة",
+    );
+  }
+
+  if (metrics.consecutiveDaysWorked > 6) {
+    recs.push(
+      isFr
+        ? `Vous travaillez depuis ${metrics.consecutiveDaysWorked} jours consécutifs — prenez un jour de repos`
+        : `أنت تعمل منذ ${metrics.consecutiveDaysWorked} أيام متتالية — خذ يوم راحة`,
+    );
+  }
+
+  if (metrics.hoursWorkedToday > 10) {
+    recs.push(
+      isFr
+        ? "Vous avez dépassé 10 heures aujourd'hui — pensez à déléguer les tâches restantes"
+        : "لقد تجاوزت 10 ساعات اليوم — فكر في تفويض المهام المتبقية",
+    );
+  }
+
+  if (metrics.patientsToday > 25) {
+    recs.push(
+      isFr
+        ? "Plus de 25 patients aujourd'hui — réduisez les créneaux demain si possible"
+        : "أكثر من 25 مريض اليوم — قلل المواعيد غداً إن أمكن",
+    );
+  }
+
+  if (recs.length === 0) {
+    recs.push(
+      isFr
+        ? "Votre charge de travail est dans les limites normales — continuez ainsi"
+        : "حجم عملك ضمن الحدود الطبيعية — استمر هكذا",
+    );
+  }
+
+  return recs;
+}
+
+async function handler(req: NextRequest, auth: AuthContext) {
+  const clinicId = auth.profile.clinic_id;
+  const doctorId = auth.profile.id;
+
+  if (!clinicId) {
+    return apiError("No clinic associated with this account", 403);
+  }
+
+  const url = new URL(req.url);
+  const language = url.searchParams.get("language") ?? "fr";
+
+  if (language !== "fr" && language !== "ar") {
+    return apiValidationError("language must be 'fr' or 'ar'");
+  }
+
+  try {
+    const now = new Date();
+    const todayStart = new Date(now);
+    todayStart.setHours(0, 0, 0, 0);
+    const weekStart = new Date(now);
+    weekStart.setDate(now.getDate() - 7);
+
+    const [todayResult, weekResult, lastOffResult] = await Promise.all([
+      auth.supabase
+        .from("appointments")
+        .select("id, start_time", { count: "exact" })
+        .eq("clinic_id", clinicId)
+        .eq("doctor_id", doctorId)
+        .gte("start_time", todayStart.toISOString())
+        .lte("start_time", now.toISOString())
+        .in("status", ["completed", "in_progress", "confirmed"]),
+      auth.supabase
+        .from("appointments")
+        .select("id", { count: "exact" })
+        .eq("clinic_id", clinicId)
+        .eq("doctor_id", doctorId)
+        .gte("start_time", weekStart.toISOString())
+        .lte("start_time", now.toISOString())
+        .in("status", ["completed", "in_progress", "confirmed"]),
+      auth.supabase
+        .from("appointments")
+        .select("start_time")
+        .eq("clinic_id", clinicId)
+        .eq("doctor_id", doctorId)
+        .lt("start_time", todayStart.toISOString())
+        .order("start_time", { ascending: false })
+        .limit(30),
+    ]);
+
+    const patientsToday = todayResult.count ?? 0;
+    const patientsThisWeek = weekResult.count ?? 0;
+
+    let consecutiveDaysWorked = 1;
+    let lastDayOff: string | null = null;
+
+    if (lastOffResult.data && lastOffResult.data.length > 0) {
+      const workDates = new Set<string>();
+      for (const row of lastOffResult.data) {
+        const d = new Date(row.start_time as string);
+        workDates.add(d.toISOString().slice(0, 10));
+      }
+      const sortedDates = Array.from(workDates).sort().reverse();
+      const today = now.toISOString().slice(0, 10);
+      const checkDate = new Date(today);
+      for (let i = 0; i < 30; i++) {
+        const dateStr = checkDate.toISOString().slice(0, 10);
+        if (workDates.has(dateStr) || dateStr === today) {
+          consecutiveDaysWorked = i + 1;
+        } else {
+          lastDayOff = dateStr;
+          break;
+        }
+        checkDate.setDate(checkDate.getDate() - 1);
+      }
+      if (!lastDayOff && sortedDates.length > 0) {
+        lastDayOff = sortedDates[sortedDates.length - 1] ?? null;
+      }
+    }
+
+    const firstAppointment = todayResult.data?.[0];
+    let hoursWorkedToday = 0;
+    if (firstAppointment) {
+      const firstTime = new Date(firstAppointment.start_time as string);
+      hoursWorkedToday = Math.round(((now.getTime() - firstTime.getTime()) / 3600000) * 10) / 10;
+    }
+
+    const metrics: WellbeingMetrics = {
+      patientsToday,
+      patientsThisWeek,
+      hoursWorkedToday,
+      consecutiveDaysWorked,
+      lastDayOff,
+    };
+
+    const score = computeBurnoutScore(metrics);
+    const burnoutRisk = getRiskLevel(score);
+    const recommendations = getRecommendations(metrics, burnoutRisk, language);
+
+    const alerts: string[] = [];
+    const isFr = language !== "ar";
+    if (burnoutRisk === "critical") {
+      alerts.push(
+        isFr
+          ? "⚠ Risque d'épuisement critique — prenez des mesures immédiates"
+          : "⚠ خطر الإرهاق حرج — اتخذ إجراءات فورية",
+      );
+    }
+    if (metrics.consecutiveDaysWorked > 10) {
+      alerts.push(
+        isFr
+          ? `Vous n'avez pas pris de jour de repos depuis ${metrics.consecutiveDaysWorked} jours`
+          : `لم تأخذ يوم راحة منذ ${metrics.consecutiveDaysWorked} يوم`,
+      );
+    }
+
+    const result: WellbeingResult = {
+      burnoutRisk,
+      score,
+      metrics,
+      recommendations,
+      alerts,
+    };
+
+    return apiSuccess(result);
+  } catch (err) {
+    logger.error("Wellbeing check failed", {
+      context: "wellbeing-check",
+      error: err instanceof Error ? err.message : String(err),
+      doctorId,
+    });
+    return apiError("Failed to compute wellbeing metrics", 500);
+  }
+}
+
+export const GET = withAuth(handler, ["doctor", "clinic_admin"]);

--- a/src/components/doctor/wellbeing-monitor.tsx
+++ b/src/components/doctor/wellbeing-monitor.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import {
+  Activity,
+  AlertTriangle,
+  Calendar,
+  Clock,
+  Heart,
+  RefreshCw,
+  Shield,
+  Users,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { useLocale } from "@/components/locale-switcher";
+
+interface WellbeingMetrics {
+  patientsToday: number;
+  patientsThisWeek: number;
+  hoursWorkedToday: number;
+  consecutiveDaysWorked: number;
+  lastDayOff: string | null;
+}
+
+type BurnoutRisk = "low" | "moderate" | "high" | "critical";
+
+interface WellbeingData {
+  burnoutRisk: BurnoutRisk;
+  score: number;
+  metrics: WellbeingMetrics;
+  recommendations: string[];
+  alerts: string[];
+}
+
+const riskColors: Record<BurnoutRisk, string> = {
+  low: "bg-green-100 text-green-800 border-green-300",
+  moderate: "bg-yellow-100 text-yellow-800 border-yellow-300",
+  high: "bg-orange-100 text-orange-800 border-orange-300",
+  critical: "bg-red-100 text-red-800 border-red-300",
+};
+
+const riskBgColors: Record<BurnoutRisk, string> = {
+  low: "bg-green-50",
+  moderate: "bg-yellow-50",
+  high: "bg-orange-50",
+  critical: "bg-red-50",
+};
+
+const riskLabels: Record<BurnoutRisk, Record<string, string>> = {
+  low: { fr: "Faible", ar: "منخفض" },
+  moderate: { fr: "Modéré", ar: "متوسط" },
+  high: { fr: "Élevé", ar: "مرتفع" },
+  critical: { fr: "Critique", ar: "حرج" },
+};
+
+export function WellbeingMonitor() {
+  const [locale] = useLocale();
+  const lang = locale === "ar" ? "ar" : "fr";
+  const isRtl = lang === "ar";
+
+  const [data, setData] = useState<WellbeingData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/doctor/wellbeing-check?language=${lang}`);
+      const json = (await res.json()) as { ok: boolean; data?: WellbeingData; error?: string };
+      if (!json.ok || !json.data) {
+        setError(json.error ?? (lang === "ar" ? "خطأ في التحميل" : "Erreur de chargement"));
+        return;
+      }
+      setData(json.data);
+    } catch {
+      setError(lang === "ar" ? "خطأ في الاتصال" : "Erreur de connexion");
+    } finally {
+      setLoading(false);
+    }
+  }, [lang]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <RefreshCw className="h-6 w-6 animate-spin text-gray-400" />
+        <span className="ml-2 text-gray-500">
+          {lang === "ar" ? "جاري التحميل..." : "Chargement..."}
+        </span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+        <p className="text-red-600">{error}</p>
+        <button
+          onClick={() => void fetchData()}
+          className="mt-3 rounded bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700"
+        >
+          {lang === "ar" ? "إعادة المحاولة" : "Réessayer"}
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { burnoutRisk, score, metrics, recommendations, alerts } = data;
+
+  return (
+    <div className={`space-y-6 ${isRtl ? "text-right" : ""}`} dir={isRtl ? "rtl" : "ltr"}>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">
+          {lang === "ar" ? "مراقبة صحة الطبيب" : "Moniteur de bien-être"}
+        </h1>
+        <button
+          onClick={() => void fetchData()}
+          className="rounded-lg border border-gray-200 p-2 hover:bg-gray-50"
+          title={lang === "ar" ? "تحديث" : "Actualiser"}
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Risk Level Card */}
+      <div className={`rounded-xl border-2 p-6 ${riskColors[burnoutRisk]}`}>
+        <div className="flex items-center gap-3">
+          {burnoutRisk === "critical" || burnoutRisk === "high" ? (
+            <AlertTriangle className="h-8 w-8" />
+          ) : (
+            <Heart className="h-8 w-8" />
+          )}
+          <div>
+            <p className="text-sm font-medium opacity-80">
+              {lang === "ar" ? "مستوى خطر الإرهاق" : "Niveau de risque d'épuisement"}
+            </p>
+            <p className="text-3xl font-bold">{riskLabels[burnoutRisk]?.[lang] ?? burnoutRisk}</p>
+          </div>
+          <div className={`${isRtl ? "mr-auto" : "ml-auto"} text-right`}>
+            <p className="text-sm opacity-80">{lang === "ar" ? "النتيجة" : "Score"}</p>
+            <p className="text-3xl font-bold">{score}/100</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Alerts */}
+      {alerts.length > 0 && (
+        <div className="space-y-2">
+          {alerts.map((alert, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3"
+            >
+              <Shield className="h-5 w-5 flex-shrink-0 text-red-600" />
+              <p className="text-sm font-medium text-red-700">{alert}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Metrics Grid */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className={`rounded-lg border p-4 ${riskBgColors[burnoutRisk]}`}>
+          <div className="flex items-center gap-2 text-gray-600">
+            <Users className="h-4 w-4" />
+            <span className="text-sm">{lang === "ar" ? "مرضى اليوم" : "Patients aujourd'hui"}</span>
+          </div>
+          <p className="mt-1 text-2xl font-bold text-gray-900">{metrics.patientsToday}</p>
+        </div>
+
+        <div className={`rounded-lg border p-4 ${riskBgColors[burnoutRisk]}`}>
+          <div className="flex items-center gap-2 text-gray-600">
+            <Activity className="h-4 w-4" />
+            <span className="text-sm">
+              {lang === "ar" ? "مرضى هذا الأسبوع" : "Patients cette semaine"}
+            </span>
+          </div>
+          <p className="mt-1 text-2xl font-bold text-gray-900">{metrics.patientsThisWeek}</p>
+        </div>
+
+        <div className={`rounded-lg border p-4 ${riskBgColors[burnoutRisk]}`}>
+          <div className="flex items-center gap-2 text-gray-600">
+            <Clock className="h-4 w-4" />
+            <span className="text-sm">
+              {lang === "ar" ? "ساعات العمل اليوم" : "Heures aujourd'hui"}
+            </span>
+          </div>
+          <p className="mt-1 text-2xl font-bold text-gray-900">
+            {metrics.hoursWorkedToday}
+            <span className="text-sm font-normal text-gray-500">h</span>
+          </p>
+        </div>
+
+        <div className={`rounded-lg border p-4 ${riskBgColors[burnoutRisk]}`}>
+          <div className="flex items-center gap-2 text-gray-600">
+            <Calendar className="h-4 w-4" />
+            <span className="text-sm">
+              {lang === "ar" ? "أيام عمل متتالية" : "Jours consécutifs"}
+            </span>
+          </div>
+          <p className="mt-1 text-2xl font-bold text-gray-900">
+            {metrics.consecutiveDaysWorked}
+            <span className="text-sm font-normal text-gray-500">
+              {lang === "ar" ? " يوم" : " j"}
+            </span>
+          </p>
+        </div>
+      </div>
+
+      {/* Last Day Off */}
+      {metrics.lastDayOff && (
+        <div className="rounded-lg border bg-gray-50 p-4">
+          <p className="text-sm text-gray-600">
+            {lang === "ar" ? "آخر يوم راحة:" : "Dernier jour de repos :"}
+            <span className="ml-2 font-semibold text-gray-900">{metrics.lastDayOff}</span>
+          </p>
+        </div>
+      )}
+
+      {/* Recommendations */}
+      <div className="rounded-lg border bg-white p-5">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900">
+          {lang === "ar" ? "التوصيات" : "Recommandations"}
+        </h2>
+        <ul className="space-y-2">
+          {recommendations.map((rec, i) => (
+            <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+              <span className="mt-0.5 block h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
+              {rec}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Doctor wellbeing monitor that tracks workload metrics and computes burnout risk level. Nobody else in the Moroccan clinic SaaS space offers this.

## Changes
- `GET /api/doctor/wellbeing-check` — computes burnout score from appointment data
  - Queries: patients today/this week, hours worked, consecutive days without rest
  - Burnout score (0-100) mapped to risk levels: low/moderate/high/critical
  - Localized recommendations in FR/AR based on metrics
- `WellbeingMonitor` component — color-coded risk card, 4-metric grid, alerts, recommendations
- Page at `/doctor/wellbeing` with `requireRole("doctor", "clinic_admin")`

## Patterns
- `withAuth` + `AuthContext` for tenant isolation (`clinic_id` + `doctor_id` scoping)
- All appointment queries filtered by `clinic_id` and `doctor_id`
- Null guard on `clinic_id` before any DB query
- FR/AR support via `useLocale()` tuple destructuring