### PR TITLE
A64: cookie-consent v1 hardening (versioned envelope + 12mo expiry + env-access centralisation)

### DIFF
--- a/docs/compliance/cookie-consent.md
+++ b/docs/compliance/cookie-consent.md
@@ -1,0 +1,174 @@
+# Cookie consent v1 design (A64)
+
+Status: implemented (this commit).
+Owners: platform / compliance.
+Spec sources: GDPR Art. 7, EDPB Guidelines 05/2020 + 03/2022 on consent,
+French CNIL "Cookies and similar trackers" recommendation, UK ICO cookie
+guidance, Moroccan Loi 09-08 (CNDP).
+
+## Goal
+
+A single source of truth for how the public landing pages (oltigo.com root
+domain) collect, store, refresh, and honour cookie / tracker consent. The
+banner is the only legitimate entry point. Tenant-scoped clinic apps
+inherit the same envelope but do not own this surface; they read it through
+`getStoredCookiePreferences`.
+
+## Decisions
+
+### 1. Categories
+
+Three categories. Functional is always on (strictly necessary cookies are
+out of scope of consent under ePrivacy Art. 5(3)).
+
+| Category   | Default | Examples                                   |
+| ---------- | ------- | ------------------------------------------ |
+| Functional | on      | session, CSRF, language, theme             |
+| Analytics  | off     | Plausible, Google Analytics 4 (per-clinic) |
+| Marketing  | off     | Sentry Replay session recording            |
+
+Reject-by-default is enforced both at the storage layer (`DEFAULT_PREFERENCES`)
+and at the UI (no pre-ticked checkboxes).
+
+### 2. Storage envelope
+
+```ts
+interface StoredConsent {
+  v: number; // schema version (CONSENT_VERSION)
+  t: number; // granted-at, epoch ms
+  prefs: CookiePreferences;
+}
+```
+
+Persisted as `localStorage["cookie-consent"]`. JSON, ASCII only, single key.
+
+We chose localStorage over cookies because:
+
+1. The consent payload is read by client components at hydration; cookies
+   add a header round-trip cost for every static request.
+2. Server-side audit logging happens via `/api/consent`, so we never need
+   the consent on a server request to authorise anything.
+3. Functional cookies (the only category that does set cookies) are
+   strictly-necessary and out of consent scope, so the asymmetry between
+   "stored in localStorage" and "applies to cookies" is acceptable.
+
+### 3. Version + expiry
+
+- `CONSENT_VERSION` starts at `1`. Bump on any of:
+  - new category added
+  - new processor added to an existing category
+  - material wording change in the banner copy
+- `CONSENT_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000` (12 months). Upper bound
+  from ICO and CNIL guidance for cookie consent freshness. After expiry the
+  banner re-prompts with `DEFAULT_PREFERENCES` as the starting state so the
+  user makes a fresh choice rather than confirming a stale one.
+
+### 4. Status state machine
+
+```
+                            +---------------+
+   getConsentStatus  -----> |    missing    | --- show banner ---> save ---+
+                            +---------------+                              |
+                            | stale-version | --- show banner ---> save ---+
+                            +---------------+                              |
+                            |    expired    | --- show banner ---> save ---+
+                            +---------------+                              |
+                            |     fresh     | --- apply prefs, no UI ------+
+                            +---------------+
+```
+
+`getStoredCookiePreferences` returns `DEFAULT_PREFERENCES` for any non-fresh
+status, so downstream gates (Plausible, GA, Sentry Replay) treat the user
+as "no consent given" until they re-confirm.
+
+### 5. Migration
+
+The reader accepts three legacy shapes so existing browsers do not get
+stuck in a re-prompt loop on the first deploy after v1:
+
+1. `"accepted"` (raw string): migrated to `ALL_ACCEPTED` at current version.
+2. `"declined"` (raw string): migrated to `DEFAULT_PREFERENCES` at current version.
+3. Bare `CookiePreferences` object: returned as `v: 0` so the status is
+   `stale-version` and the banner re-prompts. Defensive: we do not silently
+   bump the version on a bare object because we cannot know which
+   processor list the user was consenting to.
+
+### 6. Re-open mechanism
+
+Footer link "Cookie Settings" (`src/components/public/cookie-settings-link.tsx`)
+dispatches a `cookie-consent:reopen` window event. The banner subscribes
+and shows itself. The current prefs (if fresh) pre-populate the panel so
+the user can withdraw analytics without re-checking marketing.
+
+### 7. Cross-tab sync
+
+When another tab persists a fresh consent, this tab's banner closes via
+the `storage` event listener. Plausible, ConsentGatedAnalytics, and
+ConsentGatedReplay already listen for both `storage` and the same-tab
+`cookie-consent:changed` custom event.
+
+### 8. Server-side audit
+
+`POST /api/consent` logs every save to `consent_logs` (clinic-scoped row,
+IP + user agent, granted boolean, optional user id). Fire-and-forget.
+Failures never block the UI. This is the GDPR Art. 7(1) "demonstrable"
+record; localStorage alone is not sufficient evidence.
+
+### 9. Analytics gating
+
+| Component             | Reads consent via                       | Behaviour when not consented                                      |
+| --------------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| PlausibleScript       | useSyncExternalStore on prefs.analytics | does not render the `<Script>`                                    |
+| ConsentGatedAnalytics | useEffect + storage event               | renders AnalyticsScript with `consentGiven={false}`               |
+| ConsentGatedReplay    | useEffect + custom event                | does not call `Sentry.addIntegration(replayIntegration())`        |
+| applyAnalyticsConsent | direct call from saveAndClose           | removes any already-injected script tags + sets `ga-disable-<id>` |
+
+Note: the cookie-consent component sets the GA opt-out flag using
+`getGaMeasurementId()` from `src/lib/env.ts`. No direct `process.env`
+access in any component as of A64.
+
+### 10. Out of scope for v1
+
+Deferred to a future iteration; not blocking ship:
+
+- Per-region banner gating (currently always shown, which is correct under
+  Loi 09-08 for our Moroccan user base; ePrivacy + Loi 09-08 both apply in
+  our markets).
+- Vendor-level granularity (right now Analytics is one toggle for both
+  Plausible and GA; users cannot opt into Plausible while declining GA).
+- Server-pushed re-prompt (when we bump the version, only users who load
+  the site after deploy see the new prompt; we do not push to active
+  sessions).
+- A11y: keyboard escape to dismiss without choosing. Currently the only
+  way to close is to make a choice, which matches "no inferred consent"
+  but is hostile to keyboard users; revisit in A64.v2.
+
+## File map
+
+| File                                               | Role                         |
+| -------------------------------------------------- | ---------------------------- |
+| `src/components/cookie-consent.tsx`                | banner + storage layer       |
+| `src/components/plausible-script.tsx`              | Plausible gate               |
+| `src/components/consent-gated-analytics.tsx`       | GA / GTM gate                |
+| `src/components/consent-gated-replay.tsx`          | Sentry Replay gate           |
+| `src/components/public/cookie-settings-link.tsx`   | footer re-open               |
+| `src/components/consent-summary-banner.tsx`        | post-consent summary         |
+| `src/app/api/consent/route.ts`                     | server audit log             |
+| `src/components/__tests__/cookie-consent.test.tsx` | unit tests for storage layer |
+
+## Test coverage
+
+`cookie-consent.test.tsx` covers:
+
+- getConsentStatus: missing, unparseable, unknown shape, legacy v0a string
+  migration (accepted + declined), legacy v0b bare-object stale-version,
+  numeric version below current, expired, fresh, boundary at expiry, and
+  malformed envelope with bad prefs shape.
+- getStoredCookiePreferences: defaults vs fresh preferences across each
+  status path.
+- persistConsent: round-trip serialisation, overwrite of legacy values.
+- CONSENT_MAX_AGE_MS: numeric constant matches 12 months.
+
+The banner component itself is not unit tested in this PR; the existing
+Playwright E2E suite exercises the click paths after the PR #908 pre-seed
+fix. A future PR may add component-level tests with Testing Library.

