### PR TITLE
fix(ci): propagate CLOUDFLARE_API_TOKEN to opennextjs subprocess

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,19 @@ jobs:
       - name: Deploy to Cloudflare Workers
         # CICD-01 / AUDIT-16: pinned to v3.15.0 SHA for supply-chain hardening.
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
+        env:
+          # CF-DEPLOY-01: When wrangler detects an OpenNext project it
+          # delegates to `opennextjs-cloudflare deploy`, which spawns its
+          # OWN wrangler subprocess. The `apiToken:` / `accountId:` inputs
+          # are only propagated to the immediate wrangler invocation —
+          # the grand-child wrangler started by opennextjs-cloudflare does
+          # not see them and aborts with
+          #   "it's necessary to set a CLOUDFLARE_API_TOKEN environment
+          #    variable for wrangler to work".
+          # Setting them at the step `env:` level puts them in the runner
+          # process.env so every spawned process inherits them.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

Deploy workflow run [27023764724](https://github.com/groupsmix/webs-alots/actions/runs/27023764724) (triggered by merging #973) failed at the wrangler deploy step:

```
✘ [ERROR] In a non-interactive environment, it's necessary to set
  a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

## Root cause

`wrangler-action` v3.15.0 passes the `apiToken:` / `accountId:` inputs only to the wrangler subprocess it spawns directly. That wrangler invocation detects an OpenNext project and delegates to `opennextjs-cloudflare deploy`, which then spawns its **own** wrangler subprocess (see [`@opennextjs/cloudflare/dist/cli/commands/deploy.js`](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/cli/commands/deploy.ts)). The grand-child wrangler does not see `CLOUDFLARE_API_TOKEN` in its environment and aborts.

This is the first deploy where it surfaced — `npm run build:cf` previously fit in the 10 MiB compressed limit only for `main`. With #973 merged, the deploy actually attempted and hit this latent bug.

## Fix

Set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` at the step `env:` level so they live in the runner `process.env` and are inherited by every spawned process:

```
runner step
  └─ wrangler-action
       └─ wrangler deploy  ← apiToken: input goes here only
            └─ opennextjs-cloudflare deploy
                 └─ wrangler deploy  ← needs CLOUDFLARE_API_TOKEN env
```

The `apiToken:` / `accountId:` inputs are kept so the action still masks the token in logs via `core.setSecret`.

## Verification

Cannot fully verify locally because secrets only exist in GitHub Actions. Once merged, the post-merge Deploy run on `main` should succeed. If anything still goes wrong, the error message will name the next missing piece (token IS clearly the only blocker in 27023764724).

No other workflows touched.

---
Co-authored-by: Assistant <assistant@oltigo.dev>