### PR TITLE
fix(env): route cron-env-guard reads through env.ts getters (semgrep.…

### DIFF
--- a/src/lib/cron-env-guard.ts
+++ b/src/lib/cron-env-guard.ts
@@ -27,6 +27,7 @@
  */
 
 import { NextResponse } from "next/server";
+import { getAllowStagingDestructiveCrons, getWorkerEnv } from "@/lib/env";
 import { logger } from "@/lib/logger";
 
 /**
@@ -49,10 +50,10 @@ export type DestructiveCronName = "billing" | "gdpr-purge" | "stripe-reconcile" 
  * This is intentionally an explicit, audited choice — never a default.
  */
 export function assertCronAllowedInThisEnv(name: DestructiveCronName): NextResponse | null {
-  const workerEnv = process.env.WORKER_ENV;
+  const workerEnv = getWorkerEnv();
   if (workerEnv !== "staging") return null;
 
-  const explicitOptIn = process.env.ALLOW_STAGING_DESTRUCTIVE_CRONS === "true";
+  const explicitOptIn = getAllowStagingDestructiveCrons();
   if (explicitOptIn) {
     logger.warn(
       `[cron-env-guard] Destructive cron "${name}" executed in staging with explicit opt-in.`,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -935,3 +935,30 @@ export function getProfileHeaderHmacKey(): string | undefined {
 export function getPhiEncryptionKeyOld(): string | undefined {
   return process.env.PHI_ENCRYPTION_KEY_OLD;
 }
+
+/**
+ * Worker environment marker — "production" / "staging" / undefined.
+ *
+ * Audit-4 F-13: Both `[env.production.vars]` and `[env.staging.vars]` in
+ * wrangler.toml set NODE_ENV="production", so NODE_ENV cannot distinguish
+ * the two. WORKER_ENV is the per-env discriminator used by
+ * `assertCronAllowedInThisEnv()` to gate destructive crons in staging.
+ *
+ * Returns undefined locally (no marker set) and in tests, which the guard
+ * treats as "not staging" — i.e. it never blocks execution.
+ */
+export function getWorkerEnv(): string | undefined {
+  return process.env.WORKER_ENV;
+}
+
+/**
+ * Explicit opt-in flag that allows destructive crons (GDPR purge, billing,
+ * Stripe reconciliation, dedup TTL) to run in WORKER_ENV=staging.
+ *
+ * Audit-4 F-13. Returns true only when the secret is literally the string
+ * "true"; any other value (unset, "1", "TRUE", etc.) is treated as not
+ * opted in so the guard fails closed.
+ */
+export function getAllowStagingDestructiveCrons(): boolean {
+  return process.env.ALLOW_STAGING_DESTRUCTIVE_CRONS === "true";
+}


### PR DESCRIPTION
…env-access)

GHAS / semgrep.env-access flagged two direct `process.env` reads on src/lib/cron-env-guard.ts:58 (WORKER_ENV) and :61 (ALLOW_STAGING_- DESTRUCTIVE_CRONS). The rule requires runtime env reads to go through the centralized src/lib/env.ts module.

Changes:
- Added two getters to src/lib/env.ts: getWorkerEnv() — returns the per-env marker ("production"/ "staging"/undefined). Audit-4 F-13: NODE_ENV cannot distinguish staging from production because both wrangler env blocks set NODE_ENV="production". getAllowStagingDestructiveCrons() — returns true only for the literal string "true", fails-closed otherwise.
- src/lib/cron-env-guard.ts now imports both and replaces the two direct `process.env` reads with getter calls.

Existing tests use vi.stubEnv() which stubs process.env in place, so they continue to pass through the getters without modification.

Fixes GHAS findings #1471 and #1472 on PR #881.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Observability

- [ ] This PR adds/modifies logging (structured via `@/lib/logger`)
- [ ] This PR changes Sentry configuration or error handling
- [ ] N/A — no observability changes

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Coverage thresholds still met (`npm run test:coverage`)
- [ ] New API endpoints have rate limiting (fail-closed for PHI endpoints)
