### PR TITLE
fix(security): drop service-role from /api/consent ledger write

### DIFF
--- a/src/app/api/consent/route.ts
+++ b/src/app/api/consent/route.ts
@@ -83,9 +83,34 @@ export const POST = withValidation(consentSchema, async (data, request: NextRequ
     return apiSuccess({ logged: false });
   }
 
-  // CMP-006: Also write to consent_records (structured 00160 table) when userId is known.
-  // This populates the new compliance-grade ledger without breaking the legacy consent_logs flow.
-  if (userId) {
+  // CMP-006 / PR #980 corridor-security follow-up:
+  //
+  // Also write to consent_records (structured 00160 table) when the
+  // caller is authenticated. This populates the compliance-grade ledger
+  // without breaking the legacy consent_logs flow used for pre-auth
+  // cookie consent.
+  //
+  // SECURITY MODEL
+  // --------------
+  // 1.  We refuse to write consent_records without an authenticated
+  //     Supabase session (`user` from supabase.auth.getUser()).
+  //     Pre-auth cookie consent stays on consent_logs only.
+  // 2.  We use the user's own tenant-scoped client — NOT a service-role
+  //     client — so RLS enforces ownership at the database level.
+  //     Migration 00163 adds:
+  //       CREATE POLICY user_inserts_own_consent_records
+  //         ON public.consent_records FOR INSERT TO authenticated
+  //         WITH CHECK (
+  //           user_id  = (SELECT id        FROM users WHERE auth_id = auth.uid())
+  //           AND clinic_id = (SELECT clinic_id FROM users WHERE auth_id = auth.uid())
+  //         );
+  //     Even if a future change accidentally takes user_id from the
+  //     request body, the database will reject the write.
+  // 3.  Defense in depth: we re-verify in code that the resolved
+  //     profile (`userId`) still maps back to the authenticated user
+  //     via auth_id, and that profile.clinic_id matches the resolved
+  //     tenant.clinicId, before issuing the insert.
+  if (user && userId) {
     const VALID_CONSENT_TYPES = [
       "terms_of_service",
       "privacy_policy",
@@ -101,32 +126,46 @@ export const POST = withValidation(consentSchema, async (data, request: NextRequ
       : null;
 
     if (normalizedType) {
-      // SECURITY (corridor-security review): userId is NOT taken from the
-      // request body — it is server-resolved above from
-      // supabase.auth.getUser() and looked up in the users table via
-      // auth_id. The service-role insert is therefore safe; a caller
-      // cannot forge consent records for an arbitrary user UUID.
-      //
-      // We use createUntypedAdminClient (rather than createServiceClient)
-      // because consent_records was introduced by migration 00160 and is
-      // not yet in the generated Supabase types. It is the same service-
-      // role client under the hood with an untyped surface for new tables.
-      const { createUntypedAdminClient } = await import("@/lib/supabase-server");
-      const serviceSupabase = createUntypedAdminClient("super_admin", tenant.clinicId);
-      const { error: crError } = await serviceSupabase.from("consent_records").insert({
-        user_id: userId,
-        clinic_id: tenant.clinicId,
-        consent_type: normalizedType,
-        granted,
-        version: "1.0",
-        ip_address: ip,
-        user_agent: request.headers.get("user-agent") ?? null,
-      });
-      if (crError) {
-        logger.warn("Failed to write consent_records", {
+      // Defense-in-depth re-verification of ownership. The profile row
+      // must (a) belong to the authenticated auth user and (b) be
+      // attached to the resolved tenant. If either invariant fails we
+      // log and skip the structured write — never fall back to a
+      // service-role client.
+      const { data: profileCheck } = await supabase
+        .from("users")
+        .select("id, auth_id, clinic_id")
+        .eq("id", userId)
+        .maybeSingle();
+
+      const ownsProfile =
+        profileCheck?.auth_id === user.id && profileCheck?.clinic_id === tenant.clinicId;
+
+      if (!ownsProfile) {
+        logger.warn("Skipping consent_records write: profile/tenant mismatch", {
           context: "consent",
-          error: crError.message,
+          authUser: user.id,
+          resolvedUserId: userId,
+          resolvedClinic: tenant.clinicId,
         });
+      } else {
+        // Use the user's own tenant client. RLS policy
+        // user_inserts_own_consent_records (00163) enforces ownership
+        // server-side as the final authorization barrier.
+        const { error: crError } = await supabase.from("consent_records").insert({
+          user_id: userId,
+          clinic_id: tenant.clinicId,
+          consent_type: normalizedType,
+          granted,
+          version: "1.0",
+          ip_address: ip,
+          user_agent: request.headers.get("user-agent") ?? null,
+        });
+        if (crError) {
+          logger.warn("Failed to write consent_records", {
+            context: "consent",
+            error: crError.message,
+          });
+        }
       }
     }
   }

--- a/src/lib/types/database-extended.ts
+++ b/src/lib/types/database-extended.ts
@@ -47,6 +47,64 @@ type ExtendedDatabase = GenDatabase & {
         Update: UsersUpdateExtended;
         Relationships: GenDatabase["public"]["Tables"]["users"]["Relationships"];
       };
+      // PR #980 follow-up: consent_records table (00160) — added here so
+      // the typed tenant client can target it via supabase.from(...) and
+      // RLS (policy user_inserts_own_consent_records, 00163) enforces
+      // ownership without needing a service-role client.
+      consent_records: {
+        Row: {
+          id: string;
+          user_id: string | null;
+          clinic_id: string | null;
+          consent_type:
+            | "terms_of_service"
+            | "privacy_policy"
+            | "health_data_processing"
+            | "marketing_communications"
+            | "whatsapp_notifications"
+            | "data_sharing_with_clinic";
+          granted: boolean;
+          version: string;
+          ip_address: string | null;
+          user_agent: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id?: string | null;
+          clinic_id?: string | null;
+          consent_type:
+            | "terms_of_service"
+            | "privacy_policy"
+            | "health_data_processing"
+            | "marketing_communications"
+            | "whatsapp_notifications"
+            | "data_sharing_with_clinic";
+          granted: boolean;
+          version: string;
+          ip_address?: string | null;
+          user_agent?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string | null;
+          clinic_id?: string | null;
+          consent_type?:
+            | "terms_of_service"
+            | "privacy_policy"
+            | "health_data_processing"
+            | "marketing_communications"
+            | "whatsapp_notifications"
+            | "data_sharing_with_clinic";
+          granted?: boolean;
+          version?: string;
+          ip_address?: string | null;
+          user_agent?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
       // X-1: consent_logs table (not in generated types)
       consent_logs: {
         Row: {

--- a/supabase/migrations/00163_consent_records_user_self_insert.sql
+++ b/supabase/migrations/00163_consent_records_user_self_insert.sql
@@ -1,0 +1,49 @@
+-- 00163: Allow authenticated users to insert their own consent_records rows.
+--
+-- Background
+-- ----------
+-- Migration 00160 introduced public.consent_records with RLS and only the
+-- following INSERT policy:
+--
+--   CREATE POLICY service_role_insert_consent_records
+--     ON public.consent_records FOR INSERT TO service_role WITH CHECK (true);
+--
+-- This forced /api/consent to acquire a service-role client to write the
+-- structured consent ledger, even though the writer is always the
+-- authenticated end user recording their own consent decision.
+-- corridor-security flagged that pattern on PR #980: using a service-role
+-- client (which bypasses RLS) together with a request-influenced
+-- `user_id` is a consent-forgery risk if the userId derivation ever
+-- regresses.
+--
+-- This migration restores defense in depth by letting the user's own
+-- authenticated session write the row, with RLS enforcing that the row's
+-- user_id resolves to the authenticated user's profile AND the row's
+-- clinic_id matches that profile's clinic. The application code switches
+-- to the tenant-scoped client; the service-role policy stays in place
+-- for server-internal flows (cron, super-admin tools).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'consent_records'
+      AND policyname = 'user_inserts_own_consent_records'
+  ) THEN
+    CREATE POLICY user_inserts_own_consent_records
+      ON public.consent_records
+      FOR INSERT
+      TO authenticated
+      WITH CHECK (
+        user_id = (SELECT id FROM public.users WHERE auth_id = auth.uid())
+        AND clinic_id = (SELECT clinic_id FROM public.users WHERE auth_id = auth.uid())
+      );
+  END IF;
+END $$;
+
+COMMENT ON POLICY user_inserts_own_consent_records ON public.consent_records IS
+  'PR #980 follow-up. Allows authenticated users to record their own
+   consent decisions without a service-role client. RLS enforces that the
+   inserted user_id and clinic_id match the caller''s profile, preventing
+   consent forgery for arbitrary users.';


### PR DESCRIPTION
Follow-up to PR #980 (merged before the corridor-security comment landed).

## Why

corridor-security flagged the `consent_records` insert in `src/app/api/consent/route.ts` as a **consent-forgery risk**: the write used a service-role Supabase client (which bypasses RLS) on a row whose `user_id` was derived from request-influenced state. The `userId` was already server-resolved via `supabase.auth.getUser()` + a `users.auth_id` lookup, but service-role + user-attributed-row is the kind of pattern that *becomes* exploitable the moment someone copies it or wires an admin write next to it.

## What changes

1. **Migration 00163** adds an RLS INSERT policy on `consent_records`:

   ```sql
   CREATE POLICY user_inserts_own_consent_records
     ON public.consent_records FOR INSERT TO authenticated
     WITH CHECK (
       user_id   = (SELECT id        FROM users WHERE auth_id = auth.uid())
       AND clinic_id = (SELECT clinic_id FROM users WHERE auth_id = auth.uid())
     );
   ```

   The existing `service_role_insert_consent_records` policy stays in place for internal/cron flows. End-user writes now flow through authenticated identity.

2. **`/api/consent`** writes via the user’s own tenant client (no service-role import on this code path). The DB enforces ownership.

3. **Defense in depth in the route**: we explicitly require `user` (not just a resolved `userId`), re-verify that `profile.auth_id === user.id` and `profile.clinic_id === tenant.clinicId`, and only then issue the insert. Mismatch logs a warning and skips — there is no service-role fallback path.

4. **`database-extended.ts`** now declares `consent_records` so the typed tenant client can target it without unknown-casts.

## Net effect

Even if a future regression takes `user_id` from the request body, two layers (in-route ownership re-check + RLS `WITH CHECK`) prevent forged consent ledger rows. The compliance-grade ledger keeps populating exactly as before for authenticated cookie-consent writes; pre-auth cookie consent still lands on `consent_logs` only.

Closes corridor-security finding on PR #980.