### PR TITLE
feat: Analytics rate-limit status UX (P1)

### DIFF
--- a/src/app/(admin)/admin/branding/page.tsx
+++ b/src/app/(admin)/admin/branding/page.tsx
@@ -14,8 +14,10 @@ import {
   Wand2,
   Check,
   Loader2,
+  Layout,
 } from "lucide-react";
 import { useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -26,6 +28,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useAsyncData } from "@/lib/hooks/use-async-data";
 // eslint-disable-next-line import/order
 import { presetList, type TemplatePreset } from "@/lib/template-presets";
+import { templateList } from "@/lib/templates";
 
 interface BrandingState {
   name: string;
@@ -40,6 +43,7 @@ interface BrandingState {
   heading_font: string;
   body_font: string;
   hero_image_url: string | null;
+  template_id: string;
 }
 
 // eslint-disable-next-line import/order
@@ -71,6 +75,7 @@ const DEFAULT_BRANDING: BrandingState = {
   heading_font: "Geist",
   body_font: "Geist",
   hero_image_url: null,
+  template_id: "modern",
 };
 
 export default function BrandingPage() {
@@ -100,6 +105,7 @@ export default function BrandingPage() {
             heading_font: data.heading_font ?? "Geist",
             body_font: data.body_font ?? "Geist",
             hero_image_url: data.hero_image_url ?? null,
+            template_id: data.template_id ?? "modern",
           };
         }),
     DEFAULT_BRANDING,
@@ -147,6 +153,7 @@ export default function BrandingPage() {
           secondary_color: branding.secondary_color,
           heading_font: branding.heading_font,
           body_font: branding.body_font,
+          template_id: branding.template_id,
         }),
       });
       if (!res.ok) {
@@ -254,6 +261,10 @@ export default function BrandingPage() {
             <Wand2 className="h-4 w-4 mr-2" />
             Presets
           </TabsTrigger>
+          <TabsTrigger value="templates">
+            <Layout className="h-4 w-4 mr-2" />
+            Templates
+          </TabsTrigger>
           <TabsTrigger value="info">
             <Building2 className="h-4 w-4 mr-2" />
             Clinic Info
@@ -291,6 +302,7 @@ export default function BrandingPage() {
                     ...prev,
                     primary_color: preset.theme.primaryColor,
                     secondary_color: preset.theme.secondaryColor,
+                    template_id: preset.templateId,
                   }));
                   setTimeout(() => setAppliedPreset(null), 3000);
                 } else {
@@ -307,10 +319,61 @@ export default function BrandingPage() {
                 ...prev,
                 primary_color: preset.theme.primaryColor,
                 secondary_color: preset.theme.secondaryColor,
+                template_id: preset.templateId,
               }));
               setActiveTab("colors");
             }}
           />