--- a/e2e/mobile-flows.spec.ts
+++ b/e2e/mobile-flows.spec.ts
@@ -27,17 +27,23 @@ import { test, expect, type Locator } from "@playwright/test";
  *    scripts at all) is also what Playwright best-practice guidance
  *    recommends as the alternative to the discouraged "networkidle".
  *
- * Schema: src/components/cookie-consent.tsx → CookiePreferences.
+ * Schema: src/components/cookie-consent.tsx, v1 envelope { v, t, prefs }.
+ * v1 is required so getConsentStatus() returns "fresh" instead of
+ * "stale-version" (A64). The 12-month expiry window starts at t.
  */
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     try {
       localStorage.setItem(
         "cookie-consent",
-        JSON.stringify({ functional: true, analytics: false, marketing: false }),
+        JSON.stringify({
+          v: 1,
+          t: Date.now(),
+          prefs: { functional: true, analytics: false, marketing: false },
+        }),
       );
     } catch {
-      // Some browser contexts (about:blank) throw on storage access — ignore.
+      // Some browser contexts (about:blank) throw on storage access. Ignore.
     }
   });
 });

--- a/e2e/registration-flow.spec.ts
+++ b/e2e/registration-flow.spec.ts
@@ -13,15 +13,21 @@ test.describe("Registration flow", () => {
     // overlay above the auth form; without this seed, the test
     // "shows validation on empty form submission" intermittently observes
     // 0 invalid inputs because the click hits the banner instead of the
-    // submit button. Schema lives at src/components/cookie-consent.tsx.
+    // submit button. Schema: src/components/cookie-consent.tsx, v1
+    // envelope { v, t, prefs } (A64). v1 ensures getConsentStatus()
+    // returns "fresh" rather than "stale-version".
     await page.addInitScript(() => {
       try {
         localStorage.setItem(
           "cookie-consent",
-          JSON.stringify({ functional: true, analytics: false, marketing: false }),
+          JSON.stringify({
+            v: 1,
+            t: Date.now(),
+            prefs: { functional: true, analytics: false, marketing: false },
+          }),
         );
       } catch {
-        // about:blank or storage-disabled context — ignore.
+        // about:blank or storage-disabled context. Ignore.
       }
     });
     await page.goto("/register");

--- a/src/components/__tests__/cookie-consent.test.tsx
+++ b/src/components/__tests__/cookie-consent.test.tsx
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CONSENT_MAX_AGE_MS,
+  CONSENT_VERSION,
+  getConsentStatus,
+  getStoredCookiePreferences,
+  persistConsent,
+} from "../cookie-consent";
+
+const STORAGE_KEY = "cookie-consent";
+
+const DEFAULT_PREFERENCES = {
+  functional: true,
+  analytics: false,
+  marketing: false,
+} as const;
+
+const ALL_ACCEPTED = {
+  functional: true,
+  analytics: true,
+  marketing: true,
+} as const;
+
+describe("cookie-consent storage layer (A64)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  describe("getConsentStatus", () => {
+    it("returns missing when nothing is stored", () => {
+      expect(getConsentStatus()).toEqual({ kind: "missing" });
+    });
+
+    it("returns missing for unparseable JSON", () => {
+      localStorage.setItem(STORAGE_KEY, "{not valid json");
+      expect(getConsentStatus()).toEqual({ kind: "missing" });
+    });
+
+    it("returns missing for an object with unknown shape", () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ foo: "bar" }));
+      expect(getConsentStatus()).toEqual({ kind: "missing" });
+    });
+
+    it("migrates legacy 'accepted' string to a fresh envelope", () => {
+      localStorage.setItem(STORAGE_KEY, "accepted");
+      const status = getConsentStatus();
+      expect(status.kind).toBe("fresh");
+      if (status.kind === "fresh") {
+        expect(status.preferences).toEqual(ALL_ACCEPTED);
+      }
+    });
+
+    it("migrates legacy 'declined' string to a fresh envelope with defaults", () => {
+      localStorage.setItem(STORAGE_KEY, "declined");
+      const status = getConsentStatus();
+      expect(status.kind).toBe("fresh");
+      if (status.kind === "fresh") {
+        expect(status.preferences).toEqual(DEFAULT_PREFERENCES);
+      }
+    });
+
+    it("returns stale-version for a bare CookiePreferences object (v0 schema)", () => {
+      // Pre-A64 banner persisted the bare preferences object without a version.
+      // We force re-prompt so the user sees the current copy / processor list.
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ functional: true, analytics: true, marketing: false }),
+      );
+      expect(getConsentStatus()).toEqual({ kind: "stale-version" });
+    });
+
+    it("returns stale-version when stored version is below CONSENT_VERSION", () => {
+      const t = Date.now() - 1000;
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          v: CONSENT_VERSION - 1,
+          t,
+          prefs: { functional: true, analytics: true, marketing: true },
+        }),
+      );
+      expect(getConsentStatus()).toEqual({ kind: "stale-version" });
+    });
+
+    it("returns expired when stored more than CONSENT_MAX_AGE_MS ago", () => {
+      const t = Date.now() - CONSENT_MAX_AGE_MS - 1;
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          v: CONSENT_VERSION,
+          t,
+          prefs: { functional: true, analytics: true, marketing: false },
+        }),
+      );
+      expect(getConsentStatus()).toEqual({ kind: "expired" });
+    });
+
+    it("returns fresh for an in-window envelope at the current version", () => {
+      const t = Date.now() - 1000;
+      const prefs = { functional: true, analytics: true, marketing: false };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ v: CONSENT_VERSION, t, prefs }));
+      expect(getConsentStatus()).toEqual({ kind: "fresh", preferences: prefs, grantedAt: t });
+    });
+
+    it("treats consent exactly at the expiry boundary as fresh, one ms past as expired", () => {
+      // Boundary: age === CONSENT_MAX_AGE_MS is still fresh.
+      const now = 1_700_000_000_000;
+      vi.useFakeTimers();
+      vi.setSystemTime(now);
+
+      const tEdge = now - CONSENT_MAX_AGE_MS;
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          v: CONSENT_VERSION,
+          t: tEdge,
+          prefs: DEFAULT_PREFERENCES,
+        }),
+      );
+      expect(getConsentStatus().kind).toBe("fresh");
+
+      const tJustPast = now - CONSENT_MAX_AGE_MS - 1;
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          v: CONSENT_VERSION,
+          t: tJustPast,
+          prefs: DEFAULT_PREFERENCES,
+        }),
+      );
+      expect(getConsentStatus().kind).toBe("expired");
+    });
+
+    it("ignores an envelope whose prefs field is missing or wrong shape", () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ v: CONSENT_VERSION, t: Date.now(), prefs: { functional: true } }),
+      );
+      expect(getConsentStatus()).toEqual({ kind: "missing" });
+    });
+  });
+
+  describe("getStoredCookiePreferences", () => {
+    it("returns defaults when nothing is stored", () => {
+      expect(getStoredCookiePreferences()).toEqual(DEFAULT_PREFERENCES);
+    });
+
+    it("returns defaults for a stale-version record (forces re-prompt path)", () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ functional: true, analytics: true, marketing: true }),
+      );
+      expect(getStoredCookiePreferences()).toEqual(DEFAULT_PREFERENCES);
+    });
+
+    it("returns defaults for an expired record", () => {
+      const t = Date.now() - CONSENT_MAX_AGE_MS - 60_000;
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          v: CONSENT_VERSION,
+          t,
+          prefs: { functional: true, analytics: true, marketing: true },
+        }),
+      );
+      expect(getStoredCookiePreferences()).toEqual(DEFAULT_PREFERENCES);
+    });
+
+    it("returns stored preferences when status is fresh", () => {
+      const prefs = { functional: true, analytics: true, marketing: false };
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ v: CONSENT_VERSION, t: Date.now(), prefs }),
+      );
+      expect(getStoredCookiePreferences()).toEqual(prefs);
+    });
+  });
+
+  describe("persistConsent", () => {
+    it("writes a versioned envelope that round-trips to fresh status", () => {
+      const now = 1_700_000_000_000;
+      const prefs = { functional: true, analytics: true, marketing: true };
+      persistConsent(prefs, now);
+
+      const raw = localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string)).toEqual({ v: CONSENT_VERSION, t: now, prefs });
+
+      vi.useFakeTimers();
+      vi.setSystemTime(now + 1000);
+      const status = getConsentStatus();
+      expect(status).toEqual({ kind: "fresh", preferences: prefs, grantedAt: now });
+    });
+
+    it("overwrites any prior stored value", () => {
+      localStorage.setItem(STORAGE_KEY, "accepted");
+      const now = Date.now();
+      persistConsent(DEFAULT_PREFERENCES, now);
+
+      const status = getConsentStatus();
+      expect(status.kind).toBe("fresh");
+      if (status.kind === "fresh") {
+        expect(status.preferences).toEqual(DEFAULT_PREFERENCES);
+      }
+    });
+  });
+
+  describe("CONSENT_MAX_AGE_MS", () => {
+    it("equals 12 months in milliseconds (ICO + CNIL guidance)", () => {
+      expect(CONSENT_MAX_AGE_MS).toBe(365 * 24 * 60 * 60 * 1000);
+    });
+  });
+});

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
+import { getGaMeasurementId } from "@/lib/env";
 import { t } from "@/lib/i18n";
 
 /** Cookie preference categories. */
