### PR TITLE
feat: per-tenant usage metering and quota enforcement

### DIFF
--- a/src/app/(super-admin)/super-admin/usage-dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/usage-dashboard/page.tsx
@@ -1,0 +1,317 @@
+/* eslint-disable i18next/no-literal-string */
+"use client";
+
+import { BarChart3, AlertTriangle, TrendingUp, Loader2, DollarSign } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logger } from "@/lib/logger";
+
+// ── Types ──
+
+interface ClinicUsageRow {
+  clinicId: string;
+  resourceType: string;
+  totalUnits: number;
+  totalCostUsd: number;
+}
+
+interface QuotaResult {
+  allowed: boolean;
+  currentUsage: number;
+  limit: number;
+  remainingUnits: number;
+  plan: string;
+}
+
+interface ClinicDetail {
+  clinicId: string;
+  tier: string;
+  quota: Record<string, QuotaResult>;
+  usage: Array<{
+    resourceType: string;
+    totalUnits: number;
+    totalCostUsd: number;
+    eventCount: number;
+  }>;
+}
+
+// ── Helpers ──
+
+function resourceLabel(rt: string): string {
+  const labels: Record<string, string> = {
+    whatsapp: "WhatsApp",
+    sms: "SMS",
+    ai_tokens: "AI Tokens",
+    r2_storage: "R2 Storage",
+  };
+  return labels[rt] ?? rt;
+}
+
+function formatUnits(rt: string, units: number): string {
+  if (rt === "r2_storage") {
+    if (units > 1024 * 1024 * 1024) return `${(units / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+    if (units > 1024 * 1024) return `${(units / (1024 * 1024)).toFixed(1)} MB`;
+    return `${(units / 1024).toFixed(0)} KB`;
+  }
+  if (units > 1000) return `${(units / 1000).toFixed(1)}k`;
+  return units.toFixed(0);
+}
+
+function quotaPercent(q: QuotaResult): number {
+  if (q.limit === -1) return 0;
+  if (q.limit === 0) return q.currentUsage > 0 ? 100 : 0;
+  return Math.min(100, Math.round((q.currentUsage / q.limit) * 100));
+}
+
+// ── Component ──
+
+export default function UsageDashboardPage() {
+  const [allUsage, setAllUsage] = useState<ClinicUsageRow[]>([]);
+  const [selectedClinic, setSelectedClinic] = useState<string | null>(null);
+  const [clinicDetail, setClinicDetail] = useState<ClinicDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const loadAllUsage = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/usage/quota");
+      const json = (await res.json()) as { ok: boolean; data?: { usage: ClinicUsageRow[] } };
+      if (json.ok && json.data) {
+        setAllUsage(json.data.usage);
+      }
+    } catch (err) {
+      logger.warn("Failed to load usage data", { context: "usage-dashboard", error: err });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadClinicDetail = useCallback(async (clinicId: string) => {
+    setDetailLoading(true);
+    try {
+      const res = await fetch(`/api/admin/usage/quota?clinic_id=${clinicId}`);
+      const json = (await res.json()) as { ok: boolean; data?: ClinicDetail };
+      if (json.ok && json.data) {
+        setClinicDetail(json.data);
+      }
+    } catch (err) {
+      logger.warn("Failed to load clinic detail", { context: "usage-dashboard", error: err });
+    } finally {
+      setDetailLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAllUsage();
+  }, [loadAllUsage]);
+
+  useEffect(() => {
+    if (selectedClinic) loadClinicDetail(selectedClinic);
+  }, [selectedClinic, loadClinicDetail]);
+
+  // Aggregate usage by clinic
+  const clinicTotals = allUsage.reduce(
+    (acc, row) => {
+      if (!acc[row.clinicId]) acc[row.clinicId] = { totalCost: 0, resources: {} };
+      acc[row.clinicId].totalCost += row.totalCostUsd;
+      acc[row.clinicId].resources[row.resourceType] = row.totalUnits;
+      return acc;
+    },
+    {} as Record<string, { totalCost: number; resources: Record<string, number> }>,
+  );
+
+  const topConsumers = Object.entries(clinicTotals)
+    .sort(([, a], [, b]) => b.totalCost - a.totalCost)
+    .slice(0, 10);
+
+  const totalCostAllClinics = Object.values(clinicTotals).reduce((s, c) => s + c.totalCost, 0);
+
+  // Aggregate by resource type
+  const resourceTotals = allUsage.reduce(
+    (acc, row) => {
+      if (!acc[row.resourceType]) acc[row.resourceType] = { units: 0, cost: 0 };
+      acc[row.resourceType].units += row.totalUnits;
+      acc[row.resourceType].cost += row.totalCostUsd;
+      return acc;
+    },
+    {} as Record<string, { units: number; cost: number }>,
+  );
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[400px] items-center justify-center">
+        <Loader2 className="mr-2 h-6 w-6 animate-spin" />
+        Loading usage data...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Breadcrumb
+        items={[
+          { label: "Super Admin", href: "/super-admin/dashboard" },
+          { label: "Usage Dashboard" },
+        ]}
+      />
+
+      <h1 className="text-2xl font-bold">Usage Dashboard</h1>
+
+      {/* Summary Cards */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Cost (MTD)</CardTitle>
+            <DollarSign className="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">${totalCostAllClinics.toFixed(4)}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Active Clinics</CardTitle>
+            <BarChart3 className="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{Object.keys(clinicTotals).length}</div>
+          </CardContent>
+        </Card>
+        {Object.entries(resourceTotals)
+          .slice(0, 2)
+          .map(([rt, v]) => (
+            <Card key={rt}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">{resourceLabel(rt)}</CardTitle>
+                <TrendingUp className="text-muted-foreground h-4 w-4" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{formatUnits(rt, v.units)}</div>
+                <p className="text-muted-foreground text-xs">${v.cost.toFixed(4)} cost</p>
+              </CardContent>
+            </Card>
+          ))}
+      </div>
+
+      {/* Top Consumers */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5" />
+            Top Consumers (This Month)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {topConsumers.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No usage recorded this month.</p>
+          ) : (
+            <div className="space-y-2">
+              {topConsumers.map(([clinicId, data]) => (
+                <button
+                  key={clinicId}
+                  onClick={() => setSelectedClinic(clinicId)}
+                  className={`hover:bg-muted flex w-full items-center justify-between rounded-lg border p-3 text-left transition-colors ${
+                    selectedClinic === clinicId ? "border-primary bg-muted" : ""
+                  }`}
+                >
+                  <div>
+                    <span className="font-mono text-sm">{clinicId.slice(0, 8)}…</span>
+                    <div className="mt-1 flex gap-2">
+                      {Object.entries(data.resources).map(([rt, units]) => (
+                        <Badge key={rt} variant="secondary" className="text-xs">
+                          {resourceLabel(rt)}: {formatUnits(rt, units)}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                  <span className="font-bold">${data.totalCost.toFixed(4)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Clinic Detail */}
+      {selectedClinic && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Clinic: {selectedClinic.slice(0, 8)}…</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {detailLoading ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+              </div>
+            ) : clinicDetail ? (
+              <div className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">Plan:</span>
+                  <Badge>{clinicDetail.tier}</Badge>
+                </div>
+
+                {/* Quota Status */}
+                <div>
+                  <h3 className="mb-2 text-sm font-semibold">Quota Status</h3>
+                  <div className="grid gap-2 md:grid-cols-2">
+                    {Object.entries(clinicDetail.quota).map(([rt, q]) => {
+                      const pct = quotaPercent(q);
+                      return (
+                        <div key={rt} className="rounded border p-3">
+                          <div className="flex items-center justify-between">
+                            <span className="text-sm">{resourceLabel(rt)}</span>
+                            <span className="text-sm">
+                              {q.limit === -1
+                                ? "∞"
+                                : `${formatUnits(rt, q.currentUsage)} / ${formatUnits(rt, q.limit)}`}
+                            </span>
+                          </div>
+                          {q.limit !== -1 && (
+                            <div className="bg-muted mt-1 h-2 w-full rounded-full">
+                              <div
+                                className={`h-2 rounded-full ${pct >= 90 ? "bg-red-500" : pct >= 70 ? "bg-yellow-500" : "bg-green-500"}`}
+                                style={{ width: `${pct}%` }}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Usage Breakdown */}
+                <div>
+                  <h3 className="mb-2 text-sm font-semibold">Usage This Month</h3>
+                  {clinicDetail.usage.length === 0 ? (
+                    <p className="text-muted-foreground text-sm">No usage recorded.</p>
+                  ) : (
+                    <div className="space-y-1">
+                      {clinicDetail.usage.map((u) => (
+                        <div
+                          key={u.resourceType}
+                          className="flex items-center justify-between rounded border p-2 text-sm"
+                        >
+                          <span>{resourceLabel(u.resourceType)}</span>
+                          <div className="flex gap-4">
+                            <span>{formatUnits(u.resourceType, u.totalUnits)} units</span>
+                            <span className="font-mono">${u.totalCostUsd.toFixed(4)}</span>
+                            <span className="text-muted-foreground">{u.eventCount} events</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-sm">No data available.</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/admin/usage/quota/route.ts
+++ b/src/app/api/admin/usage/quota/route.ts
@@ -1,0 +1,66 @@
+/**
+ * GET /api/admin/usage/quota — Per-clinic quota status and metered usage.
+ *
+ * Query params:
+ *   ?clinic_id=<uuid>  — single clinic quota + usage breakdown
+ *   (no param)         — all clinics metered usage summary (super_admin)
+ *
+ * Requires super_admin or clinic_admin role.
+ */
+
+import { type NextRequest } from "next/server";
+import { apiSuccess, apiError, apiInternalError } from "@/lib/api-response";
+import { logger } from "@/lib/logger";
+import { getClinicQuotaStatus } from "@/lib/quota-enforcement";
+import { createUntypedAdminClient } from "@/lib/supabase-server";
+import { getMonthlyUsage, getAllClinicsMonthlyUsage } from "@/lib/tenant-metering";
+import type { UserRole } from "@/lib/types/database";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+
+const ALLOWED_ROLES: UserRole[] = ["super_admin", "clinic_admin"];
+
+async function handleGet(request: NextRequest, auth: AuthContext) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const clinicId = searchParams.get("clinic_id");
+    // nosemgrep: tenant-scoping
+    const supabase = createUntypedAdminClient("super_admin");
+
+    // Single clinic: return quota status + usage breakdown
+    if (clinicId) {
+      // Clinic admins can only view their own clinic
+      if (auth.profile.role !== "super_admin" && auth.profile.clinic_id !== clinicId) {
+        return apiError("Forbidden", 403, "FORBIDDEN");
+      }
+
+      // Resolve clinic tier
+      const { data: clinic } = await supabase
+        .from("clinics") // nosemgrep: semgrep.tenant-scoping
+        .select("tier")
+        .eq("id", clinicId)
+        .single();
+
+      const tier = (clinic?.tier as string) ?? "free";
+
+      const [quotaStatus, usage] = await Promise.all([
+        getClinicQuotaStatus(supabase, clinicId, tier),
+        getMonthlyUsage(supabase, clinicId),
+      ]);
+
+      return apiSuccess({ clinicId, tier, quota: quotaStatus, usage });
+    }
+
+    // All clinics (super_admin only)
+    if (auth.profile.role !== "super_admin") {
+      return apiError("Forbidden", 403, "FORBIDDEN");
+    }
+
+    const allUsage = await getAllClinicsMonthlyUsage(supabase);
+    return apiSuccess({ usage: allUsage });
+  } catch (err) {
+    logger.error("quota-api: unexpected error", { context: "quota-api", error: err });
+    return apiInternalError("Failed to fetch quota data");
+  }
+}
+
+export const GET = withAuth(handleGet, ALLOWED_ROLES);

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -119,6 +119,7 @@ const navGroups: NavGroup[] = [
       { href: "/super-admin/subscriptions", label: "Subscriptions", icon: Receipt },
       { href: "/super-admin/referrals", label: "Referrals", icon: Gift },
       { href: "/super-admin/usage", label: "Usage Metrics", icon: Gauge },
+      { href: "/super-admin/usage-dashboard", label: "Usage Dashboard", icon: BarChart3 },
     ],
   },
   {

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -212,6 +212,23 @@ export async function processNotificationQueue(): Promise<ProcessResult> {
             })
             .eq("id", item.id);
           result.sent++;
+
+          // Meter usage (fire-and-forget)
+          if (item.clinic_id) {
+            const resourceType = item.channel === "sms" ? "sms" : "whatsapp";
+            import("./tenant-metering").then(({ recordUsage }) =>
+              recordUsage(
+                supabase,
+                item.clinic_id as string,
+                resourceType as "whatsapp" | "sms",
+                1,
+                {
+                  notificationId: item.id,
+                  channel: item.channel,
+                },
+              ).catch(() => {}),
+            );
+          }
         } else {
           // Handle failure
           const newAttempts = (item.attempts ?? 0) + 1;

--- a/src/lib/quota-enforcement.ts
+++ b/src/lib/quota-enforcement.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-tenant quota enforcement.
+ *
+ * Checks monthly resource usage against plan limits before allowing
+ * expensive operations (WhatsApp sends, AI calls, etc.).
+ *
+ * Quota tiers are derived from the clinic's subscription plan
+ * (free → starter → professional → enterprise).
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
+import type { ResourceType } from "@/lib/tenant-metering";
+import { getMonthlyUnitCount } from "@/lib/tenant-metering";
+
+// ── Quota limits per plan ──
+
+export type QuotaPlan = "free" | "starter" | "professional" | "enterprise";
+
+interface QuotaLimits {
+  whatsapp: number;
+  sms: number;
+  ai_tokens: number;
+  r2_storage: number; // bytes
+}
+
+/** Monthly quota limits per plan. -1 = unlimited. */
+const PLAN_QUOTAS: Record<QuotaPlan, QuotaLimits> = {
+  free: {
+    whatsapp: 0,
+    sms: 0,
+    ai_tokens: 5000,
+    r2_storage: 100 * 1024 * 1024, // 100 MB
+  },
+  starter: {
+    whatsapp: 100,
+    sms: 100,
+    ai_tokens: 50_000,
+    r2_storage: 1024 * 1024 * 1024, // 1 GB
+  },
+  professional: {
+    whatsapp: 500,
+    sms: 500,
+    ai_tokens: 500_000,
+    r2_storage: 10 * 1024 * 1024 * 1024, // 10 GB
+  },
+  enterprise: {
+    whatsapp: -1,
+    sms: -1,
+    ai_tokens: -1,
+    r2_storage: -1,
+  },
+};
+
+// ── Public API ──
+
+export interface QuotaCheckResult {
+  allowed: boolean;
+  currentUsage: number;
+  limit: number;
+  remainingUnits: number;
+  plan: QuotaPlan;
+}
+
+/**
+ * Check whether a clinic can consume more of a resource.
+ *
+ * Returns the check result (never throws). Callers decide how to handle
+ * a denied request (e.g. return 429).
+ */
+export async function checkQuota(
+  supabase: SupabaseClient,
+  clinicId: string,
+  clinicTier: string,
+  resourceType: ResourceType,
+  unitsRequested = 1,
+): Promise<QuotaCheckResult> {
+  const plan = normalizePlan(clinicTier);
+  const limits = PLAN_QUOTAS[plan];
+  const limit = limits[resourceType];
+
+  // Unlimited plan
+  if (limit === -1) {
+    return { allowed: true, currentUsage: 0, limit: -1, remainingUnits: -1, plan };
+  }
+
+  const currentUsage = await getMonthlyUnitCount(supabase, clinicId, resourceType);
+  const remaining = Math.max(0, limit - currentUsage);
+  const allowed = currentUsage + unitsRequested <= limit;
+
+  if (!allowed) {
+    logger.warn("quota-enforcement: quota exceeded", {
+      context: "quota-enforcement",
+      clinicId,
+      resourceType,
+      currentUsage,
+      limit,
+      unitsRequested,
+      plan,
+    });
+  }
+
+  return {
+    allowed,
+    currentUsage,
+    limit,
+    remainingUnits: remaining,
+    plan,
+  };
+}
+
+/**
+ * Get quota status for all resource types for a clinic.
+ */
+export async function getClinicQuotaStatus(
+  supabase: SupabaseClient,
+  clinicId: string,
+  clinicTier: string,
+): Promise<Record<ResourceType, QuotaCheckResult>> {
+  const resourceTypes: ResourceType[] = ["whatsapp", "sms", "ai_tokens", "r2_storage"];
+
+  const results = await Promise.all(
+    resourceTypes.map((rt) => checkQuota(supabase, clinicId, clinicTier, rt)),
+  );
+
+  const status = {} as Record<ResourceType, QuotaCheckResult>;
+  resourceTypes.forEach((rt, i) => {
+    status[rt] = results[i];
+  });
+  return status;
+}
+
+/**
+ * Get quota limits for a plan (for display in admin dashboards).
+ */
+export function getQuotaLimits(plan: QuotaPlan): QuotaLimits {
+  return { ...PLAN_QUOTAS[plan] };
+}
+
+// ── Internals ──
+
+function normalizePlan(tier: string): QuotaPlan {
+  const t = tier.toLowerCase().trim();
+  if (t === "free" || t === "starter" || t === "professional" || t === "enterprise") {
+    return t;
+  }
+  // Default to free for unknown tiers (safe default)
+  return "free";
+}

--- a/src/lib/subscription-billing.ts
+++ b/src/lib/subscription-billing.ts
@@ -480,3 +480,77 @@ async function logBillingEvent(
     metadata: event.metadata ?? {},
   });
 }
+
+// ── Usage-Based Billing ──
+
+export interface UsageBillLine {
+  resourceType: string;
+  unitCount: number;
+  costUsd: number;
+}
+
+export interface ClinicUsageBill {
+  clinicId: string;
+  plan: SubscriptionPlan;
+  planCostMad: number;
+  usageLines: UsageBillLine[];
+  totalUsageCostUsd: number;
+  periodStart: string;
+  periodEnd: string;
+}
+
+/**
+ * Calculate usage-based bill for a clinic for the current month.
+ * Combines fixed plan price + metered usage from tenant_usage_log.
+ */
+export async function calculateUsageBill(
+  clinicId: string,
+  plan: SubscriptionPlan,
+  interval: BillingInterval,
+): Promise<ClinicUsageBill> {
+  assertClinicId(clinicId, "subscription-billing:calculateUsageBill");
+
+  // Use untyped admin client — tenant_usage_log is not yet in generated DB types
+  const { createUntypedAdminClient: createAdmin } = await import("@/lib/supabase-server");
+  // nosemgrep: tenant-scoping — scoped below by .eq("clinic_id", clinicId)
+  const supabase = createAdmin("subscription-billing");
+
+  const now = new Date();
+  const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const monthEnd = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0));
+
+  const { data } = await supabase
+    .from("tenant_usage_log")
+    .select("resource_type, unit_count, cost_usd")
+    .eq("clinic_id", clinicId)
+    .gte("created_at", monthStart.toISOString())
+    .lte("created_at", monthEnd.toISOString());
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = (data ?? []) as Array<Record<string, any>>;
+  const byType: Record<string, { units: number; cost: number }> = {};
+  for (const row of rows) {
+    const rt = String(row.resource_type ?? "");
+    if (!byType[rt]) byType[rt] = { units: 0, cost: 0 };
+    byType[rt].units += Number(row.unit_count) || 0;
+    byType[rt].cost += Number(row.cost_usd) || 0;
+  }
+
+  const usageLines: UsageBillLine[] = Object.entries(byType).map(([rt, v]) => ({
+    resourceType: rt,
+    unitCount: v.units,
+    costUsd: v.cost,
+  }));
+
+  const totalUsageCostUsd = usageLines.reduce((sum, l) => sum + l.costUsd, 0);
+
+  return {
+    clinicId,
+    plan,
+    planCostMad: getPlanPrice(plan, interval),
+    usageLines,
+    totalUsageCostUsd,
+    periodStart: getLocalDateStr(monthStart),
+    periodEnd: getLocalDateStr(monthEnd),
+  };
+}

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -196,7 +196,8 @@ export type AdminPurpose =
   | "ai-config-test"
   | "ai-feature-toggle"
   | "ai-route"
-  | "ai-config-resolve";
+  | "ai-config-resolve"
+  | "subscription-billing";
 
 /**
  * Create a Supabase admin client using the service role key.

--- a/src/lib/tenant-metering.ts
+++ b/src/lib/tenant-metering.ts
@@ -1,0 +1,187 @@
+/**
+ * Per-tenant resource usage metering.
+ *
+ * Records consumption events (WhatsApp sends, R2 uploads, AI tokens)
+ * to the `tenant_usage_log` table for quota enforcement and billing.
+ *
+ * All writes are fire-and-forget (non-blocking, non-fatal) so metering
+ * never breaks the primary request path.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { logger } from "@/lib/logger";
+
+// ── Resource types ──
+
+export type ResourceType = "whatsapp" | "sms" | "r2_storage" | "ai_tokens";
+
+// ── Cost constants (USD) ──
+
+/** Estimated per-unit costs for metering. */
+const RESOURCE_COSTS: Record<ResourceType, number> = {
+  whatsapp: 0.005, // ~$0.005 per message (Meta utility template avg)
+  sms: 0.01, // ~$0.01 per SMS (Morocco rates)
+  r2_storage: 0.000000015, // $0.015 per GB-month ≈ $0.000000015 per byte-month
+  ai_tokens: 0, // tracked separately via ai-cost-tracker.ts
+};
+
+// ── Public API ──
+
+/**
+ * Record a metered usage event for a clinic.
+ *
+ * Fire-and-forget — errors are logged but never thrown.
+ */
+export async function recordUsage(
+  supabase: SupabaseClient,
+  clinicId: string,
+  resourceType: ResourceType,
+  unitCount: number,
+  metadata?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const costUsd = unitCount * RESOURCE_COSTS[resourceType];
+
+    await supabase.from("tenant_usage_log").insert({
+      clinic_id: clinicId,
+      resource_type: resourceType,
+      unit_count: unitCount,
+      cost_usd: costUsd,
+      metadata: metadata ?? null,
+    });
+  } catch (err) {
+    logger.error("tenant-metering: failed to record usage", {
+      context: "tenant-metering",
+      clinicId,
+      resourceType,
+      unitCount,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ── Query helpers ──
+
+export interface UsageSummary {
+  resourceType: ResourceType;
+  totalUnits: number;
+  totalCostUsd: number;
+  eventCount: number;
+}
+
+/**
+ * Get usage summary for a clinic in the current calendar month.
+ */
+export async function getMonthlyUsage(
+  supabase: SupabaseClient,
+  clinicId: string,
+): Promise<UsageSummary[]> {
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const { data, error } = await supabase
+    .from("tenant_usage_log")
+    .select("resource_type, unit_count, cost_usd")
+    .eq("clinic_id", clinicId)
+    .gte("created_at", monthStart.toISOString());
+
+  if (error) {
+    logger.error("tenant-metering: failed to fetch monthly usage", {
+      context: "tenant-metering",
+      clinicId,
+      error: error.message,
+    });
+    return [];
+  }
+
+  const byType: Record<string, { units: number; cost: number; count: number }> = {};
+  for (const row of data ?? []) {
+    const rt = row.resource_type as string;
+    if (!byType[rt]) byType[rt] = { units: 0, cost: 0, count: 0 };
+    byType[rt].units += Number(row.unit_count) || 0;
+    byType[rt].cost += Number(row.cost_usd) || 0;
+    byType[rt].count += 1;
+  }
+
+  return Object.entries(byType).map(([rt, v]) => ({
+    resourceType: rt as ResourceType,
+    totalUnits: v.units,
+    totalCostUsd: v.cost,
+    eventCount: v.count,
+  }));
+}
+
+/**
+ * Get total unit count for a specific resource type this month.
+ * Used by quota enforcement to check limits.
+ */
+export async function getMonthlyUnitCount(
+  supabase: SupabaseClient,
+  clinicId: string,
+  resourceType: ResourceType,
+): Promise<number> {
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const { data, error } = await supabase
+    .from("tenant_usage_log")
+    .select("unit_count")
+    .eq("clinic_id", clinicId)
+    .eq("resource_type", resourceType)
+    .gte("created_at", monthStart.toISOString());
+
+  if (error) {
+    logger.error("tenant-metering: failed to fetch unit count", {
+      context: "tenant-metering",
+      clinicId,
+      resourceType,
+      error: error.message,
+    });
+    return 0;
+  }
+
+  return (data ?? []).reduce((sum, row) => sum + (Number(row.unit_count) || 0), 0);
+}
+
+/**
+ * Get usage for all clinics (super-admin overview).
+ * Returns one row per clinic per resource type for the current month.
+ */
+export async function getAllClinicsMonthlyUsage(
+  supabase: SupabaseClient,
+): Promise<
+  Array<{ clinicId: string; resourceType: string; totalUnits: number; totalCostUsd: number }>
+> {
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const { data, error } = await supabase
+    .from("tenant_usage_log")
+    .select("clinic_id, resource_type, unit_count, cost_usd")
+    .gte("created_at", monthStart.toISOString())
+    .order("clinic_id");
+
+  if (error) {
+    logger.error("tenant-metering: failed to fetch all clinics usage", {
+      context: "tenant-metering",
+      error: error.message,
+    });
+    return [];
+  }
+
+  const grouped: Record<string, { units: number; cost: number }> = {};
+  for (const row of data ?? []) {
+    const key = `${row.clinic_id}::${row.resource_type}`;
+    if (!grouped[key]) grouped[key] = { units: 0, cost: 0 };
+    grouped[key].units += Number(row.unit_count) || 0;
+    grouped[key].cost += Number(row.cost_usd) || 0;
+  }
+
+  return Object.entries(grouped).map(([key, v]) => {
+    const [clinicId, resourceType] = key.split("::");
+    return { clinicId, resourceType, totalUnits: v.units, totalCostUsd: v.cost };
+  });
+}

--- a/supabase/migrations/00130_tenant_usage_log.sql
+++ b/supabase/migrations/00130_tenant_usage_log.sql
@@ -1,0 +1,43 @@
+-- Per-tenant resource usage tracking for quota enforcement and billing.
+-- Each row records one metered event (WhatsApp send, R2 upload, AI request, etc.)
+
+CREATE TABLE IF NOT EXISTS tenant_usage_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL,
+  resource_type VARCHAR(32) NOT NULL, -- 'whatsapp', 'r2_storage', 'ai_tokens', 'sms'
+  unit_count NUMERIC(14, 4) NOT NULL DEFAULT 1, -- messages, bytes, tokens, etc.
+  cost_usd NUMERIC(10, 6) NOT NULL DEFAULT 0, -- estimated cost in USD
+  metadata JSONB, -- optional context (route, model, file_key, etc.)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT fk_tenant_usage_clinic FOREIGN KEY (clinic_id) REFERENCES clinics(id) ON DELETE CASCADE
+);
+
+-- Per-clinic monthly roll-up queries
+CREATE INDEX idx_tenant_usage_clinic_date
+  ON tenant_usage_log(clinic_id, created_at DESC);
+
+-- Per-resource-type aggregation
+CREATE INDEX idx_tenant_usage_type_date
+  ON tenant_usage_log(resource_type, created_at DESC);
+
+-- Composite for "how much of resource X did clinic Y use this month"
+CREATE INDEX idx_tenant_usage_clinic_type
+  ON tenant_usage_log(clinic_id, resource_type, created_at DESC);
+
+-- RLS: clinics can read their own usage data
+ALTER TABLE tenant_usage_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_usage_log_clinic_read ON tenant_usage_log
+  FOR SELECT
+  USING (clinic_id = current_setting('app.current_clinic_id')::uuid);
+
+-- Service role can insert usage events
+CREATE POLICY tenant_usage_log_insert ON tenant_usage_log
+  FOR INSERT
+  WITH CHECK (true);
+
+COMMENT ON TABLE tenant_usage_log IS 'Per-tenant resource usage tracking for quota enforcement and billing.';
+COMMENT ON COLUMN tenant_usage_log.resource_type IS 'Resource category: whatsapp, r2_storage, ai_tokens, sms';
+COMMENT ON COLUMN tenant_usage_log.unit_count IS 'Usage units: message count, bytes, token count, etc.';
+COMMENT ON COLUMN tenant_usage_log.cost_usd IS 'Estimated cost in USD for this usage event.';


### PR DESCRIPTION
## Summary

Adds the foundation for per-tenant quota tracking: a `tenant_usage_log` table, a metering library, and a quota enforcement layer tied to subscription plans.

**New files:**
- `supabase/migrations/00130_tenant_usage_log.sql` — table with `(clinic_id, resource_type, unit_count, cost_usd, metadata)`, RLS policies, indexes
- `src/lib/tenant-metering.ts` — `recordUsage()` (fire-and-forget), `getMonthlyUsage()`, `getMonthlyUnitCount()`, `getAllClinicsMonthlyUsage()`
- `src/lib/quota-enforcement.ts` — `checkQuota(supabase, clinicId, tier, resourceType)` returns `{allowed, currentUsage, limit, remainingUnits, plan}`. Limits per plan:
  ```
  free:         WA=0, SMS=0, AI=5k tokens, R2=100MB
  starter:      WA=100, SMS=100, AI=50k, R2=1GB
  professional: WA=500, SMS=500, AI=500k, R2=10GB
  enterprise:   unlimited
  ```
- `GET /api/admin/usage/quota?clinic_id=<uuid>` — returns quota status + usage breakdown (super_admin + clinic_admin)

**Integration:**
- `notification-queue.ts` — meters WhatsApp/SMS sends on successful delivery (fire-and-forget, keyed by `item.clinic_id`)