### PR TITLE
feat: Phase 1 performance — DB indexes, KV cache layer, CDN headers

### DIFF
--- a/src/lib/cache/cache-keys.ts
+++ b/src/lib/cache/cache-keys.ts
@@ -1,0 +1,33 @@
+/**
+ * Centralised cache key definitions.
+ *
+ * All keys are prefixed with the resource type for easy bulk invalidation.
+ * TTLs are in seconds.
+ */
+
+export const CACHE_TTL = {
+  /** Clinic configuration (timezone, working hours, slot duration). */
+  CLINIC_CONFIG: 300, // 5 minutes
+  /** Feature flag overrides per clinic. */
+  FEATURE_FLAGS: 300, // 5 minutes
+  /** AI provider availability status. */
+  AI_STATUS: 60, // 1 minute
+  /** User session profile (role, clinic association). */
+  USER_SESSION: 600, // 10 minutes
+} as const;
+
+export function clinicConfigKey(clinicId: string): string {
+  return `clinic:config:${clinicId}`;
+}
+
+export function featureFlagsKey(clinicId: string): string {
+  return `clinic:flags:${clinicId}`;
+}
+
+export function aiStatusKey(): string {
+  return `system:ai_status`;
+}
+
+export function userSessionKey(userId: string): string {
+  return `user:session:${userId}`;
+}

--- a/src/lib/cache/cdn-headers.ts
+++ b/src/lib/cache/cdn-headers.ts
@@ -1,0 +1,54 @@
+/**
+ * CDN cache header utilities for R2-served assets.
+ *
+ * Cloudflare automatically caches responses based on Cache-Control headers.
+ * This module provides standard header configurations for different asset types.
+ *
+ * Usage in API routes serving R2 files:
+ *   const headers = getCDNHeaders("medical-image");
+ *   return new Response(body, { headers });
+ */
+
+type AssetCategory = "medical-image" | "document" | "clinic-logo" | "phi-file" | "static-asset";
+
+const CACHE_PROFILES: Record<AssetCategory, string> = {
+  /** Medical images (X-rays, scans): cached 1 hour, must revalidate. */
+  "medical-image": "public, max-age=3600, must-revalidate",
+  /** Documents (PDFs, reports): cached 24 hours, stale while revalidate. */
+  document: "public, max-age=86400, stale-while-revalidate=3600",
+  /** Clinic logos/branding: cached 7 days. */
+  "clinic-logo": "public, max-age=604800, stale-while-revalidate=86400",
+  /** PHI files: never cache publicly, only private browser cache. */
+  "phi-file": "private, no-store, no-cache",
+  /** Static assets (JS, CSS, fonts): immutable, cached 1 year. */
+  "static-asset": "public, max-age=31536000, immutable",
+};
+
+/**
+ * Get appropriate Cache-Control headers for an asset category.
+ */
+export function getCDNHeaders(category: AssetCategory): Headers {
+  const headers = new Headers();
+  headers.set("Cache-Control", CACHE_PROFILES[category]);
+
+  // Add Vary header for content-type negotiation.
+  headers.set("Vary", "Accept-Encoding");
+
+  // Security headers for all responses.
+  headers.set("X-Content-Type-Options", "nosniff");
+
+  return headers;
+}
+
+/**
+ * Determine asset category from MIME type.
+ */
+export function categorizeAsset(mimeType: string): AssetCategory {
+  if (mimeType.startsWith("image/")) return "medical-image";
+  if (mimeType === "application/pdf") return "document";
+  if (mimeType.startsWith("text/") || mimeType.includes("javascript") || mimeType.includes("css")) {
+    return "static-asset";
+  }
+  // Default to PHI-safe (no cache) for unknown types.
+  return "phi-file";
+}

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,0 +1,15 @@
+export { kvCache } from "./kv-cache";
+export {
+  CACHE_TTL,
+  clinicConfigKey,
+  featureFlagsKey,
+  aiStatusKey,
+  userSessionKey,
+} from "./cache-keys";
+export {
+  invalidateClinicConfig,
+  invalidateFeatureFlags,
+  invalidateUserSession,
+  invalidateAIStatus,
+} from "./invalidation";
+export { getCDNHeaders, categorizeAsset } from "./cdn-headers";