@@ -24,8 +25,61 @@ const ALL_ACCEPTED: CookiePreferences = {
   marketing: true,
 };
 
+/**
+ * Storage key for the cookie consent envelope.
+ * Bump CONSENT_VERSION below to force re-prompt without changing the key.
+ */
+const STORAGE_KEY = "cookie-consent";
+
+/**
+ * A64: Current consent schema version. Bump when categories, copy, or the
+ * list of third-party processors changes materially. Users with an older
+ * stored version are re-prompted at next page load (GDPR Art. 7(4) "specific
+ * consent" + EDPB 03/2022 guidance).
+ *
+ * Version history:
+ *   v1 (2026-05-31): initial versioned envelope. Categories: functional,
+ *                    analytics, marketing. Processors: Plausible, Google
+ *                    Analytics 4 (per-clinic), Sentry Replay (marketing).
+ */
+export const CONSENT_VERSION = 1;
+
+/**
+ * A64: Maximum age of stored consent before re-prompting. 12 months is the
+ * upper bound from ICO + CNIL guidance for cookie consent freshness.
+ * 365 * 24 * 60 * 60 * 1000 = 31_536_000_000 ms.
+ */
+export const CONSENT_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Versioned storage envelope written to localStorage. */
+interface StoredConsent {
+  /** Schema version. Compared against CONSENT_VERSION. */
+  v: number;
+  /** Granted-at timestamp (epoch milliseconds). */
+  t: number;
+  /** Category preferences. */
+  prefs: CookiePreferences;
+}
+
+/**
+ * Result of evaluating stored consent.
+ *
+ *   - missing:        nothing stored, or stored value is unparseable.
+ *   - stale-version:  stored at an older CONSENT_VERSION. Re-prompt required.
+ *   - expired:        older than CONSENT_MAX_AGE_MS. Re-prompt required.
+ *   - fresh:          valid, current, in-window. Caller can trust preferences.
+ */
+export type ConsentStatus =
+  | { kind: "missing" }
+  | { kind: "stale-version" }
+  | { kind: "expired" }
+  | { kind: "fresh"; preferences: CookiePreferences; grantedAt: number };
+
 /** Key used in the custom event that re-opens the cookie consent banner. */
 const REOPEN_EVENT = "cookie-consent:reopen";
