### PR TITLE
fix(config): correct TOML routes syntax in staging and production envs

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -172,11 +172,13 @@ id = "7ac37dff0a794542b0c766f38e73f105"
 preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
 
 # W8-A31-01: Routes (was missing — worker would not receive traffic)
-[env.production.routes]
-routes = [
-  { pattern = "oltigo.com/*", zone_name = "oltigo.com" },
-  { pattern = "*.oltigo.com/*", zone_name = "oltigo.com" },
-]
+[[env.production.routes]]
+pattern = "oltigo.com/*"
+zone_name = "oltigo.com"
+
+[[env.production.routes]]
+pattern = "*.oltigo.com/*"
+zone_name = "oltigo.com"
 
 # W8-A31-01: Cron triggers (was missing — scheduled jobs would not run)
 [env.production.triggers]
@@ -297,11 +299,13 @@ id = "da3acaf35a2d448984a4a95e769bc393"          # RATE_LIMIT_KV_STAGING
 preview_id = "4965f9300c924de3afc0407679ff775b"  # RATE_LIMIT_KV_STAGING_preview
 
 # W8-A31-01: Routes for staging (uses staging subdomain)
-[env.staging.routes]
-routes = [
-  { pattern = "staging.oltigo.com/*", zone_name = "oltigo.com" },
-  { pattern = "*.staging.oltigo.com/*", zone_name = "oltigo.com" },
-]
+[[env.staging.routes]]
+pattern = "staging.oltigo.com/*"
+zone_name = "oltigo.com"
+
+[[env.staging.routes]]
+pattern = "*.staging.oltigo.com/*"
+zone_name = "oltigo.com"
 
 # W8-A31-01: Cron triggers for staging
 [env.staging.triggers]


### PR DESCRIPTION
[env.staging.routes] with routes = [...] creates nested env.staging.routes.routes instead of an array.
Use [[env.staging.routes]] array-of-tables syntax instead. Same fix applied to production env.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Observability

- [ ] This PR adds/modifies logging (structured via `@/lib/logger`)
- [ ] This PR changes Sentry configuration or error handling
- [ ] N/A — no observability changes

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Coverage thresholds still met (`npm run test:coverage`)
- [ ] New API endpoints have rate limiting (fail-closed for PHI endpoints)
