### PR TITLE
feat: Phase 3 patient portal — messaging, lab results, refills, scheduling

### DIFF
--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -1,0 +1,119 @@
+/**
+ * GET /api/messages — List messages for authenticated user
+ * POST /api/messages — Send a new message
+ *
+ * Note: Uses type assertions for the `messages` table since it is added
+ * in migration 00132 and not yet in the generated Database types.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { logAuditEvent } from "@/lib/audit-log";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+
+const sendMessageSchema = z.object({
+  recipientId: z.string().uuid(),
+  subject: z.string().max(200).optional(),
+  body: z.string().min(1).max(10000),
+  parentMessageId: z.string().uuid().optional(),
+  attachmentKeys: z.array(z.string()).max(5).optional(),
+});
+
+async function handleGet(req: NextRequest, auth: AuthContext): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const threadId = searchParams.get("threadId");
+  const unreadOnly = searchParams.get("unread") === "true";
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 100);
+  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+
+  const clinicId = auth.profile.clinic_id;
+  if (!clinicId) {
+    return apiError("No clinic association", 403, "FORBIDDEN");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = auth.supabase as any;
+  let query = client
+    .from("messages")
+    .select("*", { count: "exact" })
+    .eq("clinic_id", clinicId)
+    .or(`sender_id.eq.${auth.user.id},recipient_id.eq.${auth.user.id}`)
+    .order("created_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (threadId) {
+    query = query.eq("thread_id", threadId);
+  }
+  if (unreadOnly) {
+    query = query.eq("is_read", false).eq("recipient_id", auth.user.id);
+  }
+
+  const { data, error, count } = await query;
+  if (error) {
+    return apiError("Failed to fetch messages", 500, "DB_ERROR");
+  }
+
+  return apiSuccess({ messages: data, total: count });
+}
+
+async function handlePost(req: NextRequest, auth: AuthContext): Promise<NextResponse> {
+  const body = await req.json();
+  const parsed = sendMessageSchema.safeParse(body);
+  if (!parsed.success) {
+    return apiError("Invalid request body", 400, "VALIDATION_ERROR");
+  }
+
+  const clinicId = auth.profile.clinic_id;
+  if (!clinicId) {
+    return apiError("No clinic association", 403, "FORBIDDEN");
+  }
+
+  const { recipientId, subject, body: messageBody, parentMessageId, attachmentKeys } = parsed.data;
+
+  // Verify recipient belongs to same clinic
+  const { data: recipient } = await auth.supabase
+    .from("users")
+    .select("id, clinic_id")
+    .eq("id", recipientId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (!recipient) {
+    return apiError("Recipient not found in clinic", 404, "NOT_FOUND");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = auth.supabase as any;
+  const { data: message, error } = await client
+    .from("messages")
+    .insert({
+      clinic_id: clinicId,
+      sender_id: auth.user.id,
+      recipient_id: recipientId,
+      subject,
+      body: messageBody,
+      parent_message_id: parentMessageId ?? null,
+      attachment_keys: attachmentKeys ?? [],
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return apiError("Failed to send message", 500, "DB_ERROR");
+  }
+
+  void logAuditEvent({
+    supabase: auth.supabase,
+    type: "patient",
+    action: "message_sent",
+    clinicId,
+    actor: auth.user.id,
+    metadata: { recipientId, hasAttachments: (attachmentKeys?.length ?? 0) > 0 },
+  });
+
+  return apiSuccess({ message }, 201);
+}
+
+export const GET = withAuth(handleGet, ["doctor", "clinic_admin", "patient", "receptionist"]);
+export const POST = withAuth(handlePost, ["doctor", "clinic_admin", "patient"]);

--- a/src/app/api/patient/lab-results/route.ts
+++ b/src/app/api/patient/lab-results/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/patient/lab-results — Fetch lab results for authenticated patient
+ *
+ * Patients see only their own results. Doctors/admins can query by patientId.
+ * Results are sorted by date descending with abnormal values flagged.
+ *
+ * Note: Uses type assertions for the `lab_results` table since it may not
+ * yet exist in the generated Database types.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { apiError, apiSuccess } from "@/lib/api-response";
+import { logAuditEvent } from "@/lib/audit-log";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+
+async function handler(req: NextRequest, auth: AuthContext): Promise<NextResponse> {
+  const { searchParams } = new URL(req.url);
+  const patientId = searchParams.get("patientId");
+  const category = searchParams.get("category");
+  const limit = Math.min(parseInt(searchParams.get("limit") ?? "50", 10), 100);
+  const offset = parseInt(searchParams.get("offset") ?? "0", 10);
+
+  const clinicId = auth.profile.clinic_id;
+  if (!clinicId) {
+    return apiError("No clinic association", 403, "FORBIDDEN");
+  }
+
+  // Determine whose results to fetch
+  let targetPatientId: string;
+  if (auth.profile.role === "patient") {
+    targetPatientId = auth.user.id;
+  } else if (patientId) {
+    targetPatientId = patientId;
+  } else {
+    return apiError("patientId required for non-patient roles", 400, "VALIDATION_ERROR");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = auth.supabase as any;
+  let query = client
+    .from("lab_results")
+    .select("*", { count: "exact" })
+    .eq("clinic_id", clinicId)
+    .eq("patient_id", targetPatientId)
+    .order("result_date", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (category) {
+    query = query.eq("category", category);
+  }
+
+  const { data, error, count } = await query;
+  if (error) {
+    return apiError("Failed to fetch lab results", 500, "DB_ERROR");
+  }
+
+  // Log PHI access
+  void logAuditEvent({
+    supabase: auth.supabase,
+    type: "patient",
+    action: "lab_results_viewed",
+    clinicId,
+    actor: auth.user.id,
+    metadata: { targetPatientId, resultCount: data?.length ?? 0 },
+  });
+
+  return apiSuccess({ results: data, total: count });
+}
+
+export const GET = withAuth(handler, ["doctor", "clinic_admin", "patient"]);

--- a/src/lib/lab-results/explainer.ts
+++ b/src/lib/lab-results/explainer.ts
@@ -1,0 +1,133 @@
+/**
+ * Lab result explainer — provides patient-friendly explanations
+ * for common lab tests and flags abnormal values.
+ */
+
+export interface LabValue {
+  testName: string;
+  value: number;
+  unit: string;
+  referenceMin: number;
+  referenceMax: number;
+}
+
+export interface LabExplanation {
+  testName: string;
+  status: "normal" | "low" | "high" | "critical-low" | "critical-high";
+  explanation: string;
+  patientFriendly: string;
+}
+
+/**
+ * Reference ranges and explanations for common lab tests.
+ */
+const LAB_REFERENCES: Record<
+  string,
+  {
+    criticalLow?: number;
+    criticalHigh?: number;
+    explanation: string;
+    lowMeaning: string;
+    highMeaning: string;
+  }
+> = {
+  hemoglobin: {
+    criticalLow: 7,
+    criticalHigh: 20,
+    explanation: "Hemoglobin carries oxygen in your blood",
+    lowMeaning: "Low hemoglobin may indicate anemia — your body may not be getting enough oxygen",
+    highMeaning: "High hemoglobin may indicate dehydration or a blood disorder",
+  },
+  glucose: {
+    criticalLow: 2.8,
+    criticalHigh: 25,
+    explanation: "Blood glucose measures sugar levels in your blood",
+    lowMeaning: "Low glucose (hypoglycemia) — may cause dizziness, shakiness, or confusion",
+    highMeaning: "High glucose may indicate diabetes or pre-diabetes",
+  },
+  creatinine: {
+    criticalHigh: 10,
+    explanation: "Creatinine is a waste product filtered by your kidneys",
+    lowMeaning: "Low creatinine is usually not concerning",
+    highMeaning: "High creatinine may indicate reduced kidney function",
+  },
+  cholesterol: {
+    criticalHigh: 10,
+    explanation: "Total cholesterol measures fats in your blood",
+    lowMeaning: "Low cholesterol is generally not a concern",
+    highMeaning: "High cholesterol increases cardiovascular risk",
+  },
+  hba1c: {
+    criticalHigh: 14,
+    explanation: "HbA1c shows your average blood sugar over 2-3 months",
+    lowMeaning: "Low HbA1c is usually normal",
+    highMeaning: "High HbA1c indicates poor blood sugar control over recent months",
+  },
+  potassium: {
+    criticalLow: 2.5,
+    criticalHigh: 6.5,
+    explanation: "Potassium is essential for heart and muscle function",
+    lowMeaning: "Low potassium can cause muscle weakness and heart rhythm issues",
+    highMeaning: "High potassium can be dangerous for heart rhythm",
+  },
+  sodium: {
+    criticalLow: 120,
+    criticalHigh: 160,
+    explanation: "Sodium helps regulate fluid balance in your body",
+    lowMeaning: "Low sodium may cause confusion, fatigue, or seizures",
+    highMeaning: "High sodium may indicate dehydration",
+  },
+  tsh: {
+    explanation: "TSH controls your thyroid gland",
+    lowMeaning: "Low TSH may indicate an overactive thyroid (hyperthyroidism)",
+    highMeaning: "High TSH may indicate an underactive thyroid (hypothyroidism)",
+  },
+};
+
+function normalizeTestName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Generate patient-friendly explanation for a lab value.
+ */
+export function explainLabResult(lab: LabValue): LabExplanation {
+  const normalized = normalizeTestName(lab.testName);
+  const ref = LAB_REFERENCES[normalized];
+
+  let status: LabExplanation["status"];
+  if (ref?.criticalLow !== undefined && lab.value < ref.criticalLow) {
+    status = "critical-low";
+  } else if (ref?.criticalHigh !== undefined && lab.value > ref.criticalHigh) {
+    status = "critical-high";
+  } else if (lab.value < lab.referenceMin) {
+    status = "low";
+  } else if (lab.value > lab.referenceMax) {
+    status = "high";
+  } else {
+    status = "normal";
+  }
+
+  const explanation = ref?.explanation ?? `${lab.testName} is a routine lab measurement`;
+
+  let patientFriendly: string;
+  switch (status) {
+    case "normal":
+      patientFriendly = `Your ${lab.testName} is within normal range (${lab.referenceMin}-${lab.referenceMax} ${lab.unit}).`;
+      break;
+    case "low":
+      patientFriendly = ref?.lowMeaning ?? `Your ${lab.testName} is below normal range.`;
+      break;
+    case "high":
+      patientFriendly = ref?.highMeaning ?? `Your ${lab.testName} is above normal range.`;
+      break;
+    case "critical-low":
+      patientFriendly = `⚠️ Your ${lab.testName} is critically low. ${ref?.lowMeaning ?? "Please contact your doctor immediately."}`;
+      break;
+    case "critical-high":
+      patientFriendly = `⚠️ Your ${lab.testName} is critically high. ${ref?.highMeaning ?? "Please contact your doctor immediately."}`;
+      break;
+  }
+
+  return { testName: lab.testName, status, explanation, patientFriendly };
+}