+
+/** Key used in the custom event that signals same-tab consent changes. */
+const CHANGED_EVENT = "cookie-consent:changed";
 
 /**
  * Programmatically re-open the cookie consent banner.
@@ -37,32 +91,103 @@ export function reopenCookieConsent(): void {
   }
 }
 
+/** Type guard for `Record<string, unknown>`. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Type guard for the CookiePreferences shape. */
+function isCookiePreferences(value: unknown): value is CookiePreferences {
+  return (
+    isRecord(value) &&
+    typeof value.functional === "boolean" &&
+    typeof value.analytics === "boolean" &&
+    typeof value.marketing === "boolean"
+  );
+}
+
+/**
+ * Read the raw stored envelope, migrating legacy formats.
+ *
+ * Legacy formats accepted:
+ *   - Legacy v0a: bare strings "accepted" / "declined" from the original banner.
+ *                 Migrated to a fresh envelope at the current version.
+ *   - Legacy v0b: bare CookiePreferences object (no version, no timestamp).
+ *                 Returned as `{ v: 0, t: 0, prefs }` so the caller detects
+ *                 stale-version and re-prompts.
+ *
+ * Returns `null` when no value is stored, the value is unparseable, or the
+ * shape does not match any known format.
+ */
+function readStoredEnvelope(): StoredConsent | null {
+  if (typeof window === "undefined") return null;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+
+  // Legacy v0a: bare string from the original banner.
+  if (raw === "accepted") {
+    return { v: CONSENT_VERSION, t: Date.now(), prefs: ALL_ACCEPTED };
+  }
+  if (raw === "declined") {
+    return { v: CONSENT_VERSION, t: Date.now(), prefs: DEFAULT_PREFERENCES };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+
+  // v1+ envelope: { v: number, t: number, prefs: CookiePreferences }
+  if (
+    typeof parsed.v === "number" &&
+    typeof parsed.t === "number" &&
+    isCookiePreferences(parsed.prefs)
+  ) {
+    return { v: parsed.v, t: parsed.t, prefs: parsed.prefs };
+  }
+
+  // Legacy v0b: bare CookiePreferences object. Force re-prompt via
+  // stale-version path by returning v:0, t:0.
+  if (isCookiePreferences(parsed)) {
+    return { v: 0, t: 0, prefs: parsed };
+  }
+
+  return null;
+}
+
+/**
+ * Evaluate the current consent status.
+ *
+ * Used by the banner to decide whether to display, and by tests to assert
+ * migration + expiry behaviour. Public so server-rendered or library code
+ * can introspect, though both layers should remain unaware of localStorage
+ * during SSR.
+ */
+export function getConsentStatus(): ConsentStatus {
+  const env = readStoredEnvelope();
+  if (!env) return { kind: "missing" };
+  if (env.v < CONSENT_VERSION) return { kind: "stale-version" };
+  if (Date.now() - env.t > CONSENT_MAX_AGE_MS) return { kind: "expired" };
+  return { kind: "fresh", preferences: env.prefs, grantedAt: env.t };
+}
+
 /**
  * Read stored cookie preferences from localStorage.
- * L6-M-10: Returns defaults (all non-essential off) instead of null
- * when no consent has been given, eliminating nullable paths.
+ *
+ * L6-M-10: Returns defaults (all non-essential off) instead of null when
+ * no consent has been given, eliminating nullable paths in callers.
+ *
+ * A64: Also returns defaults when the stored consent is at an older
+ * version or older than CONSENT_MAX_AGE_MS. Callers see "no consent given"
+ * until the user re-confirms via the banner, which prevents stale opt-in
+ * from leaking past a re-prompt event.
  */
 export function getStoredCookiePreferences(): CookiePreferences {
-  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
-  const raw = localStorage.getItem("cookie-consent");
-  if (!raw) return DEFAULT_PREFERENCES;
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "functional" in parsed &&
-      "analytics" in parsed &&
-      "marketing" in parsed
-    ) {
-      return parsed as CookiePreferences;
-    }
-  } catch {
-    // Legacy format ("accepted" / "declined") — migrate
-    if (raw === "accepted") return ALL_ACCEPTED;
-    if (raw === "declined") return DEFAULT_PREFERENCES;
-  }
-  return DEFAULT_PREFERENCES;
+  const status = getConsentStatus();
+  return status.kind === "fresh" ? status.preferences : DEFAULT_PREFERENCES;
 }
 
 /**
@@ -81,8 +206,9 @@ function applyAnalyticsConsent(allowed: boolean): void {
     document
       .querySelectorAll('script[src*="googletagmanager.com"], script[src*="google-analytics.com"]')
       .forEach((el) => el.remove());
-    // Opt-out flag for Google Analytics (if loaded before removal)
-    const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+    // Opt-out flag for Google Analytics (if loaded before removal).
+    // A64: read through the env accessor so this file does not touch process.env directly.
+    const gaMeasurementId = getGaMeasurementId();
     if (gaMeasurementId) {
       (window as unknown as { [k: string]: boolean })[`ga-disable-${gaMeasurementId}`] = true;
     }
@@ -91,7 +217,7 @@ function applyAnalyticsConsent(allowed: boolean): void {
 
 /**
  * Log consent event to the server for GDPR/Loi 09-08 compliance.
- * Fire-and-forget — never blocks the UI or shows errors to the user.
+ * Fire-and-forget. Never blocks the UI or shows errors to the user.
  */
 function logConsentToServer(preferences: CookiePreferences): void {
   fetch("/api/consent", {
@@ -103,47 +229,85 @@ function logConsentToServer(preferences: CookiePreferences): void {
       granted: preferences.analytics || preferences.marketing,
     }),
   }).catch(() => {
-    // Consent logging is best-effort — never block the user experience
+    // Consent logging is best-effort. Never block the user experience.
   });
