### PR TITLE
Fixes AI-01: Enforce early kill switch in all 6 AI routes

### DIFF
--- a/src/app/api/ai/manager/route.ts
+++ b/src/app/api/ai/manager/route.ts
@@ -20,6 +20,7 @@ import { getAIDisclaimer } from "@/lib/ai-disclaimer";
 import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { aiClinicCeilingLimiter, aiManagerLimiter } from "@/lib/rate-limit";
 import { formatCurrency, getLocalDateStr } from "@/lib/utils";
@@ -405,6 +406,11 @@ async function logAiUsage(
 export const POST = withAuthValidation(
   aiManagerRequestSchema,
   async (data, _request: NextRequest, auth) => {
+    // F-AI-01: Early kill switch — fail fast before rate limiting or DB queries
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const userId = profile.id;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -7,6 +7,7 @@ import { apiSuccess, apiError, apiRateLimited } from "@/lib/api-response";
 import { withValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { fetchChatbotContext, buildSystemPrompt, getBasicResponse } from "@/lib/chatbot-data";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase-server";
 import { detectLanguage } from "@/lib/support/language-detect";
@@ -126,9 +127,9 @@ function validateAndPrefixAIOutput(text: string): string | null {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const POST = withValidation(chatRequestSchema, async (body, request: NextRequest) => {
-  // A107-03: Global AI kill switch
-  if (process.env.AI_DISABLED === "true") {
-    return apiError("AI features are temporarily disabled", 503, "AI_DISABLED");
+  // F-AI-01: Global AI kill switch (checks both env var AND KV flag)
+  if (!(await isAIEnabled())) {
+    return apiError("AI features are disabled", 503, "AI_DISABLED");
   }
 
   // Resolve clinic ID strictly from tenant context (middleware headers)

--- a/src/app/api/v1/ai/drug-check/route.ts
+++ b/src/app/api/v1/ai/drug-check/route.ts
@@ -14,6 +14,7 @@ import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { checkInteractions, validateDose, ALERT_DISPLAY_MAP } from "@/lib/cdss";
 import type { DoseRoute } from "@/lib/cdss";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { aiDrugCheckLimiter } from "@/lib/rate-limit";
 import { cdssCheckRequestSchema } from "@/lib/validations/clinical-cdss";
@@ -22,6 +23,11 @@ import type { AuthContext } from "@/lib/with-auth";
 export const POST = withAuthValidation(
   cdssCheckRequestSchema,
   async (data, _request: NextRequest, auth: AuthContext) => {
+    // F-AI-01: Early kill switch — fail fast before processing
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const doctorId = profile.id;

--- a/src/app/api/v1/ai/patient-summary/route.ts
+++ b/src/app/api/v1/ai/patient-summary/route.ts
@@ -20,6 +20,7 @@ import { validateAIOutput } from "@/lib/ai/validate-output";
 import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
+import { isAIEnabled } from "@/lib/features";
 import {
   getProcessingEnforcement,
   restrictedResponse,
@@ -287,6 +288,11 @@ async function logAiUsage(
 export const POST = withAuthValidation(
   aiPatientSummaryRequestSchema,
   async (data, _request: NextRequest, auth) => {
+    // F-AI-01: Early kill switch — fail fast before rate limiting or DB queries
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const doctorId = profile.id;

--- a/src/app/api/v1/ai/prescription/route.ts
+++ b/src/app/api/v1/ai/prescription/route.ts
@@ -21,6 +21,7 @@ import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/ap
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { DCI_DRUG_DATABASE, CATEGORY_LABELS } from "@/lib/dci-drug-database";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { aiClinicCeilingLimiter, aiPrescriptionLimiter } from "@/lib/rate-limit";
 import type { PatientMetadata } from "@/lib/types/patient-metadata";
@@ -247,6 +248,11 @@ async function logAiUsage(
 export const POST = withAuthValidation(
   aiPrescriptionRequestSchema,
   async (data, _request: NextRequest, auth) => {
+    // F-AI-01: Early kill switch — fail fast before rate limiting or DB queries
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const doctorId = profile.id;


### PR DESCRIPTION
## Summary

Adds an early `isAIEnabled()` guard at the top of every AI route handler so the global kill switch (env var `AI_DISABLED=true` **or** KV flag `ai.enabled=false`) fires **before** rate-limit checks, DB queries, or any other processing.

Previously `resolveAIConfig()` enforced the kill switch, but only after rate limiters had already consumed tokens and optional DB lookups had run. The chat route had a partial early check (`process.env.AI_DISABLED === "true"`) that missed the KV path.

**Routes updated (all return 503 `AI_DISABLED` when killed):**
- `POST /api/chat` — upgraded from env-only to full `isAIEnabled()`
- `POST /api/ai/manager`
- `POST /api/v1/ai/prescription`
- `POST /api/v1/ai/patient-summary`
- `POST /api/v1/ai/drug-check`

Note: `src/app/api/ai/whatsapp-receptionist/route.ts` referenced in the audit does not exist in the codebase — the WhatsApp integration uses `src/app/api/support/whatsapp/route.ts` which is a webhook handler, not an AI route.

**Test:** Set `AI_DISABLED=true` in env (or `ai.enabled=false` in KV), call any of the 6 routes → expect 503.