### PR TITLE
fix(resilience): streaming response guards, Sentry flush on shutdown, shell command validation [A62-E1, A62-E2, A62-E3]

### DIFF
--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -6,6 +6,7 @@
  */
 
 import { logger } from "@/lib/logger";
+import { resilientFetch, HTTP_TIMEOUTS } from "@/lib/http-resilience";
 import { PROVIDER_MODELS } from "./models";
 import type { AIProvider, AIRequest } from "./types";
 
@@ -145,19 +146,27 @@ async function callOpenAI(req: AIRequest, opts: CallOptions): Promise<ProviderRe
   if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
   messages.push({ role: "user", content: req.prompt });
 
-  const res = await fetchWithTimeout("https://api.openai.com/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${opts.apiKey}`,
+  // A74-F1/F2/F3: resilientFetch adds timeout, circuit breaker, and retry-with-jitter
+  const res = await resilientFetch(
+    "https://api.openai.com/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${opts.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        max_tokens: req.maxTokens ?? 1024,
+        temperature: req.temperature ?? 0.7,
+      }),
     },
-    body: JSON.stringify({
-      model,
-      messages,
-      max_tokens: req.maxTokens ?? 1024,
-      temperature: req.temperature ?? 0.7,
-    }),
-  });
+    {
+      serviceName: "openai",
+      timeoutMs: HTTP_TIMEOUTS.ASYNC, // 30 s — AI completions can be slow
+    },
+  );
 
   if (!res.ok) {
     const rl = parseRateLimitHeaders(res);

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -6,7 +6,6 @@
  */
 
 import { logger } from "@/lib/logger";
-import { resilientFetch, HTTP_TIMEOUTS } from "@/lib/http-resilience";
 import { PROVIDER_MODELS } from "./models";
 import type { AIProvider, AIRequest } from "./types";
 
@@ -146,27 +145,19 @@ async function callOpenAI(req: AIRequest, opts: CallOptions): Promise<ProviderRe
   if (req.systemPrompt) messages.push({ role: "system", content: req.systemPrompt });
   messages.push({ role: "user", content: req.prompt });
 
-  // A74-F1/F2/F3: resilientFetch adds timeout, circuit breaker, and retry-with-jitter
-  const res = await resilientFetch(
-    "https://api.openai.com/v1/chat/completions",
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${opts.apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages,
-        max_tokens: req.maxTokens ?? 1024,
-        temperature: req.temperature ?? 0.7,
-      }),
+  const res = await fetchWithTimeout("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${opts.apiKey}`,
     },
-    {
-      serviceName: "openai",
-      timeoutMs: HTTP_TIMEOUTS.ASYNC, // 30 s — AI completions can be slow
-    },
-  );
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: req.maxTokens ?? 1024,
+      temperature: req.temperature ?? 0.7,
+    }),
+  });
 
   if (!res.ok) {
     const rl = parseRateLimitHeaders(res);

--- a/src/lib/sentry-flush.ts
+++ b/src/lib/sentry-flush.ts
@@ -66,10 +66,10 @@ export async function flushSentryOnExit(timeoutMs: number = 5000): Promise<boole
  * export const POST = withSentryFlush(handler);
  * ```
  */
-export function withSentryFlush<T extends (...args: any[]) => Promise<Response>>(
+export function withSentryFlush<T extends (...args: unknown[]) => Promise<Response>>(
   handler: T,
 ): T {
-  return (async (...args) => {
+  return (async (...args: unknown[]) => {
     try {
       return await handler(...args);
     } catch (error) {

--- a/src/lib/sentry-flush.ts
+++ b/src/lib/sentry-flush.ts
@@ -1,0 +1,81 @@
+import * as Sentry from "@sentry/nextjs";
+import { logger } from "@/lib/logger";
+
+/**
+ * A62-E2: Sentry Error Flush on Shutdown
+ *
+ * Problem:
+ *   When a Node/Edge Runtime process exits unexpectedly (crash, timeout, kill),
+ *   Sentry error events queued in memory are lost. Audit trail gaps result,
+ *   making post-mortem debugging impossible.
+ *
+ * Solution:
+ *   - Call flushSentryOnExit() in exception handlers and finally blocks
+ *   - Waits up to 5 seconds for pending events to flush to Sentry
+ *   - Logs flush success/failure so operators know the audit trail is complete
+ */
+
+/**
+ * Flush pending Sentry events and close the client.
+ * Safe to call multiple times (idempotent).
+ *
+ * @param timeoutMs Maximum wait time for flush (default: 5000ms)
+ * @returns true if flush succeeded, false if timeout or error
+ */
+export async function flushSentryOnExit(timeoutMs: number = 5000): Promise<boolean> {
+  try {
+    const client = Sentry.getClient();
+    if (!client) {
+      return true;
+    }
+
+    const flushed = await client.close(timeoutMs);
+    if (flushed) {
+      logger.info("sentry-flush: successfully flushed pending events", {
+        context: "sentry-flush",
+      });
+    } else {
+      logger.warn("sentry-flush: timeout waiting for pending events", {
+        context: "sentry-flush",
+        timeoutMs,
+      });
+    }
+    return flushed;
+  } catch (err) {
+    logger.error("sentry-flush: error during flush", {
+      context: "sentry-flush",
+      error: err,
+    });
+    return false;
+  }
+}
+
+/**
+ * Decorator for route handlers that need guaranteed Sentry flush on error.
+ * Wraps the handler in a try-catch-finally that flushes Sentry on exception.
+ *
+ * @example
+ * ```ts
+ * import { withSentryFlush } from "@/lib/sentry-flush";
+ *
+ * const handler = async (req) => {
+ *   // ... route logic
+ *   return response;
+ * };
+ *
+ * export const POST = withSentryFlush(handler);
+ * ```
+ */
+export function withSentryFlush<T extends (...args: any[]) => Promise<Response>>(
+  handler: T,
+): T {
+  return (async (...args) => {
+    try {
+      return await handler(...args);
+    } catch (error) {
+      Sentry.captureException(error);
+      await flushSentryOnExit(5000);
+      throw error;
+    }
+  }) as T;
+}

--- a/src/lib/shell-safety.ts
+++ b/src/lib/shell-safety.ts
@@ -1,0 +1,113 @@
+/**
+ * A62-E3: Shell Command Validation and Injection Prevention
+ *
+ * Problem:
+ *   Backup and data-retention cron jobs may use child_process.exec() or spawn()
+ *   to run system commands (pg_dump, tar, mysqldump, etc.). Without validation:
+ *   - Arguments containing shell metacharacters (`;`, `|`, `$()`, etc.) can inject
+ *     arbitrary commands: e.g., `pg_dump /path/to/db; rm -rf /`
+ *   - Unbounded command execution can hang the process or exhaust resources
+ *
+ * Solution:
+ *   - Whitelist allowed commands (pg_dump, mysqldump, tar, rsync, etc.)
+ *   - Validate arguments for shell metacharacters before execution
+ *   - Use execFile() instead of exec() to avoid shell interpretation
+ *   - Enforce timeouts and output size limits
+ */
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Whitelist of allowed commands and their canonical paths.
+ * Only commands in this map can be executed.
+ */
+export const SAFE_SHELL_COMMANDS: Record<string, string> = {
+  pg_dump: "/usr/bin/pg_dump",
+  mysqldump: "/usr/bin/mysqldump",
+  tar: "/bin/tar",
+  rsync: "/usr/bin/rsync",
+  gzip: "/bin/gzip",
+  gunzip: "/bin/gunzip",
+};
+
+/**
+ * Pattern of shell metacharacters that should never appear in arguments.
+ * If matched, the argument is rejected.
+ */
+const SHELL_METACHARACTERS = /[;&|`$(){}<>\n]/;
+
+/**
+ * Safe shell command execution with validation and limits.
+ *
+ * @param command Command name (must be in SAFE_SHELL_COMMANDS whitelist)
+ * @param args Arguments to pass (each checked for shell metacharacters)
+ * @param options Timeout and output size limits
+ * @returns Promise<{stdout, stderr}> with command output
+ * @throws Error if command is not whitelisted or args contain metacharacters
+ */
+export async function safeExecCommand(
+  command: string,
+  args: string[],
+  options?: { timeoutMs?: number; maxOutputBytes?: number },
+): Promise<{ stdout: string; stderr: string }> {
+  // Validate command is whitelisted
+  if (!(command in SAFE_SHELL_COMMANDS)) {
+    throw new Error(`Command not whitelisted: ${command}. Allowed: ${Object.keys(SAFE_SHELL_COMMANDS).join(", ")}`);
+  }
+
+  // Validate each argument for shell metacharacters
+  for (const arg of args) {
+    if (SHELL_METACHARACTERS.test(arg)) {
+      throw new Error(
+        `Argument contains shell metacharacters: ${arg}. ` +
+          `Characters not allowed: ; & | \` $ ( ) { } < > newline`,
+      );
+    }
+  }
+
+  const commandPath = SAFE_SHELL_COMMANDS[command];
+  const timeoutMs = options?.timeoutMs ?? 60_000; // 60 seconds default
+  const maxOutputBytes = options?.maxOutputBytes ?? 100 * 1024 * 1024; // 100 MB default
+
+  try {
+    const result = await execFileAsync(commandPath, args, {
+      timeout: timeoutMs,
+      maxBuffer: maxOutputBytes,
+      // Do not spawn a shell — use execFile directly
+      shell: false,
+    });
+
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  } catch (err) {
+    // Re-throw with context
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Command failed: ${command} ${args.join(" ")}\n${errorMsg}`);
+  }
+}
+
+/**
+ * Example: How to use in a backup cron.
+ *
+ * ```ts
+ * import { safeExecCommand } from "@/lib/shell-safety";
+ *
+ * export async function backupDatabase(dbName: string, outputPath: string) {
+ *   try {
+ *     const result = await safeExecCommand("pg_dump", [dbName, "-f", outputPath], {
+ *       timeoutMs: 300_000, // 5 minutes
+ *       maxOutputBytes: 1024 * 1024 * 1024, // 1 GB
+ *     });
+ *     console.log("Backup succeeded", { stderr: result.stderr });
+ *   } catch (err) {
+ *     console.error("Backup failed", { error: err });
+ *     throw err;
+ *   }
+ * }
+ * ```
+ */

--- a/src/lib/shell-safety.ts
+++ b/src/lib/shell-safety.ts
@@ -55,7 +55,9 @@ export async function safeExecCommand(
 ): Promise<{ stdout: string; stderr: string }> {
   // Validate command is whitelisted
   if (!(command in SAFE_SHELL_COMMANDS)) {
-    throw new Error(`Command not whitelisted: ${command}. Allowed: ${Object.keys(SAFE_SHELL_COMMANDS).join(", ")}`);
+    throw new Error(
+      `Command not whitelisted: ${command}. Allowed: ${Object.keys(SAFE_SHELL_COMMANDS).join(", ")}`,
+    );
   }
 
   // Validate each argument for shell metacharacters

--- a/src/lib/streaming-response.ts
+++ b/src/lib/streaming-response.ts
@@ -1,0 +1,131 @@
+/**
+ * A62-E1: HTTP Streaming Response Guards
+ *
+ * Problem:
+ *   AI streaming endpoints (patient summary, prescription suggestions, etc.)
+ *   use ReadableStream without guardrails. A slow/malicious upstream could:
+ *   - Send data indefinitely (memory exhaustion on server or client)
+ *   - Hang the connection (exhausting worker threads)
+ *   - Send corrupt/partial data (downstream parsing errors)
+ *
+ * Solution:
+ *   Wrap the generator in a timeout + byte-count decorator before creating
+ *   the ReadableStream. Enforces hard limits on duration and output size.
+ */
+
+export interface StreamingConfig {
+  /** Absolute timeout in milliseconds for the entire stream (default: 30s) */
+  timeoutMs?: number;
+  /** Maximum bytes to stream before truncating (default: 10MB) */
+  maxBytes?: number;
+  /** Chunk size to minimize buffering and memory pressure (default: 4KB) */
+  chunkSizeBytes?: number;
+}
+
+const DEFAULTS: Required<StreamingConfig> = {
+  timeoutMs: 30_000, // 30 seconds
+  maxBytes: 10 * 1024 * 1024, // 10 MB
+  chunkSizeBytes: 4 * 1024, // 4 KB
+};
+
+/**
+ * Wrap an async generator in timeout + byte-count guards.
+ * Returns a safe Response with streaming body or throws an error.
+ *
+ * @param generator The async iterable yielding string chunks
+ * @param config Streaming limits (timeoutMs, maxBytes, chunkSizeBytes)
+ * @returns Promise<Response> with 200 and streaming body, or error response
+ */
+export async function safeStreamingResponse(
+  generator: AsyncIterable<string>,
+  config?: StreamingConfig,
+): Promise<Response> {
+  const cfg = { ...DEFAULTS, ...config };
+
+  let bytesEmitted = 0;
+  let timedOut = false;
+
+  // Set a hard timeout on the entire stream.
+  const timeoutHandle = setTimeout(() => {
+    timedOut = true;
+  }, cfg.timeoutMs);
+
+  // Create the streaming body with guards applied
+  const { readable, writable } = new TransformStream<string>();
+  const writer = writable.getWriter();
+
+  // Write chunks asynchronously, respecting limits
+  (async () => {
+    try {
+      for await (const chunk of generator) {
+        if (timedOut) {
+          // Append a truncation notice instead of silently dropping
+          await writer.write("[... stream timeout, truncated ...]\n");
+          break;
+        }
+
+        // Check byte limit BEFORE writing
+        if (bytesEmitted + chunk.length > cfg.maxBytes) {
+          // Emit what we can and append a truncation notice
+          const remaining = cfg.maxBytes - bytesEmitted;
+          if (remaining > 0) {
+            await writer.write(chunk.slice(0, remaining));
+            bytesEmitted += remaining;
+          }
+          await writer.write("\n[... output exceeds maximum size, truncated ...]\n");
+          break;
+        }
+
+        bytesEmitted += chunk.length;
+        await writer.write(chunk);
+
+        // Yield control periodically to avoid blocking
+        if (bytesEmitted % (cfg.chunkSizeBytes * 10) === 0) {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      }
+    } catch (err) {
+      // Write error to stream if possible; otherwise just close
+      if (bytesEmitted + 100 < cfg.maxBytes) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        await writer.write(`\n[Error: ${errMsg}]\n`);
+      }
+    } finally {
+      clearTimeout(timeoutHandle);
+      await writer.close();
+    }
+  })();
+
+  return new Response(readable, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "no-cache, no-store",
+      // Signal to the client that this is a streaming response
+      "Transfer-Encoding": "chunked",
+    },
+  });
+}
+
+/**
+ * Example: How to use in an AI streaming route.
+ *
+ * ```ts
+ * import { safeStreamingResponse } from "@/lib/streaming-response";
+ *
+ * async function* generateSummary(patientId: string) {
+ *   // Yield chunks from your AI provider
+ *   const stream = await openai.chat.completions.stream({...});
+ *   for await (const event of stream) {
+ *     yield event.choices[0]?.delta.content ?? "";
+ *   }
+ * }
+ *
+ * export const GET = async (req: NextRequest) => {
+ *   return safeStreamingResponse(generateSummary(patientId), {
+ *     timeoutMs: 45_000, // 45 seconds for patient summary
+ *     maxBytes: 20 * 1024 * 1024, // 20 MB
+ *   });
+ * };
+ * ```
+ */


### PR DESCRIPTION
## Summary

Implements three critical resilience fixes for streaming, error logging, and system command execution:

- **A62-E1**: HTTP streaming responses without safeguards (timeout, byte limit)
- **A62-E2**: Sentry error events lost on process shutdown (audit trail gaps)
- **A62-E3**: Shell commands vulnerable to injection attacks

### Changes

**`src/lib/streaming-response.ts`** (new)
- `safeStreamingResponse()` wraps async generators in guards:
  - Hard timeout (default 30s) prevents hanging connections
  - Byte count limit (default 10MB) prevents memory exhaustion
  - Chunk-size control minimizes buffering
  - Appends truncation notice if limits are hit
- Example shows integration with OpenAI streaming

**`src/lib/sentry-flush.ts`** (new)
- `flushSentryOnExit()`: Waits up to 5s for pending Sentry events
- `withSentryFlush()`: Decorator for route handlers needing guaranteed flush
- Safe to call multiple times (idempotent)
- Logs success/timeout/error for observability

**`src/lib/shell-safety.ts`** (new)
- `safeExecCommand()` enforces command whitelist + argument validation:
  - SAFE_SHELL_COMMANDS: pg_dump, mysqldump, tar, rsync, gzip, gunzip
  - Rejects args containing shell metacharacters (`;`, `|`, `` ` ``, `$`, etc.)
  - Uses execFile() instead of exec() to prevent shell interpretation
  - Timeout (60s) and output size (100MB) defaults
- Example shows backup usage

### Audit References
A62-E1 (streaming DoS), A62-E2 (Sentry audit trail), A62-E3 (shell injection)