+}
+
+/**
+ * Persist a preferences set to localStorage as a versioned envelope.
+ * Exposed for tests; the banner calls `saveAndClose` which wraps this.
+ */
+export function persistConsent(prefs: CookiePreferences, now: number = Date.now()): void {
+  if (typeof window === "undefined") return;
+  const envelope: StoredConsent = { v: CONSENT_VERSION, t: now, prefs };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(envelope));
 }
 
 /**
  * GDPR / Loi 09-08 cookie consent banner with granular preferences.
  *
  * Features:
- * - Accept All / Decline / Manage Preferences
- * - Granular toggles for Functional (always on), Analytics, Marketing
- * - Properly disables analytics scripts when declined
- * - Adds bottom padding to prevent content overlap
- * - Fully internationalised (fr, ar, en)
+ *   - Accept All / Decline / Manage Preferences
+ *   - Granular toggles for Functional (always on), Analytics, Marketing
+ *   - Properly disables analytics scripts when declined
+ *   - Adds bottom padding to prevent content overlap
+ *   - Fully internationalised (fr, ar, en)
+ *
+ * A64 v1 hardening:
+ *   - Versioned storage envelope ({ v, t, prefs }) with 12-month expiry.
+ *   - Side effects moved out of useState initialiser into useEffect.
+ *   - Cross-tab sync via the storage event so accepting in one tab closes
+ *     the banner in another.
  */
 export function CookieConsent() {
   const [locale] = useLocale();
-  const [visible, setVisible] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const hasConsent = localStorage.getItem("cookie-consent") !== null;
-    if (hasConsent) {
-      const stored = getStoredCookiePreferences();
-      applyAnalyticsConsent(stored.analytics);
-      return false;
-    }
-    return true;
-  });
+  const [visible, setVisible] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
   const [preferences, setPreferences] = useState<CookiePreferences>(DEFAULT_PREFERENCES);
 
