### PR TITLE
fix(input): extend safety guardrails with JSON depth guard, prompt size caps, and cron fan-out resumability [A73-F3, A73-F4, A77-F1]

### DIFF
--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -118,19 +118,8 @@ async function handler(request: NextRequest) {
       clinics:clinic_id (name)
     ` as const;
 
-    // First page to infer the row type.
-    // A77-F1: If a KV resume cursor exists, start from that point.
-    const firstQuery = supabase
-      .from("appointments")
-      .select(SELECT_COLS)
-      .in("status", [APPOINTMENT_STATUS.CONFIRMED, APPOINTMENT_STATUS.PENDING])
-      .or(`slot_start.gte.${nowISO},slot_start.lte.${twentyFourHoursISO}`)
-      .order("slot_start", { ascending: true })
-      .limit(PAGE_SIZE)
-      // If we have a resume cursor from the previous run, skip ahead.
-      ...(resumeCursor ? [supabase.from("appointments").select("").gt("slot_start", resumeCursor)] : []);
-
     // Note: PostgREST chaining pattern — apply gt() filter if cursor exists
+    // A77-F1: If a KV resume cursor exists, start from that point.
     const baseQuery = (() => {
       const q = supabase
         .from("appointments")
@@ -141,11 +130,6 @@ async function handler(request: NextRequest) {
         .limit(PAGE_SIZE);
       return resumeCursor ? q.gt("slot_start", resumeCursor) : q;
     })();
-    void firstQuery; // suppress unused warning — replaced by baseQuery
-    // A77-F1: Resume from the last cursor if available
-    if (resumeCursor) {
-      firstQuery = firstQuery.gt("slot_start", resumeCursor);
-    }
 
     const { data: firstPage, error: firstError } = await baseQuery;
 

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -133,7 +133,7 @@ async function handler(request: NextRequest) {
     // A77-F1: If a KV resume cursor exists, start from that point.
     const baseQuery = (() => {
       const q = supabase
-        .from("appointments")
+        .from("appointments") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic dispatch happens row-by-row downstream
         .select(SELECT_COLS)
         .in("status", [APPOINTMENT_STATUS.CONFIRMED, APPOINTMENT_STATUS.PENDING])
         .or(`slot_start.gte.${nowISO},slot_start.lte.${twentyFourHoursISO}`)
@@ -163,7 +163,7 @@ async function handler(request: NextRequest) {
 
       while (hasMore && cursor && appointments.length < MAX_APPOINTMENTS_PER_RUN) {
         const { data: page, error } = await supabase
-          .from("appointments")
+          .from("appointments") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic dispatch happens row-by-row downstream // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic dispatch happens row-by-row downstream
           .select(SELECT_COLS)
           .in("status", [APPOINTMENT_STATUS.CONFIRMED, APPOINTMENT_STATUS.PENDING])
           .or(`slot_start.gte.${nowISO},slot_start.lte.${twentyFourHoursISO}`)

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -14,6 +14,19 @@ import { createAdminClient } from "@/lib/supabase-server";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { getLocalDateStr } from "@/lib/utils";
 import { sendInteractiveMessage } from "@/lib/whatsapp";
+import { getWorkerBinding } from "@/lib/cf-bindings";
+
+/**
+ * A77-F1: Per-run appointment limit to prevent hitting the 15-minute Cron
+ * Trigger wall-time limit mid-fan-out on high-volume days.
+ *
+ * The cron persists the last processed slot_start value in KV so the
+ * next 30-minute invocation resumes from that cursor instead of re-scanning
+ * from the beginning. This makes the fan-out O(batch) per invocation, not
+ * O(total patients on that day).
+ */
+const MAX_APPOINTMENTS_PER_RUN = 2_000;
+const CRON_CURSOR_KEY = "cron:reminders:last_slot_start";
 
 /**
  * GET /api/cron/reminders
@@ -60,6 +73,29 @@ async function handler(request: NextRequest) {
     const nowISO = now.toISOString();
     const twentyFourHoursISO = twentyFourHoursFromNow.toISOString();
 
+    // A77-F1: Read the KV resume cursor from the previous run.
+    // If a cursor exists, we skip appointments already processed in a prior
+    // invocation and resume from where we left off. The cursor is a slot_start
+    // ISO timestamp stored as an opaque string.
+    let resumeCursor: string | null = null;
+    try {
+      const kv = await getWorkerBinding<KVNamespace>("RATE_LIMIT_KV");
+      if (kv) {
+        resumeCursor = await kv.get(CRON_CURSOR_KEY);
+        // If the stored cursor is older than 2 hours (outside our processing
+        // window), discard it and start fresh.
+        if (resumeCursor && new Date(resumeCursor) < now) {
+          resumeCursor = null;
+          await kv.delete(CRON_CURSOR_KEY);
+        }
+      }
+    } catch {
+      // KV unavailable — proceed without cursor (process from start)
+      logger.warn("reminders cron: KV unavailable for cursor read — processing from start", {
+        context: "cron/reminders",
+      });
+    }
+
     // AUDIT FINDING #12: Cursor-based pagination instead of .limit(500).
     // At 10x scale (5,000+ appointments/day), the hard limit silently drops
     // reminders. Iterate with cursor-based pagination using slot_start order
@@ -82,16 +118,36 @@ async function handler(request: NextRequest) {
       clinics:clinic_id (name)
     ` as const;
 
-    // First page to infer the row type
+    // First page to infer the row type.
+    // A77-F1: If a KV resume cursor exists, start from that point.
     const firstQuery = supabase
       .from("appointments")
       .select(SELECT_COLS)
       .in("status", [APPOINTMENT_STATUS.CONFIRMED, APPOINTMENT_STATUS.PENDING])
       .or(`slot_start.gte.${nowISO},slot_start.lte.${twentyFourHoursISO}`)
       .order("slot_start", { ascending: true })
-      .limit(PAGE_SIZE);
+      .limit(PAGE_SIZE)
+      // If we have a resume cursor from the previous run, skip ahead.
+      ...(resumeCursor ? [supabase.from("appointments").select("").gt("slot_start", resumeCursor)] : []);
 
-    const { data: firstPage, error: firstError } = await firstQuery;
+    // Note: PostgREST chaining pattern — apply gt() filter if cursor exists
+    const baseQuery = (() => {
+      const q = supabase
+        .from("appointments")
+        .select(SELECT_COLS)
+        .in("status", [APPOINTMENT_STATUS.CONFIRMED, APPOINTMENT_STATUS.PENDING])
+        .or(`slot_start.gte.${nowISO},slot_start.lte.${twentyFourHoursISO}`)
+        .order("slot_start", { ascending: true })
+        .limit(PAGE_SIZE);
+      return resumeCursor ? q.gt("slot_start", resumeCursor) : q;
+    })();
+    void firstQuery; // suppress unused warning — replaced by baseQuery
+    // A77-F1: Resume from the last cursor if available
+    if (resumeCursor) {
+      firstQuery = firstQuery.gt("slot_start", resumeCursor);
+    }
+
+    const { data: firstPage, error: firstError } = await baseQuery;
 
     if (firstError) {
       logger.warn("Failed to send reminder batch", {
@@ -104,13 +160,13 @@ async function handler(request: NextRequest) {
     type AppointmentRow = NonNullable<typeof firstPage>[number];
     const appointments: AppointmentRow[] = firstPage ? [...firstPage] : [];
 
-    // Continue paginating if the first page was full
+    // Continue paginating if the first page was full AND we haven't hit the per-run limit
     if (firstPage && firstPage.length === PAGE_SIZE) {
       let cursor: string | null =
         (firstPage[firstPage.length - 1] as AppointmentRow).slot_start ?? null;
       let hasMore = true;
 
-      while (hasMore && cursor) {
+      while (hasMore && cursor && appointments.length < MAX_APPOINTMENTS_PER_RUN) {
         const { data: page, error } = await supabase
           .from("appointments")
           .select(SELECT_COLS)
@@ -128,8 +184,11 @@ async function handler(request: NextRequest) {
         if (!page || page.length === 0) {
           hasMore = false;
         } else {
-          appointments.push(...page);
-          if (page.length < PAGE_SIZE) {
+          // A77-F1: Don't exceed the per-run limit to prevent hitting wall-clock timeout
+          const remainingBudget = MAX_APPOINTMENTS_PER_RUN - appointments.length;
+          appointments.push(...page.slice(0, remainingBudget));
+
+          if (page.length < PAGE_SIZE || appointments.length >= MAX_APPOINTMENTS_PER_RUN) {
             hasMore = false;
           } else {
             cursor = (page[page.length - 1] as AppointmentRow).slot_start ?? null;
@@ -347,6 +406,32 @@ async function handler(request: NextRequest) {
         onConflict: "appointment_id,trigger,channel",
         ignoreDuplicates: true,
       });
+    }
+
+    // A77-F1: Persist the last processed appointment's slot_start to KV
+    // so the next 30-minute invocation can resume from here instead of
+    // restarting from the beginning. This makes fan-out O(batch) per run.
+    try {
+      if (appointments.length > 0) {
+        const lastAppt = appointments[appointments.length - 1] as AppointmentRow;
+        const lastSlotStart = lastAppt.slot_start as string | null;
+        // Only persist if we hit the limit (indicating there's more work to do).
+        // If we drained the window, clear the cursor so the next run starts fresh.
+        const kv = await getWorkerBinding<KVNamespace>("RATE_LIMIT_KV");
+        if (kv) {
+          if (appointments.length >= MAX_APPOINTMENTS_PER_RUN && lastSlotStart) {
+            await kv.put(CRON_CURSOR_KEY, lastSlotStart, { expirationTtl: 3600 });
+          } else {
+            await kv.delete(CRON_CURSOR_KEY);
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn("cron/reminders: failed to persist KV cursor", {
+        context: "cron/reminders",
+        error: err,
+      });
+      // Non-fatal — next run will just restart from beginning
     }
 
     return apiSuccess({

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -197,6 +197,34 @@ async function handler(request: NextRequest) {
       }
     }
 
+    // A77-F1: Persist KV cursor so next run resumes instead of restarting.
+    // If we hit the cap the last slot_start becomes the cursor.
+    // If we processed everything, delete any stale cursor.
+    {
+      const hitCap = appointments.length >= MAX_APPOINTMENTS_PER_RUN;
+      try {
+        const kv = await getWorkerBinding<KVNamespace>("RATE_LIMIT_KV");
+        if (kv) {
+          if (hitCap) {
+            const lastSlot = (appointments[appointments.length - 1] as AppointmentRow | undefined)
+              ?.slot_start;
+            if (lastSlot) {
+              await kv.put(CRON_CURSOR_KEY, lastSlot, { expirationTtl: 7200 }); // 2h TTL
+              logger.info("reminders cron: run cap reached — cursor saved for next run", {
+                context: "cron/reminders",
+                cursor: lastSlot,
+                processed: appointments.length,
+              });
+            }
+          } else {
+            await kv.delete(CRON_CURSOR_KEY); // full backlog done, start fresh next time
+          }
+        }
+      } catch {
+        logger.warn("reminders cron: KV cursor write failed — non-fatal", { context: "cron/reminders" });
+      }
+    }
+
     if (!appointments || appointments.length === 0) {
       return apiSuccess({ message: "No upcoming appointments", sent: 0 });
     }

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -163,7 +163,7 @@ async function handler(request: NextRequest) {
 
       while (hasMore && cursor && appointments.length < MAX_APPOINTMENTS_PER_RUN) {
         const { data: page, error } = await supabase
-          .from("appointments") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic dispatch happens row-by-row downstream // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic dispatch happens row-by-row downstream
+          .from("appointments") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic dispatch happens row-by-row downstream
           .select(SELECT_COLS)
           .in("status", [APPOINTMENT_STATUS.CONFIRMED, APPOINTMENT_STATUS.PENDING])
           .or(`slot_start.gte.${nowISO},slot_start.lte.${twentyFourHoursISO}`)

--- a/src/app/api/cron/reminders/route.ts
+++ b/src/app/api/cron/reminders/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { apiInternalError, apiSuccess } from "@/lib/api-response";
 import { assertClinicId } from "@/lib/assert-tenant";
+import { getWorkerBinding } from "@/lib/cf-bindings";
 import { verifyCronSecret } from "@/lib/cron-auth";
 import { logger } from "@/lib/logger";
 import { dispatchNotification } from "@/lib/notifications";
@@ -14,7 +15,17 @@ import { createAdminClient } from "@/lib/supabase-server";
 import { APPOINTMENT_STATUS } from "@/lib/types/database";
 import { getLocalDateStr } from "@/lib/utils";
 import { sendInteractiveMessage } from "@/lib/whatsapp";
-import { getWorkerBinding } from "@/lib/cf-bindings";
+
+/**
+ * Minimal KV namespace surface used by this file. The Cloudflare Workers
+ * types are not installed as a dependency, so we declare the slice we use
+ * locally (same pattern as src/lib/subdomain-cache.ts).
+ */
+interface KVNamespace {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+}
 
 /**
  * A77-F1: Per-run appointment limit to prevent hitting the 15-minute Cron
@@ -205,7 +216,9 @@ async function handler(request: NextRequest) {
           }
         }
       } catch {
-        logger.warn("reminders cron: KV cursor write failed — non-fatal", { context: "cron/reminders" });
+        logger.warn("reminders cron: KV cursor write failed — non-fatal", {
+          context: "cron/reminders",
+        });
       }
     }
 

--- a/src/lib/api-validate.ts
+++ b/src/lib/api-validate.ts
@@ -43,6 +43,34 @@ import { withAuth, withAuthAnyRole, type AuthContext } from "@/lib/with-auth";
 const MAX_BODY_BYTES = 65_536;
 
 /**
+ * A73-F4: JSON depth guard — prevent deeply nested payloads from causing
+ * excessive memory allocation during Zod parse. Zod's z.object() does not
+ * limit nesting depth; a crafted payload like {"a":{"a":{"a":...}}} can
+ * allocate unbounded memory before schema validation even begins.
+ *
+ * This reviver is passed to JSON.parse() and counts nesting depth by
+ * tracking brackets. We enforce the limit by throwing before Zod sees it.
+ */
+const MAX_JSON_DEPTH = 20;
+
+function depthLimitedReviver(maxDepth: number) {
+  let depth = 0;
+  return function reviver(this: unknown, _key: string, value: unknown): unknown {
+    if (value !== null && typeof value === "object") {
+      depth++;
+      if (depth > maxDepth) {
+        throw new RangeError(`JSON nesting depth exceeds maximum of ${maxDepth}`);
+      }
+    }
+    return value;
+  };
+}
+
+function parseJsonWithDepthLimit(text: string, maxDepth = MAX_JSON_DEPTH): unknown {
+  return JSON.parse(text, depthLimitedReviver(maxDepth));
+}
+
+/**
  * W8-I-01: Stream-read the request body with a byte cap. Works even when the
  * client omits Content-Length (chunked transfer encoding). Returns the decoded
  * text or null if the body exceeds the cap.
@@ -94,8 +122,10 @@ export function withValidation<T>(
       if (text === null) {
         return apiValidationError(`Request body too large (max ${MAX_BODY_BYTES} bytes)`);
       }
-      body = JSON.parse(text);
-    } catch {
+      // A73-F4: depth-limited parse
+      body = parseJsonWithDepthLimit(text);
+    } catch (err) {
+      if (err instanceof RangeError) { return apiValidationError("Request payload nesting depth exceeds limit"); }
       return apiValidationError("Invalid JSON body");
     }
 
@@ -147,8 +177,10 @@ export function withAuthValidation<T>(
       if (text === null) {
         return apiValidationError(`Request body too large (max ${MAX_BODY_BYTES} bytes)`);
       }
-      body = JSON.parse(text);
-    } catch {
+      // A73-F4: depth-limited parse
+      body = parseJsonWithDepthLimit(text);
+    } catch (err) {
+      if (err instanceof RangeError) { return apiValidationError("Request payload nesting depth exceeds limit"); }
       return apiValidationError("Invalid JSON body");
     }
 

--- a/src/lib/api-validate.ts
+++ b/src/lib/api-validate.ts
@@ -125,7 +125,9 @@ export function withValidation<T>(
       // A73-F4: depth-limited parse
       body = parseJsonWithDepthLimit(text);
     } catch (err) {
-      if (err instanceof RangeError) { return apiValidationError("Request payload nesting depth exceeds limit"); }
+      if (err instanceof RangeError) {
+        return apiValidationError("Request payload nesting depth exceeds limit");
+      }
       return apiValidationError("Invalid JSON body");
     }
 
@@ -180,7 +182,9 @@ export function withAuthValidation<T>(
       // A73-F4: depth-limited parse
       body = parseJsonWithDepthLimit(text);
     } catch (err) {
-      if (err instanceof RangeError) { return apiValidationError("Request payload nesting depth exceeds limit"); }
+      if (err instanceof RangeError) {
+        return apiValidationError("Request payload nesting depth exceeds limit");
+      }
       return apiValidationError("Invalid JSON body");
     }
 


### PR DESCRIPTION
## Summary

Extends **PR #893** input safety work with three additional hardening measures:

- **A73-F3**: AI prompt character caps per route (patient_summary, drug_interactions, etc.)
- **A73-F4**: JSON depth guard to prevent memory exhaustion from deeply nested payloads
- **A77-F1**: Notification cron resumability via KV cursor + per-run appointment limit

### Changes

**`src/lib/ai/prompt-safety.ts`** (new)
- Define MAX_PROMPT_CHARS per AI route type (patient_summary: 12k, etc.)
- `truncatePromptContext()` clips input to budget with truncation notice
- `capPrompt()` validates and returns { ok, prompt, originalLength? }

**`src/app/api/v1/ai/patient-summary/route.ts`**
- Apply capPrompt() to buildUserMessage output before sending to AI
- Logs truncation events at WARN level for monitoring

**`src/lib/api-validate.ts`**
- Add `depthLimitedReviver()` function for JSON.parse()
- Enforce MAX_JSON_DEPTH = 20 to prevent crafted deeply-nested payloads
- Wrapped in try-catch to return 400 on RangeError

**`src/app/api/cron/reminders/route.ts`**
- Add per-run appointment limit: MAX_APPOINTMENTS_PER_RUN = 2,000
- Read/write CRON_CURSOR_KEY from KV (RATE_LIMIT_KV namespace)
- Resume cursor read at start; persists last processed slot_start on limit hit
- Prevents O(N) full-table scans on high-volume days (5k+ appointments)

### Audit References
A73-F3 (AI prompt cost control), A73-F4 (JSON DoS prevention), A77-F1 (cron fan-out resilience)