### PR TITLE
security(audit-4): enforce BOOKING_TOKEN_SECRET >= 32 chars in production (F-15)

### DIFF
--- a/src/lib/__tests__/env-booking-token-secret.test.ts
+++ b/src/lib/__tests__/env-booking-token-secret.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { enforceBookingTokenSecretMinLength } from "../env";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("enforceBookingTokenSecretMinLength (audit-4 F-15)", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does nothing outside production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("BOOKING_TOKEN_SECRET", "x");
+    expect(() => enforceBookingTokenSecretMinLength()).not.toThrow();
+  });
+
+  it("does nothing in production when the secret is unset", () => {
+    // The "missing" case is handled by ENV_RULES.required, not by this guard.
+    // This guard only fires when the value is set but short.
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BOOKING_TOKEN_SECRET", "");
+    expect(() => enforceBookingTokenSecretMinLength()).not.toThrow();
+  });
+
+  it("throws in production when the secret is shorter than 32 chars", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BOOKING_TOKEN_SECRET", "short");
+    expect(() => enforceBookingTokenSecretMinLength()).toThrow(
+      /BOOKING_TOKEN_SECRET must be at least 32 characters/,
+    );
+  });
+
+  it("throws in production when the secret is exactly 31 chars", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BOOKING_TOKEN_SECRET", "a".repeat(31));
+    expect(() => enforceBookingTokenSecretMinLength()).toThrow(
+      /BOOKING_TOKEN_SECRET must be at least 32 characters/,
+    );
+  });
+
+  it("passes in production when the secret is exactly 32 chars", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BOOKING_TOKEN_SECRET", "a".repeat(32));
+    expect(() => enforceBookingTokenSecretMinLength()).not.toThrow();
+  });
+
+  it("passes in production when the secret is comfortably longer", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BOOKING_TOKEN_SECRET", "a".repeat(64));
+    expect(() => enforceBookingTokenSecretMinLength()).not.toThrow();
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -512,6 +512,12 @@ export function enforceEnvValidation(): void {
   // A100-35: Reject CRON_SECRET shorter than 32 chars in production.
   enforceCronSecretMinLength();
 
+  // F-15 (audit-4): Reject BOOKING_TOKEN_SECRET shorter than 32 chars in
+  // production. A weak or empty secret would let attackers forge booking
+  // tokens and skip OTP verification. ENV_RULES.required only catches the
+  // missing case; this guard catches typos and short values.
+  enforceBookingTokenSecretMinLength();
+
   // S-05: Assert PROFILE_HEADER_HMAC_KEY !== CRON_SECRET to prevent a
   // leaked cron token from also forging session headers.
   enforceHmacKeyIndependence();
@@ -676,6 +682,32 @@ export function enforceCronSecretMinLength(): void {
       "[STARTUP HEALTH CHECK FAILED] CRON_SECRET must be at least 32 characters.\n" +
       "A short secret is vulnerable to brute-force. Generate one: `openssl rand -hex 32`.";
     logger.error(message, { context: "env-validation", check: "cron-secret-length" });
+    throw new Error(message);
+  }
+}
+
+/**
+ * F-15 (audit-4): Reject BOOKING_TOKEN_SECRET shorter than 32 characters
+ * in production. BOOKING_TOKEN_SECRET signs the HMAC payload that proves
+ * a booking flow has cleared OTP verification — an empty or short value
+ * lets attackers forge tokens and bypass OTP entirely.
+ *
+ * Mirrors {@link enforceCronSecretMinLength}. ENV_RULES.required already
+ * hard-fails when the variable is missing; this guard catches the case
+ * where it is set but trivially short.
+ *
+ * Exported for unit tests.
+ */
+export function enforceBookingTokenSecretMinLength(): void {
+  if (process.env.NODE_ENV !== "production") return;
+
+  const secret = process.env.BOOKING_TOKEN_SECRET;
+  if (secret && secret.length < 32) {
+    const message =
+      "[STARTUP HEALTH CHECK FAILED] BOOKING_TOKEN_SECRET must be at least 32 characters.\n" +
+      "A short secret lets attackers forge booking tokens and skip OTP verification. " +
+      "Generate one: `openssl rand -hex 32`.";
+    logger.error(message, { context: "env-validation", check: "booking-token-secret-length" });
     throw new Error(message);
   }
 }


### PR DESCRIPTION
## Audit-4 finding F-15 — BOOKING_TOKEN_SECRET length floor

This PR addresses the **actionable half** of audit-4 finding F-15 (`BOOKING_TOKEN_SECRET` + `CRON_SECRET` have no boot-time enforcement).

### Investigation

The audit grouped both secrets under one finding, but the code already handles one of them.

| Secret | ENV_RULES.required in prod? | Boot-time min-length? | Status |
|---|---|---|---|
| `CRON_SECRET` | ✅ env.ts L262 | ✅ `enforceCronSecretMinLength()` env.ts L670 (≥ 32 chars) | Already shipped, no change |
| `BOOKING_TOKEN_SECRET` | ✅ env.ts L45 | ❌ **gap — this PR** | Fixed here |

An operator could previously set `BOOKING_TOKEN_SECRET=x` and the validator would pass, because the rule only enforced *presence*, not *length*.

### Risk if unfixed

`BOOKING_TOKEN_SECRET` signs the HMAC payload that proves a booking flow has cleared OTP verification. A weak / leaked value lets attackers forge tokens and skip OTP entirely on `/booking` endpoints — directly impacting Moroccan Law 09-08 patient-data protections.

### Change

- `src/lib/env.ts` — add `enforceBookingTokenSecretMinLength()` mirroring `enforceCronSecretMinLength()`. Hard-fails boot in production if the secret is set but `< 32` chars. Called from `enforceEnvValidation()` immediately after the cron-secret guard.
- `src/lib/__tests__/env-booking-token-secret.test.ts` — 6 unit tests:
  - no-op outside production
  - no-op when unset (the missing case is owned by `ENV_RULES.required`)
  - throws on short value
  - throws on exactly 31 chars
  - passes on exactly 32 chars
  - passes on 64 chars

### F-15 leftover

The audit also asked to add `PHI_ENCRYPTION_KEY` and `STAFF_DEFAULT_PASSWORD` to the same enforcement table:

- `PHI_ENCRYPTION_KEY` — already enforced via `enforcePhiEncryptionConfigured()` (env.ts L637), validates 64 hex chars. No change needed.
- `STAFF_DEFAULT_PASSWORD` — **false positive** (also flagged by audit-3 SEC-05 and audit-4 F-09). `src/lib/constants.ts:10` falls back to ``Staff-${crypto.randomUUID()}`` when the env var is empty, so a blank value never results in a well-known password. Documented in `docs/AUDIT-ROADMAP.md` (PR #879).

### Audit cross-references

- audit-4 → F-15 (this PR, half of it)
- audit-3 → no equivalent
- etap1 → no equivalent

### Merge order

Independent of all prior open PRs; can merge any time. Roadmap doc PR will be opened separately and stacked on #879.

Please review — do not merge per standing instruction.