### PR TITLE
feat: auto-provision chatbot on subscription change + bulk activation

### DIFF
--- a/src/app/api/__tests__/billing-webhook-config-merge.test.ts
+++ b/src/app/api/__tests__/billing-webhook-config-merge.test.ts
@@ -48,18 +48,26 @@ const existingConfig: ClinicConfigShape = {
 
 vi.mock("@/lib/supabase-server", () => {
   const buildClient = () => ({
-    from: vi.fn().mockImplementation(() => {
+    from: vi.fn().mockImplementation((table: string) => {
       const builder = {
         select: vi.fn().mockReturnThis(),
+        insert: vi
+          .fn()
+          .mockReturnValue({
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
         update: vi.fn().mockImplementation((payload: CapturedUpdate) => {
-          captured.updates.push(payload);
+          if (table === "clinics") {
+            captured.updates.push(payload);
+          }
           return {
             eq: vi.fn().mockResolvedValue({ error: null }),
           };
         }),
         eq: vi.fn().mockReturnThis(),
         maybeSingle: vi.fn().mockResolvedValue({
-          data: { config: existingConfig },
+          data: table === "clinics" ? { config: existingConfig } : null,
           error: null,
         }),
       };

--- a/src/app/api/__tests__/billing-webhook-config-merge.test.ts
+++ b/src/app/api/__tests__/billing-webhook-config-merge.test.ts
@@ -51,12 +51,10 @@ vi.mock("@/lib/supabase-server", () => {
     from: vi.fn().mockImplementation((table: string) => {
       const builder = {
         select: vi.fn().mockReturnThis(),
-        insert: vi
-          .fn()
-          .mockReturnValue({
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockResolvedValue({ error: null }),
-          }),
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
         update: vi.fn().mockImplementation((payload: CapturedUpdate) => {
           if (table === "clinics") {
             captured.updates.push(payload);

--- a/src/app/api/admin/chatbot-bulk/route.ts
+++ b/src/app/api/admin/chatbot-bulk/route.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/admin/chatbot-bulk
+ *
+ * Feature Task 4: Bulk chatbot activation by subscription plan.
+ * Superadmin-only endpoint that provisions chatbot for all clinics
+ * matching a given plan tier.
+ *
+ * Body: { plan: PlanSlug, action: "enable" | "disable" }
+ * Returns: { affected: number, results: Array<{ clinicId, status }> }
+ */
+
+import { type NextRequest } from "next/server";
+import { z } from "zod";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { withAuthValidation } from "@/lib/api-validate";
+import { logAuditEvent } from "@/lib/audit-log";
+import { provisionChatbotForPlan, getChatbotLevelForPlan } from "@/lib/chatbot-provisioning";
+import { logger } from "@/lib/logger";
+import type { AuthContext } from "@/lib/with-auth";
+
+const bulkChatbotSchema = z.object({
+  plan: z.enum(["free", "starter", "professional", "enterprise"]),
+  action: z.enum(["enable", "disable"]),
+});
+
+export const POST = withAuthValidation(
+  bulkChatbotSchema,
+  async (data, _request: NextRequest, auth: AuthContext) => {
+    const { supabase, profile } = auth;
+    const targetPlan = data.plan;
+    const action = data.action;
+    const level = getChatbotLevelForPlan(targetPlan);
+
+    if (action === "enable" && level === false) {
+      return apiError(`Le plan "${targetPlan}" n'inclut pas le chatbot.`, 400, "PLAN_NO_CHATBOT");
+    }
+
+    // Find clinics on the target plan
+    const { data: clinics, error: queryErr } = await supabase
+      .from("clinics")
+      .select("id, name, config");
+
+    if (queryErr) {
+      logger.error("Failed to query clinics for bulk chatbot", {
+        context: "admin/chatbot-bulk",
+        error: queryErr,
+      });
+      return apiError("Erreur lors de la recherche des cliniques", 500);
+    }
+
+    // Filter clinics by subscription_plan in config
+    const matchingClinics = (clinics ?? []).filter((c) => {
+      const config = c.config as Record<string, unknown> | null;
+      return config?.subscription_plan === targetPlan;
+    });
+
+    if (matchingClinics.length === 0) {
+      return apiSuccess({
+        affected: 0,
+        results: [],
+        message: `Aucune clinique trouvée avec le plan "${targetPlan}".`,
+      });
+    }
+
+    const results: Array<{
+      clinicId: string;
+      clinicName: string;
+      status: "ok" | "error";
+    }> = [];
+
+    const effectivePlan = action === "disable" ? "free" : targetPlan;
+
+    for (const clinic of matchingClinics) {
+      try {
+        await provisionChatbotForPlan(supabase, clinic.id, effectivePlan);
+        results.push({
+          clinicId: clinic.id,
+          clinicName: clinic.name,
+          status: "ok",
+        });
+      } catch (err) {
+        logger.error("Bulk chatbot provisioning failed for clinic", {
+          context: "admin/chatbot-bulk",
+          clinicId: clinic.id,
+          error: err,
+        });
+        results.push({
+          clinicId: clinic.id,
+          clinicName: clinic.name,
+          status: "error",
+        });
+      }
+    }
+
+    const succeeded = results.filter((r) => r.status === "ok").length;
+
+    void logAuditEvent({
+      supabase,
+      clinicId: "system",
+      action: "bulk_chatbot_provisioning",
+      type: "config",
+      actor: profile.id,
+      description: `Bulk ${action} chatbot for ${targetPlan} plan: ${succeeded}/${matchingClinics.length} clinics`,
+      metadata: {
+        plan: targetPlan,
+        action,
+        totalClinics: matchingClinics.length,
+        succeeded,
+        failed: matchingClinics.length - succeeded,
+      },
+    });
+
+    return apiSuccess({
+      affected: succeeded,
+      total: matchingClinics.length,
+      results,
+    });
+  },
+  ["super_admin"],
+);

--- a/src/app/api/billing/webhook/route.ts
+++ b/src/app/api/billing/webhook/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { apiError, apiSuccess, apiInternalError } from "@/lib/api-response";
+import { provisionChatbotForPlan } from "@/lib/chatbot-provisioning";
 import { getPlanByPriceId, type PlanSlug } from "@/lib/config/subscription-plans";
 import { logger } from "@/lib/logger";
 import { verifyStripeSignature } from "@/lib/stripe-signature";
@@ -234,6 +235,9 @@ export async function POST(request: NextRequest) {
             error: updateError,
           });
         }
+
+        // Feature Task 1: Auto-provision chatbot for the new plan
+        void provisionChatbotForPlan(supabase, clinicId, planId);
         break;
       }
 
@@ -305,6 +309,11 @@ export async function POST(request: NextRequest) {
             clinicId,
             error: renewError,
           });
+        }
+
+        // Feature Task 1: Update chatbot intelligence on plan renewal/change
+        if (plan) {
+          void provisionChatbotForPlan(supabase, clinicId, plan.slug);
         }
         break;
       }
@@ -396,6 +405,9 @@ export async function POST(request: NextRequest) {
             error: cancelError,
           });
         }
+
+        // Feature Task 1: Disable chatbot on cancellation
+        void provisionChatbotForPlan(supabase, clinicId, "free");
         break;
       }
 

--- a/src/lib/chatbot-provisioning.ts
+++ b/src/lib/chatbot-provisioning.ts
@@ -1,0 +1,171 @@
+/**
+ * Feature Task 1 & 2: Auto-provision chatbot when a clinic upgrades.
+ *
+ * When a subscription changes (checkout.session.completed, invoice.paid),
+ * the billing webhook calls `provisionChatbotForPlan()` to ensure the
+ * clinic has a `chatbot_config` row with the intelligence level matching
+ * their plan tier.
+ *
+ * Intelligence level mapping:
+ *   free        → disabled (no chatbot)
+ *   starter     → "basic"  (keyword matching)
+ *   professional→ "smart"  (Workers AI)
+ *   enterprise  → "advanced" (OpenAI GPT-4o)
+ */
+
+import { logAuditEvent } from "@/lib/audit-log";
+import { SUBSCRIPTION_PLANS, type PlanSlug } from "@/lib/config/subscription-plans";
+import { logger } from "@/lib/logger";
+import type { createAdminClient } from "@/lib/supabase-server";
+
+type AdminClient = ReturnType<typeof createAdminClient>;
+
+/**
+ * Resolve the chatbot intelligence level for a given plan.
+ * Returns `false` if the plan doesn't include chatbot.
+ */
+export function getChatbotLevelForPlan(plan: PlanSlug): false | "basic" | "smart" | "advanced" {
+  return SUBSCRIPTION_PLANS[plan]?.limits.aiChatbot ?? false;
+}
+
+/**
+ * Auto-provision or update the chatbot config for a clinic when their
+ * subscription plan changes.
+ *
+ * - If chatbot is not included in the plan, disables any existing config.
+ * - If chatbot IS included and no config exists, creates one with defaults.
+ * - If chatbot IS included and config exists, upgrades intelligence level
+ *   (never downgrades unless the plan itself downgrades).
+ */
+export async function provisionChatbotForPlan(
+  supabase: AdminClient,
+  clinicId: string,
+  plan: PlanSlug,
+): Promise<void> {
+  const level = getChatbotLevelForPlan(plan);
+
+  // Check if chatbot_config already exists for this clinic
+  const { data: existing, error: readErr } = await supabase
+    .from("chatbot_config")
+    .select("id, enabled, intelligence")
+    .eq("clinic_id", clinicId)
+    .maybeSingle();
+
+  if (readErr) {
+    logger.error("Failed to read chatbot_config for provisioning", {
+      context: "chatbot-provisioning",
+      clinicId,
+      error: readErr,
+    });
+    return;
+  }
+
+  if (level === false) {
+    // Plan doesn't include chatbot — disable if it exists
+    if (existing && existing.enabled) {
+      const { error: disableErr } = await supabase
+        .from("chatbot_config")
+        .update({
+          enabled: false,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("clinic_id", clinicId);
+
+      if (disableErr) {
+        logger.error("Failed to disable chatbot on downgrade", {
+          context: "chatbot-provisioning",
+          clinicId,
+          error: disableErr,
+        });
+      } else {
+        void logAuditEvent({
+          supabase,
+          action: "chatbot_disabled_on_downgrade",
+          type: "config",
+          clinicId,
+          description: `Chatbot disabled — plan downgraded to ${plan}`,
+        });
+      }
+    }
+    return;
+  }
+
+  if (!existing) {
+    // No config yet — create with defaults
+    const { error: insertErr } = await supabase.from("chatbot_config").insert({
+      clinic_id: clinicId,
+      enabled: true,
+      intelligence: level,
+      greeting: "Bonjour ! Comment puis-je vous aider ?",
+      language: "fr",
+    });
+
+    if (insertErr) {
+      logger.error("Failed to create chatbot_config on subscription", {
+        context: "chatbot-provisioning",
+        clinicId,
+        plan,
+        error: insertErr,
+      });
+    } else {
+      logger.info("Chatbot auto-provisioned for new subscription", {
+        context: "chatbot-provisioning",
+        clinicId,
+        plan,
+        intelligence: level,
+      });
+      void logAuditEvent({
+        supabase,
+        action: "chatbot_auto_provisioned",
+        type: "config",
+        clinicId,
+        description: `Chatbot auto-enabled with ${level} intelligence (${plan} plan)`,
+        metadata: { plan, intelligence: level },
+      });
+    }
+    return;
+  }
+
+  // Config exists — update intelligence level and ensure enabled
+  const needsUpdate = existing.intelligence !== level || !existing.enabled;
+
+  if (needsUpdate) {
+    const { error: updateErr } = await supabase
+      .from("chatbot_config")
+      .update({
+        enabled: true,
+        intelligence: level,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("clinic_id", clinicId);
+
+    if (updateErr) {
+      logger.error("Failed to update chatbot intelligence level", {
+        context: "chatbot-provisioning",
+        clinicId,
+        plan,
+        error: updateErr,
+      });
+    } else {
+      logger.info("Chatbot intelligence level updated", {
+        context: "chatbot-provisioning",
+        clinicId,
+        plan,
+        from: existing.intelligence,
+        to: level,
+      });
+      void logAuditEvent({
+        supabase,
+        action: "chatbot_intelligence_updated",
+        type: "config",
+        clinicId,
+        description: `Chatbot intelligence: ${existing.intelligence} → ${level} (${plan} plan)`,
+        metadata: {
+          plan,
+          previousLevel: existing.intelligence,
+          newLevel: level,
+        },
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Automates chatbot provisioning based on Stripe subscription lifecycle events (Feature Tasks 1, 2, 4).

**New: `src/lib/chatbot-provisioning.ts`** — `provisionChatbotForPlan(supabase, clinicId, plan)` creates/updates/disables `chatbot_config` rows based on plan tier: free=disable, starter=basic, professional=smart, enterprise=advanced.

**Modified: `src/app/api/billing/webhook/route.ts`** — Three `void provisionChatbotForPlan(...)` calls (checkout.session.completed, invoice.paid, customer.subscription.deleted). Fire-and-forget so webhook is not blocked.

**New: `POST /api/admin/chatbot-bulk`** — Superadmin-only. Accepts `{ plan, action }`, provisions chatbot for all clinics on that plan.