### PR TITLE
fix(env-access): route http-resilience-example.ts through named getters

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -931,6 +931,16 @@ export function getStripeSecretKey(): string | undefined {
   return process.env.STRIPE_SECRET_KEY;
 }
 
+/**
+ * External EHR API key. Used by the `http-resilience-example.ts` illustrative
+ * patterns. Returns undefined when not configured; callers should null-check
+ * before use. No central validation entry: the EHR integration is opt-in and
+ * the example file documents the pattern even when the key is not set.
+ */
+export function getExternalEhrApiKey(): string | undefined {
+  return process.env.EXTERNAL_EHR_API_KEY;
+}
+
 /** Stripe webhook secret. */
 export function getStripeWebhookSecret(): string | undefined {
   return process.env.STRIPE_WEBHOOK_SECRET;

--- a/src/lib/http-resilience-example.ts
+++ b/src/lib/http-resilience-example.ts
@@ -10,8 +10,8 @@
  * rule enforces this for all source files outside the allow-list.
  */
 
-import { resilientFetch, HTTP_TIMEOUTS } from "@/lib/http-resilience";
 import { getExternalEhrApiKey, getStripeSecretKey } from "@/lib/env";
+import { resilientFetch, HTTP_TIMEOUTS } from "@/lib/http-resilience";
 
 /**
  * Example 1: Simple external API call with timeout and retries.

--- a/src/lib/http-resilience-example.ts
+++ b/src/lib/http-resilience-example.ts
@@ -1,21 +1,32 @@
 /**
  * A62-D1 / A62-D2 / A62-D3: Example usage of HTTP resilience patterns.
  *
- * This file documents how to use the resilience library in actual route handlers
- * and service functions.
+ * This file documents how to use the resilience library in actual route
+ * handlers and service functions. The patterns shown here are the
+ * project-recommended way to call any external HTTP service.
+ *
+ * NOTE: external secrets are read through the named getters in
+ * `src/lib/env.ts` (never `process.env` directly). The env-access semgrep
+ * rule enforces this for all source files outside the allow-list.
  */
 
 import { resilientFetch, HTTP_TIMEOUTS } from "@/lib/http-resilience";
+import { getExternalEhrApiKey, getStripeSecretKey } from "@/lib/env";
 
 /**
  * Example 1: Simple external API call with timeout and retries.
  */
 export async function fetchPatientFromExternalSystem(patientId: string): Promise<unknown> {
+  const apiKey = getExternalEhrApiKey();
+  if (!apiKey) {
+    throw new Error("EXTERNAL_EHR_API_KEY not configured");
+  }
+
   const response = await resilientFetch(
     `https://external-ehr.example.com/api/patients/${patientId}`,
     {
       method: "GET",
-      headers: { Authorization: `Bearer ${process.env.EXTERNAL_EHR_API_KEY}` },
+      headers: { Authorization: `Bearer ${apiKey}` },
     },
     {
       serviceName: "external-ehr",
@@ -69,12 +80,17 @@ export async function deliverWebhook(
  * Example 3: Payment processor call with tight timeout and circuit breaker.
  */
 export async function chargePaymentCard(cardToken: string, amountCents: number): Promise<string> {
+  const stripeKey = getStripeSecretKey();
+  if (!stripeKey) {
+    throw new Error("STRIPE_SECRET_KEY not configured");
+  }
+
   const response = await resilientFetch(
     "https://api.stripe.com/v1/payment_intents",
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
+        Authorization: `Bearer ${stripeKey}`,
         "Content-Type": "application/x-www-form-urlencoded",
       },
       body: new URLSearchParams({
@@ -86,7 +102,7 @@ export async function chargePaymentCard(cardToken: string, amountCents: number):
     },
     {
       serviceName: "stripe-payments",
-      timeoutMs: HTTP_TIMEOUTS.CRITICAL, // 5s — fail fast for payments
+      timeoutMs: HTTP_TIMEOUTS.CRITICAL, // 5s, fail fast for payments
       retryConfig: {
         maxAttempts: 2, // Minimal retries for payments (idempotency risk)
         baseDelayMs: 100,
@@ -121,7 +137,7 @@ export async function checkDownstreamHealth(endpoint: string): Promise<boolean> 
         serviceName: "health-check",
         timeoutMs: HTTP_TIMEOUTS.CRITICAL, // 5s
         retryConfig: {
-          maxAttempts: 1, // No retries — just check once
+          maxAttempts: 1, // No retries, just check once
           baseDelayMs: 0,
           maxDelayMs: 0,
           retryableStatuses: [],
@@ -135,7 +151,7 @@ export async function checkDownstreamHealth(endpoint: string): Promise<boolean> 
 }
 
 /**
- * Example 5: Migration guide — replacing old fetch() calls.
+ * Example 5: Migration guide, replacing old fetch() calls.
  *
  * OLD:
  *   const response = await fetch(url, { method: "POST" });


### PR DESCRIPTION
### What

Follow-up to #894 (merged): route `http-resilience-example.ts` through the named getters in `src/lib/env.ts` so the file demonstrates the correct env-access pattern instead of the anti-pattern.

### Why

The bot-review on #894 flagged two real findings:

- `src/lib/http-resilience-example.ts:18` - direct `process.env.EXTERNAL_EHR_API_KEY` access
- `src/lib/http-resilience-example.ts:80` - direct `process.env.STRIPE_SECRET_KEY` access

#894 merged before the fix landed. The example file ships in the bundle (Next.js only tree-shakes when nothing imports it) and is the recommended starting point for new external-call code, so it should model the correct pattern.

### Changes

1. `src/lib/env.ts` - add `getExternalEhrApiKey()` named getter, following the `getStripeSecretKey()` shape. No central validation registry entry: the EHR integration is opt-in and the example file documents the pattern even when the key is unset.

2. `src/lib/http-resilience-example.ts` -
    - Import both getters from `@/lib/env`.
    - Replace bare `process.env.XXX` with the getter + null check.
    - Remove the prior nosemgrep annotations (they used the wrong rule-ID prefix `semgrep.env-access` and likely would not have suppressed).
    - Add a file-level note that secrets must come from `src/lib/env.ts`.

### What this PR deliberately does **not** do

A sibling triage at `webs-alots-bot-review-fixes` suggested also adding `**/*-example.ts` to `paths.exclude` in `.semgrep/env-access.yml`. That would undermine the rule for future example files. The point of the example is to teach the correct pattern, so the rule should keep firing on any future bare `process.env` in any source file.

Signed-off-by: audit-bot <bot@oltigo.local>
