### PR TITLE
security(codeowners): require senior review on src/app/api, env.ts, supabase-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,22 @@ sentry.client.config.ts         @groupsmix
 src/middleware.ts                @groupsmix
 src/lib/middleware/*             @groupsmix
 
+# Technical audit (2026-05-30) ARCH-02: API route handlers form the public
+# attack surface. Auth bypasses, RLS leaks, IDOR, and missing tenant scoping
+# almost always land in src/app/api/* PRs. Require senior review on every
+# API route change, including new route files.
+src/app/api/**                   @groupsmix
+
+# Technical audit (2026-05-30) ARCH-02 (companion): env.ts owns startup
+# health checks for PHI encryption, rate-limit backend, masking policy,
+# security-flag acknowledgments, HMAC key independence. A regression here
+# can ship a misconfigured production deploy that boots and looks healthy.
+src/lib/env.ts                   @groupsmix
+
+# Supabase server clients — service-role usage and tenant-scoping live here
+src/lib/supabase-server.ts       @groupsmix
+src/lib/supabase-*.ts            @groupsmix
+
 # A2-05: Build-time / postinstall patcher scripts.
 # package.json runs these via `postinstall` and `build:cf`, so any change
 # to them ships to every developer machine and to the production build.


### PR DESCRIPTION
## Summary

Technical audit 2026-05-30 (audit-3) finding **ARCH-02** (HIGH, P1) — extends `.github/CODEOWNERS` with three security-critical patterns the audit explicitly called out as missing.

## Why this matters

The audit recommends: *"Require human review + approval on any PR that touches src/lib/supabase-\*.ts, src/middleware.ts, src/app/api/, supabase/migrations/, or wrangler.toml."*

The existing CODEOWNERS file already covers `supabase/migrations/*`, `wrangler.toml`, `src/middleware.ts`, `src/lib/middleware/*`, `src/lib/with-auth.ts`, `src/lib/auth.ts`, `src/lib/tenant*.ts`, and `src/lib/rate-limit.ts`. Three gaps remain:

| Path | Why it needs review |
|------|---------------------|
| `src/app/api/**` | Every API route handler is part of the public attack surface. Auth bypass, RLS leak, IDOR, and missing tenant scoping bugs almost always land here. |
| `src/lib/env.ts` | Owns `enforceEnvValidation`, `enforcePhiEncryption`, `enforcePhiMaskingPolicy`, `enforceRateLimitBackend`, `enforceSecurityFlagAcknowledgments`. A regression here can ship a misconfigured production deploy that boots and looks healthy. |
| `src/lib/supabase-*.ts` | `createAdminClient` (service-role bypass) and tenant-scoped client factories. RLS is the multi-tenant security boundary. |

## Files touched

- `.github/CODEOWNERS` — added 16 lines (3 patterns + comments)

No runtime impact. Only changes which reviewer GitHub auto-requests on PRs touching these files.

## Effect on velocity

PRs touching API routes, env validation, or Supabase clients will now require the listed code owner's approval before merge. For solo-maintainer repos this is effectively a self-checkpoint; for team repos this enforces the audit's "no AI-only merge" recommendation.

## Roll-back

Revert. Zero code, zero config side effects.

## Cross-references

- Technical audit 2026-05-30 (audit-3) — ARCH-02
- `docs/AUDIT-ROADMAP.md` audit-3 ARCH-02 row (lands in companion PR this wave)