### PR TITLE
feat(security): AI output drug name validator (F-AI-14)

### DIFF
--- a/src/app/api/ai/auto-suggest/route.ts
+++ b/src/app/api/ai/auto-suggest/route.ts
@@ -19,6 +19,7 @@
 import { type NextRequest } from "next/server";
 import { resolveAIConfig } from "@/lib/ai/config";
 import { sanitizeUntrustedText } from "@/lib/ai/sanitize";
+import { validateDrugNames } from "@/lib/ai/validate-drug-output";
 import { validateAIOutput } from "@/lib/ai/validate-output";
 import { getAIDisclaimer } from "@/lib/ai-disclaimer";
 import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/api-response";
@@ -429,11 +430,22 @@ export const POST = withAuthValidation(
       });
 
       // A109-01: Include AI disclaimer in every AI response payload.
+      // F-AI-14: Validate drug names against Moroccan DCI database
+      const sugDrugNames = suggestions.medications.map((m: SuggestedMedication) => m.name);
+      const drugValidation = validateDrugNames(sugDrugNames);
+
       return apiSuccess({
         suggestions,
         diagnosis: data.diagnosis,
         patientId: data.patientId ?? null,
         disclaimer: getAIDisclaimer(),
+        drugValidation: drugValidation.allKnown
+          ? undefined
+          : {
+              unknownDrugs: drugValidation.unknownDrugs,
+              warning:
+                "Certains médicaments suggérés ne figurent pas dans la pharmacopée marocaine. Veuillez vérifier.",
+            },
       });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {

--- a/src/app/api/v1/ai/prescription/route.ts
+++ b/src/app/api/v1/ai/prescription/route.ts
@@ -15,6 +15,7 @@ import { type NextRequest } from "next/server";
 import { resolveAIConfig } from "@/lib/ai/config";
 import { createPseudonymMap, depseudonymise, pseudonymise } from "@/lib/ai/pseudonymise";
 import { sanitizeUntrustedText } from "@/lib/ai/sanitize";
+import { validateDrugNames } from "@/lib/ai/validate-drug-output";
 import { validateAIOutput } from "@/lib/ai/validate-output";
 import { getAIDisclaimer } from "@/lib/ai-disclaimer";
 import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/api-response";
@@ -416,11 +417,22 @@ export const POST = withAuthValidation(
       });
 
       // A109-01: Include AI disclaimer in every AI response payload.
