### PR TITLE
hotfix(super-admin): disable CopilotShell to restore dashboard

### DIFF
--- a/src/app/(super-admin)/layout.tsx
+++ b/src/app/(super-admin)/layout.tsx
@@ -1,7 +1,24 @@
 // SC-01: Server component layout — client-interactive shell extracted to
 // @/components/layouts/super-admin-layout-shell (a "use client" component).
+//
+// HOTFIX 2026-06-06: CopilotShell temporarily disabled.
+// The CopilotKit runtime endpoint (/api/copilotkit) was moved to the
+// separate webs-alots-ai Worker in PR #976. That Worker requires an
+// ANTHROPIC_API_KEY secret which is not yet provisioned. With the
+// AI Worker routes removed from the zone, the main app's /api/copilotkit
+// route returns a 501 stub on every request, causing CopilotKit's
+// provider initialization to throw and the super-admin error boundary
+// to fire on every super-admin page (including /super-admin/dashboard).
+//
+// To restore the sidebar:
+//   1. Set ANTHROPIC_API_KEY on webs-alots-ai (production + staging).
+//   2. Recreate Cloudflare zone routes:
+//        oltigo.com/api/copilotkit       -> webs-alots-ai
+//        oltigo.com/api/copilotkit/*     -> webs-alots-ai
+//        oltigo.com/api/builder/sandbox  -> webs-alots-ai
+//        oltigo.com/api/builder/sandbox/* -> webs-alots-ai
+//   3. Re-enable the <CopilotShell> wrapper below.
 import { Suspense } from "react";
-import { CopilotShell } from "@/components/admin/copilot-shell";
 import { ImpersonationBanner } from "@/components/admin/ImpersonationBanner";
 import SuperAdminLayoutShell from "@/components/layouts/super-admin-layout-shell";
 import SuperAdminLoading from "./loading";
@@ -11,9 +28,7 @@ export default function SuperAdminLayout({ children }: { children: React.ReactNo
     <>
       <ImpersonationBanner />
       <SuperAdminLayoutShell>
-        <CopilotShell>
-          <Suspense fallback={<SuperAdminLoading />}>{children}</Suspense>
-        </CopilotShell>
+        <Suspense fallback={<SuperAdminLoading />}>{children}</Suspense>
       </SuperAdminLayoutShell>
     </>
   );


### PR DESCRIPTION
## Problem

Production `/super-admin/dashboard` (and every super-admin page) shows the error boundary fallback after PR #976 was merged.

## Root cause

PR #976 split the CopilotKit + AI Builder routes into a separate `webs-alots-ai` Worker to stay under the 10 MiB Cloudflare Worker bundle limit. The main app keeps a 501 stub at `/api/copilotkit/route.ts` that is supposed to be intercepted by Cloudflare zone routes pointing `/api/copilotkit/*` to `webs-alots-ai`.

The AI Worker is deployed but `ANTHROPIC_API_KEY` was not provisioned, so the AI Worker returns 500 on every request. The zone routes were removed so requests fall through to the main app and now hit the 501 stub directly.

The super-admin layout renders `<CopilotShell>`, which mounts `<CopilotKit runtimeUrl="/api/copilotkit">`. CopilotKit probes the runtime on mount; the 501 response causes the provider to throw, and the error bubbles to `(super-admin)/error.tsx`.

Evidence: 6+ `501 POST /api/copilotkit` events on `webs-alots` Worker in the last hour.

## Fix

Remove `<CopilotShell>` from the super-admin layout. Dashboard renders normally. The AI Builder page (`/builder`) remains accessible but its chat will not work until `ANTHROPIC_API_KEY` is set on `webs-alots-ai` and the zone routes are recreated.

## Restoration plan (documented in `layout.tsx`)

1. Set `ANTHROPIC_API_KEY` (and `E2B_API_KEY`) on `webs-alots-ai`.
2. Recreate zone routes pointing `/api/copilotkit/*` and `/api/builder/sandbox/*` to `webs-alots-ai`.
3. Re-enable `<CopilotShell>` wrapper.

## Risk

- The Copilot sidebar disappears from super-admin pages temporarily. No data loss, no auth changes.
- One-file change, fully reversible.
