### PR TITLE
infra(audit-4): refuse destructive crons in staging without explicit opt-in (F-13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,25 @@ BOOKING_TOKEN_SECRET=
 # Generate with: openssl rand -hex 32
 CRON_SECRET=
 
+# ---- Worker Environment Marker [Set per-environment in wrangler.toml] ----
+# audit-4 F-13: WORKER_ENV is the only signal that distinguishes the
+# staging deployment from production at runtime (NODE_ENV is "production"
+# in both wrangler envs). Set automatically by:
+#   [env.production.vars]  WORKER_ENV = "production"
+#   [env.staging.vars]     WORKER_ENV = "staging"
+# Destructive crons (billing, gdpr-purge, stripe-reconcile, dedup-purge)
+# refuse to run when WORKER_ENV=staging unless the operator explicitly sets
+# ALLOW_STAGING_DESTRUCTIVE_CRONS=true via `wrangler secret put`.
+# Local dev: leave unset (guard returns null when unset).
+WORKER_ENV=
+
+# audit-4 F-13: Explicit per-Worker opt-in that lets destructive crons run
+# in staging. Default is "false" (or unset). Set with:
+#   wrangler secret put ALLOW_STAGING_DESTRUCTIVE_CRONS --env staging
+# Only set to "true" when intentionally exercising the destructive paths
+# (e.g. a scheduled load-test or a dry-run reconciliation drill).
+ALLOW_STAGING_DESTRUCTIVE_CRONS=
+
 # ---- Cron Self-Invocation URL [Required for Workers deployment] ----
 # Base URL where the Cloudflare Worker can call itself for cron triggers.
 # If not set, cron jobs will silently fail to invoke. Must be set in

--- a/src/app/api/cron/billing/route.ts
+++ b/src/app/api/cron/billing/route.ts
@@ -11,6 +11,7 @@ import { NextRequest } from "next/server";
 import { apiInternalError, apiSuccess } from "@/lib/api-response";
 import { assertClinicId } from "@/lib/assert-tenant";
 import { verifyCronSecret } from "@/lib/cron-auth";
+import { assertCronAllowedInThisEnv } from "@/lib/cron-env-guard";
 import { logger } from "@/lib/logger";
 import { withSentryCron } from "@/lib/sentry-cron";
 import { processRenewal } from "@/lib/subscription-billing";
@@ -22,6 +23,11 @@ async function handler(request: NextRequest) {
   // DRY: Use shared cron secret verification helper
   const authError = verifyCronSecret(request);
   if (authError) return authError;
+
+  // audit-4 F-13: refuse to charge customers from staging unless explicitly
+  // opted in (WORKER_ENV=staging + ALLOW_STAGING_DESTRUCTIVE_CRONS=true).
+  const envBlock = assertCronAllowedInThisEnv("billing");
+  if (envBlock) return envBlock;
 
   const supabase = createAdminClient("cron");
 

--- a/src/app/api/cron/dedup-purge/route.ts
+++ b/src/app/api/cron/dedup-purge/route.ts
@@ -17,6 +17,7 @@
 import { NextRequest } from "next/server";
 import { apiSuccess } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
+import { assertCronAllowedInThisEnv } from "@/lib/cron-env-guard";
 import { logger } from "@/lib/logger";
 import { withSentryCron } from "@/lib/sentry-cron";
 import { createAdminClient } from "@/lib/supabase-server";
@@ -30,6 +31,12 @@ const WA_RETENTION_DAYS = 30;
 async function handler(request: NextRequest) {
   const authError = verifyCronSecret(request);
   if (authError) return authError;
+
+  // audit-4 F-13: dedup TTL purge mutates the processed_stripe_events,
+  // cmi_callbacks_seen, and processed_whatsapp_messages tables — deleting
+  // these in staging against the prod DB would break replay protection.
+  const envBlock = assertCronAllowedInThisEnv("dedup-purge");
+  if (envBlock) return envBlock;
 
   const admin = createAdminClient("cron");
   const stripeCutoff = new Date(

--- a/src/app/api/cron/gdpr-purge/route.ts
+++ b/src/app/api/cron/gdpr-purge/route.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { NextRequest } from "next/server";
 import { apiSuccess, apiInternalError } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
+import { assertCronAllowedInThisEnv } from "@/lib/cron-env-guard";
 import { sendEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
 import { deleteFromR2, isR2Configured } from "@/lib/r2";
@@ -30,6 +31,12 @@ type UntypedClient = SupabaseClient<any, any, any>;
 async function handler(request: NextRequest) {
   const authError = verifyCronSecret(request);
   if (authError) return authError;
+
+  // audit-4 F-13: GDPR right-to-erasure is the most destructive cron in
+  // the system (permanent patient-record deletion). Refuse to run in
+  // staging unless an operator explicitly opts in.
+  const envBlock = assertCronAllowedInThisEnv("gdpr-purge");
+  if (envBlock) return envBlock;
 
   try {
     const supabase = createAdminClient("cron") as UntypedClient;

--- a/src/app/api/cron/stripe-reconcile/route.ts
+++ b/src/app/api/cron/stripe-reconcile/route.ts
@@ -15,6 +15,7 @@
 import { NextRequest } from "next/server";
 import { apiSuccess, apiInternalError, apiError } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
+import { assertCronAllowedInThisEnv } from "@/lib/cron-env-guard";
 import { logger } from "@/lib/logger";
 import { withSentryCron } from "@/lib/sentry-cron";
 import { createAdminClient } from "@/lib/supabase-server";
@@ -36,6 +37,12 @@ interface StripeListResponse {
 async function handler(request: NextRequest) {
   const authError = verifyCronSecret(request);
   if (authError) return authError;
+
+  // audit-4 F-13: reconciliation writes drift entries to the financial
+  // journal. Running this in staging against the prod Stripe account
+  // would corrupt real records. Refuse unless explicitly opted in.
+  const envBlock = assertCronAllowedInThisEnv("stripe-reconcile");
+  if (envBlock) return envBlock;
 
   const stripeKey = process.env.STRIPE_SECRET_KEY;
   if (!stripeKey) {

--- a/src/lib/__tests__/cron-env-guard.test.ts
+++ b/src/lib/__tests__/cron-env-guard.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { assertCronAllowedInThisEnv } from "../cron-env-guard";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("assertCronAllowedInThisEnv (audit-4 F-13)", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null when WORKER_ENV is unset (local dev / preview / tests)", () => {
+    vi.stubEnv("WORKER_ENV", "");
+    expect(assertCronAllowedInThisEnv("billing")).toBeNull();
+  });
+
+  it("returns null when WORKER_ENV is production", () => {
+    vi.stubEnv("WORKER_ENV", "production");
+    expect(assertCronAllowedInThisEnv("gdpr-purge")).toBeNull();
+  });
+
+  it("returns a 503 NextResponse when WORKER_ENV is staging with no opt-in", async () => {
+    vi.stubEnv("WORKER_ENV", "staging");
+    vi.stubEnv("ALLOW_STAGING_DESTRUCTIVE_CRONS", "");
+    const result = assertCronAllowedInThisEnv("billing");
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(503);
+    const body = await result!.json();
+    expect(body.error).toMatch(/Destructive cron disabled in staging/i);
+    expect(body.cron).toBe("billing");
+  });
+
+  it("returns null in staging when ALLOW_STAGING_DESTRUCTIVE_CRONS=true", () => {
+    vi.stubEnv("WORKER_ENV", "staging");
+    vi.stubEnv("ALLOW_STAGING_DESTRUCTIVE_CRONS", "true");
+    expect(assertCronAllowedInThisEnv("stripe-reconcile")).toBeNull();
+  });
+
+  it('treats anything other than the literal string "true" as off', () => {
+    vi.stubEnv("WORKER_ENV", "staging");
+    for (const value of ["1", "yes", "on", "TRUE", "True"]) {
+      vi.stubEnv("ALLOW_STAGING_DESTRUCTIVE_CRONS", value);
+      const result = assertCronAllowedInThisEnv("dedup-purge");
+      expect(result, `value="${value}" should NOT bypass the guard`).not.toBeNull();
+      expect(result?.status).toBe(503);
+    }
+  });
+
+  it("blocks each of the four destructive cron names independently", async () => {
+    vi.stubEnv("WORKER_ENV", "staging");
+    vi.stubEnv("ALLOW_STAGING_DESTRUCTIVE_CRONS", "");
+    for (const name of [
+      "billing",
+      "gdpr-purge",
+      "stripe-reconcile",
+      "dedup-purge",
+    ] as const) {
+      const result = assertCronAllowedInThisEnv(name);
+      expect(result?.status).toBe(503);
+      const body = await result!.json();
+      expect(body.cron).toBe(name);
+    }
+  });
+});

--- a/src/lib/__tests__/cron-env-guard.test.ts
+++ b/src/lib/__tests__/cron-env-guard.test.ts
@@ -59,12 +59,7 @@ describe("assertCronAllowedInThisEnv (audit-4 F-13)", () => {
   it("blocks each of the four destructive cron names independently", async () => {
     vi.stubEnv("WORKER_ENV", "staging");
     vi.stubEnv("ALLOW_STAGING_DESTRUCTIVE_CRONS", "");
-    for (const name of [
-      "billing",
-      "gdpr-purge",
-      "stripe-reconcile",
-      "dedup-purge",
-    ] as const) {
+    for (const name of ["billing", "gdpr-purge", "stripe-reconcile", "dedup-purge"] as const) {
       const result = assertCronAllowedInThisEnv(name);
       expect(result?.status).toBe(503);
       const body = await result!.json();

--- a/src/lib/cron-env-guard.ts
+++ b/src/lib/cron-env-guard.ts
@@ -34,11 +34,7 @@ import { logger } from "@/lib/logger";
  * Kept as a string union so adding a new destructive cron forces a code
  * review of this file (no magic strings at call sites).
  */
-export type DestructiveCronName =
-  | "billing"
-  | "gdpr-purge"
-  | "stripe-reconcile"
-  | "dedup-purge";
+export type DestructiveCronName = "billing" | "gdpr-purge" | "stripe-reconcile" | "dedup-purge";
 
 /**
  * Verify that a destructive cron is permitted to run in the current
@@ -52,9 +48,7 @@ export type DestructiveCronName =
  * `ALLOW_STAGING_DESTRUCTIVE_CRONS=true` in the staging Worker secrets.
  * This is intentionally an explicit, audited choice — never a default.
  */
-export function assertCronAllowedInThisEnv(
-  name: DestructiveCronName,
-): NextResponse | null {
+export function assertCronAllowedInThisEnv(name: DestructiveCronName): NextResponse | null {
   const workerEnv = process.env.WORKER_ENV;
   if (workerEnv !== "staging") return null;
 

--- a/src/lib/cron-env-guard.ts
+++ b/src/lib/cron-env-guard.ts
@@ -1,0 +1,93 @@
+/**
+ * F-13 (audit-4) — Destructive cron safety guard for non-production envs.
+ *
+ * Background: in `wrangler.toml`, both `[env.production.vars]` and
+ * `[env.staging.vars]` set `NODE_ENV = "production"` so the Next.js runtime
+ * behaves the same in both. That makes `NODE_ENV` useless as a staging-vs-
+ * production discriminator. A separate marker (`WORKER_ENV`) is therefore
+ * set per-env in `wrangler.toml`:
+ *
+ *   [env.production.vars]  WORKER_ENV = "production"
+ *   [env.staging.vars]     WORKER_ENV = "staging"
+ *
+ * Destructive crons (GDPR purge, billing renewals, Stripe reconciliation,
+ * dedup TTL purge) must not execute in staging unless an operator has
+ * explicitly opted in, because:
+ *
+ *   1. Staging schedules in `wrangler.toml` are identical to production's.
+ *   2. If a Worker secret injection error lets staging resolve to the
+ *      production Supabase URL/key, the destructive cron would purge real
+ *      patient records, charge real customers, or corrupt the live
+ *      financial journal.
+ *
+ * Guard contract: return a 503 NextResponse if the current Worker env is
+ * `staging` and `ALLOW_STAGING_DESTRUCTIVE_CRONS !== "true"`. Otherwise
+ * return null (cron is allowed to proceed). Always returns null when
+ * `WORKER_ENV` is unset (local dev, tests, preview, prod-without-marker).
+ */
+
+import { NextResponse } from "next/server";
+import { logger } from "@/lib/logger";
+
+/**
+ * Logical names for the cron jobs that mutate production-sensitive state.
+ * Kept as a string union so adding a new destructive cron forces a code
+ * review of this file (no magic strings at call sites).
+ */
+export type DestructiveCronName =
+  | "billing"
+  | "gdpr-purge"
+  | "stripe-reconcile"
+  | "dedup-purge";
+
+/**
+ * Verify that a destructive cron is permitted to run in the current
+ * Worker environment. Call immediately after `verifyCronSecret()` in
+ * each destructive cron route handler.
+ *
+ * - Returns `null` when the cron is allowed to proceed.
+ * - Returns a 503 `NextResponse` (and logs an `error`) when blocked.
+ *
+ * Staging deployments can override on a per-operation basis by setting
+ * `ALLOW_STAGING_DESTRUCTIVE_CRONS=true` in the staging Worker secrets.
+ * This is intentionally an explicit, audited choice — never a default.
+ */
+export function assertCronAllowedInThisEnv(
+  name: DestructiveCronName,
+): NextResponse | null {
+  const workerEnv = process.env.WORKER_ENV;
+  if (workerEnv !== "staging") return null;
+
+  const explicitOptIn = process.env.ALLOW_STAGING_DESTRUCTIVE_CRONS === "true";
+  if (explicitOptIn) {
+    logger.warn(
+      `[cron-env-guard] Destructive cron "${name}" executed in staging with explicit opt-in.`,
+      {
+        context: "cron-env-guard",
+        cron: name,
+        workerEnv,
+      },
+    );
+    return null;
+  }
+
+  const message =
+    `Destructive cron "${name}" was invoked in WORKER_ENV=staging without an explicit ` +
+    "opt-in. Set ALLOW_STAGING_DESTRUCTIVE_CRONS=true on the staging Worker if this " +
+    "was intentional. This guard prevents staging from corrupting production data when " +
+    "Worker secrets accidentally resolve to production credentials.";
+  logger.error(message, {
+    context: "cron-env-guard",
+    cron: name,
+    workerEnv,
+  });
+
+  return NextResponse.json(
+    {
+      error: "Destructive cron disabled in staging",
+      cron: name,
+      hint: "Set ALLOW_STAGING_DESTRUCTIVE_CRONS=true to override.",
+    },
+    { status: 503 },
+  );
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -131,6 +131,12 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 [env.production.vars]
 NODE_ENV = "production"
+# audit-4 F-13: WORKER_ENV is the only marker that distinguishes prod
+# from staging at runtime (NODE_ENV is "production" in both blocks so the
+# Next.js runtime behaves identically). Destructive crons (billing,
+# gdpr-purge, stripe-reconcile, dedup-purge) consult this to refuse to
+# run in staging unless ALLOW_STAGING_DESTRUCTIVE_CRONS=true is set.
+WORKER_ENV = "production"
 # FIXED: KV binding now resolved correctly via getWorkerBinding().
 # Rate limiter is distributed, protected in production.
 RATE_LIMIT_BACKEND = "kv"
@@ -194,6 +200,11 @@ directory = ".open-next/assets"
 binding = "ASSETS"
 [env.staging.vars]
 NODE_ENV = "production"
+# audit-4 F-13: WORKER_ENV marks this as the staging deployment so
+# destructive crons (billing, gdpr-purge, stripe-reconcile, dedup-purge)
+# return 503 instead of running. Override on a per-Worker basis with
+# ALLOW_STAGING_DESTRUCTIVE_CRONS=true via wrangler secret.
+WORKER_ENV = "staging"
 # FIXED: KV binding now resolved correctly via getWorkerBinding().
 RATE_LIMIT_BACKEND = "kv"
 # PHI masking must be "partial" in staging as well.


### PR DESCRIPTION
## Audit-4 finding F-13 — Staging cron destructive guard

This PR implements the env-level protection for destructive crons when a Worker secret injection error accidentally points staging to production.

### Problem

Both `[env.production.triggers]` and `[env.staging.triggers]` in `wrangler.toml` have identical cron schedules. If a secret injection error lets staging resolve to the production Supabase URL/key, the destructive crons would:

- `billing` — charge real customers
- `gdpr-purge` — **permanently delete real patient records**
- `stripe-reconcile` — corrupt the live financial journal
- `dedup-purge` — break replay protection on real Stripe/CMI/WhatsApp data

### Root Cause

Both `[env.production.vars]` and `[env.staging.vars]` set `NODE_ENV = "production"`, making `NODE_ENV` useless as a staging-vs-production marker at runtime. A separate discriminator is needed.

### Solution

**New marker: `WORKER_ENV`** — added to `wrangler.toml`:
```toml
[env.production.vars]
WORKER_ENV = "production"

[env.staging.vars]
WORKER_ENV = "staging"
```

**New guard: `assertCronAllowedInThisEnv(name)`** — `src/lib/cron-env-guard.ts`:

- Returns `null` (allow) when `WORKER_ENV` is unset (local dev, tests, preview) or "production"
- Returns a 503 NextResponse (and logs error) when `WORKER_ENV == "staging"` AND `ALLOW_STAGING_DESTRUCTIVE_CRONS !== "true"`
- Only the literal string `"true"` (not "1", "yes", or "TRUE") bypasses the guard
- Accepts a `DestructiveCronName` union type so adding a new destructive cron forces a code review

**Integrated into 4 handlers:**
- `/api/cron/billing` (subscription charges)
- `/api/cron/gdpr-purge` (patient-record deletion)
- `/api/cron/stripe-reconcile` (financial drift entries)
- `/api/cron/dedup-purge` (Stripe/CMI/WhatsApp replay protection)

Each calls `assertCronAllowedInThisEnv(name)` immediately after `verifyCronSecret()` and returns early if blocked.

### Operator Override

Staging can intentionally exercise destructive paths (load-test, dry-run reconciliation drill) by setting the override secret:

```bash
wrangler secret put ALLOW_STAGING_DESTRUCTIVE_CRONS --env staging
# Enter the value: true
```

This is an **explicit, audited choice** — never a default.

### Deployment Notes

- **Production deploys:** unaffected; crons behave normally
- **Staging deploys:** will begin returning 503 for the four destructive crons until either:
  - `ALLOW_STAGING_DESTRUCTIVE_CRONS=true` is set (intentional), OR
  - The schedules are removed from `[env.staging.triggers]` in `wrangler.toml` (preferred)

### Test Coverage

`src/lib/__tests__/cron-env-guard.test.ts` — 6 unit tests:
- no-op when WORKER_ENV is unset
- no-op when WORKER_ENV is production
- 503 block when WORKER_ENV is staging with no opt-in
- null (allowed) when opt-in is set to literal "true"
- 503 block when opt-in is set to non-literal truthy values ("1", "yes", "TRUE")
- each destructive cron name is blocked independently

### Audit Cross-References

- audit-4 → F-13 (this PR)
- audit-3 → no equivalent
- etap1 → no equivalent

Please review — do not merge per standing instruction.