### PR TITLE
fix(build): fix Cloudflare Workers Builds OOM — skip redundant TypeScript check + increase heap

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,13 @@ const nextConfig: NextConfig = {
   // MEDIUM-9: Suppress X-Powered-By header (information disclosure).
   poweredByHeader: false,
 
+  // CI runs `tsc --noEmit` (ci.yml) so the redundant type-check inside
+  // `next build` is unnecessary. On the Cloudflare Workers Builds runner
+  // (≈2 GB heap) it OOMs during this phase — skipping it fixes the build.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+
   // PERF-01: Enable the stable `use cache` directive (Next.js 16).
   experimental: {
     useCache: true,


### PR DESCRIPTION
## Summary

Every Cloudflare Workers Builds run fails with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` during the `Running TypeScript ...` phase of `next build`. The runner has ~2 GB heap; the TypeScript checker exhausts it after compilation succeeds.

**Two-part fix:**

1. **Code** — `typescript.ignoreBuildErrors = true` in `next.config.ts`. Safe because CI already runs `tsc --noEmit` (ci.yml L181), making the in-build check redundant.

2. **API** — Set `NODE_OPTIONS=--max-old-space-size=4096` on both Workers Builds triggers (production + preview) via the Cloudflare Builds API as a safety net for any other memory-hungry build phases.

Build log extract showing the failure:
```
✓ Compiled successfully in 51s
  Running TypeScript ...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```