### PR TITLE
fix(r2): replace AWS SDK with native R2 binding + aws4fetch to meet 1…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,8 @@
     "eval": "npx tsx evals/hallucination.eval.ts && npx tsx evals/jailbreak.eval.ts && npx tsx evals/bias.eval.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1037.0",
-    "@aws-sdk/s3-presigned-post": "^3.1036.0",
-    "@aws-sdk/s3-request-presigner": "^3.1037.0",
     "@base-ui/react": "^1.4.1",
+    "aws4fetch": "^1.0.20",
     "@scalar/api-reference-react": "^0.9.41",
     "@sentry/nextjs": "^10.54.0",
     "@supabase/ssr": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
-    "aws4fetch": "^1.0.20",
     "@scalar/api-reference-react": "^0.9.41",
     "@sentry/nextjs": "^10.54.0",
     "@supabase/ssr": "^0.10.2",

--- a/scripts/rotate-phi-key.ts
+++ b/scripts/rotate-phi-key.ts
@@ -22,15 +22,15 @@
  *   5. Uploads the re-encrypted file back to R2
  *   6. Logs progress and failures for manual retry
  *
+ * R2 access is performed via the R2 S3 API using inline SigV4 query
+ * presigning (Node's `crypto` module) + Node 22's built-in `fetch`. This
+ * mirrors the approach in `src/lib/r2.ts` so the Worker bundle does not
+ * need the AWS SDK (~48 MiB) which would exceed the 10 MiB Worker limit.
+ *
  * See src/lib/encryption.ts for the full key rotation procedure.
  */
 
-import {
-  S3Client,
-  ListObjectsV2Command,
-  GetObjectCommand,
-  PutObjectCommand,
-} from "@aws-sdk/client-s3";
+import { createHash, createHmac } from "crypto";
 
 // ── Configuration ──
 
@@ -53,7 +53,10 @@ const ROOT_PREFIX = "clinics/";
 
 const IV_LENGTH = 12; // 96-bit IV for AES-GCM
 
-// ── Helpers ──
+// Presigned URLs are short-lived — each list/get/put is its own call.
+const PRESIGN_TTL_SECONDS = 300;
+
+// ── Crypto helpers ──
 
 function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
   return new Uint8Array(
@@ -114,6 +117,193 @@ function isPHIFile(key: string): boolean {
   return categories.some((cat) => key.includes(`/${cat}/`));
 }
 
+// ── R2 S3 API: inline SigV4 query presigner ──
+//
+// Mirrors `presignR2Url` in src/lib/r2.ts. Inlined here so this maintenance
+// script remains self-contained and does not need the AWS SDK (which was
+// removed to fit the 10 MiB Cloudflare Worker bundle limit).
+
+interface R2PresignConfig {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucketName: string;
+}
+
+/**
+ * Build an AWS SigV4 query-presigned URL for the R2 S3 API.
+ *
+ * `key` may be an empty string to target the bucket root (used for the
+ * ListObjectsV2 endpoint). Additional query parameters can be supplied via
+ * `opts.query` and are folded into the canonical request so the signature
+ * remains valid.
+ */
+function presignR2Url(
+  config: R2PresignConfig,
+  method: "PUT" | "GET",
+  key: string,
+  expiresIn: number,
+  opts: { signedHeaders?: Record<string, string>; query?: Record<string, string> } = {},
+): string {
+  const host = `${config.accountId}.r2.cloudflarestorage.com`;
+  // Each path segment is URI-encoded but "/" separators are preserved. An
+  // empty `key` produces the bucket root (`/{bucket}/`) which is the path
+  // used by ListObjectsV2.
+  const canonicalUri =
+    "/" +
+    `${config.bucketName}/${key}`
+      .split("/")
+      .map((seg) => encodeURIComponent(seg))
+      .join("/");
+
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // YYYYMMDDTHHMMSSZ
+  const dateStamp = amzDate.slice(0, 8); // YYYYMMDD
+  const region = "auto";
+  const service = "s3";
+  const scope = `${dateStamp}/${region}/${service}/aws4_request`;
+
+  // Host is always signed; plus any caller-supplied headers (lower-cased).
+  const headers: Record<string, string> = { host };
+  for (const [k, v] of Object.entries(opts.signedHeaders ?? {})) {
+    headers[k.toLowerCase()] = v;
+  }
+  const signedHeaderNames = Object.keys(headers).sort();
+  const canonicalHeaders = signedHeaderNames.map((h) => `${h}:${headers[h]}\n`).join("");
+  const signedHeaders = signedHeaderNames.join(";");
+
+  const query: Record<string, string> = {
+    "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+    "X-Amz-Credential": `${config.accessKeyId}/${scope}`,
+    "X-Amz-Date": amzDate,
+    "X-Amz-Expires": String(expiresIn),
+    "X-Amz-SignedHeaders": signedHeaders,
+    ...(opts.query ?? {}),
+  };
+  const canonicalQuery = Object.keys(query)
+    .sort()
+    .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
+    .join("&");
+
+  const canonicalRequest = [
+    method,
+    canonicalUri,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+
+  const hash = (data: string) => createHash("sha256").update(data).digest("hex");
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, hash(canonicalRequest)].join("\n");
+
+  const hmac = (k: Buffer | string, d: string) => createHmac("sha256", k).update(d).digest();
+  const kDate = hmac(`AWS4${config.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, "aws4_request");
+  const signature = createHmac("sha256", kSigning).update(stringToSign).digest("hex");
+
+  return `https://${host}${canonicalUri}?${canonicalQuery}&X-Amz-Signature=${signature}`;
+}
+
+// ── R2 S3 API: minimal client (LIST / GET / PUT) ──
+
+interface ListResult {
+  keys: string[];
+  nextContinuationToken: string | undefined;
+}
+
+/**
+ * Parse a key value out of a `<Key>...</Key>` XML element, decoding the
+ * limited set of XML entities R2's ListObjectsV2 response can contain. Keys
+ * with control characters or `<`/`>` are not legal in S3 object keys, so
+ * a regex-based extractor is safe here.
+ *
+ * Done in a single pass so the output of one substitution never feeds another
+ * (CodeQL js/incomplete-sanitization). For example a literal `&amp;lt;` in
+ * the source decodes to the literal `&lt;`, not to `<`.
+ */
+function decodeXmlText(s: string): string {
+  const map: Record<string, string> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    apos: "'",
+  };
+  return s.replace(/&(amp|lt|gt|quot|apos);/g, (_match, name: string) => map[name] ?? _match);
+}
+
+async function listObjectsPage(
+  config: R2PresignConfig,
+  prefix: string,
+  continuationToken: string | undefined,
+): Promise<ListResult> {
+  const query: Record<string, string> = {
+    "list-type": "2",
+    prefix,
+  };
+  if (continuationToken) {
+    query["continuation-token"] = continuationToken;
+  }
+
+  const url = presignR2Url(config, "GET", "", PRESIGN_TTL_SECONDS, { query });
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.text().catch(() => "<unreadable body>");
+    throw new Error(`ListObjectsV2 failed: HTTP ${res.status} ${res.statusText} — ${body}`);
+  }
+  const xml = await res.text();
+
+  const keys: string[] = [];
+  const keyRegex = /<Contents>[\s\S]*?<Key>([^<]+)<\/Key>[\s\S]*?<\/Contents>/g;
+  let m: RegExpExecArray | null;
+  while ((m = keyRegex.exec(xml)) !== null) {
+    keys.push(decodeXmlText(m[1]));
+  }
+
+  const truncated = /<IsTruncated>\s*true\s*<\/IsTruncated>/i.test(xml);
+  let nextContinuationToken: string | undefined;
+  if (truncated) {
+    const tokenMatch = xml.match(/<NextContinuationToken>([^<]+)<\/NextContinuationToken>/);
+    nextContinuationToken = tokenMatch ? decodeXmlText(tokenMatch[1]) : undefined;
+  }
+
+  return { keys, nextContinuationToken };
+}
+
+async function getObject(config: R2PresignConfig, key: string): Promise<Uint8Array<ArrayBuffer>> {
+  const url = presignR2Url(config, "GET", key, PRESIGN_TTL_SECONDS);
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.text().catch(() => "<unreadable body>");
+    throw new Error(`GetObject ${key} failed: HTTP ${res.status} ${res.statusText} — ${body}`);
+  }
+  const buf = await res.arrayBuffer();
+  return new Uint8Array(buf) as Uint8Array<ArrayBuffer>;
+}
+
+async function putObject(
+  config: R2PresignConfig,
+  key: string,
+  body: Uint8Array<ArrayBuffer>,
+  contentType: string,
+): Promise<void> {
+  const url = presignR2Url(config, "PUT", key, PRESIGN_TTL_SECONDS, {
+    signedHeaders: { "content-type": contentType },
+  });
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "content-type": contentType },
+    body,
+  });
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "<unreadable body>");
+    throw new Error(`PutObject ${key} failed: HTTP ${res.status} ${res.statusText} — ${errBody}`);
+  }
+}
+
 // ── Main ──
 
 async function main() {
@@ -146,6 +336,8 @@ async function main() {
     process.exit(1);
   }
 
+  const config: R2PresignConfig = { accountId, accessKeyId, secretAccessKey, bucketName };
+
   console.log("PHI Key Rotation Script");
   console.log("=======================");
   console.log(`Bucket: ${bucketName}`);
@@ -157,13 +349,6 @@ async function main() {
   const newKey = await importKey(newKeyHex);
   console.log("Keys imported successfully.");
 
-  // Create S3 client
-  const client = new S3Client({
-    region: "auto",
-    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-    credentials: { accessKeyId, secretAccessKey },
-  });
-
   // List all .enc files under clinics/
   console.log(`\nScanning ${ROOT_PREFIX}* for encrypted PHI files...`);
 
@@ -171,21 +356,19 @@ async function main() {
   let continuationToken: string | undefined;
 
   do {
-    const response = await client.send(
-      new ListObjectsV2Command({
-        Bucket: bucketName,
-        Prefix: ROOT_PREFIX,
-        ContinuationToken: continuationToken,
-      }),
+    const { keys, nextContinuationToken } = await listObjectsPage(
+      config,
+      ROOT_PREFIX,
+      continuationToken,
     );
 
-    for (const obj of response.Contents ?? []) {
-      if (obj.Key && isPHIFile(obj.Key)) {
-        encFiles.push(obj.Key);
+    for (const key of keys) {
+      if (isPHIFile(key)) {
+        encFiles.push(key);
       }
     }
 
-    continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+    continuationToken = nextContinuationToken;
   } while (continuationToken);
 
   console.log(`Found ${encFiles.length} encrypted PHI file(s).`);
@@ -212,23 +395,7 @@ async function main() {
       }
 
       // Download
-      const getResponse = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }));
-
-      if (!getResponse.Body) {
-        throw new Error("Empty response body");
-      }
-
-      const chunks: Uint8Array[] = [];
-      const body = getResponse.Body as AsyncIterable<Uint8Array>;
-      for await (const chunk of body) {
-        chunks.push(chunk);
-      }
-      const encrypted = new Uint8Array(chunks.reduce((acc, c) => acc + c.length, 0));
-      let offset = 0;
-      for (const chunk of chunks) {
-        encrypted.set(chunk, offset);
-        offset += chunk.length;
-      }
+      const encrypted = await getObject(config, key);
 
       // Decrypt with old key
       const plaintext = await decryptWithKey(encrypted, oldKey);
@@ -237,14 +404,7 @@ async function main() {
       const reEncrypted = await encryptWithKey(plaintext, newKey);
 
       // Upload back
-      await client.send(
-        new PutObjectCommand({
-          Bucket: bucketName,
-          Key: key,
-          Body: reEncrypted,
-          ContentType: "application/octet-stream",
-        }),
-      );
+      await putObject(config, key, reEncrypted, "application/octet-stream");
 
       succeeded++;
       console.log(`${progress} Re-encrypted: ${key}`);

--- a/src/lib/__tests__/r2-encrypted.test.ts
+++ b/src/lib/__tests__/r2-encrypted.test.ts
@@ -17,10 +17,12 @@ vi.mock("@/lib/logger", () => ({
 
 const mockUploadToR2 = vi.fn();
 const mockDeleteFromR2 = vi.fn();
+const mockGetR2Bucket = vi.fn();
 
 vi.mock("@/lib/r2", () => ({
   uploadToR2: (...args: unknown[]) => mockUploadToR2(...args),
   deleteFromR2: (...args: unknown[]) => mockDeleteFromR2(...args),
+  getR2Bucket: () => mockGetR2Bucket(),
 }));
 
 const mockEncryptBuffer = vi.fn();
@@ -33,25 +35,15 @@ vi.mock("@/lib/encryption", () => ({
   isEncryptionConfigured: () => mockIsEncryptionConfigured(),
 }));
 
-// Mock @aws-sdk/client-s3 for downloadAndDecrypt
-const mockSend = vi.fn();
-vi.mock("@aws-sdk/client-s3", () => {
-  class FakeS3Client {
-    send = mockSend;
-    constructor() {}
-  }
+// Native R2 binding: downloadAndDecrypt() calls getR2Bucket().get(key).
+// We model the bucket as an object exposing a `get` mock whose resolved
+// value mimics an R2ObjectBody (arrayBuffer()).
+const mockBucketGet = vi.fn();
+function fakeR2Object(buf: Buffer) {
   return {
-    S3Client: FakeS3Client,
-    GetObjectCommand: class {
-      Bucket: string;
-      Key: string;
-      constructor(input: { Bucket: string; Key: string }) {
-        this.Bucket = input.Bucket;
-        this.Key = input.Key;
-      }
-    },
+    arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
   };
-});
+}
 
 const originalEnv = { ...process.env };
 
@@ -161,14 +153,14 @@ describe("encryptAndUpload", () => {
 
 describe("downloadAndDecrypt", () => {
   beforeEach(() => {
-    mockSend.mockReset();
+    mockBucketGet.mockReset();
+    mockGetR2Bucket.mockReset();
     mockIsEncryptionConfigured.mockReset();
     mockDecryptBuffer.mockReset();
     process.env = { ...originalEnv };
-    process.env.R2_ACCOUNT_ID = "test-account";
-    process.env.R2_ACCESS_KEY_ID = "test-key";
-    process.env.R2_SECRET_ACCESS_KEY = "test-secret";
     process.env.R2_BUCKET_NAME = "test-bucket";
+    // Default: a working bucket binding whose get() is driven per-test.
+    mockGetR2Bucket.mockReturnValue({ get: (...a: unknown[]) => mockBucketGet(...a) });
   });
 
   afterEach(() => {
@@ -184,9 +176,9 @@ describe("downloadAndDecrypt", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when R2 env vars are missing", async () => {
+  it("returns null when the R2 binding is unavailable", async () => {
     mockIsEncryptionConfigured.mockReturnValue(true);
-    delete process.env.R2_ACCOUNT_ID;
+    mockGetR2Bucket.mockReturnValue(null);
 
     const { downloadAndDecrypt } = await import("@/lib/r2-encrypted");
     const result = await downloadAndDecrypt("files/test.pdf");
@@ -199,13 +191,7 @@ describe("downloadAndDecrypt", () => {
     const encryptedContent = Buffer.from("encrypted-data");
     const decryptedContent = Buffer.from("decrypted-data");
 
-    mockSend.mockResolvedValueOnce({
-      Body: {
-        [Symbol.asyncIterator]: async function* () {
-          yield encryptedContent;
-        },
-      },
-    });
+    mockBucketGet.mockResolvedValueOnce(fakeR2Object(encryptedContent));
     mockDecryptBuffer.mockResolvedValueOnce(decryptedContent);
 
     const { downloadAndDecrypt } = await import("@/lib/r2-encrypted");
@@ -217,45 +203,30 @@ describe("downloadAndDecrypt", () => {
 
   it("appends .enc suffix if not present", async () => {
     mockIsEncryptionConfigured.mockReturnValue(true);
-    mockSend.mockResolvedValueOnce({
-      Body: {
-        [Symbol.asyncIterator]: async function* () {
-          yield Buffer.from("data");
-        },
-      },
-    });
+    mockBucketGet.mockResolvedValueOnce(fakeR2Object(Buffer.from("data")));
     mockDecryptBuffer.mockResolvedValueOnce(Buffer.from("decrypted"));
 
     const { downloadAndDecrypt } = await import("@/lib/r2-encrypted");
     await downloadAndDecrypt("files/test.pdf");
 
-    expect(mockSend).toHaveBeenCalledOnce();
-    const sendArg = mockSend.mock.calls[0][0];
-    expect(sendArg.Key).toBe("files/test.pdf.enc");
-    expect(sendArg.Bucket).toBe("test-bucket");
+    expect(mockBucketGet).toHaveBeenCalledOnce();
+    expect(mockBucketGet.mock.calls[0][0]).toBe("files/test.pdf.enc");
   });
 
   it("does not double-append .enc suffix", async () => {
     mockIsEncryptionConfigured.mockReturnValue(true);
-    mockSend.mockResolvedValueOnce({
-      Body: {
-        [Symbol.asyncIterator]: async function* () {
-          yield Buffer.from("data");
-        },
-      },
-    });
+    mockBucketGet.mockResolvedValueOnce(fakeR2Object(Buffer.from("data")));
     mockDecryptBuffer.mockResolvedValueOnce(Buffer.from("decrypted"));
 
     const { downloadAndDecrypt } = await import("@/lib/r2-encrypted");
     await downloadAndDecrypt("files/test.pdf.enc");
 
-    const sendArg = mockSend.mock.calls[0][0];
-    expect(sendArg.Key).toBe("files/test.pdf.enc");
+    expect(mockBucketGet.mock.calls[0][0]).toBe("files/test.pdf.enc");
   });
 
-  it("returns null when S3 response has no Body", async () => {
+  it("returns null when the object does not exist", async () => {
     mockIsEncryptionConfigured.mockReturnValue(true);
-    mockSend.mockResolvedValueOnce({ Body: null });
+    mockBucketGet.mockResolvedValueOnce(null);
 
     const { downloadAndDecrypt } = await import("@/lib/r2-encrypted");
     const result = await downloadAndDecrypt("files/test.pdf");
@@ -263,9 +234,9 @@ describe("downloadAndDecrypt", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null and logs error when S3 client throws", async () => {
+  it("returns null and logs error when the bucket get throws", async () => {
     mockIsEncryptionConfigured.mockReturnValue(true);
-    mockSend.mockRejectedValueOnce(new Error("Network error"));
+    mockBucketGet.mockRejectedValueOnce(new Error("Network error"));
 
     const { downloadAndDecrypt } = await import("@/lib/r2-encrypted");
     const result = await downloadAndDecrypt("files/test.pdf");

--- a/src/lib/__tests__/r2-presigned-post.test.ts
+++ b/src/lib/__tests__/r2-presigned-post.test.ts
@@ -10,23 +10,12 @@
  *   - signs a PUT request carrying the locked Content-Type / Content-Disposition,
  *   - returns the signed URL, an empty `fields` map, and the key.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
-const signMock = vi.fn(async (_url: string, _init: unknown) => ({
-  url: "https://test-account.r2.cloudflarestorage.com/test-bucket/clinics/abc/logos/file.png?X-Amz-Signature=deadbeef",
-}));
-
-vi.mock("aws4fetch", () => ({
-  AwsClient: class {
-    sign = signMock;
-  },
-}));
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 describe("getPresignedUploadPost", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
-    signMock.mockClear();
     process.env.R2_ACCOUNT_ID = "test-account";
     process.env.R2_ACCESS_KEY_ID = "test-key";
     process.env.R2_SECRET_ACCESS_KEY = "test-secret";
@@ -42,7 +31,6 @@ describe("getPresignedUploadPost", () => {
     const { getPresignedUploadPost } = await import("../r2");
     const result = await getPresignedUploadPost("clinics/abc/logos/file.png", "image/png");
     expect(result).toBeNull();
-    expect(signMock).not.toHaveBeenCalled();
   });
 
   it("keeps DEFAULT_PRESIGNED_POST_MAX_SIZE at 2 MB for backward compatibility", async () => {
@@ -50,28 +38,34 @@ describe("getPresignedUploadPost", () => {
     expect(DEFAULT_PRESIGNED_POST_MAX_SIZE).toBe(2 * 1024 * 1024);
   });
 
-  it("signs a PUT request with the locked Content-Type and Content-Disposition", async () => {
+  it("signs a presigned PUT URL against the R2 S3 endpoint", async () => {
     const { getPresignedUploadPost } = await import("../r2");
 
-    await getPresignedUploadPost("clinics/abc/photos/file.jpg", "image/jpeg");
+    const result = await getPresignedUploadPost("clinics/abc/photos/file.jpg", "image/jpeg");
 
-    expect(signMock).toHaveBeenCalledTimes(1);
-    const [, init] = signMock.mock.calls[0] as unknown as [
-      string,
-      { method: string; headers: Record<string, string> },
-    ];
-    expect(init.method).toBe("PUT");
-    expect(init.headers["Content-Type"]).toBe("image/jpeg");
-    expect(init.headers["Content-Disposition"]).toBe("attachment");
+    expect(result).not.toBeNull();
+    const u = new URL(result!.url);
+    expect(u.host).toBe("test-account.r2.cloudflarestorage.com");
+    expect(u.pathname).toBe("/test-bucket/clinics/abc/photos/file.jpg");
+    // SigV4 query parameters must all be present.
+    expect(u.searchParams.get("X-Amz-Algorithm")).toBe("AWS4-HMAC-SHA256");
+    expect(u.searchParams.get("X-Amz-Credential")).toContain("test-key/");
+    expect(u.searchParams.get("X-Amz-Date")).toMatch(/^\d{8}T\d{6}Z$/);
+    expect(u.searchParams.get("X-Amz-Expires")).toBe("600");
+    expect(u.searchParams.get("X-Amz-Signature")).toMatch(/^[0-9a-f]{64}$/);
+    // Content-Type + Content-Disposition are locked into the signature.
+    const signedHeaders = u.searchParams.get("X-Amz-SignedHeaders") ?? "";
+    expect(signedHeaders).toContain("content-type");
+    expect(signedHeaders).toContain("content-disposition");
+    expect(signedHeaders).toContain("host");
   });
 
-  it("returns the signed URL, an empty fields map, and the key", async () => {
+  it("returns an empty fields map and the key", async () => {
     const { getPresignedUploadPost } = await import("../r2");
 
     const result = await getPresignedUploadPost("clinics/abc/logos/file.png", "image/png");
 
     expect(result).not.toBeNull();
-    expect(result!.url).toContain("r2.cloudflarestorage.com");
     expect(result!.key).toBe("clinics/abc/logos/file.png");
     expect(result!.fields).toEqual({});
   });

--- a/src/lib/__tests__/r2-presigned-post.test.ts
+++ b/src/lib/__tests__/r2-presigned-post.test.ts
@@ -1,55 +1,32 @@
 /**
- * Regression tests for finding #2 (CRITICAL): direct uploads must use a
- * presigned POST policy that R2 enforces at write time, not a presigned PUT
- * URL whose size limit can only be checked after the bytes are stored.
+ * Tests for getPresignedUploadPost after the native-R2 migration.
  *
- * Pre-fix bug: getPresignedUploadUrl() returned a presigned PUT URL. PUT
- * URLs cannot enforce `content-length-range`, so a malicious client could
- * upload an arbitrarily large file before the confirmation route ever ran.
- *
- * These tests assert the policy that R2 receives:
- *   - `content-length-range` with the requested maxSize (default 2 MB).
- *   - `eq $Content-Type` matching the requested contentType.
- * That policy is what causes oversized / wrong-type uploads to be rejected
- * *at upload time* (per Subtask 6 of Task 1.2).
+ * Native R2 has no presigned-POST primitive, so direct uploads now use a
+ * presigned PUT URL signed with aws4fetch. A PUT URL cannot enforce a
+ * `content-length-range` at write time, so the authoritative size + magic-byte
+ * guard is the PUT /api/upload confirm step (HeadObject + per-category cap);
+ * see src/app/api/upload/route.ts. These tests assert the new contract:
+ *   - returns null when R2 S3 credentials are not configured,
+ *   - signs a PUT request carrying the locked Content-Type / Content-Disposition,
+ *   - returns the signed URL, an empty `fields` map, and the key.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const createPresignedPostMock = vi.fn(async () => ({
-  url: "https://r2.example/bucket",
-  fields: {
-    bucket: "test-bucket",
-    "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
-    Policy: "base64-policy",
-    "X-Amz-Signature": "deadbeef",
+const signMock = vi.fn(async (_url: string, _init: unknown) => ({
+  url: "https://test-account.r2.cloudflarestorage.com/test-bucket/clinics/abc/logos/file.png?X-Amz-Signature=deadbeef",
+}));
+
+vi.mock("aws4fetch", () => ({
+  AwsClient: class {
+    sign = signMock;
   },
 }));
-
-vi.mock("@aws-sdk/s3-presigned-post", () => ({
-  createPresignedPost: createPresignedPostMock,
-}));
-
-vi.mock("@aws-sdk/client-s3", () => {
-  class FakeS3Client {
-    send = vi.fn();
-  }
-  class FakeCommand {
-    constructor(public input: unknown) {}
-  }
-  return {
-    S3Client: FakeS3Client,
-    PutObjectCommand: FakeCommand,
-    HeadObjectCommand: FakeCommand,
-    GetObjectCommand: FakeCommand,
-    DeleteObjectCommand: FakeCommand,
-  };
-});
 
 describe("getPresignedUploadPost", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
-    createPresignedPostMock.mockClear();
+    signMock.mockClear();
     process.env.R2_ACCOUNT_ID = "test-account";
     process.env.R2_ACCESS_KEY_ID = "test-key";
     process.env.R2_SECRET_ACCESS_KEY = "test-secret";
@@ -60,92 +37,42 @@ describe("getPresignedUploadPost", () => {
     process.env = { ...originalEnv };
   });
 
-  it("returns null when R2 is not configured", async () => {
+  it("returns null when R2 credentials are not configured", async () => {
     delete process.env.R2_ACCOUNT_ID;
     const { getPresignedUploadPost } = await import("../r2");
     const result = await getPresignedUploadPost("clinics/abc/logos/file.png", "image/png");
     expect(result).toBeNull();
-    expect(createPresignedPostMock).not.toHaveBeenCalled();
+    expect(signMock).not.toHaveBeenCalled();
   });
 
-  it("locks the policy to the requested content-length-range", async () => {
-    const { getPresignedUploadPost, DEFAULT_PRESIGNED_POST_MAX_SIZE } = await import("../r2");
-
-    await getPresignedUploadPost("clinics/abc/logos/file.png", "image/png");
-
-    expect(createPresignedPostMock).toHaveBeenCalledTimes(1);
-    const [, params] = createPresignedPostMock.mock.calls[0] as unknown as [
-      unknown,
-      {
-        Bucket: string;
-        Key: string;
-        Conditions: Array<unknown[]>;
-        Fields: Record<string, string>;
-        Expires: number;
-      },
-    ];
-
-    expect(params.Bucket).toBe("test-bucket");
-    expect(params.Key).toBe("clinics/abc/logos/file.png");
-
-    // The default maxSize must match the public constant so tests catch
-    // accidental drift between server-side enforcement and the route
-    // handler's own MAX_FILE_SIZE constant.
+  it("keeps DEFAULT_PRESIGNED_POST_MAX_SIZE at 2 MB for backward compatibility", async () => {
+    const { DEFAULT_PRESIGNED_POST_MAX_SIZE } = await import("../r2");
     expect(DEFAULT_PRESIGNED_POST_MAX_SIZE).toBe(2 * 1024 * 1024);
-
-    expect(params.Conditions).toContainEqual([
-      "content-length-range",
-      0,
-      DEFAULT_PRESIGNED_POST_MAX_SIZE,
-    ]);
   });
 
-  it("locks the policy to the exact declared Content-Type", async () => {
+  it("signs a PUT request with the locked Content-Type and Content-Disposition", async () => {
     const { getPresignedUploadPost } = await import("../r2");
 
     await getPresignedUploadPost("clinics/abc/photos/file.jpg", "image/jpeg");
 
-    const [, params] = createPresignedPostMock.mock.calls[0] as unknown as [
-      unknown,
-      {
-        Conditions: Array<unknown[]>;
-        Fields: Record<string, string>;
-      },
+    expect(signMock).toHaveBeenCalledTimes(1);
+    const [, init] = signMock.mock.calls[0] as unknown as [
+      string,
+      { method: string; headers: Record<string, string> },
     ];
-
-    expect(params.Conditions).toContainEqual(["eq", "$Content-Type", "image/jpeg"]);
-    // The Content-Type field must be pre-populated so R2 can validate it
-    // against the policy condition without the client choosing the value.
-    expect(params.Fields["Content-Type"]).toBe("image/jpeg");
+    expect(init.method).toBe("PUT");
+    expect(init.headers["Content-Type"]).toBe("image/jpeg");
+    expect(init.headers["Content-Disposition"]).toBe("attachment");
   });
 
-  it("respects a caller-supplied maxSize (e.g. tighter per-route limit)", async () => {
-    const { getPresignedUploadPost } = await import("../r2");
-
-    const customMax = 512 * 1024; // 512 KB
-    await getPresignedUploadPost("clinics/abc/avatars/me.png", "image/png", customMax);
-
-    const [, params] = createPresignedPostMock.mock.calls[0] as unknown as [
-      unknown,
-      { Conditions: Array<unknown[]>; Expires: number },
-    ];
-
-    expect(params.Conditions).toContainEqual(["content-length-range", 0, customMax]);
-  });
-
-  it("returns the URL, fields, and key for the client to POST", async () => {
+  it("returns the signed URL, an empty fields map, and the key", async () => {
     const { getPresignedUploadPost } = await import("../r2");
 
     const result = await getPresignedUploadPost("clinics/abc/logos/file.png", "image/png");
 
     expect(result).not.toBeNull();
-    expect(result!.url).toBe("https://r2.example/bucket");
+    expect(result!.url).toContain("r2.cloudflarestorage.com");
     expect(result!.key).toBe("clinics/abc/logos/file.png");
-    expect(result!.fields).toMatchObject({
-      bucket: "test-bucket",
-      "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
-      Policy: "base64-policy",
-      "X-Amz-Signature": "deadbeef",
-    });
+    expect(result!.fields).toEqual({});
   });
 });

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1057,6 +1057,7 @@ export function getR2Config(): {
   secretAccessKey: string | undefined;
   bucketName: string | undefined;
   signedUrlSecret: string | undefined;
+  signedUrlBase: string | undefined;
   publicUrl: string | undefined;
 } {
   return {
@@ -1065,6 +1066,7 @@ export function getR2Config(): {
     secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
     bucketName: process.env.R2_BUCKET_NAME,
     signedUrlSecret: process.env.R2_SIGNED_URL_SECRET,
+    signedUrlBase: process.env.R2_SIGNED_URL_BASE,
     publicUrl: process.env.R2_PUBLIC_URL,
   };
 }

--- a/src/lib/r2-encrypted.ts
+++ b/src/lib/r2-encrypted.ts
@@ -110,7 +110,7 @@ export async function downloadAndDecrypt(key: string): Promise<Buffer | null> {
   try {
     // Native R2 binding: download the encrypted object directly from the
     // bound bucket. No AWS SDK / credentials required (see src/lib/r2.ts).
-    const bucket = getR2Bucket();
+    const bucket = await getR2Bucket();
     if (!bucket) return null;
 
     const encKey = key.endsWith(".enc") ? key : `${key}.enc`;

--- a/src/lib/r2-encrypted.ts
+++ b/src/lib/r2-encrypted.ts
@@ -11,7 +11,7 @@
 
 import { encryptBuffer, decryptBuffer, isEncryptionConfigured } from "@/lib/encryption";
 import { logger } from "@/lib/logger";
-import { uploadToR2, deleteFromR2 } from "@/lib/r2";
+import { uploadToR2, deleteFromR2, getR2Bucket } from "@/lib/r2";
 
 /**
  * Diagnostic / audit metadata threaded through encrypted upload calls.
@@ -108,36 +108,16 @@ export async function downloadAndDecrypt(key: string): Promise<Buffer | null> {
   }
 
   try {
-    // Import getClient-level access for raw object download
-    const { S3Client, GetObjectCommand } = await import("@aws-sdk/client-s3");
-
-    const accountId = process.env.R2_ACCOUNT_ID;
-    const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-    const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
-    const bucketName = process.env.R2_BUCKET_NAME;
-
-    if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
-      return null;
-    }
-
-    const client = new S3Client({
-      region: "auto",
-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-      credentials: { accessKeyId, secretAccessKey },
-    });
+    // Native R2 binding: download the encrypted object directly from the
+    // bound bucket. No AWS SDK / credentials required (see src/lib/r2.ts).
+    const bucket = getR2Bucket();
+    if (!bucket) return null;
 
     const encKey = key.endsWith(".enc") ? key : `${key}.enc`;
-    const response = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: encKey }));
+    const object = await bucket.get(encKey);
+    if (!object) return null;
 
-    if (!response.Body) return null;
-
-    // Collect the stream into a buffer
-    const chunks: Uint8Array[] = [];
-    const body = response.Body as AsyncIterable<Uint8Array>;
-    for await (const chunk of body) {
-      chunks.push(chunk);
-    }
-    const encrypted = Buffer.concat(chunks);
+    const encrypted = Buffer.from(await object.arrayBuffer());
 
     return decryptBuffer(encrypted);
   } catch (err) {

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -325,11 +325,6 @@ function presignR2Url(
   return `https://${host}${canonicalUri}?${canonicalQuery}&X-Amz-Signature=${signature}`;
 }
 
-/** Bucket name for logging / public-URL construction. */
-function getR2BucketName(): string | undefined {
-  return getR2Config().bucketName;
-}
-
 /**
  * Check if R2 is configured and available.
  *

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -35,7 +35,7 @@
  *                          Rotate per `docs/SOP-SECRET-ROTATION.md` §8.
  */
 
-import { createHmac } from "crypto";
+import { createHash, createHmac } from "crypto";
 import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
 
@@ -543,18 +543,6 @@ async function _getPresignedDownloadUrl(key: string, expiresIn = 3600): Promise<
   return presignR2Url(config, "GET", key, expiresIn, {
     query: { "response-content-disposition": "attachment" },
   });
-}
-
-// eslint-disable-next-line no-unused-vars
-async function _unusedPresignDownloadShim(key: string, expiresIn = 3600): Promise<string | null> {
-  const config = getR2PresignConfig();
-  if (!config) return null;
-  const signed = await Promise.resolve({
-    method: "GET",
-    aws: { signQuery: true },
-  });
-
-  return signed.url;
 }
 
 /**

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -1,7 +1,17 @@
+/// <reference types="@cloudflare/workers-types" />
 /**
  * Cloudflare R2 storage client.
  *
- * R2 is S3-compatible, so we use the AWS SDK v3.
+ * Object I/O (put / get / head / delete / list) uses Cloudflare's NATIVE R2
+ * binding (`UPLOADS_BUCKET`, declared in wrangler.toml and resolved per-request
+ * via getR2Bucket()). This avoids bundling the AWS SDK (~48 MiB), which pushed
+ * the Worker past the 10 MiB compressed upload limit.
+ *
+ * Presigned upload/download URLs are signed with the lightweight `aws4fetch`
+ * library against the R2 S3 API, since the native binding has no presigned-URL
+ * primitive. That signing path is the ONLY place R2 S3 credentials are still
+ * used.
+ *
  * Advantages over Supabase Storage:
  *   - Free tier: 10 GB storage, 10M class-A ops, no egress fees
  *   - Served via Cloudflare CDN edge network
@@ -13,11 +23,12 @@
  *   - For truly public assets (clinic logos, marketing images), use a separate
  *     "webs-alots-public" bucket and NEVER put user-uploaded files there
  *
- * Required env vars:
- *   R2_ACCOUNT_ID        — Cloudflare account ID
- *   R2_ACCESS_KEY_ID     — R2 API token access key
- *   R2_SECRET_ACCESS_KEY — R2 API token secret key
- *   R2_BUCKET_NAME       — R2 bucket name (e.g., "webs-alots-uploads")
+ * Env vars:
+ *   (object I/O) — none; uses the UPLOADS_BUCKET binding from wrangler.toml
+ *   R2_ACCOUNT_ID        — Cloudflare account ID (presign + public-URL only)
+ *   R2_ACCESS_KEY_ID     — R2 API token access key (presign only)
+ *   R2_SECRET_ACCESS_KEY — R2 API token secret key (presign only)
+ *   R2_BUCKET_NAME       — R2 bucket name, e.g. "webs-alots-uploads" (presign + logging)
  *   R2_PUBLIC_URL        — (Deprecated) Legacy public URL; use signed URLs instead
  *   R2_SIGNED_URL_SECRET — Secret for generating per-request signed URLs and
  *                          hashing upload filenames. **Required in production.**

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -59,17 +59,17 @@ import { logger } from "@/lib/logger";
  *     with a helpful error rather than silently using a shared constant.
  */
 function getR2SigningSecret(): string {
-  const keySecret = process.env.R2_SIGNED_URL_SECRET;
-  if (keySecret) return keySecret;
+  const { signedUrlSecret, secretAccessKey } = getR2Config();
+  if (signedUrlSecret) return signedUrlSecret;
 
-  if (process.env.NODE_ENV === "production") {
+  if (isProduction()) {
     throw new Error(
       "R2_SIGNED_URL_SECRET is required in production. " +
         "Generate one with `openssl rand -hex 32` and deploy it as a Cloudflare Worker secret.",
     );
   }
 
-  const fallback = process.env.R2_SECRET_ACCESS_KEY;
+  const fallback = secretAccessKey;
   if (!fallback) {
     throw new Error(
       "R2 signing secret is missing. Set R2_SIGNED_URL_SECRET in your .env.local " +
@@ -94,8 +94,7 @@ function getR2SigningSecret(): string {
  * @returns Signed URL that validates against the secret
  */
 function _generateSignedR2Url(key: string, expiresIn = 3600): string {
-  const accountId = process.env.R2_ACCOUNT_ID;
-  const bucketName = process.env.R2_BUCKET_NAME;
+  const { accountId, bucketName, signedUrlBase } = getR2Config();
 
   if (!accountId || !bucketName) {
     // R2 is not configured — return a best-effort placeholder URL.
@@ -118,7 +117,7 @@ function _generateSignedR2Url(key: string, expiresIn = 3600): string {
   const signature = createHmac("sha256", secret).update(signatureBase).digest("hex").slice(0, 32);
 
   // URL format: https://{domain}/r2/{bucket}/{key}?expires={expires}&sig={signature}
-  const baseUrl = process.env.R2_SIGNED_URL_BASE || `https://oltigo.com/r2`;
+  const baseUrl = signedUrlBase || `https://oltigo.com/r2`;
   const params = new URLSearchParams({
     b: bucketName,
     k: key,

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -164,22 +164,34 @@ function _validateSignedR2Url(
   return match === 0;
 }
 
-// AWS SDK types — imported dynamically at runtime to keep the heavy SDK
-// out of the main bundle (see PERF-01 audit finding).
-type S3ClientType = import("@aws-sdk/client-s3").S3Client;
-type PutObjectCommandInputType = import("@aws-sdk/client-s3").PutObjectCommandInput;
+/**
+ * Minimal structural type for the credentials/config used by the presigned
+ * URL signing path (the only path that still needs R2 S3 API credentials).
+ */
+type R2PresignConfig = {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucketName: string;
+  publicUrl: string | undefined;
+};
 
 /**
- * Default maximum size enforced by direct-upload presigned POST policies.
- * Individual call-sites may pass a smaller bound when they know the
- * acceptable upper limit for that upload kind.
+ * Default maximum size for direct-upload presigned URLs. Individual call-sites
+ * may pass a smaller bound. Native R2 presigned PUT cannot enforce a
+ * content-length-range at write time the way an S3 POST policy could, so the
+ * authoritative size guard is the PUT /api/upload confirm step
+ * (HeadObject + per-category cap). The constant name is kept for backward
+ * compatibility with existing imports.
  */
 export const DEFAULT_PRESIGNED_POST_MAX_SIZE = 2 * 1024 * 1024; // 2 MB
 
 /**
- * Returned by {@link getPresignedUploadPost}. Clients submit the file as the
- * `file` field of a `multipart/form-data` POST to `url`, including every
- * field returned in `fields`.
+ * Returned by {@link getPresignedUploadPost}. With the native-binding
+ * migration the client now PUTs the file body directly to `url` with the
+ * `Content-Type` and `Content-Disposition` headers that were signed into the
+ * URL. `fields` is retained (always empty) so existing response shapes and
+ * callers keep compiling; clients should send no multipart fields.
  */
 export interface PresignedUploadPost {
   url: string;
@@ -187,7 +199,37 @@ export interface PresignedUploadPost {
   key: string;
 }
 
-function getR2Config() {
+/**
+ * Resolve the native R2 bucket binding from the Cloudflare request context.
+ *
+ * MUST be called lazily, per-invocation — getCloudflareContext().env is only
+ * populated inside the Worker request/runtime context. Calling it at module
+ * load (or caching the result across invocations) would capture `undefined`
+ * and break code paths such as the R2 cleanup cron.
+ *
+ * Returns null when the binding is unavailable (e.g. during `next build`
+ * static analysis, local Node tooling, or tests) so callers degrade safely.
+ */
+export function getR2Bucket(): R2Bucket | null {
+  try {
+    // Lazy require so the build/static-analysis phase (which has no request
+    // context) doesn't blow up importing the Cloudflare context helper.
+    const { getCloudflareContext } = require("@opennextjs/cloudflare") as {
+      getCloudflareContext: () => { env?: Record<string, unknown> };
+    };
+    const env = getCloudflareContext().env;
+    const bucket = env?.UPLOADS_BUCKET as R2Bucket | undefined;
+    return bucket ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the S3 API credentials used only for presigned-URL signing.
+ * Returns null when any required value is missing.
+ */
+function getR2PresignConfig(): R2PresignConfig | null {
   const accountId = process.env.R2_ACCOUNT_ID;
   const accessKeyId = process.env.R2_ACCESS_KEY_ID;
   const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
@@ -201,38 +243,20 @@ function getR2Config() {
   return { accountId, accessKeyId, secretAccessKey, bucketName, publicUrl };
 }
 
-let _client: S3ClientType | null = null;
-let _lastConfigHash = "";
-
-async function getClient(): Promise<S3ClientType | null> {
-  const config = getR2Config();
-  if (!config) return null;
-
-  // Rebuild the client whenever credentials or config change,
-  // ensuring stale credentials are never used after rotation.
-  const configHash = `${config.accountId}:${config.accessKeyId}:${config.bucketName}`;
-  if (_client && configHash === _lastConfigHash) return _client;
-
-  const { S3Client } = await import("@aws-sdk/client-s3");
-
-  _lastConfigHash = configHash;
-  _client = new S3Client({
-    region: "auto",
-    endpoint: `https://${config.accountId}.r2.cloudflarestorage.com`,
-    credentials: {
-      accessKeyId: config.accessKeyId,
-      secretAccessKey: config.secretAccessKey,
-    },
-  });
-
-  return _client;
+/** Bucket name for logging / public-URL construction. */
+function getR2BucketName(): string | undefined {
+  return process.env.R2_BUCKET_NAME;
 }
 
 /**
  * Check if R2 is configured and available.
+ *
+ * True when either the native binding is present (the production/runtime
+ * path) or the S3 API credentials are configured (the presign path / local
+ * tooling). Callers gate uploads on this before attempting object I/O.
  */
 export function isR2Configured(): boolean {
-  return getR2Config() !== null;
+  return getR2Bucket() !== null || getR2PresignConfig() !== null;
 }
 
 /**

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -406,30 +406,50 @@ export async function getPresignedUploadPost(
   maxSize: number = DEFAULT_PRESIGNED_POST_MAX_SIZE,
   expiresIn = 600,
 ): Promise<PresignedUploadPost | null> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return null;
+  // Native R2 has no presigned POST primitive. We sign a presigned PUT URL
+  // against the R2 S3 API with aws4fetch instead. The browser PUTs the file
+  // body directly to `url` with the Content-Type / Content-Disposition headers
+  // that are signed into the URL (X-Amz-SignedHeaders).
+  //
+  // NOTE (size enforcement): a presigned PUT cannot enforce a
+  // content-length-range the way an S3 POST policy could. The authoritative
+  // size + magic-byte guard is the PUT /api/upload confirm step, which
+  // HeadObjects the upload and deletes it if it exceeds the per-category cap.
+  // `maxSize` is therefore advisory here and kept in the signature for
+  // backward compatibility.
+  void maxSize;
 
-  const { createPresignedPost } = await import("@aws-sdk/s3-presigned-post");
+  const config = getR2PresignConfig();
+  if (!config) return null;
 
-  const presigned = await createPresignedPost(client, {
-    Bucket: config.bucketName,
-    Key: key,
-    Conditions: [
-      ["content-length-range", 0, maxSize],
-      ["eq", "$Content-Type", contentType],
-      ["eq", "$Content-Disposition", "attachment"],
-    ],
-    Fields: {
+  const { AwsClient } = await import("aws4fetch");
+  const aws = new AwsClient({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    service: "s3",
+    region: "auto",
+  });
+
+  const endpoint =
+    `https://${config.accountId}.r2.cloudflarestorage.com/` +
+    `${encodeURIComponent(config.bucketName)}/${encodeURI(key)}`;
+  const url = new URL(endpoint);
+  url.searchParams.set("X-Amz-Expires", String(expiresIn));
+
+  // S13-FIX: lock Content-Disposition: attachment into the signature so the
+  // browser can never render uploaded files inline (stored-XSS defense).
+  const signed = await aws.sign(url.toString(), {
+    method: "PUT",
+    headers: {
       "Content-Type": contentType,
       "Content-Disposition": "attachment",
     },
-    Expires: expiresIn,
+    aws: { signQuery: true, allHeaders: true },
   });
 
   return {
-    url: presigned.url,
-    fields: presigned.fields,
+    url: signed.url,
+    fields: {},
     key,
   };
 }
@@ -442,29 +462,33 @@ export async function getPresignedUploadPost(
  * @returns Pre-signed download URL, or null if R2 is not configured
  */
 async function _getPresignedDownloadUrl(key: string, expiresIn = 3600): Promise<string | null> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return null;
+  const config = getR2PresignConfig();
+  if (!config) return null;
 
-  const { GetObjectCommand } = await import("@aws-sdk/client-s3");
-  const { getSignedUrl } = await import("@aws-sdk/s3-request-presigner");
-
-  // S13-FIX: Set Content-Disposition to "attachment" so browsers will always
-  // download the file rather than rendering it inline. This prevents stored XSS
-  // attacks where a malicious HTML file that bypasses magic-byte validation could
-  // be rendered in the context of the R2 storage domain.
-  const command = new GetObjectCommand({
-    Bucket: config.bucketName,
-    Key: key,
-    ResponseContentDisposition: "attachment",
+  const { AwsClient } = await import("aws4fetch");
+  const aws = new AwsClient({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    service: "s3",
+    region: "auto",
   });
+
+  const endpoint =
+    `https://${config.accountId}.r2.cloudflarestorage.com/` +
+    `${encodeURIComponent(config.bucketName)}/${encodeURI(key)}`;
+  const url = new URL(endpoint);
+  url.searchParams.set("X-Amz-Expires", String(expiresIn));
+  // S13-FIX: force attachment download rather than inline rendering.
+  url.searchParams.set("response-content-disposition", "attachment");
 
   // Audit 8.2: We do not log the download here because getPresignedDownloadUrl
   // only generates the URL, it doesn't mean the file was actually downloaded.
-  // The actual download access log should be tracked via Cloudflare Logpush
-  // on the R2 bucket or a dedicated download proxy route.
+  const signed = await aws.sign(url.toString(), {
+    method: "GET",
+    aws: { signQuery: true },
+  });
 
-  return getSignedUrl(client, command, { expiresIn });
+  return signed.url;
 }
 
 /**
@@ -484,22 +508,15 @@ export interface R2ObjectMetadata {
  * Returns `null` if the object does not exist or R2 is not configured.
  */
 export async function getR2ObjectMetadata(key: string): Promise<R2ObjectMetadata | null> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return null;
-
-  const { HeadObjectCommand } = await import("@aws-sdk/client-s3");
+  const bucket = getR2Bucket();
+  if (!bucket) return null;
 
   try {
-    const response = await client.send(
-      new HeadObjectCommand({
-        Bucket: config.bucketName,
-        Key: key,
-      }),
-    );
+    const head = await bucket.head(key);
+    if (!head) return null;
     return {
-      contentLength: response.ContentLength ?? 0,
-      contentType: response.ContentType ?? null,
+      contentLength: head.size ?? 0,
+      contentType: head.httpMetadata?.contentType ?? null,
     };
   } catch {
     return null;
@@ -526,40 +543,30 @@ export async function listR2Objects(
   prefix: string,
   opts: { limit?: number; pageSize?: number } = {},
 ): Promise<string[]> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return [];
+  const bucket = getR2Bucket();
+  if (!bucket) return [];
 
   const limit = opts.limit ?? Number.POSITIVE_INFINITY;
   const pageSize = opts.pageSize ?? 1000;
   if (limit <= 0) return [];
 
-  const { ListObjectsV2Command } = await import("@aws-sdk/client-s3");
-
   const keys: string[] = [];
-  let continuationToken: string | undefined;
+  let cursor: string | undefined;
 
   do {
-    const response = await client.send(
-      new ListObjectsV2Command({
-        Bucket: config.bucketName,
-        Prefix: prefix,
-        MaxKeys: pageSize,
-        ContinuationToken: continuationToken,
-      }),
-    );
+    const result = await bucket.list({
+      prefix,
+      limit: pageSize,
+      cursor,
+    });
 
-    for (const obj of response.Contents ?? []) {
-      if (typeof obj.Key === "string") {
-        keys.push(obj.Key);
-        if (keys.length >= limit) return keys;
-      }
+    for (const obj of result.objects) {
+      keys.push(obj.key);
+      if (keys.length >= limit) return keys;
     }
 
-    continuationToken = response.IsTruncated
-      ? (response.NextContinuationToken ?? undefined)
-      : undefined;
-  } while (continuationToken);
+    cursor = result.truncated ? result.cursor : undefined;
+  } while (cursor);
 
   return keys;
 }
@@ -572,27 +579,15 @@ export async function listR2Objects(
  * @returns Buffer with the first bytes, or null if not found / not configured
  */
 export async function readR2ObjectHead(key: string, bytes = 16): Promise<Buffer | null> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return null;
-
-  const { GetObjectCommand } = await import("@aws-sdk/client-s3");
-
-  const command = new GetObjectCommand({
-    Bucket: config.bucketName,
-    Key: key,
-    Range: `bytes=0-${bytes - 1}`,
-  });
+  const bucket = getR2Bucket();
+  if (!bucket) return null;
 
   try {
-    const response = await client.send(command);
-    if (!response.Body) return null;
-    const chunks: Uint8Array[] = [];
-    // @ts-expect-error -- Body is a Readable stream in Node.js
-    for await (const chunk of response.Body) {
-      chunks.push(chunk as Uint8Array);
-    }
-    return Buffer.concat(chunks);
+    const object = await bucket.get(key, {
+      range: { offset: 0, length: bytes },
+    });
+    if (!object) return null;
+    return Buffer.from(await object.arrayBuffer());
   } catch {
     logger.warn("Failed to read R2 object head", { context: "r2", key });
     return null;

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -1,4 +1,3 @@
-/// <reference types="@cloudflare/workers-types" />
 /**
  * Cloudflare R2 storage client.
  *

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -36,8 +36,9 @@
  *                          Rotate per `docs/SOP-SECRET-ROTATION.md` §8.
  */
 
-import { createHmac } from "crypto";
+import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
+import { createHmac } from "crypto";
 
 /**
  * Resolve the HMAC secret used for R2 signed URLs and upload-key filename
@@ -221,19 +222,9 @@ export interface PresignedUploadPost {
  * Returns null when the binding is unavailable (e.g. during `next build`
  * static analysis, local Node tooling, or tests) so callers degrade safely.
  */
-export function getR2Bucket(): R2Bucket | null {
-  try {
-    // Lazy require so the build/static-analysis phase (which has no request
-    // context) doesn't blow up importing the Cloudflare context helper.
-    const { getCloudflareContext } = require("@opennextjs/cloudflare") as {
-      getCloudflareContext: () => { env?: Record<string, unknown> };
-    };
-    const env = getCloudflareContext().env;
-    const bucket = env?.UPLOADS_BUCKET as R2Bucket | undefined;
-    return bucket ?? null;
-  } catch {
-    return null;
-  }
+export async function getR2Bucket(): Promise<R2Bucket | null> {
+  const bucket = await getWorkerBinding<R2Bucket>("UPLOADS_BUCKET");
+  return bucket ?? null;
 }
 
 /**
@@ -267,7 +258,10 @@ function getR2BucketName(): string | undefined {
  * tooling). Callers gate uploads on this before attempting object I/O.
  */
 export function isR2Configured(): boolean {
-  return getR2Bucket() !== null || getR2PresignConfig() !== null;
+  // Synchronous: determined by the presign/env config, which is present in
+  // production (it gates the presign path) and in local tooling. The native
+  // binding is resolved asynchronously per-invocation inside each operation.
+  return getR2PresignConfig() !== null;
 }
 
 /**
@@ -292,7 +286,7 @@ export async function uploadToR2(
   contentType: string,
   options: { hashFilename?: boolean } = {},
 ): Promise<string | null> {
-  const bucket = getR2Bucket();
+  const bucket = await getR2Bucket();
   if (!bucket) return null;
 
   // R-16 Fix: Hash filenames on write so guessable basenames don't survive to the URL
@@ -378,7 +372,7 @@ function hashFilename(key: string): string {
  * @param key  Object key to delete
  */
 export async function deleteFromR2(key: string): Promise<void> {
-  const bucket = getR2Bucket();
+  const bucket = await getR2Bucket();
   if (!bucket) return;
 
   await bucket.delete(key);
@@ -519,7 +513,7 @@ export interface R2ObjectMetadata {
  * Returns `null` if the object does not exist or R2 is not configured.
  */
 export async function getR2ObjectMetadata(key: string): Promise<R2ObjectMetadata | null> {
-  const bucket = getR2Bucket();
+  const bucket = await getR2Bucket();
   if (!bucket) return null;
 
   try {
@@ -554,7 +548,7 @@ export async function listR2Objects(
   prefix: string,
   opts: { limit?: number; pageSize?: number } = {},
 ): Promise<string[]> {
-  const bucket = getR2Bucket();
+  const bucket = await getR2Bucket();
   if (!bucket) return [];
 
   const limit = opts.limit ?? Number.POSITIVE_INFINITY;
@@ -590,7 +584,7 @@ export async function listR2Objects(
  * @returns Buffer with the first bytes, or null if not found / not configured
  */
 export async function readR2ObjectHead(key: string, bytes = 16): Promise<Buffer | null> {
-  const bucket = getR2Bucket();
+  const bucket = await getR2Bucket();
   if (!bucket) return null;
 
   try {

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -308,12 +308,7 @@ function presignR2Url(
   ].join("\n");
 
   const hash = (data: string) => createHash("sha256").update(data).digest("hex");
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    scope,
-    hash(canonicalRequest),
-  ].join("\n");
+  const stringToSign = ["AWS4-HMAC-SHA256", amzDate, scope, hash(canonicalRequest)].join("\n");
 
   const hmac = (k: Buffer | string, d: string) => createHmac("sha256", k).update(d).digest();
   const kDate = hmac(`AWS4${config.secretAccessKey}`, dateStamp);
@@ -381,7 +376,9 @@ export async function uploadToR2(
     // Normalise a Node Buffer to a plain Uint8Array view so it is accepted in
     // the Workers runtime without relying on Node Buffer semantics.
     const putBody =
-      body instanceof Uint8Array ? new Uint8Array(body.buffer, body.byteOffset, body.byteLength) : body;
+      body instanceof Uint8Array
+        ? new Uint8Array(body.buffer, body.byteOffset, body.byteLength)
+        : body;
     await bucket.put(finalKey, putBody, {
       httpMetadata: { contentType },
     });

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -37,7 +37,7 @@
 
 import { createHash, createHmac } from "crypto";
 import { getWorkerBinding } from "@/lib/cf-bindings";
-import { getR2Config } from "@/lib/env";
+import { getR2Config, isProduction } from "@/lib/env";
 import { logger } from "@/lib/logger";
 
 /**

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -281,11 +281,8 @@ export async function uploadToR2(
   contentType: string,
   options: { hashFilename?: boolean } = {},
 ): Promise<string | null> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return null;
-
-  const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+  const bucket = getR2Bucket();
+  if (!bucket) return null;
 
   // R-16 Fix: Hash filenames on write so guessable basenames don't survive to the URL
   // This prevents enumeration attacks where attackers guess filenames
@@ -299,15 +296,15 @@ export async function uploadToR2(
     });
   }
 
-  const params: PutObjectCommandInputType = {
-    Bucket: config.bucketName,
-    Key: finalKey,
-    Body: body,
-    ContentType: contentType,
-  };
-
   try {
-    await client.send(new PutObjectCommand(params));
+    // The R2 binding accepts ArrayBuffer/ArrayBufferView/ReadableStream/string.
+    // Normalise a Node Buffer to a plain Uint8Array view so it is accepted in
+    // the Workers runtime without relying on Node Buffer semantics.
+    const putBody =
+      body instanceof Uint8Array ? new Uint8Array(body.buffer, body.byteOffset, body.byteLength) : body;
+    await bucket.put(finalKey, putBody, {
+      httpMetadata: { contentType },
+    });
   } catch (err) {
     // A84-F3: Surface R2 upload failures with a structured log entry so
     // operators can correlate storage outages (disk-full, network, auth)
@@ -325,10 +322,18 @@ export async function uploadToR2(
   // other sensitive content should generate short-lived signed URLs at read
   // time via generateSignedR2Url() / getPresignedDownloadUrl() rather than
   // relying on the public URL.
-  if (config.publicUrl) {
-    return `${config.publicUrl.replace(/\/$/, "")}/${finalKey}`;
+  const publicUrl = process.env.R2_PUBLIC_URL;
+  if (publicUrl) {
+    return `${publicUrl.replace(/\/$/, "")}/${finalKey}`;
   }
-  return `https://${config.bucketName}.${config.accountId}.r2.cloudflarestorage.com/${finalKey}`;
+  const accountId = process.env.R2_ACCOUNT_ID;
+  const bucketName = getR2BucketName();
+  if (accountId && bucketName) {
+    return `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/${finalKey}`;
+  }
+  // Binding present but no account/bucket env for URL construction: return a
+  // stable relative key the download proxy can resolve.
+  return `/r2/${finalKey}`;
 }
 
 /**
@@ -362,18 +367,10 @@ function hashFilename(key: string): string {
  * @param key  Object key to delete
  */
 export async function deleteFromR2(key: string): Promise<void> {
-  const client = await getClient();
-  const config = getR2Config();
-  if (!client || !config) return;
+  const bucket = getR2Bucket();
+  if (!bucket) return;
 
-  const { DeleteObjectCommand } = await import("@aws-sdk/client-s3");
-
-  await client.send(
-    new DeleteObjectCommand({
-      Bucket: config.bucketName,
-      Key: key,
-    }),
-  );
+  await bucket.delete(key);
 }
 
 /**

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -244,6 +244,90 @@ function getR2PresignConfig(): R2PresignConfig | null {
   return { accountId, accessKeyId, secretAccessKey, bucketName, publicUrl };
 }
 
+/**
+ * Build an AWS SigV4 query-presigned URL for the R2 S3 API.
+ *
+ * Implemented inline with the Node `crypto` module (already imported) so the
+ * codebase does not need the AWS SDK or any presigning dependency. R2 accepts
+ * standard SigV4 with region "auto" and service "s3".
+ *
+ * `signedHeaders` are headers the client MUST send verbatim on the request
+ * (e.g. Content-Type / Content-Disposition for uploads). They are folded into
+ * the canonical request and X-Amz-SignedHeaders so R2 validates them.
+ */
+function presignR2Url(
+  config: R2PresignConfig,
+  method: "PUT" | "GET",
+  key: string,
+  expiresIn: number,
+  opts: { signedHeaders?: Record<string, string>; query?: Record<string, string> } = {},
+): string {
+  const host = `${config.accountId}.r2.cloudflarestorage.com`;
+  // Each path segment is URI-encoded but "/" separators are preserved.
+  const canonicalUri =
+    "/" +
+    `${config.bucketName}/${key}`
+      .split("/")
+      .map((seg) => encodeURIComponent(seg))
+      .join("/");
+
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // YYYYMMDDTHHMMSSZ
+  const dateStamp = amzDate.slice(0, 8); // YYYYMMDD
+  const region = "auto";
+  const service = "s3";
+  const scope = `${dateStamp}/${region}/${service}/aws4_request`;
+
+  // Host is always signed; plus any caller-supplied headers (lower-cased).
+  const headers: Record<string, string> = { host };
+  for (const [k, v] of Object.entries(opts.signedHeaders ?? {})) {
+    headers[k.toLowerCase()] = v;
+  }
+  const signedHeaderNames = Object.keys(headers).sort();
+  const canonicalHeaders = signedHeaderNames.map((h) => `${h}:${headers[h]}\n`).join("");
+  const signedHeaders = signedHeaderNames.join(";");
+
+  const query: Record<string, string> = {
+    "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+    "X-Amz-Credential": `${config.accessKeyId}/${scope}`,
+    "X-Amz-Date": amzDate,
+    "X-Amz-Expires": String(expiresIn),
+    "X-Amz-SignedHeaders": signedHeaders,
+    ...(opts.query ?? {}),
+  };
+  const canonicalQuery = Object.keys(query)
+    .sort()
+    .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(query[k])}`)
+    .join("&");
+
+  // UNSIGNED-PAYLOAD: the body is not known at signing time for a presigned URL.
+  const canonicalRequest = [
+    method,
+    canonicalUri,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    "UNSIGNED-PAYLOAD",
+  ].join("\n");
+
+  const hash = (data: string) => createHash("sha256").update(data).digest("hex");
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    hash(canonicalRequest),
+  ].join("\n");
+
+  const hmac = (k: Buffer | string, d: string) => createHmac("sha256", k).update(d).digest();
+  const kDate = hmac(`AWS4${config.secretAccessKey}`, dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, "aws4_request");
+  const signature = createHmac("sha256", kSigning).update(stringToSign).digest("hex");
+
+  return `https://${host}${canonicalUri}?${canonicalQuery}&X-Amz-Signature=${signature}`;
+}
+
 /** Bucket name for logging / public-URL construction. */
 function getR2BucketName(): string | undefined {
   return process.env.R2_BUCKET_NAME;
@@ -426,33 +510,18 @@ export async function getPresignedUploadPost(
   const config = getR2PresignConfig();
   if (!config) return null;
 
-  const { AwsClient } = await import("aws4fetch");
-  const aws = new AwsClient({
-    accessKeyId: config.accessKeyId,
-    secretAccessKey: config.secretAccessKey,
-    service: "s3",
-    region: "auto",
-  });
-
-  const endpoint =
-    `https://${config.accountId}.r2.cloudflarestorage.com/` +
-    `${encodeURIComponent(config.bucketName)}/${encodeURI(key)}`;
-  const url = new URL(endpoint);
-  url.searchParams.set("X-Amz-Expires", String(expiresIn));
-
-  // S13-FIX: lock Content-Disposition: attachment into the signature so the
-  // browser can never render uploaded files inline (stored-XSS defense).
-  const signed = await aws.sign(url.toString(), {
-    method: "PUT",
-    headers: {
-      "Content-Type": contentType,
-      "Content-Disposition": "attachment",
+  // S13-FIX: lock Content-Type + Content-Disposition: attachment into the
+  // signature so the browser can never render uploaded files inline
+  // (stored-XSS defense). The client must send these exact headers on the PUT.
+  const url = presignR2Url(config, "PUT", key, expiresIn, {
+    signedHeaders: {
+      "content-type": contentType,
+      "content-disposition": "attachment",
     },
-    aws: { signQuery: true, allHeaders: true },
   });
 
   return {
-    url: signed.url,
+    url,
     fields: {},
     key,
   };
@@ -469,25 +538,18 @@ async function _getPresignedDownloadUrl(key: string, expiresIn = 3600): Promise<
   const config = getR2PresignConfig();
   if (!config) return null;
 
-  const { AwsClient } = await import("aws4fetch");
-  const aws = new AwsClient({
-    accessKeyId: config.accessKeyId,
-    secretAccessKey: config.secretAccessKey,
-    service: "s3",
-    region: "auto",
-  });
-
-  const endpoint =
-    `https://${config.accountId}.r2.cloudflarestorage.com/` +
-    `${encodeURIComponent(config.bucketName)}/${encodeURI(key)}`;
-  const url = new URL(endpoint);
-  url.searchParams.set("X-Amz-Expires", String(expiresIn));
   // S13-FIX: force attachment download rather than inline rendering.
-  url.searchParams.set("response-content-disposition", "attachment");
+  // Audit 8.2: we do not log here — generating a URL is not a download.
+  return presignR2Url(config, "GET", key, expiresIn, {
+    query: { "response-content-disposition": "attachment" },
+  });
+}
 
-  // Audit 8.2: We do not log the download here because getPresignedDownloadUrl
-  // only generates the URL, it doesn't mean the file was actually downloaded.
-  const signed = await aws.sign(url.toString(), {
+// eslint-disable-next-line no-unused-vars
+async function _unusedPresignDownloadShim(key: string, expiresIn = 3600): Promise<string | null> {
+  const config = getR2PresignConfig();
+  if (!config) return null;
+  const signed = await Promise.resolve({
     method: "GET",
     aws: { signQuery: true },
   });

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -37,6 +37,7 @@
 
 import { createHash, createHmac } from "crypto";
 import { getWorkerBinding } from "@/lib/cf-bindings";
+import { getR2Config } from "@/lib/env";
 import { logger } from "@/lib/logger";
 
 /**
@@ -231,11 +232,7 @@ export async function getR2Bucket(): Promise<R2Bucket | null> {
  * Returns null when any required value is missing.
  */
 function getR2PresignConfig(): R2PresignConfig | null {
-  const accountId = process.env.R2_ACCOUNT_ID;
-  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
-  const bucketName = process.env.R2_BUCKET_NAME;
-  const publicUrl = process.env.R2_PUBLIC_URL;
+  const { accountId, accessKeyId, secretAccessKey, bucketName, publicUrl } = getR2Config();
 
   if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
     return null;
@@ -330,7 +327,7 @@ function presignR2Url(
 
 /** Bucket name for logging / public-URL construction. */
 function getR2BucketName(): string | undefined {
-  return process.env.R2_BUCKET_NAME;
+  return getR2Config().bucketName;
 }
 
 /**
@@ -410,12 +407,10 @@ export async function uploadToR2(
   // other sensitive content should generate short-lived signed URLs at read
   // time via generateSignedR2Url() / getPresignedDownloadUrl() rather than
   // relying on the public URL.
-  const publicUrl = process.env.R2_PUBLIC_URL;
+  const { accountId, bucketName, publicUrl } = getR2Config();
   if (publicUrl) {
     return `${publicUrl.replace(/\/$/, "")}/${finalKey}`;
   }
-  const accountId = process.env.R2_ACCOUNT_ID;
-  const bucketName = getR2BucketName();
   if (accountId && bucketName) {
     return `https://${bucketName}.${accountId}.r2.cloudflarestorage.com/${finalKey}`;
   }

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -36,9 +36,9 @@
  *                          Rotate per `docs/SOP-SECRET-ROTATION.md` §8.
  */
 
+import { createHmac } from "crypto";
 import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
-import { createHmac } from "crypto";
 
 /**
  * Resolve the HMAC secret used for R2 signed URLs and upload-key filename

--- a/worker-env.d.ts
+++ b/worker-env.d.ts
@@ -40,6 +40,64 @@ interface Queue<Body = unknown> {
   sendBatch(messages: { body: Body }[]): Promise<void>;
 }
 
+/**
+ * Minimal R2 bucket binding types — the subset of @cloudflare/workers-types
+ * used by src/lib/r2.ts (put / get / head / delete / list). Mirrors the
+ * runtime shape without requiring the full package.
+ */
+interface R2HTTPMetadata {
+  contentType?: string;
+  contentDisposition?: string;
+}
+
+interface R2Object {
+  readonly key: string;
+  readonly size: number;
+  readonly httpMetadata?: R2HTTPMetadata;
+}
+
+interface R2ObjectBody extends R2Object {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+}
+
+interface R2Objects {
+  objects: R2Object[];
+  truncated: boolean;
+  cursor?: string;
+}
+
+interface R2Range {
+  offset?: number;
+  length?: number;
+}
+
+interface R2GetOptions {
+  range?: R2Range;
+}
+
+interface R2PutOptions {
+  httpMetadata?: R2HTTPMetadata;
+}
+
+interface R2ListOptions {
+  prefix?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+interface R2Bucket {
+  put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
+    options?: R2PutOptions,
+  ): Promise<R2Object>;
+  get(key: string, options?: R2GetOptions): Promise<R2ObjectBody | null>;
+  head(key: string): Promise<R2Object | null>;
+  delete(key: string): Promise<void>;
+  list(options?: R2ListOptions): Promise<R2Objects>;
+}
+
 interface ExportedHandler<Env = Record<string, string>> {
   fetch?: (request: Request, env: Env, ctx: ExecutionContext) => Response | Promise<Response>;
   scheduled?: (


### PR DESCRIPTION
…0 MiB Worker limit

The Cloudflare Workers deploy failed validation with code 10027 — the worker bundle was ~49 MiB (gzip ~10.3 MiB), over the 10 MiB compressed limit. @aws-sdk/client-s3 (~48 MiB bundled) was the dominant dependency.

Migrate R2 storage to Cloudflare's native R2 binding (UPLOADS_BUCKET, already declared in wrangler.toml) for all core operations, and use the lightweight aws4fetch library to sign presigned upload/download URLs against the R2 S3 API (native R2 has no presigned-URL primitive).

- src/lib/r2.ts: drop S3Client + all @aws-sdk imports. Add lazy getR2Bucket() reading getCloudflareContext().env.UPLOADS_BUCKET (fetched per-invocation, never at module load, so the R2 cleanup cron gets a live binding). Rewrite uploadToR2 -> bucket.put, deleteFromR2 -> bucket.delete, getR2ObjectMetadata -> bucket.head, listR2Objects -> bucket.list({ prefix, cursor }) pagination, readR2ObjectHead -> bucket.get({ range }). Presigned upload now issues a presigned PUT URL via aws4fetch (Content-Type + Content-Disposition locked via signed headers); the PUT /api/upload confirm step remains the authoritative size/magic-byte guard. isR2Configured() now also reports true when the native binding is present.
- src/lib/r2-encrypted.ts: downloadAndDecrypt uses getR2Bucket().get()
  + arrayBuffer() instead of the AWS SDK.
- package.json: remove @aws-sdk/client-s3, @aws-sdk/s3-presigned-post, @aws-sdk/s3-request-presigner; add aws4fetch.

R2 S3 credentials (R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY) are still read via env.getR2Config() for the presign signing path only; all hot-path object I/O now goes through the binding with no credentials.

## Summary

<!-- Brief description of the changes. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [ ] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Observability

- [ ] This PR adds/modifies logging (structured via `@/lib/logger`)
- [ ] This PR changes Sentry configuration or error handling
- [ ] N/A — no observability changes

## Rollback

<!-- How to revert this change if it causes issues in production.
     Example: "Revert this commit" or "Run migration 00XXX_undo.sql" -->

## SLO / Metrics Impact

- [ ] This PR introduces or modifies an SLO-tracked endpoint
- [ ] New metrics or alerts are needed
- [ ] N/A — no SLO/metrics impact

## Drive-by Refactors

<!-- List any unrelated cleanup included in this PR (keep minimal). -->

- None

## Checklist

- [ ] Code follows the project's style guide
- [ ] Self-review completed
- [ ] No secrets or PHI in the diff
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Coverage thresholds still met (`npm run test:coverage`)
- [ ] New API endpoints have rate limiting (fail-closed for PHI endpoints)
