### PR TITLE
perf: cache /_next/static/* immutable for 1 year

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,40 @@
+# Cloudflare Workers Static Assets - cache headers
+# https://developers.cloudflare.com/workers/static-assets/headers/
+#
+# PERF: Without this file Workers Static Assets defaults to
+# `cache-control: public, max-age=0, must-revalidate` which forces the
+# browser to re-validate every Next.js chunk on every navigation. The
+# headers() rules in next.config.ts only apply to requests that go
+# through the Worker, not to assets served directly from the [assets]
+# binding. This file is the source of truth for asset cache headers.
+
+# Next.js content-hashed chunks (JS, CSS, media). File names contain a
+# build hash so they can be cached forever.
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Next.js image optimizer output — content keyed by URL params, safe to
+# cache long-term but allow revalidation in case of optimizer changes.
+/_next/image/*
+  Cache-Control: public, max-age=2592000, must-revalidate
+
+# Static media in /public (favicons, icons, og images). Filenames are
+# stable across deploys, so a 1-day cache + revalidation is reasonable.
+/*.ico
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.png
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.jpg
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.jpeg
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.svg
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.webp
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.avif
+  Cache-Control: public, max-age=86400, must-revalidate
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Problem

Diagnosed from prod latency complaint. Probed `https://oltigo.com/_next/static/chunks/*.js` and every chunk returns:

```
cache-control: public, max-age=0, must-revalidate
```

The homepage references 22 hashed chunks. Browser revalidates all 22 on every navigation — that's the bulk of perceived slowness.

## Root cause

`headers()` in `next.config.ts` already specifies the correct immutable header for `/_next/static/*`, but those rules **only apply to requests that go through the Worker**. The repo uses Cloudflare Workers Static Assets:

```toml
[assets]
directory = ".open-next/assets"
binding = "ASSETS"
```

When Workers Static Assets serves a file directly (which it does for everything under `/_next/static/*`), it bypasses the Next.js handler entirely. The defaults take over: `public, max-age=0, must-revalidate`.

## Fix

Add `public/_headers` (Cloudflare Workers Static Assets reads this file the same way Cloudflare Pages does). The file is copied to `.open-next/assets/_headers` during build and overrides the defaults:

```
/_next/static/*  →  public, max-age=31536000, immutable
/_next/image/*   →  public, max-age=2592000, must-revalidate
/*.woff,woff2    →  public, max-age=31536000, immutable
/*.{ico,png,...} →  public, max-age=86400, must-revalidate
```

## Impact

From Worker analytics (last 24h): wall p75 = 993ms, p99 = 7066ms on `webs-alots`. Most of this is chunk revalidation, not actual server work (CPU p75 = 74ms).

- **First visit:** unchanged (still has to download chunks)
- **Subsequent navigations:** browser caches chunks for 1 year, skips revalidation entirely
- **Cloudflare edge:** stops seeing the revalidation traffic, frees Worker CPU budget

Fully reversible — revert the commit and the file is gone.

## Verification post-merge

```
curl -sI https://oltigo.com/_next/static/chunks/<any>.js | grep cache-control
# expect: cache-control: public, max-age=31536000, immutable
```

Docs: https://developers.cloudflare.com/workers/static-assets/headers/