+        </TabsContent>
+
+        {/* ── Templates Tab ── */}
+        <TabsContent value="templates">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base flex items-center gap-2">
+                <Layout className="h-4 w-4" />
+                Base Layout Templates
+              </CardTitle>
+              <CardDescription>
+                Select a layout template to define the structural arrangement of your public site.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {templateList.map((tmpl) => {
+                  const isSelected = branding.template_id === tmpl.id;
+                  return (
+                    <Card
+                      key={tmpl.id}
+                      className={`cursor-pointer transition-all hover:shadow-md ${
+                        isSelected ? "ring-2 ring-primary shadow-md" : "hover:ring-1 hover:ring-border"
+                      }`}
+                      onClick={() => setBranding((p) => ({ ...p, template_id: tmpl.id }))}
+                    >
+                      <CardHeader className="pb-3">
+                        <div className="flex items-center justify-between">
+                          <CardTitle className="text-base flex items-center gap-2">
+                            <Layout className="h-4 w-4" />
+                            {tmpl.name}
+                          </CardTitle>
+                          {isSelected && (
+                            <Badge variant="default" className="gap-1">
+                              <Check className="h-3 w-3" />
+                              Selected
+                            </Badge>
+                          )}
+                        </div>
+                        <CardDescription>{tmpl.description}</CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <p className="text-xs text-muted-foreground">{tmpl.preview}</p>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </div>
+            </CardContent>
+          </Card>
         </TabsContent>
 
         {/* ── Clinic Info Tab ── */}

--- a/src/app/api/analytics/dashboard/route.ts
+++ b/src/app/api/analytics/dashboard/route.ts
@@ -1,0 +1,336 @@
+import { type NextRequest } from "next/server";
+import { apiSuccess, apiError } from "@/lib/api-response";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+import { getLocalDateStr } from "@/lib/utils";
+
+type AnalyticsPeriod = "week" | "month" | "quarter" | "year";
+
+function getPeriodRange(period: AnalyticsPeriod): {
+  start: Date;
+  end: Date;
+  prevStart: Date;
+  prevEnd: Date;
+} {
+  const now = new Date();
+  const end = new Date(now);
+  let start: Date;
+  let prevStart: Date;
+  let prevEnd: Date;
+
+  switch (period) {
+    case "week": {
+      start = new Date(now);
+      start.setDate(start.getDate() - 7);
+      prevEnd = new Date(start);
+      prevStart = new Date(prevEnd);
+      prevStart.setDate(prevStart.getDate() - 7);
+      break;
+    }
+    case "month": {
+      start = new Date(now);
+      start.setMonth(start.getMonth() - 1);
+      prevEnd = new Date(start);
+      prevStart = new Date(prevEnd);
+      prevStart.setMonth(prevStart.getMonth() - 1);
+      break;
+    }
+    case "quarter": {
+      start = new Date(now);
+      start.setMonth(start.getMonth() - 3);
+      prevEnd = new Date(start);
+      prevStart = new Date(prevEnd);
+      prevStart.setMonth(prevStart.getMonth() - 3);
+      break;
+    }
+    case "year": {
+      start = new Date(now);
+      start.setFullYear(start.getFullYear() - 1);
+      prevEnd = new Date(start);
+      prevStart = new Date(prevEnd);
+      prevStart.setFullYear(prevStart.getFullYear() - 1);
+      break;
+    }
+  }
+
+  return { start, end, prevStart, prevEnd };
+}
+
+type ApptRow = {
+  id: string;
+  appointment_date: string;
+  start_time: string;
+  status: string;
+  patient_id: string;
+  service_id: string | null;
+  booking_source: string | null;
+  doctor_id: string | null;
+};
+type PaymentRow = {
+  id: string;
+  amount: number;
+  created_at: string;
+  payment_method: string | null;
+  doctor_id: string | null;
+  service_id: string | null;
+};
+type ReviewRow = { id: string; stars: number; created_at: string };
+type PatientRow = { id: string; created_at: string };
+
+function computeComparison(
+  appts: ApptRow[],
+  payments: PaymentRow[],
+  period: AnalyticsPeriod,
+) {
+  const { start, end, prevStart, prevEnd } = getPeriodRange(period);
+  const startStr = getLocalDateStr(start);
+  const endStr = getLocalDateStr(end);
+  const prevStartStr = getLocalDateStr(prevStart);
+  const prevEndStr = getLocalDateStr(prevEnd);
+
+  const currentAppts = appts.filter(
+    (a) => a.appointment_date >= startStr && a.appointment_date <= endStr,
+  );
+  const prevAppts = appts.filter(
+    (a) => a.appointment_date >= prevStartStr && a.appointment_date <= prevEndStr,
+  );
+
+  const currentPayments = payments.filter((p) => {
+    const d = p.created_at?.split("T")[0];
+    return d && d >= startStr && d <= endStr;
+  });
+  const prevPayments = payments.filter((p) => {
+    const d = p.created_at?.split("T")[0];
+    return d && d >= prevStartStr && d <= prevEndStr;
+  });
+
+  const currentRevenue = currentPayments.reduce((s, p) => s + p.amount, 0);
+  const previousRevenue = prevPayments.reduce((s, p) => s + p.amount, 0);
+  const currentPatients = new Set(currentAppts.map((a) => a.patient_id)).size;
+  const previousPatients = new Set(prevAppts.map((a) => a.patient_id)).size;
+  const currentNoShows = currentAppts.filter((a) => a.status === "no_show").length;
+  const previousNoShows = prevAppts.filter((a) => a.status === "no_show").length;
+
+  function pctChange(current: number, previous: number): number {
+    if (previous === 0) return current > 0 ? 100 : 0;
+    return Math.round(((current - previous) / previous) * 100);
+  }
+
+  return {
+    currentRevenue,
+    previousRevenue,
+    revenueChange: pctChange(currentRevenue, previousRevenue),
+    currentPatients,
+    previousPatients,
+    patientChange: pctChange(currentPatients, previousPatients),
+    currentAppointments: currentAppts.length,
+    previousAppointments: prevAppts.length,
+    appointmentChange: pctChange(currentAppts.length, prevAppts.length),
+    currentNoShows,
+    previousNoShows,
+    noShowChange: pctChange(currentNoShows, previousNoShows),
+  };
+}
+
+async function handler(request: NextRequest, auth: AuthContext) {
+  const url = new URL(request.url);
+  const period = (url.searchParams.get("period") as AnalyticsPeriod) || "month";
+  const clinicId = auth.profile.clinic_id;
+
+  if (!clinicId) {
+    return apiError("No clinic context", 403);
+  }
+
+  const supabase = auth.supabase;
+  const { prevStart, end } = getPeriodRange(period);
+  const periodStart = getLocalDateStr(prevStart);
+  const periodEnd = getLocalDateStr(end);
+
+  const [apptsRes, paymentsRes, reviewsRes, patientsRes, servicesRes] = await Promise.all([
+    supabase
+      .from("appointments")
+      .select(
+        "id, appointment_date, start_time, status, patient_id, service_id, booking_source, doctor_id",
+      )
+      .eq("clinic_id", clinicId)
+      .gte("appointment_date", periodStart)
+      .lte("appointment_date", periodEnd),
+    supabase
+      .from("payments")
+      .select("id, amount, created_at, payment_method, doctor_id, service_id")
+      .eq("clinic_id", clinicId)
+      .eq("status", "completed")
+      .gte("created_at", `${periodStart}T00:00:00`)
+      .lte("created_at", `${periodEnd}T23:59:59`),
+    supabase
+      .from("reviews")
+      .select("id, stars, created_at")
+      .eq("clinic_id", clinicId)
+      .gte("created_at", `${periodStart}T00:00:00`)
+      .lte("created_at", `${periodEnd}T23:59:59`),
+    supabase.from("users").select("id, created_at").eq("clinic_id", clinicId).eq("role", "patient"),
+    supabase.from("services").select("id, name, price").eq("clinic_id", clinicId),
+  ]);
+
+  const appts = (apptsRes.data ?? []) as unknown as ApptRow[];
+  const payments = (paymentsRes.data ?? []) as unknown as PaymentRow[];
+  const reviews = (reviewsRes.data ?? []) as ReviewRow[];
+  const allPatients = (patientsRes.data ?? []) as PatientRow[];
+  const services = (servicesRes.data ?? []) as { id: string; name: string; price: number }[];
+
+  const serviceMap = new Map(services.map((s) => [s.id, { name: s.name, price: s.price }]));
+
+  const periodComparison = computeComparison(appts, payments, period);
+
+  const periodDays =
+    period === "week" ? 7 : period === "month" ? 30 : period === "quarter" ? 90 : 365;
+  const dailyMap = new Map<string, any>();
+  const now = new Date();
+  for (let i = Math.min(periodDays, 30) - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const dateStr = getLocalDateStr(d);
+    dailyMap.set(dateStr, {
+      date: dateStr,
+      patientCount: 0,
+      revenue: 0,
+      appointments: 0,
+      noShows: 0,
+      walkIns: 0,
+      onlineBookings: 0,
+    });
+  }
+  for (const a of appts) {
+    const day = dailyMap.get(a.appointment_date);
+    if (!day) continue;
+    day.appointments++;
+    day.patientCount++;
+    if (a.status === "no_show") day.noShows++;
+    if (a.booking_source === "walk_in") day.walkIns++;
+    if (a.booking_source === "online" || a.booking_source === "website") day.onlineBookings++;
+  }
+  for (const p of payments) {
+    const dateStr = p.created_at?.split("T")[0];
+    const day = dailyMap.get(dateStr);
+    if (day) day.revenue += p.amount;
+  }
+  const dailyAnalytics = [...dailyMap.values()];
+
+  const weeklyRevenue: any[] = [];
+  for (let i = 0; i < dailyAnalytics.length; i += 7) {
+    const chunk = dailyAnalytics.slice(i, i + 7);
+    if (chunk.length === 0) break;
+    const weekNum = Math.floor(i / 7) + 1;
+    weeklyRevenue.push({
+      week: `Week ${weekNum} (${chunk[0].date.slice(5)} - ${chunk[chunk.length - 1].date.slice(5)})`,
+      revenue: chunk.reduce((s, d) => s + d.revenue, 0),
+      patients: chunk.reduce((s, d) => s + d.patientCount, 0),
+    });
+  }
+
+  const monthlyRevenue: any[] = [];
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthStr = d.toISOString().slice(0, 7);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    const monthAppts = appts.filter((a) => a.appointment_date?.startsWith(monthStr));
+    const monthPayments = payments.filter((p) => p.created_at?.startsWith(monthStr));
+    const uniquePatients = new Set(monthAppts.map((a) => a.patient_id));
+    monthlyRevenue.push({
+      month: label,
+      revenue: monthPayments.reduce((s, p) => s + p.amount, 0),
+      patients: uniquePatients.size,
+      appointments: monthAppts.length,
+    });
+  }
+
+  const serviceCount = new Map<string, { count: number; revenue: number }>();
+  for (const a of appts) {
+    const svcName = a.service_id
+      ? (serviceMap.get(a.service_id)?.name ?? "Other")
+      : "Consultation";
+    const entry = serviceCount.get(svcName) ?? { count: 0, revenue: 0 };
+    entry.count++;
+    if (a.service_id) {
+      entry.revenue += serviceMap.get(a.service_id)?.price ?? 0;
+    }
+    serviceCount.set(svcName, entry);
+  }
+  const totalSvcCount = appts.length || 1;
+  const servicePopularity = [...serviceCount.entries()]
+    .map(([name, val]) => ({
+      serviceName: name,
+      count: val.count,
+      revenue: val.revenue,
+      percentage: Math.round((val.count / totalSvcCount) * 100),
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const heatmap = new Map<string, Map<number, number>>();
+  for (const name of dayNames) heatmap.set(name, new Map());
+  for (const a of appts) {
+    const date = new Date(a.appointment_date);
+    const dayName = dayNames[date.getDay()];
+    const hour = parseInt(a.start_time?.slice(0, 2) ?? "0", 10);
+    const dayMap = heatmap.get(dayName)!;
+    dayMap.set(hour, (dayMap.get(hour) ?? 0) + 1);
+  }
+  const hourlyHeatmap = dayNames.slice(1, 7).map((day) => ({
+    day,
+    hours: [9, 10, 11, 12, 14, 15, 16, 17].map((hour) => ({
+      hour,
+      count: heatmap.get(day)?.get(hour) ?? 0,
+    })),
+  }));
+
+  const reviewTrends: any[] = [];
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthStr = d.toISOString().slice(0, 7);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    const monthReviews = reviews.filter((r) => r.created_at?.startsWith(monthStr));
+    const avg =
+      monthReviews.length > 0
+        ? monthReviews.reduce((s, r) => s + r.stars, 0) / monthReviews.length
+        : 0;
+    reviewTrends.push({
+      month: label,
+      averageScore: Math.round(avg * 10) / 10,
+      count: monthReviews.length,
+    });
+  }
+
+  const patientRetention: any[] = [];
+  for (let i = 5; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const monthStr = d.toISOString().slice(0, 7);
+    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    const newPts = allPatients.filter((p) => p.created_at?.startsWith(monthStr)).length;
+    const monthAppts = appts.filter((a) => a.appointment_date?.startsWith(monthStr));
+    const returningIds = new Set(monthAppts.map((a) => a.patient_id));
+    const returning = returningIds.size;
+    const total = newPts + returning || 1;
+    patientRetention.push({
+      month: label,
+      newPatients: newPts,
+      returningPatients: returning,
+      retentionRate: Math.round((returning / total) * 100),
+    });
+  }
+
+  return apiSuccess({
+    dailyAnalytics,
+    weeklyRevenue,
+    monthlyRevenue,
+    servicePopularity,
+    hourlyHeatmap,
+    reviewTrends,
+    patientRetention,
+    totalPatients: allPatients.length,
+    totalAppointments: appts.length,
+    periodComparison,
+    period,
+  });
+}
+
+export const GET = withAuth(handler, ["clinic_admin", "doctor"]);

--- a/src/app/api/analytics/dashboard/route.ts
+++ b/src/app/api/analytics/dashboard/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest } from "next/server";
 import { apiSuccess, apiError } from "@/lib/api-response";
-import { withAuth, type AuthContext } from "@/lib/with-auth";
 import { getLocalDateStr } from "@/lib/utils";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
 
 type AnalyticsPeriod = "week" | "month" | "quarter" | "year";
 
@@ -76,11 +76,7 @@ type PaymentRow = {
 type ReviewRow = { id: string; stars: number; created_at: string };
 type PatientRow = { id: string; created_at: string };
 
-function computeComparison(
-  appts: ApptRow[],
-  payments: PaymentRow[],
-  period: AnalyticsPeriod,
-) {
+function computeComparison(appts: ApptRow[], payments: PaymentRow[], period: AnalyticsPeriod) {
   const { start, end, prevStart, prevEnd } = getPeriodRange(period);
   const startStr = getLocalDateStr(start);
   const endStr = getLocalDateStr(end);
@@ -186,9 +182,19 @@ async function handler(request: NextRequest, auth: AuthContext) {
 
   const periodComparison = computeComparison(appts, payments, period);
 
+  type DailyAnalyticsRow = {
+    date: string;
+    patientCount: number;
+    revenue: number;
+    appointments: number;
+    noShows: number;
+    walkIns: number;
+    onlineBookings: number;
+  };
+
   const periodDays =
     period === "week" ? 7 : period === "month" ? 30 : period === "quarter" ? 90 : 365;
-  const dailyMap = new Map<string, any>();
+  const dailyMap = new Map<string, DailyAnalyticsRow>();
   const now = new Date();
   for (let i = Math.min(periodDays, 30) - 1; i >= 0; i--) {
     const d = new Date(now);
@@ -220,7 +226,7 @@ async function handler(request: NextRequest, auth: AuthContext) {
   }
   const dailyAnalytics = [...dailyMap.values()];
 
-  const weeklyRevenue: any[] = [];
+  const weeklyRevenue: { week: string; revenue: number; patients: number }[] = [];
   for (let i = 0; i < dailyAnalytics.length; i += 7) {
     const chunk = dailyAnalytics.slice(i, i + 7);
     if (chunk.length === 0) break;
@@ -232,7 +238,12 @@ async function handler(request: NextRequest, auth: AuthContext) {
     });
   }
 
-  const monthlyRevenue: any[] = [];
+  const monthlyRevenue: {
+    month: string;
+    revenue: number;
+    patients: number;
+    appointments: number;
+  }[] = [];
   for (let i = 5; i >= 0; i--) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
     const monthStr = d.toISOString().slice(0, 7);
@@ -250,9 +261,7 @@ async function handler(request: NextRequest, auth: AuthContext) {
 
   const serviceCount = new Map<string, { count: number; revenue: number }>();
   for (const a of appts) {
-    const svcName = a.service_id
-      ? (serviceMap.get(a.service_id)?.name ?? "Other")
-      : "Consultation";
+    const svcName = a.service_id ? (serviceMap.get(a.service_id)?.name ?? "Other") : "Consultation";
     const entry = serviceCount.get(svcName) ?? { count: 0, revenue: 0 };
     entry.count++;
     if (a.service_id) {
@@ -288,7 +297,7 @@ async function handler(request: NextRequest, auth: AuthContext) {
     })),
   }));
 
-  const reviewTrends: any[] = [];
+  const reviewTrends: { month: string; averageScore: number; count: number }[] = [];
   for (let i = 5; i >= 0; i--) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
     const monthStr = d.toISOString().slice(0, 7);
@@ -305,7 +314,12 @@ async function handler(request: NextRequest, auth: AuthContext) {
     });
   }
 
-  const patientRetention: any[] = [];
+  const patientRetention: {
+    month: string;
+    newPatients: number;
+    returningPatients: number;
+    retentionRate: number;
+  }[] = [];
   for (let i = 5; i >= 0; i--) {
     const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
     const monthStr = d.toISOString().slice(0, 7);

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -252,7 +252,10 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
             Live Data
           </Badge>
           {rateLimit?.remaining && rateLimit?.limit && (
-            <Badge variant="outline" className="text-xs border-primary/50 text-primary bg-primary/5">
+            <Badge
+              variant="outline"
+              className="text-xs border-primary/50 text-primary bg-primary/5"
+            >
               {rateLimit.remaining}/{rateLimit.limit} API quota
             </Badge>
           )}

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -46,7 +46,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   getCurrentUser,
   fetchAnalytics,
-  type AnalyticsData,
+  type FetchAnalyticsResponse,
   type AnalyticsPeriod,
 } from "@/lib/data/client";
 import { exportToCSV } from "@/lib/export-data";
@@ -94,7 +94,7 @@ function ChangeIndicator({ value, inverted = false }: { value: number; inverted?
 export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "doctor" }) {
   const [revenuePeriod, setRevenuePeriod] = useState<"daily" | "weekly" | "monthly">("daily");
   const [timePeriod, setTimePeriod] = useState<AnalyticsPeriod>("month");
-  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
+  const [analytics, setAnalytics] = useState<FetchAnalyticsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -158,6 +158,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
     totalPatients: _totalPatients,
     totalAppointments,
     periodComparison,
+    rateLimit,
   } = analytics;
 
   const noShowAppts = dailyAnalytics.reduce((sum, d) => sum + d.noShows, 0);
@@ -250,6 +251,11 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
             <RefreshCw className="h-3 w-3 mr-1" />
             Live Data
           </Badge>
+          {rateLimit?.remaining && rateLimit?.limit && (
+            <Badge variant="outline" className="text-xs border-primary/50 text-primary bg-primary/5">
+              {rateLimit.remaining}/{rateLimit.limit} API quota
+            </Badge>
+          )}
         </div>
       </div>
 

--- a/src/lib/__tests__/rate-limit-binding.test.ts
+++ b/src/lib/__tests__/rate-limit-binding.test.ts
@@ -51,14 +51,16 @@ describe("Rate limiter — KV binding unavailable (prod 429 outage regression)",
 
     // Trip the circuit breaker — every call finds the KV binding missing.
     for (let i = 0; i < 5; i++) {
-      expect(await globalPageLimiter.check(`warmup-${i}`)).toBe(true);
+      const r = await globalPageLimiter.check(`warmup-${i}`);
+      expect(typeof r === "boolean" ? r : r.allowed).toBe(true);
     }
 
     // Advance past the 1s grace period (circuit still open: reset is 60s).
     vi.advanceTimersByTime(5_000);
 
     // Regression: previously this returned false (HTTP 429) for EVERYONE.
-    expect(await globalPageLimiter.check("fresh-visitor")).toBe(true);
+    const fresh = await globalPageLimiter.check("fresh-visitor");
+    expect(typeof fresh === "boolean" ? fresh : fresh.allowed).toBe(true);
   });
 
   it("globalPageLimiter still limits by real count when degraded to in-memory", async () => {
@@ -68,9 +70,11 @@ describe("Rate limiter — KV binding unavailable (prod 429 outage regression)",
     // globalPageLimiter is 120 req / 60s. The in-memory fallback must enforce
     // the real count, not blanket-allow.
     for (let i = 0; i < 120; i++) {
-      expect(await globalPageLimiter.check(key)).toBe(true);
+      const r = await globalPageLimiter.check(key);
+      expect(typeof r === "boolean" ? r : r.allowed).toBe(true);
     }
-    expect(await globalPageLimiter.check(key)).toBe(false);
+    const r = await globalPageLimiter.check(key);
+    expect(typeof r === "boolean" ? r : r.allowed).toBe(false);
   });
 
   it("failClosed:true limiters still fail closed once the grace period expires with no KV", async () => {
@@ -84,6 +88,7 @@ describe("Rate limiter — KV binding unavailable (prod 429 outage regression)",
     vi.advanceTimersByTime(5_000);
 
     // Security-critical endpoints remain protected: deny after grace expiry.
-    expect(await limiter.check("attacker")).toBe(false);
+    const r = await limiter.check("attacker");
+    expect(typeof r === "boolean" ? r : r.allowed).toBe(false);
   });
 });

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { logger } from "../logger";
-import { extractClientIp, createRateLimiter } from "../rate-limit";
+import { extractClientIp, createRateLimiter, type RateLimitResult } from "../rate-limit";
+
+// The in-memory limiter is synchronous, but RateLimiter.check() returns a
+// union (sync or async). Narrow to the sync case for these tests.
+function allowed(r: RateLimitResult | Promise<RateLimitResult>): boolean {
+  if (r instanceof Promise) {
+    throw new Error("in-memory limiter unexpectedly returned a Promise");
+  }
+  return typeof r === "boolean" ? r : r.allowed;
+}
 
 // Mock NextRequest
 function createMockRequest(headers: Record<string, string> = {}): {
@@ -116,70 +125,53 @@ describe("createRateLimiter (in-memory)", () => {
   it("allows requests within the limit", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 5 });
     for (let i = 0; i < 5; i++) {
-      const result = limiter.check("ip-1");
-      expect(typeof result === "boolean" ? result : result.allowed).toBe(true);
+      expect(allowed(limiter.check("ip-1"))).toBe(true);
     }
   });
 
   it("blocks requests exceeding the limit", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 3 });
-    const r1 = limiter.check("ip-2");
-    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
-    const r2 = limiter.check("ip-2");
-    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
-    const r3 = limiter.check("ip-2");
-    expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(true);
-    const r4 = limiter.check("ip-2");
-    expect(typeof r4 === "boolean" ? r4 : r4.allowed).toBe(false);
+    expect(allowed(limiter.check("ip-2"))).toBe(true);
+    expect(allowed(limiter.check("ip-2"))).toBe(true);
+    expect(allowed(limiter.check("ip-2"))).toBe(true);
+    expect(allowed(limiter.check("ip-2"))).toBe(false);
   });
 
   it("tracks different keys independently", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 1 });
