### PR TITLE
obs(cron/payment-reminders): wrap with withSentryCron for monitoring (PERF-01)

### DIFF
--- a/src/app/api/cron/payment-reminders/route.ts
+++ b/src/app/api/cron/payment-reminders/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { untypedClient } from "@/lib/billing-db";
 import { verifyCronSecret } from "@/lib/cron-auth";
 import { logger } from "@/lib/logger";
+import { withSentryCron } from "@/lib/sentry-cron";
 import { sendTextMessage } from "@/lib/whatsapp";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,8 +12,17 @@ type UntypedTable = { from(table: string): any };
  * POST /api/cron/payment-reminders
  * Automated cron job to send payment reminders for overdue invoices and upcoming installments.
  * Iterates per-clinic as required by AGENTS.md.
+ *
+ * Technical audit (2026-05-30) PERF-01 — wrapped with withSentryCron so silent
+ * failures surface in the Sentry Crons dashboard. Placeholder schedule
+ * "0 9 * * *" (09:00 Africa/Casablanca daily) matches the team's convention
+ * for the other unwired cron routes (data-retention, daily-briefing, etc.)
+ * and reflects the route's "today vs N-day-overdue" daily logic. The route
+ * is not yet wired in worker-cron-handler.ts CRON_ROUTES; until it is, Sentry
+ * may emit `missed` check-ins for this monitor — that is the expected signal
+ * to either wire the schedule or remove the monitor.
  */
-export async function POST(request: NextRequest): Promise<NextResponse> {
+async function handler(request: NextRequest): Promise<NextResponse> {
   const authError = verifyCronSecret(request);
   if (authError) return authError;
 
@@ -357,3 +367,10 @@ async function sendAndRecordReminder(
     results.failed++;
   }
 }
+
+// Technical audit (2026-05-30) PERF-01 — wrap the handler with Sentry Cron
+// Monitoring so the route's invocations (and any silent failures) are visible
+// in the Sentry Crons dashboard alongside the other 15 cron routes that
+// already use this pattern. See the JSDoc on `handler` above for the
+// schedule rationale and the wiring caveat.
+export const POST = withSentryCron("payment-reminders", "0 9 * * *", handler);


### PR DESCRIPTION
## Summary

Technical audit 2026-05-30 (audit-3) finding **PERF-01** (MEDIUM, P2) — closes the last gap in cron Sentry monitoring.

## Context

The audit recommended wrapping each cron handler with `Sentry.captureCheckIn({ monitorSlug, ... })` so silent cron failures (the GDPR purge example in the audit) surface in the Sentry Crons dashboard instead of disappearing into Workers Logs.

This pattern is **already shipped for 15 of 16** cron routes under `src/app/api/cron/*`. They all import `withSentryCron` from `src/lib/sentry-cron.ts` (existing helper) and export their handler as:

```ts
export const GET = withSentryCron("slug", "schedule", handler);
```

The one exception was `payment-reminders/route.ts`, which kept the original `export async function POST(...)` form and had no monitor attached.

## What this PR does

- Adds `withSentryCron` to the import block.
- Renames `export async function POST` → `async function handler` so the wrapper can compose over it.
- Re-exports `POST` as `withSentryCron("payment-reminders", "0 9 * * *", handler)`.

Placeholder schedule `"0 9 * * *"` (09:00 Africa/Casablanca daily) is consistent with the team's other unwired routes:
- `data-retention` → `"0 3 * * *"`
- `daily-briefing` → `"0 * * * *"`
- `retry-webhooks` → `"*/5 * * * *"`

It reflects the route's daily "today / 3-day / 7-day / 14-day overdue" calculation logic.

## Honest caveat

`payment-reminders` is **not currently wired** to `worker-cron-handler.ts` `CRON_ROUTES`. Until an operator wires the schedule (or the route is invoked externally on this cadence), Sentry may emit `missed` check-ins for this monitor. That is the expected signal to either wire the schedule or drop the monitor. Inline JSDoc says this.

## Files touched

- `src/app/api/cron/payment-reminders/route.ts` (+18 / -1)

No runtime behavior change for in-flight requests. The Sentry SDK is already loaded via `@sentry/nextjs ^10.54.0`; this just registers one more monitor slug.

## Roll-back

Revert. The pre-change handler still works; the only loss is the monitor.

## Cross-references

- Technical audit 2026-05-30 (audit-3) — PERF-01
- `src/lib/sentry-cron.ts` (existing helper, no changes)
- `docs/AUDIT-ROADMAP.md` PERF-01 row (lands in companion PR this wave)