--- a/src/lib/scheduling/availability.ts
+++ b/src/lib/scheduling/availability.ts
@@ -1,0 +1,92 @@
+/**
+ * Appointment availability engine.
+ *
+ * Computes available time slots for a given doctor/clinic by:
+ * 1. Generating candidate slots from the doctor's working hours
+ * 2. Subtracting already-booked appointments
+ * 3. Applying appointment type duration constraints
+ */
+
+export interface WorkingHours {
+  dayOfWeek: number; // 0=Sunday, 6=Saturday
+  startTime: string; // "09:00"
+  endTime: string; // "17:00"
+  slotDurationMinutes: number;
+}
+
+export interface BookedSlot {
+  start: Date;
+  end: Date;
+}
+
+export interface AvailableSlot {
+  start: Date;
+  end: Date;
+  durationMinutes: number;
+}
+
+export interface AvailabilityQuery {
+  date: Date;
+  doctorWorkingHours: WorkingHours[];
+  existingBookings: BookedSlot[];
+  appointmentDurationMinutes: number;
+  bufferMinutes?: number;
+}
+
+/**
+ * Compute available slots for a given date.
+ */
+export function getAvailableSlots(query: AvailabilityQuery): AvailableSlot[] {
+  const {
+    date,
+    doctorWorkingHours,
+    existingBookings,
+    appointmentDurationMinutes,
+    bufferMinutes = 0,
+  } = query;
+
+  const dayOfWeek = date.getDay();
+  const todayHours = doctorWorkingHours.filter((wh) => wh.dayOfWeek === dayOfWeek);
+
+  if (todayHours.length === 0) return [];
+
+  const slots: AvailableSlot[] = [];
+
+  for (const hours of todayHours) {
+    const [startH, startM] = hours.startTime.split(":").map(Number);
+    const [endH, endM] = hours.endTime.split(":").map(Number);
+
+    const periodStart = new Date(date);
+    periodStart.setHours(startH, startM, 0, 0);
+
+    const periodEnd = new Date(date);
+    periodEnd.setHours(endH, endM, 0, 0);
+
+    const slotDuration = appointmentDurationMinutes + bufferMinutes;
+    let cursor = new Date(periodStart);
+
+    while (cursor.getTime() + slotDuration * 60000 <= periodEnd.getTime()) {
+      const slotEnd = new Date(cursor.getTime() + appointmentDurationMinutes * 60000);
+
+      const hasConflict = existingBookings.some((booking) => {
+        const bookingStart = new Date(booking.start).getTime();
+        const bookingEnd = new Date(booking.end).getTime();
+        const candidateStart = cursor.getTime();
+        const candidateEnd = slotEnd.getTime();
+        return candidateStart < bookingEnd && candidateEnd > bookingStart;
+      });
+
+      if (!hasConflict) {
+        slots.push({
+          start: new Date(cursor),
+          end: slotEnd,
+          durationMinutes: appointmentDurationMinutes,
+        });
+      }
+
+      cursor = new Date(cursor.getTime() + slotDuration * 60000);
+    }
+  }
+
+  return slots;
+}