-    const r1 = limiter.check("ip-a");
-    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
-    const r2 = limiter.check("ip-b");
-    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
-    const r3 = limiter.check("ip-a");
-    expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(false);
-    const r4 = limiter.check("ip-b");
-    expect(typeof r4 === "boolean" ? r4 : r4.allowed).toBe(false);
+    expect(allowed(limiter.check("ip-a"))).toBe(true);
+    expect(allowed(limiter.check("ip-b"))).toBe(true);
+    expect(allowed(limiter.check("ip-a"))).toBe(false);
+    expect(allowed(limiter.check("ip-b"))).toBe(false);
   });
 
   it("evicts oldest key when maxKeys is reached (LRU)", () => {
     // A78-01: Changed from reject-when-full to LRU eviction.
     // New keys now evict the oldest entry instead of being rejected.
     const limiter = createRateLimiter({ windowMs: 60_000, max: 10, maxKeys: 2 });
-    const r1 = limiter.check("ip-1");
-    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
-    const r2 = limiter.check("ip-2");
-    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
-    const r3 = limiter.check("ip-3");
-    expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(true); // evicts ip-1, admits ip-3
+    expect(allowed(limiter.check("ip-1"))).toBe(true);
+    expect(allowed(limiter.check("ip-2"))).toBe(true);
+    expect(allowed(limiter.check("ip-3"))).toBe(true); // evicts ip-1, admits ip-3
   });
 
   it("allows existing keys even when maxKeys is reached", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 10, maxKeys: 2 });
     limiter.check("ip-1");
     limiter.check("ip-2");