--- a/src/lib/cache/invalidation.ts
+++ b/src/lib/cache/invalidation.ts
@@ -1,0 +1,41 @@
+/**
+ * Cache invalidation helpers.
+ *
+ * Call these after mutations that affect cached data to ensure consistency.
+ * Each invalidation targets specific cache keys rather than flushing everything.
+ */
+
+import { clinicConfigKey, featureFlagsKey, userSessionKey, aiStatusKey } from "./cache-keys";
+import { kvCache } from "./kv-cache";
+
+/**
+ * Invalidate clinic configuration cache.
+ * Call after updating clinic settings (timezone, working hours, etc.).
+ */
+export async function invalidateClinicConfig(clinicId: string): Promise<void> {
+  await kvCache.invalidate(clinicConfigKey(clinicId));
+}
+
+/**
+ * Invalidate feature flags cache for a clinic.
+ * Call after toggling features or updating per-clinic overrides.
+ */
+export async function invalidateFeatureFlags(clinicId: string): Promise<void> {
+  await kvCache.invalidate(featureFlagsKey(clinicId));
+}
+
+/**
+ * Invalidate user session cache.
+ * Call after role changes, clinic reassignment, or logout.
+ */
+export async function invalidateUserSession(userId: string): Promise<void> {
+  await kvCache.invalidate(userSessionKey(userId));
+}
+
+/**
+ * Invalidate AI provider status cache.
+ * Call after AI provider health check changes.
+ */
+export async function invalidateAIStatus(): Promise<void> {
+  await kvCache.invalidate(aiStatusKey());
+}

--- a/src/lib/cache/kv-cache.ts
+++ b/src/lib/cache/kv-cache.ts
@@ -1,0 +1,113 @@
+/**
+ * Application-level KV cache for frequently accessed read-heavy data.
+ *
+ * Uses Cloudflare KV (APP_CACHE_KV binding) with automatic fallback to an
+ * in-memory LRU for development and test environments.
+ *
+ * Usage:
+ *   const config = await kvCache.get<ClinicConfig>(clinicConfigKey(id));
+ *   if (!config) {
+ *     const fresh = await fetchClinicConfig(id);
+ *     await kvCache.set(clinicConfigKey(id), fresh, CACHE_TTL.CLINIC_CONFIG);
+ *   }
+ */
+
+import { getWorkerBinding } from "@/lib/cf-bindings";
+import { logger } from "@/lib/logger";
+
+interface KVLike {
+  get(key: string, options?: { type: "text" }): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+// In-memory fallback for dev/test (evicts LRU after 500 entries).
+const memStore = new Map<string, { value: string; expiresAt: number }>();
+const MAX_MEM_ENTRIES = 500;
+
+function evictIfNeeded(): void {
+  if (memStore.size <= MAX_MEM_ENTRIES) return;
+  // Evict oldest entries.
+  const entries = [...memStore.entries()].sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+  const toRemove = entries.slice(0, entries.length - MAX_MEM_ENTRIES);
+  for (const [key] of toRemove) memStore.delete(key);
+}
+
+const memKV: KVLike = {
+  async get(key) {
+    const entry = memStore.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      memStore.delete(key);
+      return null;
+    }
+    return entry.value;
+  },
+  async put(key, value, options) {
+    const ttl = options?.expirationTtl ?? 300;
+    memStore.set(key, { value, expiresAt: Date.now() + ttl * 1000 });
+    evictIfNeeded();
+  },
+  async delete(key) {
+    memStore.delete(key);
+  },
+};
+
+async function resolveKV(): Promise<KVLike> {
+  const kv = await getWorkerBinding<KVLike>("APP_CACHE_KV");
+  return kv ?? memKV;
+}
+
+export const kvCache = {
+  /**
+   * Get a cached value. Returns null on miss.
+   */
+  async get<T>(key: string): Promise<T | null> {
+    try {
+      const kv = await resolveKV();
+      const raw = await kv.get(key);
+      if (!raw) return null;
+      return JSON.parse(raw) as T;
+    } catch (err) {
+      logger.warn("Cache get failed", { key, error: err });
+      return null;
+    }
+  },
+
+  /**
+   * Store a value with TTL (seconds).
+   */
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    try {
+      const kv = await resolveKV();
+      await kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds });
+    } catch (err) {
+      logger.warn("Cache set failed", { key, error: err });
+    }
+  },
+
+  /**
+   * Invalidate a cached key.
+   */
+  async invalidate(key: string): Promise<void> {
+    try {
+      const kv = await resolveKV();
+      await kv.delete(key);
+    } catch (err) {
+      logger.warn("Cache invalidate failed", { key, error: err });
+    }
+  },
+
+  /**
+   * Invalidate all keys matching a prefix.
+   * Note: KV does not support prefix deletion natively. For production,
+   * callers should invalidate specific keys. This method is provided for
+   * local dev where the in-memory store supports iteration.
+   */
+  async invalidatePrefix(prefix: string): Promise<void> {
+    // Only works with in-memory store; KV requires listing.
+    for (const key of memStore.keys()) {
+      if (key.startsWith(prefix)) memStore.delete(key);
+    }
+  },
+};

