### PR TITLE
Fix Clinic rate limit exceeded error in analytics

### DIFF
--- a/src/app/(super-admin)/super-admin/analytics/page.tsx
+++ b/src/app/(super-admin)/super-admin/analytics/page.tsx
@@ -48,8 +48,15 @@ interface AnalyticsData {
   clinics: ClinicAnalytics[];
 }
 
+interface RateLimitStatus {
+  limit: string | null;
+  remaining: string | null;
+  reset: string | null;
+}
+
 export default function MultiClinicAnalyticsPage() {
   const [data, setData] = useState<AnalyticsData | null>(null);
+  const [rateLimit, setRateLimit] = useState<RateLimitStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<"revenue" | "appointments" | "churn">("revenue");
@@ -58,6 +65,11 @@ export default function MultiClinicAnalyticsPage() {
     try {
       setLoading(true);
       const res = await fetch("/api/analytics/multi-clinic");
+      setRateLimit({
+        limit: res.headers.get("X-RateLimit-Limit"),
+        remaining: res.headers.get("X-RateLimit-Remaining"),
+        reset: res.headers.get("X-RateLimit-Reset"),
+      });
       const json = await res.json();
       if (!json.ok) throw new Error(json.error ?? "Failed to load analytics");
       setData(json.data);
@@ -109,7 +121,14 @@ export default function MultiClinicAnalyticsPage() {
 
   return (
     <div className="space-y-6 p-6">
-      <Breadcrumb items={[{ label: "Super Admin" }, { label: "Multi-Clinic Analytics" }]} />
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Breadcrumb items={[{ label: "Super Admin" }, { label: "Multi-Clinic Analytics" }]} />
+        {rateLimit?.remaining && rateLimit.limit && (
+          <Badge variant="outline">
+            {rateLimit.remaining}/{rateLimit.limit} requests
+          </Badge>
+        )}
+      </div>
 
       <div className="grid gap-4 md:grid-cols-4">
         <Card>

--- a/src/lib/data/client/analytics.ts
+++ b/src/lib/data/client/analytics.ts
@@ -87,6 +87,20 @@ export interface AnalyticsData {
   period: AnalyticsPeriod;
 }
 
+const ANALYTICS_CACHE_TTL_MS = 5 * 60_000;
+
+const analyticsCache = new Map<
+  string,
+  {
+    expiresAt: number;
+    data: AnalyticsData;
+  }
+>();
+
+function getAnalyticsCacheKey(clinicId: string, period: AnalyticsPeriod): string {
+  return `analytics:${clinicId}:${period}`;
+}
+
 function getPeriodRange(period: AnalyticsPeriod): {
   start: Date;
   end: Date;
@@ -217,6 +231,17 @@ export async function fetchAnalytics(
   clinicId: string,
   period: AnalyticsPeriod = "month",
 ): Promise<AnalyticsData> {
+  const cacheKey = getAnalyticsCacheKey(clinicId, period);
+  const cached = analyticsCache.get(cacheKey);
+  const nowMs = Date.now();
+
+  if (cached && cached.expiresAt > nowMs) {
+    return cached.data;
+  }
+  if (cached) {
+    analyticsCache.delete(cacheKey);
+  }
+
   const supabase = createClient();
 
   const { prevStart, end } = getPeriodRange(period);
@@ -403,7 +428,7 @@ export async function fetchAnalytics(
     });
   }
 
-  return {
+  const data: AnalyticsData = {
     dailyAnalytics,
     weeklyRevenue,
     monthlyRevenue,
@@ -416,6 +441,13 @@ export async function fetchAnalytics(
     periodComparison,
     period,
   };
+
+  analyticsCache.set(cacheKey, {
+    expiresAt: nowMs + ANALYTICS_CACHE_TTL_MS,
+    data,
+  });
+
+  return data;
 }
 
 // ── Revenue Analytics (Feature 15) ──────────────────────

--- a/src/lib/middleware/__tests__/rate-limiting.test.ts
+++ b/src/lib/middleware/__tests__/rate-limiting.test.ts
@@ -15,6 +15,7 @@ import type { CspHeaderValues } from "../security-headers";
 
 const h = vi.hoisted(() => ({
   apptCheck: vi.fn(),
+  analyticsCheck: vi.fn(),
   catchAllCheck: vi.fn(),
   globalCheck: vi.fn(),
   clinicCheck: vi.fn(),
@@ -24,6 +25,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@/lib/rate-limit", () => ({
   rateLimitRules: [
     { prefix: "/api/appointments", limiter: { check: h.apptCheck }, windowMs: 60_000, max: 10 },
+    { prefix: "/api/analytics", limiter: { check: h.analyticsCheck }, windowMs: 60_000, max: 100 },
     { prefix: "/api/", limiter: { check: h.catchAllCheck }, windowMs: 60_000, max: 30 },
   ],
   extractClientIp: () => "1.2.3.4",
@@ -49,6 +51,7 @@ beforeEach(() => {
   // Disable the CI bypass so the real limiting logic runs.
   delete process.env.GITHUB_ACTIONS;
   h.apptCheck.mockResolvedValue(true);
+  h.analyticsCheck.mockResolvedValue(true);
   h.catchAllCheck.mockResolvedValue(true);
   h.globalCheck.mockResolvedValue(true);
   h.clinicCheck.mockResolvedValue(true);
@@ -114,6 +117,18 @@ describe("applyRateLimit — per-rule limiting", () => {
     );
     expect(h.catchAllCheck).toHaveBeenCalledWith("clinic.oltigo.com:1.2.3.4");
   });
+
+  it("uses the analytics-specific rule for analytics reads", async () => {
+    const { response, rateLimitInfo } = await applyRateLimit(
+      makeRequest("https://clinic.oltigo.com/api/analytics/clinic", "GET"),
+      csp,
+      withSecurityHeaders,
+    );
+
+    expect(response).toBeNull();
+    expect(h.analyticsCheck).toHaveBeenCalledWith("clinic.oltigo.com:1.2.3.4");
+    expect(rateLimitInfo).toEqual({ limit: 100, remaining: 99, reset: expect.any(Number) });
+  });
 });
 
 describe("applyRateLimit — global page limiter", () => {
@@ -169,5 +184,16 @@ describe("applyRateLimit — per-clinic cap", () => {
     expect(response?.status).toBe(429);
     const body = await response!.json();
     expect(body.code).toBe("CLINIC_RATE_LIMIT_EXCEEDED");
+  });
+
+  it("does not count analytics requests against the per-clinic cap", async () => {
+    await applyRateLimit(
+      makeRequest("https://clinic.oltigo.com/api/analytics/clinic", "GET"),
+      csp,
+      withSecurityHeaders,
+    );
+
+    expect(h.analyticsCheck).toHaveBeenCalled();
+    expect(h.clinicCheck).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -113,7 +113,7 @@ export async function applyRateLimit(
   // W8-T-02/W8-RL-03: Key on clinic_id rather than hostname so custom-domain
   // aliases for the same clinic share a single counter. The subdomain cache is
   // populated by earlier middleware invocations and is a fast Map lookup.
-  if (pathname.startsWith("/api/") && hostname) {
+  if (pathname.startsWith("/api/") && !pathname.startsWith("/api/analytics") && hostname) {
     let clinicKey = hostname;
     const parts = hostname.split(".");
     const subdomain = parts.length >= 3 ? parts[0] : hostname;

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -850,13 +850,20 @@ const cspReportLimiter = createRateLimiter({
 });
 
 /**
- * A39-04: Per-clinic global rate cap — 10 000 req / 60s per clinic_id.
+ * A39-04: Per-clinic global rate cap — 50 000 req / 60s per clinic_id.
  * Prevents a malicious clinic admin from accumulating API calls across
  * multiple authenticated sessions. Keyed by clinic_id, not IP.
  */
 export const perClinicLimiter = createRateLimiter({
   windowMs: 60_000,
-  max: 10_000,
+  max: 50_000,
+});
+
+/** Analytics reads: 100 req / 60s per IP. */
+const analyticsLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 100,
+  failClosed: false,
 });
 
 /**
@@ -945,6 +952,7 @@ export const rateLimitRules: RateLimitRule[] = [
   { prefix: "/api/webhooks", limiter: webhookLimiter, windowMs: 60_000, max: 100 },
   { prefix: "/api/branding", limiter: brandingLimiter, windowMs: 60_000, max: 20 },
   { prefix: "/api/notifications", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
+  { prefix: "/api/analytics", limiter: analyticsLimiter, windowMs: 60_000, max: 100 },
   // Catch-all for other API mutations (applied in middleware only to POST/PUT/PATCH/DELETE)
   { prefix: "/api/", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
 ];


### PR DESCRIPTION
Resolves the rate limit exceeded error on the analytics overview page by adjusting limiters, adding caching, and excluding analytics endpoints from the per-clinic limiter.