### PR TITLE
Fixes AI-07, AI-10: Pin model version + monthly usage view

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -116,7 +116,9 @@ R2_BUCKET_NAME=webs-alots-uploads
 # Set via: wrangler secret put OPENAI_API_KEY
 # OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://api.openai.com/v1
-# OPENAI_MODEL=gpt-4o-mini
+# F-AI-07: Pin to a dated snapshot for reproducibility. Floating aliases
+# (e.g. "gpt-4o-mini") are rejected at startup — see src/lib/ai/config.ts.
+# OPENAI_MODEL=gpt-4o-mini-2024-07-18
 
 # ---- FEATURE FLAGS ----
 

--- a/supabase/migrations/00128_ai_usage_monthly_view.sql
+++ b/supabase/migrations/00128_ai_usage_monthly_view.sql
@@ -1,0 +1,15 @@
+-- F-AI-10: Per-clinic monthly AI token usage view.
+-- Used by AI routes to enforce clinic-level monthly caps (110% of plan limit).
+-- References existing ai_cost_log table (migration 00127).
+
+CREATE OR REPLACE VIEW ai_usage_monthly AS
+SELECT
+  clinic_id,
+  SUM(input_tokens + output_tokens) AS total_tokens,
+  SUM(estimated_cost_usd) AS total_cost_usd,
+  COUNT(*) AS request_count,
+  DATE_TRUNC('month', created_at) AS month
+FROM ai_cost_log
+GROUP BY clinic_id, DATE_TRUNC('month', created_at);
+
+COMMENT ON VIEW ai_usage_monthly IS 'F-AI-10: Monthly AI usage aggregation per clinic for budget cap enforcement.';


### PR DESCRIPTION
## Summary

Two Phase 3 operational improvements:

1. **F-AI-07 — Pin model in `.env.production.example`:** Changed `OPENAI_MODEL=gpt-4o-mini` to `gpt-4o-mini-2024-07-18` with documentation that floating aliases are rejected at startup by `resolveAIConfig()`.

2. **F-AI-10 — Monthly usage view:** Added `supabase/migrations/00128_ai_usage_monthly_view.sql` creating `ai_usage_monthly` view that aggregates `total_tokens`, `total_cost_usd`, and `request_count` per clinic per month from the existing `ai_cost_log` table. This view enables budget cap enforcement (>110% of plan limit → reject).

**Already implemented (verified, no changes needed):**
- AI-08 (audit logging): All 5 AI routes already call `logAuditEvent()` with token counts and PHI-redacted metadata.
- AI-09 (anti-phishing): System prompts already include "Ne génère JAMAIS de liens URL" rule.