-    const r = limiter.check("ip-1");
-    expect(typeof r === "boolean" ? r : r.allowed).toBe(true); // existing key still works
+    expect(allowed(limiter.check("ip-1"))).toBe(true); // existing key still works
   });
 
   it("resets counter after window expires", () => {
     vi.useFakeTimers();
     try {
       const limiter = createRateLimiter({ windowMs: 1_000, max: 2 });
-      const r1 = limiter.check("ip-x");
-      expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
-      const r2 = limiter.check("ip-x");
-      expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
-      const r3 = limiter.check("ip-x");
-      expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(false);
+      expect(allowed(limiter.check("ip-x"))).toBe(true);
+      expect(allowed(limiter.check("ip-x"))).toBe(true);
+      expect(allowed(limiter.check("ip-x"))).toBe(false);
 
       vi.advanceTimersByTime(1_001);
 
-      const r4 = limiter.check("ip-x");
-      expect(typeof r4 === "boolean" ? r4 : r4.allowed).toBe(true);
+      expect(allowed(limiter.check("ip-x"))).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -187,9 +179,7 @@ describe("createRateLimiter (in-memory)", () => {
 
   it("max: 1 allows exactly one request", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 1 });
-    const r1 = limiter.check("single");
-    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
-    const r2 = limiter.check("single");
-    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(false);
+    expect(allowed(limiter.check("single"))).toBe(true);
+    expect(allowed(limiter.check("single"))).toBe(false);
   });
 });

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -116,53 +116,70 @@ describe("createRateLimiter (in-memory)", () => {
   it("allows requests within the limit", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 5 });
     for (let i = 0; i < 5; i++) {
-      expect(limiter.check("ip-1")).toBe(true);
+      const result = limiter.check("ip-1");
+      expect(typeof result === "boolean" ? result : result.allowed).toBe(true);
     }
   });
 
   it("blocks requests exceeding the limit", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 3 });
-    expect(limiter.check("ip-2")).toBe(true);
-    expect(limiter.check("ip-2")).toBe(true);
-    expect(limiter.check("ip-2")).toBe(true);
-    expect(limiter.check("ip-2")).toBe(false);
+    const r1 = limiter.check("ip-2");
+    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
+    const r2 = limiter.check("ip-2");
+    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
+    const r3 = limiter.check("ip-2");
+    expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(true);
+    const r4 = limiter.check("ip-2");
+    expect(typeof r4 === "boolean" ? r4 : r4.allowed).toBe(false);
   });
 
   it("tracks different keys independently", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 1 });
-    expect(limiter.check("ip-a")).toBe(true);
-    expect(limiter.check("ip-b")).toBe(true);
-    expect(limiter.check("ip-a")).toBe(false);
-    expect(limiter.check("ip-b")).toBe(false);
+    const r1 = limiter.check("ip-a");
+    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
+    const r2 = limiter.check("ip-b");
+    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
+    const r3 = limiter.check("ip-a");
+    expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(false);
+    const r4 = limiter.check("ip-b");
+    expect(typeof r4 === "boolean" ? r4 : r4.allowed).toBe(false);
   });
 
   it("evicts oldest key when maxKeys is reached (LRU)", () => {
     // A78-01: Changed from reject-when-full to LRU eviction.
     // New keys now evict the oldest entry instead of being rejected.
     const limiter = createRateLimiter({ windowMs: 60_000, max: 10, maxKeys: 2 });
-    expect(limiter.check("ip-1")).toBe(true);
-    expect(limiter.check("ip-2")).toBe(true);
-    expect(limiter.check("ip-3")).toBe(true); // evicts ip-1, admits ip-3
+    const r1 = limiter.check("ip-1");
+    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
+    const r2 = limiter.check("ip-2");
+    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
+    const r3 = limiter.check("ip-3");
+    expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(true); // evicts ip-1, admits ip-3
   });
 
   it("allows existing keys even when maxKeys is reached", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 10, maxKeys: 2 });
     limiter.check("ip-1");
     limiter.check("ip-2");
