### PR TITLE
infra(staging): document audit #5 — KV namespace shared with production

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -211,10 +211,36 @@ binding = "UPLOADS_BUCKET"
 bucket_name = "webs-alots-uploads-staging"
 
 # W8-A31-01: KV namespace binding for staging
+#
+# etap1 audit finding #5 — DO NOT MERGE THIS FILE'S STAGING BLOCK
+# until the steps below are completed.
+#
+# CURRENT STATE (launch blocker): the IDs below are the SAME ones used by
+# [[env.production.kv_namespaces]] above. That means rate-limit counters
+# are shared between staging and production:
+#
+#   • Load tests on staging exhaust prod counters → real users get 429s.
+#   • A prod rate-limit event blocks staging testing.
+#   • Staging auth attempts count against prod IP / user buckets.
+#
+# Action required before launch (run once on a workstation with `wrangler login`):
+#
+#   wrangler kv:namespace create RATE_LIMIT_KV_STAGING
+#   wrangler kv:namespace create RATE_LIMIT_KV_STAGING --preview
+#
+# Then replace the two `id` / `preview_id` values below with the new
+# staging-specific IDs returned by the wrangler commands, and verify
+# isolation by tailing logs on both envs during a staging load test:
+#
+#   wrangler tail --env staging   # should see KV ops; prod tail should not.
+#
+# Until the IDs are replaced, treat staging and production as a single
+# rate-limit surface. R2 buckets are already correctly separated
+# (webs-alots-uploads-staging vs webs-alots-uploads).
 [[env.staging.kv_namespaces]]
 binding = "RATE_LIMIT_KV"
-id = "7ac37dff0a794542b0c766f38e73f105"
-preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
+id = "7ac37dff0a794542b0c766f38e73f105"          # TODO(audit-#5): replace with staging KV ID
+preview_id = "854c78ea8c9442ed8706d3ec31fe292e"  # TODO(audit-#5): replace with staging KV preview ID
 
 # W8-A31-01: Routes for staging (uses staging subdomain)
 [env.staging.routes]


### PR DESCRIPTION
## Summary

Documents etap1 audit finding **#5** (HIGH — Security/Deployment): `[[env.staging.kv_namespaces]]` currently references the **same** KV namespace ID as production.

```toml
# production
id = "7ac37dff0a794542b0c766f38e73f105"
preview_id = "854c78ea8c9442ed8706d3ec31fe292e"

# staging — SAME IDs
id = "7ac37dff0a794542b0c766f38e73f105"
preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
```

Rate-limit counters therefore bleed between environments. Staging load tests will 429 real production users; production rate-limit events will block staging testing; staging auth attempts count against production IP / user buckets.

## Why this PR is docs-only (intentional)

The actual fix requires creating two new KV namespaces with `wrangler kv:namespace create`, which needs `wrangler login` on a workstation with Cloudflare account access. I do not have those credentials.

This PR therefore lands an inline checklist on the staging block (plus `TODO(audit-#5)` markers on the two ID lines) so the action is visible to anyone deploying staging. Merging this PR does **not** change runtime behaviour — the IDs remain as they are.

## Action required before final merge

```bash
# On a workstation with `wrangler login`:
wrangler kv:namespace create RATE_LIMIT_KV_STAGING
wrangler kv:namespace create RATE_LIMIT_KV_STAGING --preview

# Then edit wrangler.toml and replace the two TODO-marked values in
# [[env.staging.kv_namespaces]] with the IDs returned above.

# Verify isolation:
wrangler tail --env staging  # KV ops should appear here
wrangler tail --env production  # but NOT here for the same request
```

## Files touched

- `wrangler.toml` — added a comment block above `[[env.staging.kv_namespaces]]` with the action checklist; added inline `TODO(audit-#5)` markers on the two ID lines. **No runtime change.**

## Cross-references

- etap1 audit finding **#5**
- `docs/AUDIT-ROADMAP.md` row 5 (lands in PR-J in this same wave)
- Companion to etap1 #1 / #6 (rate-limit KV binding) — addressed in PR #873

## Roll-back

Revert. This PR adds 28 lines of comments and 2 trailing-comment markers; reverting is safe at any time.