### PR TITLE
fix(security): add AI kill switch to all routes (F-AI-01)

### DIFF
--- a/src/app/api/ai/drug-interactions/route.ts
+++ b/src/app/api/ai/drug-interactions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { routeAIRequest, loadProviderConfigs } from "@/lib/ai/router";
 import type { AIRequest } from "@/lib/ai/types";
 import { apiSuccess, apiError, apiInternalError, apiValidationError } from "@/lib/api-response";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
 import { withAuth } from "@/lib/with-auth";
@@ -23,6 +24,11 @@ import type { AuthContext } from "@/lib/with-auth";
  *   language?: "fr" | "ar" (default: "fr")
  */
 async function handler(req: NextRequest, auth: AuthContext) {
+  // F-AI-01: Early kill switch — fail fast before processing
+  if (!(await isAIEnabled())) {
+    return apiError("AI features are disabled", 503, "AI_DISABLED");
+  }
+
   const clinicId = auth.profile.clinic_id;
   if (!clinicId) {
     return apiError("Clinic context required", 400);

--- a/src/app/api/ai/lab-preread/route.ts
+++ b/src/app/api/ai/lab-preread/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { routeAIRequest, loadProviderConfigs } from "@/lib/ai/router";
 import type { AIRequest } from "@/lib/ai/types";
 import { apiSuccess, apiError, apiInternalError, apiValidationError } from "@/lib/api-response";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
 import { withAuth } from "@/lib/with-auth";
@@ -20,6 +21,11 @@ import type { AuthContext } from "@/lib/with-auth";
  *   language?: "fr" | "ar" (default: "fr")
  */
 async function handler(req: NextRequest, auth: AuthContext) {
+  // F-AI-01: Early kill switch — fail fast before processing
+  if (!(await isAIEnabled())) {
+    return apiError("AI features are disabled", 503, "AI_DISABLED");
+  }
+
   const clinicId = auth.profile.clinic_id;
   if (!clinicId) {
     return apiError("Clinic context required", 400);

--- a/src/app/api/ai/referral-letter/route.ts
+++ b/src/app/api/ai/referral-letter/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { routeAIRequest, loadProviderConfigs } from "@/lib/ai/router";
 import type { AIRequest } from "@/lib/ai/types";
 import { apiSuccess, apiError, apiInternalError, apiValidationError } from "@/lib/api-response";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
 import { withAuth } from "@/lib/with-auth";
@@ -26,6 +27,11 @@ import type { AuthContext } from "@/lib/with-auth";
  *   language?: "fr" | "ar" (default: "fr")
  */
 async function handler(req: NextRequest, auth: AuthContext) {
+  // F-AI-01: Early kill switch — fail fast before processing
+  if (!(await isAIEnabled())) {
+    return apiError("AI features are disabled", 503, "AI_DISABLED");
+  }
+
   const clinicId = auth.profile.clinic_id;
   if (!clinicId) {
     return apiError("Clinic context required", 400);

--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -21,6 +21,7 @@ import { isAIFeatureEnabled, loadFeatureToggles } from "@/lib/ai/feature-toggles
 import { routeAIRequest, loadProviderConfigs, AllProvidersFailedError } from "@/lib/ai/router";
 import type { AIRequest, AITaskType, TaskComplexity, AIProvider } from "@/lib/ai/types";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
 import { withAuth } from "@/lib/with-auth";
@@ -40,6 +41,11 @@ const VALID_TASKS: AITaskType[] = [
 const VALID_COMPLEXITIES: TaskComplexity[] = ["simple", "medium", "complex", "critical"];
 
 async function handlePost(req: NextRequest, auth: AuthContext) {
+  // F-AI-01: Early kill switch — fail fast before processing
+  if (!(await isAIEnabled())) {
+    return apiError("AI features are disabled", 503, "AI_DISABLED");
+  }
+
   let body: Record<string, unknown>;
   try {
     body = (await req.json()) as Record<string, unknown>;

--- a/src/app/api/chat/stream/route.ts
+++ b/src/app/api/chat/stream/route.ts
@@ -12,6 +12,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createStreamingChatResponse } from "@/lib/ai/streaming-chat";
 import { apiError } from "@/lib/api-response";
 import { buildSystemPrompt, fetchChatbotContext } from "@/lib/chatbot-data";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { requireTenant } from "@/lib/tenant";
 import { withAuth, type AuthContext } from "@/lib/with-auth";
@@ -24,9 +25,9 @@ const MAX_MESSAGE_LENGTH = 2000;
 
 export const POST = withAuth(
   async (request: NextRequest, _auth: AuthContext) => {
-    // AI kill switch
-    if (process.env.AI_DISABLED === "true") {
-      return apiError("Les fonctionnalités IA sont temporairement désactivées", 503, "AI_DISABLED");
+    // F-AI-01: Early kill switch (checks both env var AND KV flag)
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
     }
 
     const tenant = await requireTenant();

--- a/src/app/api/v1/ai/drug-interaction-alerts/route.ts
+++ b/src/app/api/v1/ai/drug-interaction-alerts/route.ts
@@ -18,6 +18,7 @@ import { apiSuccess, apiError, apiRateLimited } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { checkAllInteractions, type InteractionAlert } from "@/lib/check-interactions";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { aiDrugCheckLimiter, aiClinicCeilingLimiter } from "@/lib/rate-limit";
 import type { PatientMetadata } from "@/lib/types/patient-metadata";
@@ -155,6 +156,11 @@ Tous les médicaments: ${allMeds.map(sanitizeUntrustedText).join(", ")}`;
 export const POST = withAuthValidation(
   aiDrugInteractionCheckRequestSchema,
   async (data, _request: NextRequest, auth: AuthContext) => {
+    // F-AI-01: Early kill switch — fail fast before processing
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const doctorId = profile.id;

--- a/src/app/api/v1/ai/smart-prescription/route.ts
+++ b/src/app/api/v1/ai/smart-prescription/route.ts
@@ -21,6 +21,7 @@ import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/ap
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
 import { DCI_DRUG_DATABASE, CATEGORY_LABELS } from "@/lib/dci-drug-database";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { aiSmartPrescriptionLimiter, aiClinicCeilingLimiter } from "@/lib/rate-limit";
 import type { PatientMetadata } from "@/lib/types/patient-metadata";
@@ -165,6 +166,11 @@ function parseSmartPrescriptionResponse(content: string): SmartPrescriptionResul
 export const POST = withAuthValidation(
   aiSmartPrescriptionRequestSchema,
   async (data, _request: NextRequest, auth: AuthContext) => {
+    // F-AI-01: Early kill switch — fail fast before processing
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const doctorId = profile.id;

--- a/src/app/api/v1/ai/voice-notes/route.ts
+++ b/src/app/api/v1/ai/voice-notes/route.ts
@@ -20,6 +20,7 @@ import { getAIDisclaimer } from "@/lib/ai-disclaimer";
 import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logAuditEvent } from "@/lib/audit-log";
+import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { aiVoiceNoteLimiter, aiClinicCeilingLimiter } from "@/lib/rate-limit";
 import type { PatientMetadata } from "@/lib/types/patient-metadata";
@@ -100,6 +101,11 @@ function parseSoapResponse(content: string): SoapNote | null {
 export const POST = withAuthValidation(
   aiVoiceNoteRequestSchema,
   async (data, _request: NextRequest, auth: AuthContext) => {
+    // F-AI-01: Early kill switch — fail fast before processing
+    if (!(await isAIEnabled())) {
+      return apiError("AI features are disabled", 503, "AI_DISABLED");
+    }
+
     const { profile, supabase } = auth;
     const clinicId = profile.clinic_id;
     const doctorId = profile.id;


### PR DESCRIPTION
## Summary

Adds isAIEnabled() early kill switch check to **8 AI routes** that were missing it.

**Routes that used routeAIRequest() directly** (bypassed the kill switch entirely):
- api/ai/route.ts
- api/ai/drug-interactions
- api/ai/lab-preread
- api/ai/referral-letter

**Routes using resolveAIConfig() without early guard:**
- api/v1/ai/drug-interaction-alerts
- api/v1/ai/smart-prescription
- api/v1/ai/voice-notes

**Upgraded from old-style check:**
- api/chat/stream — replaced process.env.AI_DISABLED with isAIEnabled()

46 insertions, 3 deletions across 8 files.