--- a/supabase/migrations/00131_performance_indexes.sql
+++ b/supabase/migrations/00131_performance_indexes.sql
@@ -1,0 +1,38 @@
+-- Performance indexes for hot query paths.
+-- Targets: appointment scheduling, patient lookup, recent notes, audit queries.
+
+-- Appointments: clinic + status + slot_start covers scheduling queries.
+-- The existing idx_appointments_clinic_active only covers active statuses;
+-- this composite serves all status-filtered queries sorted by time.
+CREATE INDEX IF NOT EXISTS idx_appointments_clinic_status_slot
+  ON appointments (clinic_id, status, slot_start DESC);
+
+-- Appointments: upcoming appointments per doctor (dashboard widget).
+CREATE INDEX IF NOT EXISTS idx_appointments_doctor_upcoming
+  ON appointments (doctor_id, slot_start)
+  WHERE status IN ('pending', 'confirmed', 'checked_in');
+
+-- Users (patients): fast ILIKE patient search by name within a clinic.
+-- trigram GIN index supports ILIKE '%pattern%' queries.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX IF NOT EXISTS idx_users_name_trgm
+  ON users USING GIN (name gin_trgm_ops);
+
+-- Users: clinic + role for role-filtered queries (e.g. list patients).
+CREATE INDEX IF NOT EXISTS idx_users_clinic_role
+  ON users (clinic_id, role);
+
+-- Consultation notes: recent notes per clinic for dashboard.
+CREATE INDEX IF NOT EXISTS idx_consultation_notes_clinic_created
+  ON consultation_notes (clinic_id, created_at DESC);
+
+-- Activity logs (audit): clinic + timestamp for audit trail queries.
+-- Partial index excludes NULL clinic_id (system-level events).
+CREATE INDEX IF NOT EXISTS idx_activity_logs_clinic_timestamp
+  ON activity_logs (clinic_id, timestamp DESC)
+  WHERE clinic_id IS NOT NULL;
+
+-- Notification queue: dequeue performance (claim_notification_batch RPC).
+CREATE INDEX IF NOT EXISTS idx_notification_queue_dequeue
+  ON notification_queue (status, next_attempt_at ASC)
+  WHERE status IN ('pending', 'failed');

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -58,6 +58,15 @@ binding = "RATE_LIMIT_KV"
 id = "7ac37dff0a794542b0c766f38e73f105"
 preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
 
+# Application cache for clinic configs, feature flags, AI status.
+# Provision via:
+#   wrangler kv:namespace create APP_CACHE_KV
+#   wrangler kv:namespace create APP_CACHE_KV --preview
+[[kv_namespaces]]
+binding = "APP_CACHE_KV"
+id = "placeholder-provision-before-deploy"
+preview_id = "placeholder-provision-before-deploy"
+
 # ── Durable Objects ───────────────────────────────────────────────────
 # H-03 (DEFERRED): Strongly consistent rate limiting via a RateLimiterDO
 # Durable Object was scaffolded in src/lib/rate-limit-do.ts, but the
@@ -170,6 +179,11 @@ bucket_name = "webs-alots-uploads"
 binding = "RATE_LIMIT_KV"
 id = "7ac37dff0a794542b0c766f38e73f105"
 preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
+
+[[env.production.kv_namespaces]]
+binding = "APP_CACHE_KV"
+id = "placeholder-provision-before-deploy"
+preview_id = "placeholder-provision-before-deploy"
 
 # W8-A31-01: Routes (was missing — worker would not receive traffic)
 [[env.production.routes]]
@@ -297,6 +311,11 @@ binding = "RATE_LIMIT_KV"
 # Created via Cloudflare API (account 0dadac33…1ba4).
 id = "da3acaf35a2d448984a4a95e769bc393"          # RATE_LIMIT_KV_STAGING
 preview_id = "4965f9300c924de3afc0407679ff775b"  # RATE_LIMIT_KV_STAGING_preview
+
+[[env.staging.kv_namespaces]]
+binding = "APP_CACHE_KV"
+id = "placeholder-provision-before-deploy"
+preview_id = "placeholder-provision-before-deploy"
 
 # W8-A31-01: Routes for staging (uses staging subdomain)
 [[env.staging.routes]]


### PR DESCRIPTION
## Summary

Implements Phase 1 (Performance & Scalability) of the feature roadmap — DB indexes for hot query paths, application-level KV caching with in-memory fallback, and CDN cache header profiles.

**Database indexes** (`supabase/migrations/00131_performance_indexes.sql`):
- Composite indexes on `appointments(clinic_id, status, slot_start DESC)` and `(doctor_id, slot_start)` with partial filter
- GIN trigram index on `users(name)` for fuzzy patient search
- Composite on `consultation_notes(clinic_id, created_at DESC)` and `activity_logs` (partial)
- Dequeue index on `notification_queue(status, next_attempt_at)`

**KV cache layer** (`src/lib/cache/`):
- `kv-cache.ts`: `get<T>/set<T>/invalidate/invalidatePrefix` backed by Cloudflare KV with automatic in-memory LRU fallback (500 entries) for dev/test
- `cache-keys.ts`: typed key builders + TTL constants (clinic config 5min, flags 5min, AI status 1min, sessions 10min)
- `invalidation.ts`: targeted helpers (`invalidateClinicConfig()`, etc.)
- `cdn-headers.ts`: `getCDNHeaders(category)` returning Cache-Control profiles (no-store for PHI, immutable for static assets)

**wrangler.toml**: Added `APP_CACHE_KV` namespace binding (top-level + production + staging) with placeholder IDs pending provisioning.