### PR TITLE
fix: Add order column allow-list + CSP URI scrubbing (Q-03, Q-23)

### DIFF
--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -58,6 +58,21 @@ function truncateField(value: unknown): string | undefined {
   return value.length > MAX_FIELD_CHARS ? value.slice(0, MAX_FIELD_CHARS) : value;
 }
 
+/**
+ * Q-23: Scrub potential secrets/tokens/nonces from CSP report URIs.
+ * Removes query strings, fragments, and inline nonce/hash values that
+ * may contain session tokens or CSP nonces.
+ */
+function scrubUri(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  let scrubbed = value;
+  // Remove query strings and fragments (may contain tokens)
+  scrubbed = scrubbed.replace(/[?#].*$/, "");
+  // Redact inline nonce/hash patterns (e.g. 'nonce-abc123', 'sha256-...')
+  scrubbed = scrubbed.replace(/'(nonce|sha\d+)-[^']+'/g, "'$1-REDACTED'");
+  return truncateField(scrubbed);
+}
+
 export async function POST(request: NextRequest) {
   // Read the raw body first so we can enforce a hard size cap before
   // parsing. `request.text()` materialises the entire body, but the
@@ -98,12 +113,13 @@ export async function POST(request: NextRequest) {
     // alert rule (Audit 3.4 Fix). Every field is truncated and the
     // original-policy is intentionally dropped — it is large, low-signal,
     // and attacker-influenced via document-uri reflection.
+    // Q-23: Scrub URIs to prevent token/nonce leakage in logs.
     logger.error("CSP violation detected", {
       context: "csp-report",
-      blockedUri: truncateField(report["blocked-uri"]),
+      blockedUri: scrubUri(report["blocked-uri"]),
       violatedDirective: truncateField(report["violated-directive"]),
-      documentUri: truncateField(report["document-uri"]),
-      referrer: truncateField(report.referrer),
+      documentUri: scrubUri(report["document-uri"]),
+      referrer: scrubUri(report.referrer),
       alert: true,
     });
   }

--- a/src/lib/data/client/_core.ts
+++ b/src/lib/data/client/_core.ts
@@ -11,6 +11,15 @@ import { logger } from "@/lib/logger";
 import { createClient, createTenantClient } from "@/lib/supabase-client";
 import type { Database } from "@/lib/types/database";
 
+/** Q-03: Allow-list of columns that may appear in `.order()` calls. */
+const ALLOWED_ORDER_COLUMNS = new Set([
+  "id", "created_at", "updated_at", "appointment_date", "start_time",
+  "slot_start", "slot_end", "start_date", "due_date", "day_of_week",
+  "sent_at", "name", "first_name", "last_name", "tooth_number",
+  "sterilized_at", "before_date", "sort_order", "date", "status",
+  "priority", "amount", "price",
+]);
+
 /**
  * Booking configuration that callers must provide from the tenant's DB
  * config instead of relying on static clinicConfig values.
@@ -99,7 +108,13 @@ export async function fetchRows<T>(
   }
   if (opts?.gte) q = q.gte(opts.gte[0] as string, opts.gte[1]);
   if (opts?.lte) q = q.lte(opts.lte[0] as string, opts.lte[1]);
-  if (opts?.order) q = q.order(opts.order[0], opts.order[1]);
+  if (opts?.order) {
+    if (!ALLOWED_ORDER_COLUMNS.has(opts.order[0])) {
+      logger.warn("Rejected unknown order column", { context: "data/client", column: opts.order[0] });
+    } else {
+      q = q.order(opts.order[0], opts.order[1]);
+    }
+  }
   // Apply an upper-bound limit to prevent unbounded result sets.
   // Callers can override with a smaller value via opts.limit.
   q = q.limit(opts?.limit ?? 1000);

--- a/src/lib/data/client/_core.ts
+++ b/src/lib/data/client/_core.ts
@@ -13,11 +13,29 @@ import type { Database } from "@/lib/types/database";
 
 /** Q-03: Allow-list of columns that may appear in `.order()` calls. */
 const ALLOWED_ORDER_COLUMNS = new Set([
-  "id", "created_at", "updated_at", "appointment_date", "start_time",
-  "slot_start", "slot_end", "start_date", "due_date", "day_of_week",
-  "sent_at", "name", "first_name", "last_name", "tooth_number",
-  "sterilized_at", "before_date", "sort_order", "date", "status",
-  "priority", "amount", "price",
+  "id",
+  "created_at",
+  "updated_at",
+  "appointment_date",
+  "start_time",
+  "slot_start",
+  "slot_end",
+  "start_date",
+  "due_date",
+  "day_of_week",
+  "sent_at",
+  "name",
+  "first_name",
+  "last_name",
+  "tooth_number",
+  "sterilized_at",
+  "before_date",
+  "sort_order",
+  "date",
+  "status",
+  "priority",
+  "amount",
+  "price",
 ]);
 
 /**
@@ -110,7 +128,10 @@ export async function fetchRows<T>(
   if (opts?.lte) q = q.lte(opts.lte[0] as string, opts.lte[1]);
   if (opts?.order) {
     if (!ALLOWED_ORDER_COLUMNS.has(opts.order[0])) {
-      logger.warn("Rejected unknown order column", { context: "data/client", column: opts.order[0] });
+      logger.warn("Rejected unknown order column", {
+        context: "data/client",
+        column: opts.order[0],
+      });
     } else {
       q = q.order(opts.order[0], opts.order[1]);
     }

--- a/src/lib/data/server.ts
+++ b/src/lib/data/server.ts
@@ -24,6 +24,37 @@ type TableName = keyof Database["public"]["Tables"];
 /** Default upper-bound limit for list queries to prevent unbounded result sets. */
 const DEFAULT_QUERY_LIMIT = 1000;
 
+/**
+ * Q-03: Allow-list of columns that may appear in dynamic `.order()` calls.
+ * Prevents enumeration or SQL injection via order parameter even though
+ * callers currently pass hardcoded strings. Defense-in-depth.
+ */
+const ALLOWED_ORDER_COLUMNS = new Set([
+  "id",
+  "created_at",
+  "updated_at",
+  "appointment_date",
+  "start_time",
+  "slot_start",
+  "slot_end",
+  "start_date",
+  "due_date",
+  "day_of_week",
+  "sent_at",
+  "name",
+  "first_name",
+  "last_name",
+  "tooth_number",
+  "sterilized_at",
+  "before_date",
+  "sort_order",
+  "date",
+  "status",
+  "priority",
+  "amount",
+  "price",
+]);
+
 /** Paginated result envelope returned by `queryPaginated`. */
 interface PaginatedResult<T> {
   data: T[];
@@ -56,7 +87,16 @@ async function query<T>(
     q = q.in(opts.inFilter[0], opts.inFilter[1] as string[]);
   }
   if (opts?.order) {
-    q = q.order(opts.order[0], opts.order[1]);
+    // Q-03: Reject unknown order columns to prevent enumeration attacks.
+    if (!ALLOWED_ORDER_COLUMNS.has(opts.order[0])) {
+      logger.warn("Rejected unknown order column", {
+        context: "data/server",
+        table,
+        column: opts.order[0],
+      });
+    } else {
+      q = q.order(opts.order[0], opts.order[1]);
+    }
   }
   // Always apply an upper-bound limit to prevent unbounded result sets.
   // Callers can override with a smaller value via opts.limit.
@@ -102,7 +142,15 @@ async function _queryPaginated<T>(
     q = q.in(opts.inFilter[0], opts.inFilter[1] as string[]);
   }
   if (opts?.order) {
-    q = q.order(opts.order[0], opts.order[1]);
+    // Q-03: Reject unknown order columns (defense-in-depth).
+    if (!ALLOWED_ORDER_COLUMNS.has(opts.order[0])) {
+      logger.warn("Rejected unknown order column", {
+        context: "data/server/paginated",
+        column: opts.order[0],
+      });
+    } else {
+      q = q.order(opts.order[0], opts.order[1]);
+    }
   }
   q = q.range(from, to);
 

--- a/src/lib/data/specialists.ts
+++ b/src/lib/data/specialists.ts
@@ -12,6 +12,15 @@ import type { Database } from "@/lib/types/database";
 
 type TableName = keyof Database["public"]["Tables"];
 
+/** Q-03: Allow-list of columns that may appear in `.order()` calls. */
+const ALLOWED_ORDER_COLUMNS = new Set([
+  "id", "created_at", "updated_at", "appointment_date", "start_time",
+  "slot_start", "slot_end", "start_date", "due_date", "day_of_week",
+  "sent_at", "name", "first_name", "last_name", "tooth_number",
+  "sterilized_at", "before_date", "sort_order", "date", "status",
+  "priority", "amount", "price",
+]);
+
 // ── Patient name resolution helper ──
 
 async function resolvePatientNames(patientIds: string[]): Promise<Map<string, string>> {
@@ -48,7 +57,13 @@ async function fetchRows<T>(
       q = q.eq(col, val as string);
     }
   }
-  if (opts?.order) q = q.order(opts.order[0], opts.order[1]);
+  if (opts?.order) {
+    if (!ALLOWED_ORDER_COLUMNS.has(opts.order[0])) {
+      logger.warn("Rejected unknown order column", { context: "data/specialists", column: opts.order[0] });
+    } else {
+      q = q.order(opts.order[0], opts.order[1]);
+    }
+  }
   if (opts?.limit) q = q.limit(opts.limit);
   const { data, error } = await q;
   if (error) {

--- a/src/lib/data/specialists.ts
+++ b/src/lib/data/specialists.ts
@@ -14,11 +14,29 @@ type TableName = keyof Database["public"]["Tables"];
 
 /** Q-03: Allow-list of columns that may appear in `.order()` calls. */
 const ALLOWED_ORDER_COLUMNS = new Set([
-  "id", "created_at", "updated_at", "appointment_date", "start_time",
-  "slot_start", "slot_end", "start_date", "due_date", "day_of_week",
-  "sent_at", "name", "first_name", "last_name", "tooth_number",
-  "sterilized_at", "before_date", "sort_order", "date", "status",
-  "priority", "amount", "price",
+  "id",
+  "created_at",
+  "updated_at",
+  "appointment_date",
+  "start_time",
+  "slot_start",
+  "slot_end",
+  "start_date",
+  "due_date",
+  "day_of_week",
+  "sent_at",
+  "name",
+  "first_name",
+  "last_name",
+  "tooth_number",
+  "sterilized_at",
+  "before_date",
+  "sort_order",
+  "date",
+  "status",
+  "priority",
+  "amount",
+  "price",
 ]);
 
 // ── Patient name resolution helper ──
@@ -59,7 +77,10 @@ async function fetchRows<T>(
   }
   if (opts?.order) {
     if (!ALLOWED_ORDER_COLUMNS.has(opts.order[0])) {
-      logger.warn("Rejected unknown order column", { context: "data/specialists", column: opts.order[0] });
+      logger.warn("Rejected unknown order column", {
+        context: "data/specialists",
+        column: opts.order[0],
+      });
     } else {
       q = q.order(opts.order[0], opts.order[1]);
     }


### PR DESCRIPTION
## Summary

Addresses audit findings Q-03 (dynamic order column injection) and Q-23 (CSP report PHI leakage).

## Changes

### 1. Order Column Allow-list (Q-03, P1)
- **Files:** `src/lib/data/server.ts`, `src/lib/data/specialists.ts`, `src/lib/data/client/_core.ts`
- Added `ALLOWED_ORDER_COLUMNS` set with all legitimate column names used across the codebase
- `.order()` calls now validate the column name against the allow-list
- Unknown columns are rejected with a warning log (query proceeds without ordering)
- Defense-in-depth: all current callers use hardcoded strings, but this prevents future regressions

### 2. CSP Report URI Scrubbing (Q-23, P2)
- **File:** `src/app/api/csp-report/route.ts`
- Added `scrubUri()` function that strips query strings, fragments, and nonce/hash patterns
- `blocked-uri`, `document-uri`, and `referrer` fields now scrubbed before logging
- Prevents session tokens and CSP nonces from leaking into structured logs

## Findings Already Resolved (verified during investigation)

| Finding | Status | Evidence |
|---------|--------|----------|
| Stripe JSONB overwrite (P0) | ✅ Already fixed | Uses `mergeClinicConfig()` (line 222, 291) |
| Sentry PHI scrubbing (P0) | ✅ Already fixed | Comprehensive `beforeSend` with redactPII, scrubUrl, header scrubbing |
| Cron schedules in wrangler.toml (P1) | ✅ Already fixed | `[triggers] crons` present with all 8 schedules |
| Workers Logs (P1) | ✅ Already fixed | `[observability] enabled = true` |
| CPU limits (P2) | ✅ Already fixed | `cpu_ms = 30000` |
| Unknown cron alert (P2) | ✅ Already fixed | `reportCronError` fires on unknown cron |
| Cross-env cron (P1) | ✅ Already fixed | Fails if neither CRON_SELF_BASE_URL nor ROOT_DOMAIN set |
| WhatsApp replay protection (P1) | ✅ Already fixed | Message-level dedup via DB unique constraint |
| Stripe timeouts (P1) | ✅ Already fixed | `AbortSignal.timeout(STRIPE_API_TIMEOUT_MS)` |

## Rollback

Revert this commit. No migrations, no infra changes.

## New SLO / metric required?

No

## Drive-by refactors

None