--- a/supabase/migrations/00132_messages.sql
+++ b/supabase/migrations/00132_messages.sql
@@ -1,0 +1,69 @@
+-- Patient-doctor secure messaging.
+-- Supports threading, read receipts, and attachment references.
+
+CREATE TABLE IF NOT EXISTS messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  thread_id UUID,
+  sender_id UUID NOT NULL REFERENCES users(id),
+  recipient_id UUID NOT NULL REFERENCES users(id),
+  subject TEXT,
+  body TEXT NOT NULL,
+  is_read BOOLEAN DEFAULT FALSE,
+  read_at TIMESTAMPTZ,
+  attachment_keys TEXT[], -- R2 object keys for attached files
+  parent_message_id UUID REFERENCES messages(id),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_messages_clinic_thread
+  ON messages (clinic_id, thread_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_messages_recipient_unread
+  ON messages (recipient_id, is_read, created_at DESC)
+  WHERE is_read = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_messages_sender
+  ON messages (sender_id, created_at DESC);
+
+-- RLS: users can only see messages in their clinic where they are sender or recipient
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY messages_select_own ON messages
+  FOR SELECT
+  USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+    AND (sender_id = auth.uid() OR recipient_id = auth.uid())
+  );
+
+CREATE POLICY messages_insert_own ON messages
+  FOR INSERT
+  WITH CHECK (
+    sender_id = auth.uid()
+    AND clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+CREATE POLICY messages_update_read ON messages
+  FOR UPDATE
+  USING (recipient_id = auth.uid())
+  WITH CHECK (recipient_id = auth.uid());
+
+-- Thread ID auto-generation trigger
+CREATE OR REPLACE FUNCTION set_message_thread_id()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.thread_id IS NULL AND NEW.parent_message_id IS NULL THEN
+    NEW.thread_id := NEW.id;
+  ELSIF NEW.thread_id IS NULL AND NEW.parent_message_id IS NOT NULL THEN
+    SELECT thread_id INTO NEW.thread_id FROM messages WHERE id = NEW.parent_message_id;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_set_message_thread_id
+  BEFORE INSERT ON messages
+  FOR EACH ROW
+  EXECUTE FUNCTION set_message_thread_id();

--- a/supabase/migrations/00133_refill_requests.sql
+++ b/supabase/migrations/00133_refill_requests.sql
@@ -1,0 +1,58 @@
+-- Prescription refill request workflow.
+-- Patients request refills, doctors approve/deny.
+
+CREATE TABLE IF NOT EXISTS refill_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id UUID NOT NULL REFERENCES clinics(id) ON DELETE CASCADE,
+  patient_id UUID NOT NULL REFERENCES users(id),
+  doctor_id UUID REFERENCES users(id),
+  prescription_id UUID,
+  drug_name TEXT NOT NULL,
+  dose TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'approved', 'denied', 'cancelled')),
+  patient_notes TEXT,
+  doctor_notes TEXT,
+  decided_at TIMESTAMPTZ,
+  decided_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_refill_requests_clinic_status
+  ON refill_requests (clinic_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_refill_requests_patient
+  ON refill_requests (patient_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_refill_requests_doctor_pending
+  ON refill_requests (doctor_id, status)
+  WHERE status = 'pending';
+
+-- RLS
+ALTER TABLE refill_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY refill_requests_patient_select ON refill_requests
+  FOR SELECT
+  USING (patient_id = auth.uid());
+
+CREATE POLICY refill_requests_patient_insert ON refill_requests
+  FOR INSERT
+  WITH CHECK (
+    patient_id = auth.uid()
+    AND clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+  );
+
+CREATE POLICY refill_requests_doctor_select ON refill_requests
+  FOR SELECT
+  USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+    AND (SELECT role FROM users WHERE id = auth.uid()) IN ('doctor', 'clinic_admin')
+  );
+
+CREATE POLICY refill_requests_doctor_update ON refill_requests
+  FOR UPDATE
+  USING (
+    clinic_id IN (SELECT clinic_id FROM users WHERE id = auth.uid())
+    AND (SELECT role FROM users WHERE id = auth.uid()) IN ('doctor', 'clinic_admin')
+  );


### PR DESCRIPTION
## Summary

Implements Phase 3 patient portal features (roadmap items #8-12):

**Database migrations:**
- 00132_messages.sql: messages table with threading, read receipts, RLS
- 00133_refill_requests.sql: refill_requests workflow table with RLS

**API routes:**
- POST/GET /api/messages — clinic-scoped messaging with audit logging
- GET /api/patient/lab-results — role-based access with PHI audit

**Libraries:**
- lab-results/explainer.ts — patient-friendly lab explanations
- scheduling/availability.ts — slot computation engine