### PR TITLE
cleanup(C7): Replace console.* with logger in production code

### DIFF
--- a/src/lib/ai-cost-tracker.ts
+++ b/src/lib/ai-cost-tracker.ts
@@ -14,6 +14,7 @@
  */
 
 import { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
 
 /**
  * Cost per token (in USD) for each AI model.
@@ -65,7 +66,13 @@ export async function logAICost(
     });
   } catch (err) {
     // Non-fatal — log but don't crash the AI request
-    console.error("ai-cost-tracker: failed to log cost", { clinicId, route, model, error: err });
+    logger.error("ai-cost-tracker: failed to log cost", {
+      context: "ai-cost-tracker",
+      clinicId,
+      route,
+      model,
+      error: err,
+    });
   }
 }
 
@@ -90,7 +97,11 @@ export async function getAICostLast30Days(
     .gte("created_at", thirtyDaysAgo);
 
   if (error) {
-    console.error("ai-cost-tracker: failed to fetch costs", { clinicId, error });
+    logger.error("ai-cost-tracker: failed to fetch costs", {
+      context: "ai-cost-tracker",
+      clinicId,
+      error,
+    });
     return 0;
   }
 
@@ -122,7 +133,11 @@ export async function getAICostByRoute(
     .gte("created_at", thirtyDaysAgo);
 
   if (error) {
-    console.error("ai-cost-tracker: failed to fetch costs by route", { clinicId, error });
+    logger.error("ai-cost-tracker: failed to fetch costs by route", {
+      context: "ai-cost-tracker",
+      clinicId,
+      error,
+    });
     return [];
   }
 

--- a/src/lib/http-resilience-example.ts
+++ b/src/lib/http-resilience-example.ts
@@ -12,6 +12,7 @@
 
 import { getExternalEhrApiKey, getStripeSecretKey } from "@/lib/env";
 import { resilientFetch, HTTP_TIMEOUTS } from "@/lib/http-resilience";
+import { logger } from "@/lib/logger";
 
 /**
  * Example 1: Simple external API call with timeout and retries.
@@ -66,7 +67,11 @@ export async function deliverWebhook(
         retryableStatuses: [408, 429, 500, 502, 503, 504], // Standard retryables
       },
       onRetry: (attemptNumber, reason) => {
-        console.log(`Webhook retry ${attemptNumber}: ${reason}`);
+        logger.info("Webhook retry", {
+          context: "webhook-delivery",
+          attemptNumber,
+          reason,
+        });
       },
     },
   );


### PR DESCRIPTION
## What

Replaces direct `console.error`/`console.log` calls with structured `logger` calls in the two production-code files that still used them:

- `src/lib/ai-cost-tracker.ts`: 3 `console.error` → `logger.error`
- `src/lib/http-resilience-example.ts`: 1 `console.log` → `logger.info`

Other `console.*` usages were intentionally left alone:
- `src/lib/logger.ts` — IS the logging infrastructure itself
- `src/lib/middleware/security-headers.ts` — edge-runtime fallback (explicit comment in code: _"console.error is appropriate here since the structured logger may not be available in the edge runtime"_)
- `src/instrumentation.ts` — bootstrap `.catch()` path before the logger module can be imported (explicit comment in code)
- Various other `.ts` files: only inside code comments or string literals (e.g. `phi-compliance.ts` description, JSDoc examples)

## Why

Direct `console.*` skips:
- Sentry forwarding (errors and breadcrumbs)
- PHI auto-redaction (`PHI_FIELD_PATTERNS` in logger.ts)
- Per-message sampling
- Structured JSON output for log sinks

These three cost-tracker error paths are exactly the kind of cross-tenant errors we want surfaced in Sentry.

## Proof of safety

| Check | Result |
| --- | --- |
| `npx tsc --noEmit` | clean |
| `npx prettier --check` on changed files | clean |
| `npx eslint` on changed files | 0 warnings |
| `vitest run` (full suite) | **1654 passed / 60 skipped** |
| Behavior change | none — same messages, same call sites |

## Risk

**Low.** Pure logging-call swap inside non-fatal error paths. No control-flow changes.

## Rollback

`git revert <sha>` is safe — there is no behavioral coupling between these files and any caller.

## Out of scope

- Any new logger features
- Edge-runtime logger refactor (would be needed before `security-headers.ts` could switch)
- Adding tests for the now-logger-using code paths (the underlying error paths were untested before; that's a separate cleanup)

---

**Finding Register ID:** `FR-005` (Category `C7`)