-    expect(limiter.check("ip-1")).toBe(true); // existing key still works
+    const r = limiter.check("ip-1");
+    expect(typeof r === "boolean" ? r : r.allowed).toBe(true); // existing key still works
   });
 
   it("resets counter after window expires", () => {
     vi.useFakeTimers();
     try {
       const limiter = createRateLimiter({ windowMs: 1_000, max: 2 });
-      expect(limiter.check("ip-x")).toBe(true);
-      expect(limiter.check("ip-x")).toBe(true);
-      expect(limiter.check("ip-x")).toBe(false);
+      const r1 = limiter.check("ip-x");
+      expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
+      const r2 = limiter.check("ip-x");
+      expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(true);
+      const r3 = limiter.check("ip-x");
+      expect(typeof r3 === "boolean" ? r3 : r3.allowed).toBe(false);
 
       vi.advanceTimersByTime(1_001);
 
-      expect(limiter.check("ip-x")).toBe(true);
+      const r4 = limiter.check("ip-x");
+      expect(typeof r4 === "boolean" ? r4 : r4.allowed).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -170,7 +187,9 @@ describe("createRateLimiter (in-memory)", () => {
 
   it("max: 1 allows exactly one request", () => {
     const limiter = createRateLimiter({ windowMs: 60_000, max: 1 });
-    expect(limiter.check("single")).toBe(true);
-    expect(limiter.check("single")).toBe(false);
+    const r1 = limiter.check("single");
+    expect(typeof r1 === "boolean" ? r1 : r1.allowed).toBe(true);
+    const r2 = limiter.check("single");
+    expect(typeof r2 === "boolean" ? r2 : r2.allowed).toBe(false);
   });
 });

--- a/src/lib/data/client/analytics.ts
+++ b/src/lib/data/client/analytics.ts
@@ -151,61 +151,6 @@ function getPeriodRange(period: AnalyticsPeriod): {
   return { start, end, prevStart, prevEnd };
 }
 
-function computeComparison(
-  appts: ApptRow[],
-  payments: PaymentRow[],
-  period: AnalyticsPeriod,
-): PeriodComparison {
-  const { start, end, prevStart, prevEnd } = getPeriodRange(period);
-  const startStr = getLocalDateStr(start);
-  const endStr = getLocalDateStr(end);
-  const prevStartStr = getLocalDateStr(prevStart);
-  const prevEndStr = getLocalDateStr(prevEnd);
-
-  const currentAppts = appts.filter(
-    (a) => a.appointment_date >= startStr && a.appointment_date <= endStr,
-  );
-  const prevAppts = appts.filter(
-    (a) => a.appointment_date >= prevStartStr && a.appointment_date <= prevEndStr,
-  );
-
-  const currentPayments = payments.filter((p) => {
-    const d = p.created_at?.split("T")[0];
-    return d && d >= startStr && d <= endStr;
-  });
-  const prevPayments = payments.filter((p) => {
-    const d = p.created_at?.split("T")[0];
-    return d && d >= prevStartStr && d <= prevEndStr;
-  });
-
-  const currentRevenue = currentPayments.reduce((s, p) => s + p.amount, 0);
-  const previousRevenue = prevPayments.reduce((s, p) => s + p.amount, 0);
-  const currentPatients = new Set(currentAppts.map((a) => a.patient_id)).size;
-  const previousPatients = new Set(prevAppts.map((a) => a.patient_id)).size;
-  const currentNoShows = currentAppts.filter((a) => a.status === "no_show").length;
-  const previousNoShows = prevAppts.filter((a) => a.status === "no_show").length;
-
-  function pctChange(current: number, previous: number): number {
-    if (previous === 0) return current > 0 ? 100 : 0;
-    return Math.round(((current - previous) / previous) * 100);
-  }
-
-  return {
-    currentRevenue,
-    previousRevenue,
-    revenueChange: pctChange(currentRevenue, previousRevenue),
-    currentPatients,
-    previousPatients,
-    patientChange: pctChange(currentPatients, previousPatients),
-    currentAppointments: currentAppts.length,
-    previousAppointments: prevAppts.length,
-    appointmentChange: pctChange(currentAppts.length, prevAppts.length),
-    currentNoShows,
-    previousNoShows,
-    noShowChange: pctChange(currentNoShows, previousNoShows),
-  };
-}
-
 type ApptRow = {
   id: string;
   appointment_date: string;
@@ -224,9 +169,6 @@ type PaymentRow = {
   doctor_id: string | null;
   service_id: string | null;
 };
-type ReviewRow = { id: string; stars: number; created_at: string };
-type PatientRow = { id: string; created_at: string };
-
 export interface RateLimitStatus {
   limit: string | null;
   remaining: string | null;

--- a/src/lib/data/client/analytics.ts
+++ b/src/lib/data/client/analytics.ts
@@ -227,227 +227,52 @@ type PaymentRow = {
 type ReviewRow = { id: string; stars: number; created_at: string };
 type PatientRow = { id: string; created_at: string };
 
+export interface RateLimitStatus {
+  limit: string | null;
+  remaining: string | null;
+  reset: string | null;
+}
+
+export type FetchAnalyticsResponse = AnalyticsData & { rateLimit?: RateLimitStatus };
+
 export async function fetchAnalytics(
   clinicId: string,
   period: AnalyticsPeriod = "month",
-): Promise<AnalyticsData> {
+): Promise<FetchAnalyticsResponse> {
   const cacheKey = getAnalyticsCacheKey(clinicId, period);
   const cached = analyticsCache.get(cacheKey);
   const nowMs = Date.now();
 
   if (cached && cached.expiresAt > nowMs) {
+    // Re-return cached data, but without rate limits
     return cached.data;
   }
   if (cached) {
     analyticsCache.delete(cacheKey);
   }
 
-  const supabase = createClient();
+  // Hit the Next.js API route so it passes through middleware for rate-limiting
+  const res = await fetch(`/api/analytics/dashboard?period=${period}`);
+  const json = await res.json();
 
-  const { prevStart, end } = getPeriodRange(period);
-  const periodStart = getLocalDateStr(prevStart);
-  const periodEnd = getLocalDateStr(end);
-
-  const [apptsRes, paymentsRes, reviewsRes, patientsRes] = await Promise.all([
-    supabase
-      .from("appointments")
-      .select(
-        "id, appointment_date, start_time, status, patient_id, service_id, booking_source, doctor_id",
-      )
-      .eq("clinic_id", clinicId)
-      .gte("appointment_date", periodStart)
-      .lte("appointment_date", periodEnd),
-    supabase
-      .from("payments")
-      .select("id, amount, created_at, payment_method, doctor_id, service_id")
-      .eq("clinic_id", clinicId)
-      .eq("status", "completed")
-      .gte("created_at", `${periodStart}T00:00:00`)
-      .lte("created_at", `${periodEnd}T23:59:59`),
-    // nosemgrep: tenant-scoping
-    supabase
-      .from("reviews")
-      .select("id, stars, created_at")
-      .eq("clinic_id", clinicId)
-      .gte("created_at", `${periodStart}T00:00:00`)
-      .lte("created_at", `${periodEnd}T23:59:59`),
-    supabase.from("users").select("id, created_at").eq("clinic_id", clinicId).eq("role", "patient"),
-  ]);
-
-  const appts = (apptsRes.data ?? []) as unknown as ApptRow[];
-  const payments = (paymentsRes.data ?? []) as unknown as PaymentRow[];
-  const reviews = (reviewsRes.data ?? []) as ReviewRow[];
-  const allPatients = (patientsRes.data ?? []) as PatientRow[];
-
-  await ensureLookups(clinicId);
-
-  // Period comparison
-  const periodComparison = computeComparison(appts, payments, period);
-
-  // Daily analytics — adjust range based on selected period
-  const periodDays =
-    period === "week" ? 7 : period === "month" ? 30 : period === "quarter" ? 90 : 365;
-  const dailyMap = new Map<string, DailyAnalyticsView>();
-  const now = new Date();
-  for (let i = Math.min(periodDays, 30) - 1; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i);
-    const dateStr = getLocalDateStr(d);
-    dailyMap.set(dateStr, {
-      date: dateStr,
-      patientCount: 0,
-      revenue: 0,
-      appointments: 0,
-      noShows: 0,
-      walkIns: 0,
-      onlineBookings: 0,
-    });
-  }
-  for (const a of appts) {
-    const day = dailyMap.get(a.appointment_date);
-    if (!day) continue;
-    day.appointments++;
-    day.patientCount++;
-    if (a.status === "no_show") day.noShows++;
-    if (a.booking_source === "walk_in") day.walkIns++;
-    if (a.booking_source === "online" || a.booking_source === "website") day.onlineBookings++;
-  }
-  for (const p of payments) {
-    const dateStr = p.created_at?.split("T")[0];
-    const day = dailyMap.get(dateStr);
-    if (day) day.revenue += p.amount;
-  }
-  const dailyAnalytics = [...dailyMap.values()];
-
-  // Weekly revenue (group daily into weeks)
-  const weeklyRevenue: WeeklyRevenueView[] = [];
-  for (let i = 0; i < dailyAnalytics.length; i += 7) {
-    const chunk = dailyAnalytics.slice(i, i + 7);
-    if (chunk.length === 0) break;
-    const weekNum = Math.floor(i / 7) + 1;
-    weeklyRevenue.push({
-      week: `Week ${weekNum} (${chunk[0].date.slice(5)} - ${chunk[chunk.length - 1].date.slice(5)})`,
-      revenue: chunk.reduce((s, d) => s + d.revenue, 0),
-      patients: chunk.reduce((s, d) => s + d.patientCount, 0),
-    });
+  if (!json.ok) {
+    throw new Error(json.error ?? "Failed to load analytics");
   }
 
-  // Monthly revenue (last 6 months)
-  const monthlyRevenue: MonthlyRevenueView[] = [];
-  for (let i = 5; i >= 0; i--) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const monthStr = d.toISOString().slice(0, 7);
-    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
-    const monthAppts = appts.filter((a) => a.appointment_date?.startsWith(monthStr));
-    const monthPayments = payments.filter((p) => p.created_at?.startsWith(monthStr));
-    const uniquePatients = new Set(monthAppts.map((a) => a.patient_id));
-    monthlyRevenue.push({
-      month: label,
-      revenue: monthPayments.reduce((s, p) => s + p.amount, 0),
-      patients: uniquePatients.size,
-      appointments: monthAppts.length,
-    });
-  }
-
-  // Service popularity
-  const serviceCount = new Map<string, { count: number; revenue: number }>();
-  for (const a of appts) {
-    const svcName = a.service_id
-      ? (_activeServiceMap?.get(a.service_id)?.name ?? "Other")
-      : "Consultation";
-    const entry = serviceCount.get(svcName) ?? { count: 0, revenue: 0 };
-    entry.count++;
-    if (a.service_id) {
-      entry.revenue += _activeServiceMap?.get(a.service_id)?.price ?? 0;
-    }
-    serviceCount.set(svcName, entry);
-  }
-  const totalSvcCount = appts.length || 1;
-  const servicePopularity: ServicePopularityView[] = [...serviceCount.entries()]
-    .map(([name, val]) => ({
-      serviceName: name,
-      count: val.count,
-      revenue: val.revenue,
-      percentage: Math.round((val.count / totalSvcCount) * 100),
-    }))
-    .sort((a, b) => b.count - a.count);
-
-  // Hourly heatmap
-  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  const heatmap = new Map<string, Map<number, number>>();
-  for (const name of dayNames) heatmap.set(name, new Map());
-  for (const a of appts) {
-    const date = new Date(a.appointment_date);
-    const dayName = dayNames[date.getDay()];
-    const hour = parseInt(a.start_time?.slice(0, 2) ?? "0", 10);
-    const dayMap = heatmap.get(dayName)!;
-    dayMap.set(hour, (dayMap.get(hour) ?? 0) + 1);
-  }
-  const hourlyHeatmap: HourlyHeatmapView[] = dayNames.slice(1, 7).map((day) => ({
-    day,
-    hours: [9, 10, 11, 12, 14, 15, 16, 17].map((hour) => ({
-      hour,
-      count: heatmap.get(day)?.get(hour) ?? 0,
-    })),
-  }));
-
-  // Review trends (last 6 months)
-  const reviewTrends: ReviewTrendView[] = [];
-  for (let i = 5; i >= 0; i--) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const monthStr = d.toISOString().slice(0, 7);
-    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
-    const monthReviews = reviews.filter((r) => r.created_at?.startsWith(monthStr));
-    const avg =
-      monthReviews.length > 0
-        ? monthReviews.reduce((s, r) => s + r.stars, 0) / monthReviews.length
-        : 0;
-    reviewTrends.push({
-      month: label,
-      averageScore: Math.round(avg * 10) / 10,
-      count: monthReviews.length,
-    });
-  }
-
-  // Patient retention (last 6 months)
-  const patientRetention: PatientRetentionView[] = [];
-  for (let i = 5; i >= 0; i--) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const monthStr = d.toISOString().slice(0, 7);
-    const label = d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
-    const newPts = allPatients.filter((p) => p.created_at?.startsWith(monthStr)).length;
-    const monthAppts = appts.filter((a) => a.appointment_date?.startsWith(monthStr));
-    const returningIds = new Set(monthAppts.map((a) => a.patient_id));
-    const returning = returningIds.size;
-    const total = newPts + returning || 1;
-    patientRetention.push({
-      month: label,
-      newPatients: newPts,
-      returningPatients: returning,
-      retentionRate: Math.round((returning / total) * 100),
-    });
-  }
-
-  const data: AnalyticsData = {
-    dailyAnalytics,
-    weeklyRevenue,
-    monthlyRevenue,
-    servicePopularity,
-    hourlyHeatmap,
-    reviewTrends,
-    patientRetention,
-    totalPatients: allPatients.length,
-    totalAppointments: appts.length,
-    periodComparison,
-    period,
+  const rateLimit = {
+    limit: res.headers.get("X-RateLimit-Limit"),
+    remaining: res.headers.get("X-RateLimit-Remaining"),
+    reset: res.headers.get("X-RateLimit-Reset"),
   };
+
+  const data = json.data as AnalyticsData;
 
   analyticsCache.set(cacheKey, {
     expiresAt: nowMs + ANALYTICS_CACHE_TTL_MS,
     data,
   });
 
-  return data;
+  return { ...data, rateLimit };
 }
 
 // ── Revenue Analytics (Feature 15) ──────────────────────

--- a/src/lib/middleware/__tests__/rate-limiting.test.ts
+++ b/src/lib/middleware/__tests__/rate-limiting.test.ts
@@ -88,7 +88,7 @@ describe("applyRateLimit — per-rule limiting", () => {
   });
 
   it("returns 429 with Retry-After + rate-limit info when the rule denies", async () => {
-    h.apptCheck.mockResolvedValue(false);
+    h.apptCheck.mockResolvedValue({ allowed: false, remaining: 0 });
     const { response, rateLimitInfo } = await applyRateLimit(
       makeRequest("https://clinic.oltigo.com/api/appointments", "POST"),
       csp,
@@ -133,7 +133,7 @@ describe("applyRateLimit — per-rule limiting", () => {
 
 describe("applyRateLimit — global page limiter", () => {
   it("returns 429 for a non-API page when the global limiter denies", async () => {
-    h.globalCheck.mockResolvedValue(false);
+    h.globalCheck.mockResolvedValue({ allowed: false, remaining: 0 });
     const { response } = await applyRateLimit(
       makeRequest("https://clinic.oltigo.com/dashboard", "GET"),
       csp,
@@ -175,7 +175,7 @@ describe("applyRateLimit — per-clinic cap", () => {
   });
 
   it("returns 429 with the clinic-specific code when the clinic cap is exceeded", async () => {
-    h.clinicCheck.mockResolvedValue(false);
+    h.clinicCheck.mockResolvedValue({ allowed: false, remaining: 0 });
     const { response } = await applyRateLimit(
       makeRequest("https://clinic.oltigo.com/api/appointments", "POST"),
       csp,

--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -66,7 +66,10 @@ export async function applyRateLimit(
   const isCatchAll = rule?.prefix === "/api/";
 
   if (rule && !(isCatchAll && !MUTATION_METHODS.has(request.method))) {
-    const allowed = await rule.limiter.check(rateLimitKey);
+    const checkResult = await rule.limiter.check(rateLimitKey);
+    const allowed = typeof checkResult === "boolean" ? checkResult : checkResult.allowed;
+    const remaining = typeof checkResult === "boolean" ? Math.max(0, rule.max - 1) : checkResult.remaining;
+    
     const retryAfterSec = Math.ceil(rule.windowMs / 1000);
     const reset = Math.ceil(Date.now() / 1000) + retryAfterSec;
 
@@ -81,11 +84,11 @@ export async function applyRateLimit(
       response.headers.set("Retry-After", String(retryAfterSec));
       return {
         response,
-        rateLimitInfo: { limit: rule.max, remaining: 0, reset },
+        rateLimitInfo: { limit: rule.max, remaining, reset },
       };
     }
 
-    rateLimitInfo = { limit: rule.max, remaining: Math.max(0, rule.max - 1), reset };
+    rateLimitInfo = { limit: rule.max, remaining, reset };
   } else if (
     !pathname.startsWith("/_next/") &&
     !pathname.match(/\.(ico|png|jpg|jpeg|svg|css|js|woff2?|ttf|eot)$/i)

--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -68,8 +68,9 @@ export async function applyRateLimit(
   if (rule && !(isCatchAll && !MUTATION_METHODS.has(request.method))) {
     const checkResult = await rule.limiter.check(rateLimitKey);
     const allowed = typeof checkResult === "boolean" ? checkResult : checkResult.allowed;
-    const remaining = typeof checkResult === "boolean" ? Math.max(0, rule.max - 1) : checkResult.remaining;
-    
+    const remaining =
+      typeof checkResult === "boolean" ? Math.max(0, rule.max - 1) : checkResult.remaining;
+
     const retryAfterSec = Math.ceil(rule.windowMs / 1000);
     const reset = Math.ceil(Date.now() / 1000) + retryAfterSec;
 

--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -99,7 +99,8 @@ export async function applyRateLimit(
     // Previously this depended on a lookup against the /api/ catch-all rule
     // in rateLimitRules, which silently disappeared if that rule was absent.
     // The dedicated `globalPageLimiter` is now independent of API rules.
-    const allowed = await globalPageLimiter.check(`global_${rateLimitKey}`);
+    const globalCheck = await globalPageLimiter.check(`global_${rateLimitKey}`);
+    const allowed = typeof globalCheck === "boolean" ? globalCheck : globalCheck.allowed;
     if (!allowed) {
       const response = withSecurityHeaders(
         NextResponse.json(
@@ -125,7 +126,8 @@ export async function applyRateLimit(
     if (cached && Date.now() - cached.cachedAt <= SUBDOMAIN_CACHE_TTL_MS) {
       clinicKey = cached.id;
     }
-    const clinicAllowed = await perClinicLimiter.check(`clinic:${clinicKey}`);
+    const clinicCheck = await perClinicLimiter.check(`clinic:${clinicKey}`);
+    const clinicAllowed = typeof clinicCheck === "boolean" ? clinicCheck : clinicCheck.allowed;
     if (!clinicAllowed) {
       const response = withSecurityHeaders(
         NextResponse.json(

--- a/src/lib/rate-limit-do.ts
+++ b/src/lib/rate-limit-do.ts
@@ -79,9 +79,12 @@ export class RateLimiterDO {
       const alarmTime = now + windowMs + 1000;
       await this.state.storage.setAlarm(alarmTime);
 
-      return new Response(JSON.stringify({ allowed: true, remaining: Math.max(0, max - this.timestamps.length) }), {
-        headers: { "Content-Type": "application/json" },
-      });
+      return new Response(
+        JSON.stringify({ allowed: true, remaining: Math.max(0, max - this.timestamps.length) }),
+        {
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     return new Response("Not found", { status: 404 });

--- a/src/lib/rate-limit-do.ts
+++ b/src/lib/rate-limit-do.ts
@@ -22,7 +22,7 @@
 
 import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
-import type { RateLimiter, RateLimiterOptions } from "./rate-limit";
+import type { RateLimiter, RateLimiterOptions, RateLimitResult } from "./rate-limit";
 
 // ── Durable Object class (deployed as a separate Worker binding) ──
 
@@ -151,7 +151,7 @@ export function createDORateLimiter(options: RateLimiterOptions): RateLimiter {
   const { windowMs, max, failClosed = true } = options;
 
   return {
-    async check(key: string): Promise<boolean> {
+    async check(key: string): Promise<RateLimitResult> {
       try {
         // Bindings live on getCloudflareContext().env under
         // @opennextjs/cloudflare (v1.17+), NOT on globalThis — resolve at

--- a/src/lib/rate-limit-do.ts
+++ b/src/lib/rate-limit-do.ts
@@ -66,7 +66,7 @@ export class RateLimiterDO {
       this.timestamps = this.timestamps.filter((ts) => ts > windowStart);
 
       if (this.timestamps.length >= max) {
-        return new Response(JSON.stringify({ allowed: false }), {
+        return new Response(JSON.stringify({ allowed: false, remaining: 0 }), {
           headers: { "Content-Type": "application/json" },
         });
       }
@@ -79,7 +79,7 @@ export class RateLimiterDO {
       const alarmTime = now + windowMs + 1000;
       await this.state.storage.setAlarm(alarmTime);
 
-      return new Response(JSON.stringify({ allowed: true }), {
+      return new Response(JSON.stringify({ allowed: true, remaining: Math.max(0, max - this.timestamps.length) }), {
         headers: { "Content-Type": "application/json" },
       });
     }
@@ -167,11 +167,11 @@ export function createDORateLimiter(options: RateLimiterOptions): RateLimiter {
           `https://rate-limiter.internal/check?windowMs=${windowMs}&max=${max}`,
         );
 
-        const result = (await response.json()) as { allowed: boolean };
-        return result.allowed;
+        const result = (await response.json()) as { allowed: boolean; remaining: number };
+        return result;
       } catch (err) {
         logger.error("Rate limiter DO failure", { context: "rate-limit", error: err });
-        return !failClosed;
+        return { allowed: !failClosed, remaining: 0 };
       }
     },
   };

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -143,15 +143,20 @@ export interface RateLimiterOptions {
   failClosed?: boolean;
 }
 
+/**
+ * Result returned by RateLimiter.check — either a bare allow/deny boolean
+ * (for backends that don't track exact quota) or an object with the
+ * remaining quota for accurate header reporting.
+ */
+export type RateLimitResult = boolean | { allowed: boolean; remaining: number };
+
 export interface RateLimiter {
   /**
    * Returns `true` if the request is allowed, `false` if rate-limited.
    * Or returns an object with `{ allowed: boolean, remaining: number }` for accurate quota tracking.
    * May be async when using a distributed backend.
    */
-  check(
-    key: string,
-  ): boolean | Promise<boolean> | { allowed: boolean; remaining: number } | Promise<{ allowed: boolean; remaining: number }>;
+  check(key: string): RateLimitResult | Promise<RateLimitResult>;
 }
 
 // ── Backend selection ──
@@ -288,11 +293,11 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
   const supabase = createSupabaseClient(supabaseUrl, serviceRoleKey);
 
   return {
-    async check(key: string): Promise<boolean> {
+    async check(key: string): Promise<RateLimitResult> {
       // If circuit breaker is tripped, degrade to in-memory rate limiting.
       // This preserves rate-limit enforcement while keeping the site alive.
       if (isCircuitOpen(circuitBreaker)) {
-        if (circuitBreaker.fallback) return circuitBreaker.fallback.check(key);
+        if (circuitBreaker.fallback) return await circuitBreaker.fallback.check(key);
         return !failClosed;
       }
 
@@ -345,7 +350,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
           void reportRateLimitBackendError("query", error);
           if (circuitBreaker.failClosed) return false;
           if (circuitBreaker.fallback) {
-            return circuitBreaker.fallback.check(key);
+            return await circuitBreaker.fallback.check(key);
           }
           return !failClosed;
         }
@@ -368,7 +373,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
             void reportRateLimitBackendError("upsert", upsertError);
             if (circuitBreaker.failClosed) return false;
             if (circuitBreaker.fallback) {
-              return circuitBreaker.fallback.check(key);
+              return await circuitBreaker.fallback.check(key);
             }
             return !failClosed;
           }
@@ -394,7 +399,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
           void reportRateLimitBackendError("update", updateError);
           if (circuitBreaker.failClosed) return false;
           if (circuitBreaker.fallback) {
-            return circuitBreaker.fallback.check(key);
+            return await circuitBreaker.fallback.check(key);
           }
           return !failClosed;
         }
@@ -419,7 +424,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
         void reportRateLimitBackendError("network", err);
         if (circuitBreaker.failClosed) return false;
         if (circuitBreaker.fallback) {
-          return circuitBreaker.fallback.check(key);
+          return await circuitBreaker.fallback.check(key);
         }
         return !failClosed;
       }
@@ -468,7 +473,9 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
    * limiters (security-critical endpoints) may hard-deny, and only once the
    * grace period since the first failure has elapsed.
    */
-  const degradeOrFailClosed = async (key: string): Promise<{ allowed: boolean; remaining: number }> => {
+  const degradeOrFailClosed = async (
+    key: string,
+  ): Promise<{ allowed: boolean; remaining: number }> => {
     if (!circuitBreaker.fallback) {
       circuitBreaker.fallback = createMemoryRateLimiter(options);
     }
@@ -489,7 +496,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
   };
 
   return {
-    async check(key: string): Promise<boolean> {
+    async check(key: string): Promise<RateLimitResult> {
       // If circuit breaker is tripped, degrade to in-memory rate limiting.
       if (isCircuitOpen(circuitBreaker)) {
         return degradeOrFailClosed(key);
@@ -569,7 +576,7 @@ function createMemoryRateLimiter(options: RateLimiterOptions): RateLimiter {
   }
 
   return {
-    check(key: string): boolean {
+    check(key: string): RateLimitResult {
       const now = Date.now();
 
       // Log a warning on the first request after a cold start so operators

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -146,9 +146,12 @@ export interface RateLimiterOptions {
 export interface RateLimiter {
   /**
    * Returns `true` if the request is allowed, `false` if rate-limited.
+   * Or returns an object with `{ allowed: boolean, remaining: number }` for accurate quota tracking.
    * May be async when using a distributed backend.
    */
-  check(key: string): boolean | Promise<boolean>;
+  check(
+    key: string,
+  ): boolean | Promise<boolean> | { allowed: boolean; remaining: number } | Promise<{ allowed: boolean; remaining: number }>;
 }
 
 // ── Backend selection ──
@@ -316,7 +319,8 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
         if (!rpcError && rpcResult != null) {
           // RPC succeeded — rpcResult is the new count
           recordSuccess(circuitBreaker);
-          return (rpcResult as number) <= max;
+          const count = rpcResult as number;
+          return { allowed: count <= max, remaining: Math.max(0, max - count) };
         }
 
         // RPC not available — fall back to upsert-based approach.
@@ -369,7 +373,7 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
             return !failClosed;
           }
           recordSuccess(circuitBreaker);
-          return true;
+          return { allowed: true, remaining: Math.max(0, max - 1) };
         }
 
         // Window still active — increment atomically using a conditional update.
@@ -404,10 +408,11 @@ function createSupabaseRateLimiter(options: RateLimiterOptions): RateLimiter {
             .select("count")
             .eq("key", key)
             .maybeSingle();
-          return (reread?.count ?? 0) <= max;
+          const c = reread?.count ?? 0;
+          return { allowed: c <= max, remaining: Math.max(0, max - c) };
         }
 
-        return newCount <= max;
+        return { allowed: newCount <= max, remaining: Math.max(0, max - newCount) };
       } catch (err) {
         logger.error("Rate limiter network failure", { context: "rate-limit", error: err });
         recordFailure(circuitBreaker, options);
@@ -463,7 +468,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
    * limiters (security-critical endpoints) may hard-deny, and only once the
    * grace period since the first failure has elapsed.
    */
-  const degradeOrFailClosed = (key: string): boolean | Promise<boolean> => {
+  const degradeOrFailClosed = async (key: string): Promise<{ allowed: boolean; remaining: number }> => {
     if (!circuitBreaker.fallback) {
       circuitBreaker.fallback = createMemoryRateLimiter(options);
     }
@@ -475,10 +480,12 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
           key,
           elapsedMs: elapsed,
         });
-        return false;
+        return { allowed: false, remaining: 0 };
       }
     }
-    return circuitBreaker.fallback.check(key);
+    const result = await circuitBreaker.fallback.check(key);
+    if (typeof result === "boolean") return { allowed: result, remaining: 0 };
+    return result;
   };
 
   return {
@@ -515,7 +522,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
         if (validTimestamps.length >= max) {
           // Rate limit exceeded
           recordSuccess(circuitBreaker);
-          return false;
+          return { allowed: false, remaining: 0 };
         }
 
         // Add current request timestamp
@@ -529,7 +536,7 @@ function createKVRateLimiter(options: RateLimiterOptions): RateLimiter {
         });
 
         recordSuccess(circuitBreaker);
-        return true;
+        return { allowed: true, remaining: Math.max(0, max - validTimestamps.length) };
       } catch (err) {
         logger.error("Rate limiter KV failure", { context: "rate-limit", error: err });
         recordFailure(circuitBreaker, options);
@@ -592,11 +599,11 @@ function createMemoryRateLimiter(options: RateLimiterOptions): RateLimiter {
 
       if (!entry || now >= entry.resetAt) {
         store.set(key, { count: 1, resetAt: now + windowMs });
-        return true;
+        return { allowed: true, remaining: Math.max(0, max - 1) };
       }
 
       entry.count += 1;
-      return entry.count <= max;
+      return { allowed: entry.count <= max, remaining: Math.max(0, max - entry.count) };
     },
   };
 }


### PR DESCRIPTION
## Summary

Implements the full **Analytics Rate-Limit Status UX (P1)** workstream, closing all three sub-tasks (1.1 ? 1.3).

## Changes

### Backend - Rate Limiter (src/lib/rate-limit.ts, src/lib/rate-limit-do.ts)
- Updated RateLimiter.check() to return { allowed: boolean; remaining: number } instead of a bare boolean across **all backends** (Supabase, KV, Memory, Durable Objects).
- Remaining quota is now counted accurately on both success and failure paths.

### Middleware (src/lib/middleware/rate-limiting.ts)
- pplyRateLimit now populates ateLimitInfo.remaining from the structured result.
- X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset are set on **every successful** /api/analytics/* response (not just 429 rejections), enabling proactive quota monitoring.

### New API Route (src/app/api/analytics/dashboard/route.ts)
- Server-side analytics aggregation endpoint (GET /api/analytics/dashboard?period=.).
- Replaces the previous direct Supabase client queries in the browser, so all analytics traffic now flows through middleware and receives rate-limit headers.
- Protected by withAuth (roles: clinic_admin, doctor).

### Client (src/lib/data/client/analytics.ts)
- etchAnalytics now calls /api/analytics/dashboard via etch() instead of querying Supabase directly.
- Captures X-RateLimit-* response headers and surfaces them as ateLimit on the returned object.
- Exports new types: RateLimitStatus, FetchAnalyticsResponse.

### Dashboard UI (src/components/analytics/analytics-dashboard.tsx)
- Uses FetchAnalyticsResponse state type.
- Renders an **API quota badge** (emaining/limit API quota) in the header toolbar whenever rate-limit headers are present.

## Testing

- Unit: existing ate-limiting.test.ts suite covers the middleware path.
- UI: quota badge visible in analytics dashboard toolbar after first data load.