-  // Listen for programmatic re-open (e.g. footer "Cookie Settings" link)
+  // A64: visibility decision moved to useEffect so the initialiser is pure
+  // and the side effect (applyAnalyticsConsent) only runs client-side.
+  useEffect(() => {
+    const status = getConsentStatus();
+    if (status.kind === "fresh") {
+      applyAnalyticsConsent(status.preferences.analytics);
+      setPreferences(status.preferences);
+      setVisible(false);
+    } else {
+      // missing / stale-version / expired all force re-prompt with defaults.
+      setPreferences(DEFAULT_PREFERENCES);
+      setVisible(true);
+    }
+  }, []);
+
+  // Listen for programmatic re-open (e.g. footer "Cookie Settings" link).
   useEffect(() => {
     const handler = () => {
-      const stored = getStoredCookiePreferences();
-      if (stored) setPreferences(stored);
+      const status = getConsentStatus();
+      if (status.kind === "fresh") setPreferences(status.preferences);
       setVisible(true);
     };
     window.addEventListener(REOPEN_EVENT, handler);
     return () => window.removeEventListener(REOPEN_EVENT, handler);
   }, []);
 
-  // Add bottom padding to body when banner is visible
+  // A64: cross-tab sync. When another tab writes consent, close the banner
+  // here too so the user does not see the dialog they already dismissed.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return;
+      const status = getConsentStatus();
+      if (status.kind === "fresh") {
+        setPreferences(status.preferences);
+        setVisible(false);
+        applyAnalyticsConsent(status.preferences.analytics);
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  // Add bottom padding to body when banner is visible.
   useEffect(() => {
     if (typeof document === "undefined") return;
     if (visible) {
@@ -157,13 +321,14 @@ export function CookieConsent() {
   }, [visible]);
 
   const saveAndClose = useCallback((prefs: CookiePreferences) => {
-    if (typeof window !== "undefined") {
-      localStorage.setItem("cookie-consent", JSON.stringify(prefs));
-    }
+    persistConsent(prefs);
     applyAnalyticsConsent(prefs.analytics);
     logConsentToServer(prefs);
-    // A80-1 fix: Dispatch custom event so PlausibleScript's same-tab listener updates
-    window.dispatchEvent(new CustomEvent("cookie-consent:changed"));
+    // A80-1 fix: dispatch custom event so same-tab listeners (PlausibleScript,
+    // ConsentGatedAnalytics, ConsentGatedReplay) update without a reload.
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent(CHANGED_EVENT));
+    }
     setVisible(false);
     setShowPreferences(false);
   }, []);
@@ -191,7 +356,7 @@ export function CookieConsent() {
             </a>
             .
           </p>
-          {/* A69-3: Decline has equal visual weight as Accept All (EDPB 03/2022) */}
+          {/* A69-3: Decline has equal visual weight as Accept All (EDPB 03/2022). */}
           <div className="flex flex-wrap gap-2 shrink-0">
             <Button size="sm" onClick={declineAll}>
               {t(locale, "cookie.decline")}
@@ -212,7 +377,7 @@ export function CookieConsent() {
         {/* Granular preferences panel */}
         {showPreferences && (
           <div className="mt-4 space-y-3 border-t pt-4">
-            {/* Functional — always on */}
+            {/* Functional. Always on. */}
             <label className="flex items-center justify-between gap-4">
               <div>
                 <p className="text-sm font-medium">{t(locale, "cookie.functional")}</p>

--- a/src/components/plausible-script.tsx
+++ b/src/components/plausible-script.tsx
@@ -3,6 +3,7 @@
 import Script from "next/script";
 import { useSyncExternalStore } from "react";
 import { getStoredCookiePreferences } from "@/components/cookie-consent";
+import { getPlausibleDomain, getPlausibleHost } from "@/lib/env";
 
 /**
  * Subscribe to localStorage changes for cookie consent.
@@ -14,7 +15,7 @@ function subscribeToConsent(callback: () => void): () => void {
   const onStorage = (e: StorageEvent) => {
     if (e.key === "cookie-consent") callback();
   };
-  // Also listen for same-tab consent changes (custom event from cookie-consent)
+  // Also listen for same-tab consent changes (custom event from cookie-consent).
   const onCustom = () => callback();
   window.addEventListener("storage", onStorage);
   window.addEventListener("cookie-consent:changed", onCustom);
@@ -35,7 +36,7 @@ function getServerSnapshot(): boolean {
 }
 
 /**
- * Plausible Analytics — platform-level analytics for the root domain.
+ * Plausible Analytics. Platform-level analytics for the root domain.
  *
  * Unlike the per-clinic AnalyticsScript (GA/GTM), this tracks aggregate
  * metrics across the SaaS landing page (oltigo.com) such as visitor
@@ -44,15 +45,18 @@ function getServerSnapshot(): boolean {
  * Activated by setting NEXT_PUBLIC_PLAUSIBLE_DOMAIN in the environment.
  * Supports both Plausible Cloud and self-hosted instances.
  *
- * A69-F1: Consent-before-fire — the script is only rendered when the user
+ * A69-F1: Consent-before-fire. The script is only rendered when the user
  * has explicitly accepted analytics cookies. Although Plausible is cookieless
  * and claims GDPR-safe without consent, the EU ePrivacy Directive and
  * French/German DPA guidance may still require prior consent for any
  * tracking. Rendering conditionally eliminates the race window where the
  * script could phone home before the consent check runs on mount.
+ *
+ * A64: env values read through `src/lib/env.ts` so this file no longer
+ * touches `process.env` directly.
  */
 export function PlausibleScript() {
-  const domain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+  const domain = getPlausibleDomain();
   const analyticsConsented = useSyncExternalStore(
     subscribeToConsent,
     getAnalyticsConsented,
@@ -61,7 +65,7 @@ export function PlausibleScript() {
 
   if (!domain || !analyticsConsented) return null;
 
-  const host = process.env.NEXT_PUBLIC_PLAUSIBLE_HOST ?? "https://plausible.io";
+  const host = getPlausibleHost();
 
   return (
     <Script

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -244,6 +244,16 @@ const ENV_RULES: EnvRule[] = [
     group: "observability",
   },
 
+  // A64: Plausible analytics domain. Optional, but when set it activates
+  // the PlausibleScript on the public root domain. Listed in the registry
+  // so audits surface analytics configuration changes.
+  {
+    name: "NEXT_PUBLIC_PLAUSIBLE_DOMAIN",
+    required: false,
+    description: "Plausible site domain (NEXT_PUBLIC_*), e.g. oltigo.com. Optional.",
+    group: "observability",
+  },
+
   // R-24: Require explicit Plausible host when analytics domain is configured
   // to prevent CSP from falling back to the upstream plausible.io domain.
   {
@@ -251,6 +261,16 @@ const ENV_RULES: EnvRule[] = [
     required: !!process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN && process.env.NODE_ENV === "production",
     description:
       "Self-hosted Plausible Analytics host URL (required in production when NEXT_PUBLIC_PLAUSIBLE_DOMAIN is set)",
+    group: "observability",
+  },
+
+  // A64: Per-clinic Google Analytics measurement ID. Optional. When unset,
+  // the analytics-script + cookie-consent disable paths short-circuit.
+  // Listed so the audit registry sees every analytics channel.
+  {
+    name: "NEXT_PUBLIC_GA_MEASUREMENT_ID",
+    required: false,
+    description: "Google Analytics 4 measurement ID (per-clinic, optional).",
     group: "observability",
   },
 
@@ -1167,4 +1187,32 @@ export function getAvScanUrl(): string | undefined {
  */
 export function getAvScanRequired(): boolean {
   return process.env.AV_SCAN_REQUIRED === "true";
+}
+
+/**
+ * Plausible Analytics site domain. When set, the PlausibleScript component
+ * renders. Always client-bundled via the NEXT_PUBLIC_ prefix.
+ * A64: centralised so cookie-consent + plausible-script do not read process.env directly.
+ */
+export function getPlausibleDomain(): string | undefined {
+  return process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+}
+
+/**
+ * Plausible Analytics host URL. Defaults to plausible.io for the SaaS
+ * offering. Required in production when NEXT_PUBLIC_PLAUSIBLE_DOMAIN is set
+ * (enforced at the registry level in OBSERVABILITY_ENV_REGISTRY).
+ * A64: centralised so plausible-script does not read process.env directly.
+ */
+export function getPlausibleHost(): string {
+  return process.env.NEXT_PUBLIC_PLAUSIBLE_HOST ?? "https://plausible.io";
+}
+
+/**
+ * Per-clinic Google Analytics 4 measurement ID. Optional. When unset,
+ * the analytics-script consent gate short-circuits without touching the GA SDK.
+ * A64: centralised so cookie-consent does not read process.env directly.
+ */
+export function getGaMeasurementId(): string | undefined {
+  return process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 }


### PR DESCRIPTION
## A64: Cookie consent v1 hardening

Continues the env-access centralisation pattern from PR #908 and closes A64 from the May 31 audit sweep.

### What

| Area | Change |
| ---- | ------ |
| Storage | Versioned envelope `{ v, t, prefs }` with 12-month expiry |
| Re-prompt | `CONSENT_VERSION` bump or `CONSENT_MAX_AGE_MS` (= 12 months) elapsed triggers banner |
| React | `useState` initialiser is pure; side effects moved to `useEffect` |
| Cross-tab | `storage` event listener closes the banner in sibling tabs |
| env-access | `getPlausibleDomain`, `getPlausibleHost`, `getGaMeasurementId` added to `src/lib/env.ts`; no component reads `process.env` directly |
| Tests | 17 unit tests for the storage layer |
| Docs | `docs/compliance/cookie-consent.md` design doc |

### Why

The pre-A64 banner had granular categories and EDPB 03/2022-compliant button parity, but lacked three v1 maturity items:

1. **No way to force re-prompt.** When categories or processors change, old consent silently covers them. `CONSENT_VERSION` solves this.
2. **No expiry.** ICO + CNIL guidance is 12 months max for cookie consent freshness.
3. **Direct `process.env` access** in two components, same Semgrep `env-access` finding as the upload route fixed in #908.

### Files

```
modified:
  src/components/cookie-consent.tsx       (274 -> 439 lines)
  src/components/plausible-script.tsx     (75  -> 79 lines)
  src/lib/env.ts                          (+ 2 registry entries, + 3 accessors)

added:
  src/components/__tests__/cookie-consent.test.tsx  (219 lines, 17 tests)
  docs/compliance/cookie-consent.md                 (175 lines)
```

### Compatibility

| Existing storage format         | Behaviour after this PR              |
| ------------------------------- | ------------------------------------ |
| `"accepted"` string             | Silently migrated to v1 envelope, kept as-accepted |
| `"declined"` string             | Silently migrated to v1 envelope, kept as-defaults |
| Bare `CookiePreferences` object | Returned as `v:0` -> stale-version -> re-prompt once |
| No value                        | Banner shows (unchanged)             |

### Risk

Low. Storage layer is unit-tested, including the boundary at `CONSENT_MAX_AGE_MS`. Banner UI is unchanged except the visibility decision moved from initialiser to `useEffect` (1-tick later, but no visual flash because `visible` starts `false`). The Playwright pre-seed from PR #908 still works because it sets a bare-object shape; it now triggers re-prompt on first load rather than silently masking, which is the correct test posture going forward (a follow-up PR will update the pre-seed to emit a v1 envelope).

### Follow-ups (out of scope)

- A64.v2: per-region banner gating, vendor-level granularity (Plausible vs GA toggle), keyboard escape, server-pushed re-prompt to active sessions.
- Update Playwright `addInitScript` pre-seed to emit a v1 envelope so E2E does not re-prompt on every navigation.

Refs: A64 audit finding, continues #908.