### PR TITLE
cleanup(C7): Fix stale references to removed secrets-template.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Built with **Next.js 16** (App Router) + **Supabase** + **Cloudflare Workers** (
 npm install
 
 # Copy environment variables
-cp secrets-template.env .env.local
+cp .env.example .env.local
 # Edit .env.local with your Supabase and WhatsApp credentials
 
 # Run the development server

--- a/scripts/recover.sh
+++ b/scripts/recover.sh
@@ -6,7 +6,7 @@
 # Rebuilds the entire platform from scratch using a single command.
 #
 # Prerequisites:
-#   1. Copy secrets-template.env → .env and fill in your secrets
+#   1. Copy .env.example → .env and fill in your secrets
 #   2. Node.js 22+ installed
 #   3. Supabase CLI installed (npx supabase)
 #   4. Wrangler CLI installed (npx wrangler)
@@ -66,8 +66,8 @@ log_step "Step 1/8: Validating secrets..."
 
 if [[ ! -f ".env" ]]; then
   log_error ".env file not found!"
-  log_error "Copy secrets-template.env to .env and fill in your values:"
-  log_error "  cp secrets-template.env .env"
+  log_error "Copy .env.example to .env and fill in your values:"
+  log_error "  cp .env.example .env"
   exit 1
 fi
 


### PR DESCRIPTION
## What

Fixes two user-facing references to `secrets-template.env`, a file that was deleted in PR #873 but whose name still appears in:

- `README.md` (line 32): _"cp secrets-template.env .env.local"_
- `scripts/recover.sh` (prereqs comment + disaster-recovery error message)

Both now point at the canonical `.env.example` that actually exists.

## Why

A new contributor following the README hits **"No such file or directory"** on their first `cp` command. The disaster-recovery script's error message is doubly wrong because it fires precisely when an operator is already stressed.

Historical references inside `docs/AUDIT-CLEANUP-WAVE-0-2.md`, `docs/AUDIT-ROADMAP.md`, and `docs/audit/open-actions.md` are correct as audit-trail and were left alone.

## Proof of safety

| Check | Result |
| --- | --- |
| `grep -r secrets-template` in user-facing files | **0 hits** |
| `prettier --check README.md` | clean |
| `bash -n scripts/recover.sh` | syntax OK |
| Code paths / env-var contracts | unchanged |

## Risk

**Low.** Documentation-only / hard-coded-string fix.

## Rollback

`git revert <sha>` restores the stale references — no risk because the referenced file does not exist either way.

## Out of scope

- Creating `.env.example` (already exists — 16 kB, comprehensive — verified)
- Re-auditing every `.md` doc for other stale paths

---

**Finding Register ID:** `FR-006` (Category `C7`)
**Context:** Wave 1 Task 3 of the cleanup audit. The audit asked for `.env.example` creation; that file was already present, so the residual work was fixing references to its now-deleted predecessor.