+      // F-AI-14: Validate drug names against Moroccan DCI database
+      const rxDrugNames = prescription.medications.map((m: AiMedication) => m.name);
+      const drugValidation = validateDrugNames(rxDrugNames);
+
       return apiSuccess({
         prescription,
         patientId: data.patientId,
         diagnosis: data.diagnosis,
         disclaimer: getAIDisclaimer(),
+        drugValidation: drugValidation.allKnown
+          ? undefined
+          : {
+              unknownDrugs: drugValidation.unknownDrugs,
+              warning:
+                "Certains médicaments suggérés ne figurent pas dans la pharmacopée marocaine. Veuillez vérifier.",
+            },
       });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {

--- a/src/app/api/v1/ai/smart-prescription/route.ts
+++ b/src/app/api/v1/ai/smart-prescription/route.ts
@@ -15,6 +15,7 @@ import { resolveAIConfig } from "@/lib/ai/config";
 import { createPseudonymMap, depseudonymise, pseudonymise } from "@/lib/ai/pseudonymise";
 import { sanitizeUntrustedText } from "@/lib/ai/sanitize";
 import { fromUntyped } from "@/lib/ai/untyped-tables";
+import { validateDrugNames } from "@/lib/ai/validate-drug-output";
 import { validateAIOutput } from "@/lib/ai/validate-output";
 import { getAIDisclaimer } from "@/lib/ai-disclaimer";
 import { apiSuccess, apiError, apiRateLimited, apiInternalError } from "@/lib/api-response";
@@ -350,10 +351,25 @@ Donne les informations complètes pour prescrire ce médicament à ce patient.`;
           }
         });
 
+      // F-AI-14: Validate drug names against Moroccan DCI database
+      const drugNames = [
+        result.medication.name,
+        result.medication.dci,
+        ...result.alternatives,
+      ].filter(Boolean);
+      const drugValidation = validateDrugNames(drugNames);
+
       return apiSuccess({
         ...result,
         patientId: data.patientId,
         disclaimer: getAIDisclaimer(),
+        drugValidation: drugValidation.allKnown
+          ? undefined
+          : {
+              unknownDrugs: drugValidation.unknownDrugs,
+              warning:
+                "Certains médicaments suggérés ne figurent pas dans la pharmacopée marocaine. Veuillez vérifier.",
+            },
       });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {

--- a/src/lib/ai/validate-drug-output.ts
+++ b/src/lib/ai/validate-drug-output.ts
@@ -1,0 +1,120 @@
+/**
+ * F-AI-14 / A108: AI output drug name validator.
+ *
+ * Checks drug names returned by AI against the Moroccan DCI drug database.
+ * Flags unrecognised drug names so clinicians are warned about potential
+ * hallucinations before accepting an AI-suggested prescription.
+ *
+ * This is NOT a hard reject — it returns warnings alongside the original
+ * output. The doctor always has final say.
+ */
+
+import { DCI_DRUG_DATABASE } from "@/lib/dci-drug-database";
+import { logger } from "@/lib/logger";
+
+// Build a normalised lookup set at module load time for O(1) checks.
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim();
+}
+
+/** All known drug names (DCI + brands), normalised. */
+const KNOWN_DRUG_NAMES: Set<string> = new Set();
+for (const drug of DCI_DRUG_DATABASE) {
+  KNOWN_DRUG_NAMES.add(normalize(drug.dci));
+  for (const brand of drug.brands) {
+    KNOWN_DRUG_NAMES.add(normalize(brand));
+  }
+}
+
+export interface DrugValidationResult {
+  /** Drug names that were NOT found in the Moroccan DCI database. */
+  unknownDrugs: string[];
+  /** Drug names that matched a known DCI or brand. */
+  knownDrugs: string[];
+  /** True if all drug names were recognised. */
+  allKnown: boolean;
+}
+
+/**
+ * Validate a list of drug names against the Moroccan DCI database.
+ *
+ * @param drugNames Array of drug name strings to check
+ * @returns Validation result with known/unknown drug lists
+ */
+export function validateDrugNames(drugNames: string[]): DrugValidationResult {
+  const knownDrugs: string[] = [];
+  const unknownDrugs: string[] = [];
+
+  for (const name of drugNames) {
+    if (!name || name.trim().length === 0) continue;
+
+    const norm = normalize(name);
+    // Check exact match first, then prefix match (≥3 chars)
+    if (KNOWN_DRUG_NAMES.has(norm) || matchesKnownDrugPrefix(norm)) {
+      knownDrugs.push(name);
+    } else {
+      unknownDrugs.push(name);
+    }
+  }
+
+  if (unknownDrugs.length > 0) {
+    logger.warn("ai.drug_validation.unknown_drugs", {
+      context: "ai-drug-validator",
+      unknownDrugs,
+      total: drugNames.length,
+      unknownCount: unknownDrugs.length,
+    });
+  }
+
+  return {
+    unknownDrugs,
+    knownDrugs,
+    allKnown: unknownDrugs.length === 0,
+  };
+}
+
+/**
+ * Check if a normalised drug name matches any known drug by prefix.
+ * Handles cases where the AI might abbreviate or use a slightly
+ * different form of the drug name (e.g. "amoxicilline" vs "amoxicillin").
+ */
+function matchesKnownDrugPrefix(norm: string): boolean {
+  if (norm.length < 3) return false;
+  for (const known of KNOWN_DRUG_NAMES) {
+    if (known.startsWith(norm) || norm.startsWith(known)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Extract drug names from a structured AI prescription response.
+ * Handles common output formats: array of medication objects,
+ * or newline-separated text with drug names.
+ */
+export function extractDrugNamesFromPrescription(response: Record<string, unknown>): string[] {
+  const names: string[] = [];
+
+  // Handle { medications: [{ name: "..." }, ...] }
+  const medications = response.medications ?? response.medicaments ?? response.drugs;
+  if (Array.isArray(medications)) {
+    for (const med of medications) {
+      if (typeof med === "string") {
+        names.push(med);
+      } else if (med && typeof med === "object") {
+        const obj = med as Record<string, unknown>;
+        const name = obj.name ?? obj.nom ?? obj.dci ?? obj.drug ?? obj.medication;
+        if (typeof name === "string") {
+          names.push(name);
+        }
+      }
+    }
+  }
+
+  return names;
+}


### PR DESCRIPTION
## Summary

Adds post-processing validation of AI-suggested drug names against the Moroccan DCI database (~200 drugs + brand names). When the AI hallucinates a drug not in the pharmacopeia, the response includes a `drugValidation.warning` field so the doctor sees a flag before accepting.

**New file:** `src/lib/ai/validate-drug-output.ts`
- `validateDrugNames(names)` — O(1) lookup via pre-built `Set<string>` of normalised DCI + brand names, with prefix matching for abbreviated forms
- `extractDrugNamesFromPrescription(response)` — utility to pull drug names from structured AI output

**Integrated in 3 prescription routes:**
- `/api/v1/ai/smart-prescription` — validates `medication.name`, `medication.dci`, and `alternatives`
- `/api/v1/ai/prescription` — validates each `medications[].name`
- `/api/ai/auto-suggest` — validates each `medications[].name`

Response shape when unknown drugs found:
```json
{ "drugValidation": { "unknownDrugs": ["fakedrugol"], "warning": "Certains médicaments..." } }
```

When all drugs are known, `drugValidation` is `undefined` (no payload bloat).