### PR TITLE
fix(ci): add BACKUP_ENCRYPTION_KEY placeholder to Playwright env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -790,6 +790,13 @@ jobs:
           # C-08: PHI_ENCRYPTION_KEY is now required in production mode.
           # Must be exactly 64 hex chars (AES-256-GCM key shape).
           PHI_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+          # A6-05/A22-01: BACKUP_ENCRYPTION_KEY is required in production mode
+          # (enforceBackupEncryptionConfigured in src/lib/env.ts). `next start`
+          # boots in production; the validator hard-fails without this key
+          # and Playwright never gets a running web server. The actual
+          # backup encryption path is never exercised by E2E, so a 64-hex
+          # placeholder satisfies the startup health check.
+          BACKUP_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
           # Force the in-memory rate limiter in CI. The Supabase rate-limit RPC
           # (rate_limit_check_and_increment) isn't reliably available on the
           # ephemeral supabase-cli instance during boot, so the limiter's


### PR DESCRIPTION
## Summary

The **E2E Tests (Playwright)** job boots the app with `next start`, which runs in production mode. `enforceBackupEncryptionConfigured()` in `src/lib/env.ts` hard-fails on startup when `BACKUP_ENCRYPTION_KEY` is unset (A6-05 / A22-01, Moroccan Law 09-08), so the web server never starts and every E2E test fails with a connect error.

This currently blocks CI on:
- **#888** TC-01/03 e2e tests + KV isolation guard
- **#890** PHI-masking Sentry, HIBP

Neither PR touches the backup encryption path; the failure is purely a startup gate.

## Change

Add a 64-hex zero placeholder to the Playwright env block (same shape as `PHI_ENCRYPTION_KEY`). The backup encryption code is never exercised by E2E - only the startup health check needs to pass.

## Why it is safe

- The placeholder is never used to encrypt or decrypt real data; E2E does not trigger backup paths.
- 64-hex zeros parse as a valid AES-256-GCM key shape (matches `PHI_ENCRYPTION_KEY` placeholder pattern).
- Workflow-only change, no runtime code modified.

Signed-off-by: audit-bot <bot@oltigo.local>