### PR TITLE
feat(patient): insurance/financial profiling (CNSS/RAMED/AMO auto-detect)

### DIFF
--- a/src/app/(doctor)/doctor/patient-finance/page.tsx
+++ b/src/app/(doctor)/doctor/patient-finance/page.tsx
@@ -1,0 +1,11 @@
+import { PatientFinanceView } from "@/components/doctor/patient-finance-view";
+import { requireRole } from "@/lib/auth";
+
+export default async function PatientFinancePage() {
+  await requireRole("doctor", "clinic_admin", "receptionist");
+  return (
+    <div className="mx-auto max-w-4xl p-4">
+      <PatientFinanceView />
+    </div>
+  );
+}

--- a/src/app/api/patient/insurance-profile/route.ts
+++ b/src/app/api/patient/insurance-profile/route.ts
@@ -1,0 +1,267 @@
+import { NextRequest } from "next/server";
+import { apiError, apiSuccess, apiValidationError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { withAuth } from "@/lib/with-auth";
+import type { AuthContext } from "@/lib/with-auth";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SupabaseUntyped = { from(table: string): any };
+
+type InsuranceType = "cnss" | "cnops" | "amo" | "ramed" | "private" | "none";
+
+interface InsuranceProfile {
+  insuranceType: InsuranceType;
+  membershipNumber: string | null;
+  coveragePercentage: number;
+  requiresPreApproval: boolean;
+  formTemplate: string;
+  copayEstimate: number;
+  notes: string[];
+}
+
+const INSURANCE_CONFIGS: Record<
+  InsuranceType,
+  {
+    coveragePercentage: number;
+    requiresPreApproval: boolean;
+    formTemplate: string;
+    copayBase: number;
+    notesFr: string[];
+    notesAr: string[];
+  }
+> = {
+  cnss: {
+    coveragePercentage: 70,
+    requiresPreApproval: false,
+    formTemplate: "cnss_feuille_soin",
+    copayBase: 30,
+    notesFr: [
+      "Feuille de soins CNSS obligatoire",
+      "Le patient paie 30% du tarif conventionné",
+      "Médicaments: remboursement sur liste CNSS uniquement",
+      "Délai de remboursement: 2-4 semaines",
+    ],
+    notesAr: [
+      "ورقة العلاج CNSS إلزامية",
+      "يدفع المريض 30% من التعرفة المتفق عليها",
+      "الأدوية: استرداد فقط حسب قائمة CNSS",
+      "مدة الاسترداد: 2-4 أسابيع",
+    ],
+  },
+  cnops: {
+    coveragePercentage: 80,
+    requiresPreApproval: false,
+    formTemplate: "cnops_feuille_soin",
+    copayBase: 20,
+    notesFr: [
+      "Feuille de soins CNOPS à remplir",
+      "Le patient paie 20% du tarif",
+      "Prise en charge directe possible dans les cliniques conventionnées",
+      "Carte CNOPS à vérifier avant consultation",
+    ],
+    notesAr: [
+      "ملء ورقة العلاج CNOPS",
+      "يدفع المريض 20% من التعرفة",
+      "إمكانية التكفل المباشر في العيادات المتعاقدة",
+      "التحقق من بطاقة CNOPS قبل الاستشارة",
+    ],
+  },
+  amo: {
+    coveragePercentage: 70,
+    requiresPreApproval: true,
+    formTemplate: "amo_prise_en_charge",
+    copayBase: 30,
+    notesFr: [
+      "Accord préalable requis pour hospitalisation et actes lourds",
+      "Tiers payant possible avec convention",
+      "Vérifier la validité de la carte AMO",
+      "Plafond annuel applicable — vérifier le solde restant",
+    ],
+    notesAr: [
+      "موافقة مسبقة مطلوبة للاستشفاء والعمليات الكبيرة",
+      "الدفع المباشر ممكن مع الاتفاقية",
+      "التحقق من صلاحية بطاقة AMO",
+      "سقف سنوي قابل للتطبيق — التحقق من الرصيد المتبقي",
+    ],
+  },
+  ramed: {
+    coveragePercentage: 100,
+    requiresPreApproval: true,
+    formTemplate: "ramed_attestation",
+    copayBase: 0,
+    notesFr: [
+      "RAMED couvre uniquement les hôpitaux publics",
+      "Carte RAMED valide obligatoire",
+      "Pas de prise en charge dans le privé sauf urgence",
+      "Renouvellement annuel de la carte à vérifier",
+    ],
+    notesAr: [
+      "RAMED يغطي فقط المستشفيات العمومية",
+      "بطاقة RAMED صالحة إلزامية",
+      "لا تكفل في القطاع الخاص إلا في حالات الطوارئ",
+      "التحقق من تجديد البطاقة السنوي",
+    ],
+  },
+  private: {
+    coveragePercentage: 80,
+    requiresPreApproval: true,
+    formTemplate: "private_claim_form",
+    copayBase: 20,
+    notesFr: [
+      "Vérifier les conditions de la police d'assurance",
+      "Accord préalable souvent requis pour hospitalisation",
+      "Plafond et exclusions selon le contrat",
+      "Demander une copie de la carte d'assurance",
+    ],
+    notesAr: [
+      "التحقق من شروط بوليصة التأمين",
+      "موافقة مسبقة مطلوبة غالباً للاستشفاء",
+      "سقف واستثناءات حسب العقد",
+      "طلب نسخة من بطاقة التأمين",
+    ],
+  },
+  none: {
+    coveragePercentage: 0,
+    requiresPreApproval: false,
+    formTemplate: "cash_receipt",
+    copayBase: 100,
+    notesFr: [
+      "Patient sans couverture — paiement intégral",
+      "Proposer un reçu/facture pour chaque consultation",
+      "Possibilité de facilités de paiement",
+      "Orienter vers l'inscription RAMED si éligible",
+    ],
+    notesAr: [
+      "مريض بدون تغطية — الدفع الكامل",
+      "تقديم إيصال/فاتورة لكل استشارة",
+      "إمكانية تسهيلات الدفع",
+      "توجيه للتسجيل في RAMED إذا كان مؤهلاً",
+    ],
+  },
+};
+
+/**
+ * GET /api/patient/insurance-profile?patient_id=xxx
+ * Returns the insurance profile for a patient.
+ */
+async function handleGet(req: NextRequest, auth: AuthContext) {
+  const clinicId = auth.profile.clinic_id;
+  if (!clinicId) {
+    return apiError("No clinic associated with this account", 403);
+  }
+
+  const url = new URL(req.url);
+  const patientId = url.searchParams.get("patient_id");
+  const language = url.searchParams.get("language") ?? "fr";
+
+  if (!patientId) {
+    return apiValidationError("patient_id is required");
+  }
+
+  try {
+    const sb = auth.supabase as unknown as SupabaseUntyped;
+    const { data: patient, error } = await sb
+      .from("patients")
+      .select("id, insurance_type, insurance_number")
+      .eq("clinic_id", clinicId)
+      .eq("id", patientId)
+      .single();
+
+    if (error || !patient) {
+      return apiError("Patient not found", 404);
+    }
+
+    const insuranceType = (patient.insurance_type as InsuranceType) ?? "none";
+    const config = INSURANCE_CONFIGS[insuranceType] ?? INSURANCE_CONFIGS.none;
+
+    const profile: InsuranceProfile = {
+      insuranceType,
+      membershipNumber: patient.insurance_number as string | null,
+      coveragePercentage: config.coveragePercentage,
+      requiresPreApproval: config.requiresPreApproval,
+      formTemplate: config.formTemplate,
+      copayEstimate: config.copayBase,
+      notes: language === "ar" ? config.notesAr : config.notesFr,
+    };
+
+    return apiSuccess({ profile });
+  } catch (err) {
+    logger.error("Insurance profile fetch failed", {
+      context: "insurance-profile",
+      error: err instanceof Error ? err.message : String(err),
+      clinicId,
+    });
+    return apiError("Failed to fetch insurance profile", 500);
+  }
+}
+
+/**
+ * POST /api/patient/insurance-profile
+ * Updates a patient's insurance type and number.
+ */
+async function handlePost(req: NextRequest, auth: AuthContext) {
+  const clinicId = auth.profile.clinic_id;
+  if (!clinicId) {
+    return apiError("No clinic associated with this account", 403);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await req.json()) as Record<string, unknown>;
+  } catch {
+    return apiValidationError("Invalid JSON body");
+  }
+
+  const patientId = body.patientId as string | undefined;
+  const insuranceType = body.insuranceType as string | undefined;
+  const insuranceNumber = body.insuranceNumber as string | undefined;
+
+  if (!patientId || typeof patientId !== "string") {
+    return apiValidationError("patientId is required");
+  }
+
+  const validTypes: InsuranceType[] = ["cnss", "cnops", "amo", "ramed", "private", "none"];
+  if (!insuranceType || !validTypes.includes(insuranceType as InsuranceType)) {
+    return apiValidationError(`insuranceType must be one of: ${validTypes.join(", ")}`);
+  }
+
+  try {
+    const sb = auth.supabase as unknown as SupabaseUntyped;
+    const { error } = await sb
+      .from("patients")
+      .update({
+        insurance_type: insuranceType,
+        insurance_number: insuranceNumber ?? null,
+      })
+      .eq("clinic_id", clinicId)
+      .eq("id", patientId);
+
+    if (error) {
+      logger.error("Insurance profile update failed", {
+        context: "insurance-profile",
+        error: error.message,
+        clinicId,
+        patientId,
+      });
+      return apiError("Failed to update insurance profile", 500);
+    }
+
+    const config = INSURANCE_CONFIGS[insuranceType as InsuranceType];
+
+    return apiSuccess({
+      updated: true,
+      insuranceType,
+      coveragePercentage: config.coveragePercentage,
+      formTemplate: config.formTemplate,
+    });
+  } catch (err) {
+    logger.error("Insurance profile update error", {
+      context: "insurance-profile",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return apiError("Internal error", 500);
+  }
+}
+
+export const GET = withAuth(handleGet, ["doctor", "clinic_admin", "receptionist"]);
+export const POST = withAuth(handlePost, ["doctor", "clinic_admin", "receptionist"]);

--- a/src/components/doctor/patient-finance-view.tsx
+++ b/src/components/doctor/patient-finance-view.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { AlertTriangle, CheckCircle, CreditCard, FileText, Loader2, Shield } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useLocale } from "@/components/locale-switcher";
+
+type InsuranceType = "cnss" | "cnops" | "amo" | "ramed" | "private" | "none";
+
+interface InsuranceProfile {
+  insuranceType: InsuranceType;
+  membershipNumber: string | null;
+  coveragePercentage: number;
+  requiresPreApproval: boolean;
+  formTemplate: string;
+  copayEstimate: number;
+  notes: string[];
+}
+
+const insuranceLabels: Record<InsuranceType, Record<string, string>> = {
+  cnss: { fr: "CNSS", ar: "CNSS" },
+  cnops: { fr: "CNOPS", ar: "CNOPS" },
+  amo: { fr: "AMO", ar: "AMO" },
+  ramed: { fr: "RAMED", ar: "راميد" },
+  private: { fr: "Assurance privée", ar: "تأمين خاص" },
+  none: { fr: "Sans couverture", ar: "بدون تغطية" },
+};
+
+const insuranceColors: Record<InsuranceType, string> = {
+  cnss: "bg-blue-100 text-blue-800 border-blue-300",
+  cnops: "bg-indigo-100 text-indigo-800 border-indigo-300",
+  amo: "bg-purple-100 text-purple-800 border-purple-300",
+  ramed: "bg-green-100 text-green-800 border-green-300",
+  private: "bg-cyan-100 text-cyan-800 border-cyan-300",
+  none: "bg-gray-100 text-gray-800 border-gray-300",
+};
+
+const insuranceTypes: InsuranceType[] = ["cnss", "cnops", "amo", "ramed", "private", "none"];
+
+export function PatientFinanceView() {
+  const [locale] = useLocale();
+  const lang = locale === "ar" ? "ar" : "fr";
+  const isRtl = lang === "ar";
+
+  const [patientId, setPatientId] = useState("");
+  const [profile, setProfile] = useState<InsuranceProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [editMode, setEditMode] = useState(false);
+  const [editType, setEditType] = useState<InsuranceType>("none");
+  const [editNumber, setEditNumber] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const fetchProfile = useCallback(async () => {
+    if (!patientId.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/patient/insurance-profile?patient_id=${encodeURIComponent(patientId)}&language=${lang}`,
+      );
+      const json = (await res.json()) as {
+        ok: boolean;
+        data?: { profile: InsuranceProfile };
+        error?: string;
+      };
+      if (!json.ok || !json.data) {
+        setError(json.error ?? (lang === "ar" ? "مريض غير موجود" : "Patient non trouvé"));
+        return;
+      }
+      setProfile(json.data.profile);
+      setEditType(json.data.profile.insuranceType);
+      setEditNumber(json.data.profile.membershipNumber ?? "");
+    } catch {
+      setError(lang === "ar" ? "خطأ في الاتصال" : "Erreur de connexion");
+    } finally {
+      setLoading(false);
+    }
+  }, [patientId, lang]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/patient/insurance-profile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          patientId,
+          insuranceType: editType,
+          insuranceNumber: editNumber || null,
+        }),
+      });
+      const json = (await res.json()) as { ok: boolean; error?: string };
+      if (!json.ok) {
+        setError(json.error ?? (lang === "ar" ? "خطأ في الحفظ" : "Erreur de sauvegarde"));
+        return;
+      }
+      setEditMode(false);
+      void fetchProfile();
+    } catch {
+      setError(lang === "ar" ? "خطأ في الاتصال" : "Erreur de connexion");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={`space-y-6 ${isRtl ? "text-right" : ""}`} dir={isRtl ? "rtl" : "ltr"}>
+      <h1 className="text-2xl font-bold text-gray-900">
+        <CreditCard className="mr-2 inline-block h-6 w-6" />
+        {lang === "ar" ? "الملف المالي للمريض" : "Profil financier du patient"}
+      </h1>
+
+      {/* Patient ID input */}
+      <div className="flex gap-3">
+        <input
+          type="text"
+          placeholder={lang === "ar" ? "معرف المريض (UUID)" : "ID du patient (UUID)"}
+          value={patientId}
+          onChange={(e) => setPatientId(e.target.value)}
+          className="flex-1 rounded-lg border px-4 py-2 text-sm"
+        />
+        <button
+          onClick={() => void fetchProfile()}
+          disabled={loading || !patientId.trim()}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : lang === "ar" ? (
+            "بحث"
+          ) : (
+            "Rechercher"
+          )}
+        </button>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+          <p className="text-sm text-red-600">{error}</p>
+        </div>
+      )}
+
+      {profile && (
+        <div className="space-y-4">
+          {/* Insurance type badge */}
+          <div className={`rounded-xl border-2 p-6 ${insuranceColors[profile.insuranceType]}`}>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Shield className="h-8 w-8" />
+                <div>
+                  <p className="text-sm opacity-80">
+                    {lang === "ar" ? "نوع التأمين" : "Type d'assurance"}
+                  </p>
+                  <p className="text-2xl font-bold">
+                    {insuranceLabels[profile.insuranceType]?.[lang] ?? profile.insuranceType}
+                  </p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className="text-sm opacity-80">
+                  {lang === "ar" ? "نسبة التغطية" : "Couverture"}
+                </p>
+                <p className="text-3xl font-bold">{profile.coveragePercentage}%</p>
+              </div>
+            </div>
+            {profile.membershipNumber && (
+              <p className="mt-3 text-sm">
+                {lang === "ar" ? "رقم العضوية:" : "N° adhérent:"}{" "}
+                <span className="font-mono font-bold">{profile.membershipNumber}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Key info grid */}
+          <div className="grid grid-cols-3 gap-4">
+            <div className="rounded-lg border bg-white p-4">
+              <div className="flex items-center gap-2 text-gray-600">
+                <CreditCard className="h-4 w-4" />
+                <span className="text-sm">{lang === "ar" ? "حصة المريض" : "Part patient"}</span>
+              </div>
+              <p className="mt-1 text-2xl font-bold text-gray-900">{profile.copayEstimate}%</p>
+            </div>
+            <div className="rounded-lg border bg-white p-4">
+              <div className="flex items-center gap-2 text-gray-600">
+                <FileText className="h-4 w-4" />
+                <span className="text-sm">{lang === "ar" ? "النموذج" : "Formulaire"}</span>
+              </div>
+              <p className="mt-1 text-sm font-semibold text-gray-900">
+                {profile.formTemplate.replace(/_/g, " ")}
+              </p>
+            </div>
+            <div className="rounded-lg border bg-white p-4">
+              <div className="flex items-center gap-2 text-gray-600">
+                {profile.requiresPreApproval ? (
+                  <AlertTriangle className="h-4 w-4 text-orange-500" />
+                ) : (
+                  <CheckCircle className="h-4 w-4 text-green-500" />
+                )}
+                <span className="text-sm">
+                  {lang === "ar" ? "موافقة مسبقة" : "Accord préalable"}
+                </span>
+              </div>
+              <p className="mt-1 text-sm font-semibold text-gray-900">
+                {profile.requiresPreApproval
+                  ? lang === "ar"
+                    ? "مطلوب"
+                    : "Requis"
+                  : lang === "ar"
+                    ? "غير مطلوب"
+                    : "Non requis"}
+              </p>
+            </div>
+          </div>
+
+          {/* Notes */}
+          <div className="rounded-lg border bg-white p-5">
+            <h2 className="mb-3 text-lg font-semibold text-gray-900">
+              {lang === "ar" ? "ملاحظات مهمة" : "Notes importantes"}
+            </h2>
+            <ul className="space-y-2">
+              {profile.notes.map((note, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                  <span className="mt-0.5 block h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
+                  {note}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Edit insurance */}
+          {editMode ? (
+            <div className="space-y-3 rounded-lg border bg-gray-50 p-4">
+              <h3 className="font-semibold">
+                {lang === "ar" ? "تعديل التأمين" : "Modifier l'assurance"}
+              </h3>
+              <select
+                value={editType}
+                onChange={(e) => setEditType(e.target.value as InsuranceType)}
+                className="w-full rounded border px-3 py-2 text-sm"
+              >
+                {insuranceTypes.map((type) => (
+                  <option key={type} value={type}>
+                    {insuranceLabels[type]?.[lang] ?? type}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="text"
+                placeholder={lang === "ar" ? "رقم العضوية" : "N° adhérent"}
+                value={editNumber}
+                onChange={(e) => setEditNumber(e.target.value)}
+                className="w-full rounded border px-3 py-2 text-sm"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => void handleSave()}
+                  disabled={saving}
+                  className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {saving
+                    ? lang === "ar"
+                      ? "جاري الحفظ..."
+                      : "Enregistrement..."
+                    : lang === "ar"
+                      ? "حفظ"
+                      : "Enregistrer"}
+                </button>
+                <button
+                  onClick={() => setEditMode(false)}
+                  className="rounded border px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+                >
+                  {lang === "ar" ? "إلغاء" : "Annuler"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setEditMode(true)}
+              className="w-full rounded-lg border border-gray-200 py-2 text-sm text-gray-600 hover:bg-gray-50"
+            >
+              {lang === "ar" ? "تعديل نوع التأمين" : "Modifier le type d'assurance"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Patient financial profiling that auto-detects insurance type and adjusts billing flow. Covers all Moroccan insurance systems: CNSS, CNOPS, AMO, RAMED, private, and uninsured.

## Changes
- `GET /api/patient/insurance-profile` — fetch patient insurance profile with coverage %, form template, co-pay estimate, pre-approval requirements
- `POST /api/patient/insurance-profile` — update patient insurance type and membership number
- Full config for each insurance type: coverage percentages, form templates, billing notes in FR/AR
- `PatientFinanceView` component — insurance badge with color coding, 3-metric grid (co-pay, form, pre-approval), editable insurance type
- Page at `/doctor/patient-finance` with `requireRole("doctor", "clinic_admin", "receptionist")`

## Insurance Types
| Type | Coverage | Pre-approval | Form |
|------|----------|-------------|------|
| CNSS | 70% | No | cnss_feuille_soin |
| CNOPS | 80% | No | cnops_feuille_soin |
| AMO | 70% | Yes | amo_prise_en_charge |
| RAMED | 100% | Yes | ramed_attestation |
| Private | 80% | Yes | private_claim_form |
| None | 0% | No | cash_receipt |

## Patterns
- `withAuth` + `AuthContext` for tenant isolation
- All queries scoped by `clinic_id`
- Untyped Supabase client for `patients` table fields not yet in generated types
- FR/AR localization via `useLocale()` tuple
- Accessible to receptionist role (not just doctors)