### PR TITLE
fix(audit): reserved subdomains, Sentry boot check, contact JSON-LD, skip links

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -40,12 +40,10 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <div className="flex min-h-screen bg-muted/50">
-      <a
-        href="#auth-form"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:text-sm focus:font-medium"
-      >
-        {t(locale, "nav.skipToForm")}
-      </a>
+      {/* F-5: No skip link here. The root layout already renders the single
+          "skip to content" link, and on auth pages it targets #main-content
+          below (the form). A second skip link caused a WCAG 2.4.1 ambiguity
+          (two "Aller au…" targets) on /login/. */}
 
       {/* ── Left hero panel (hidden on mobile) ── */}
       <div className="relative hidden lg:flex lg:w-[480px] xl:w-[520px] flex-col justify-between overflow-hidden bg-gradient-to-br from-[#005a3b] via-[#00795a] to-[#009e74] text-white">
@@ -134,7 +132,10 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
           </div>
         </header>
 
-        <div id="auth-form" className="flex flex-1 items-center justify-center p-4 sm:p-6 lg:p-8">
+        <div
+          id="main-content"
+          className="flex flex-1 items-center justify-center p-4 sm:p-6 lg:p-8"
+        >
           <div className="w-full max-w-md">{children}</div>
         </div>
       </div>

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -40,41 +40,65 @@ export default async function ContactPage() {
   const whatsapp = wsCfg?.contact?.whatsapp || defaultCfg.whatsapp;
   const whatsappMessage = defaultCfg.whatsappMessage;
 
+  // F-3: A value like "+212 520-000000" / "+212 600-000000" is a placeholder,
+  // not a real contact. Never show it to users or emit it as structured data —
+  // it gets flagged by Google and makes the business look fake. Heuristic: any
+  // number whose digits contain a run of 5+ zeros is treated as a placeholder.
+  const isPlaceholderValue = (val?: string | null): boolean => {
+    if (!val || !val.trim()) return true;
+    return /0{5,}/.test(val.replace(/\D/g, ""));
+  };
+
   const contactInfo = [
     { icon: Phone, label: "Téléphone", value: phone },
     { icon: MessageCircle, label: "WhatsApp", value: whatsapp },
     { icon: Mail, label: "Email", value: email },
     { icon: MapPin, label: "Adresse", value: address },
-  ];
+  ].filter((info) => Boolean(info.value) && !isPlaceholderValue(info.value));
 
   const whatsappLink = `https://wa.me/${whatsapp.replace(/\s+/g, "")}?text=${encodeURIComponent(whatsappMessage)}`;
+  const showWhatsappCta = !isPlaceholderValue(whatsapp);
 
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://example.com";
 
-  const contactSchema = {
-    "@context": "https://schema.org",
-    "@type": "ContactPage",
-    url: `${baseUrl}/contact`,
-    mainEntity: {
-      "@type": "MedicalBusiness",
-      name: branding?.clinicName || title,
-      telephone: phone,
-      email: email,
-      address: {
-        "@type": "PostalAddress",
-        streetAddress: address,
-      },
-    },
+  // F-3: The marketing contact page represents the Oltigo *Organization*, not a
+  // MedicalBusiness — only a real clinic tenant is a MedicalBusiness. Emit only
+  // contact fields that are real, and drop the structured data entirely for a
+  // clinic tenant that has not filled in any real contact details (empty is
+  // better than fake for Google Search Console).
+  const isClinicTenant = Boolean(branding?.clinicName);
+  const mainEntity: Record<string, unknown> = {
+    "@type": isClinicTenant ? "MedicalBusiness" : "Organization",
+    name: branding?.clinicName || "Oltigo",
+    url: baseUrl,
   };
+  if (!isPlaceholderValue(phone)) mainEntity.telephone = phone;
+  if (email && email.includes("@") && !isPlaceholderValue(email)) mainEntity.email = email;
+  if (address && address.trim() && !isPlaceholderValue(address)) {
+    mainEntity.address = { "@type": "PostalAddress", streetAddress: address };
+  }
+
+  const hasRealContactDetails = "telephone" in mainEntity || "email" in mainEntity;
+  const contactSchema =
+    isClinicTenant && !hasRealContactDetails
+      ? null
+      : {
+          "@context": "https://schema.org",
+          "@type": "ContactPage",
+          url: `${baseUrl}/contact`,
+          mainEntity,
+        };
 
   return (
     <div className="container mx-auto px-4 py-12">
-      <script
-        type="application/ld+json"
-        // SAFETY: JSON.stringify of a server-controlled object built from static
-        // config values (defaultWebsiteConfig) and tenant branding.
-        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(contactSchema) }}
-      />
+      {contactSchema && (
+        <script
+          type="application/ld+json"
+          // SAFETY: JSON.stringify of a server-controlled object built from static
+          // config values (defaultWebsiteConfig) and tenant branding.
+          dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(contactSchema) }}
+        />
+      )}
       <div className="text-center mb-12">
         <h1 className="text-3xl font-bold mb-4">{title}</h1>
         <p className="text-muted-foreground max-w-2xl mx-auto">{subtitle}</p>
@@ -98,28 +122,30 @@ export default async function ContactPage() {
             ))}
           </div>
 
-          {/* WhatsApp CTA */}
-          <Card className="border-green-200 bg-green-50/50">
-            <CardContent className="flex items-center gap-4 p-6">
-              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-green-100">
-                <MessageCircle className="h-6 w-6 text-green-600" />
-              </div>
-              <div className="flex-1">
-                <p className="font-medium">Écrivez-nous sur WhatsApp</p>
-                <p className="text-sm text-muted-foreground">
-                  Réponses rapides pendant les heures de travail
-                </p>
-              </div>
-              <Link
-                href={whatsappLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center rounded-lg bg-green-600 text-white px-4 py-2 text-sm font-medium hover:bg-green-700 transition-colors"
-              >
-                Ouvrir WhatsApp
-              </Link>
-            </CardContent>
-          </Card>
+          {/* WhatsApp CTA — only when a real WhatsApp number is configured (F-3) */}
+          {showWhatsappCta && (
+            <Card className="border-green-200 bg-green-50/50">
+              <CardContent className="flex items-center gap-4 p-6">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-green-100">
+                  <MessageCircle className="h-6 w-6 text-green-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium">Écrivez-nous sur WhatsApp</p>
+                  <p className="text-sm text-muted-foreground">
+                    Réponses rapides pendant les heures de travail
+                  </p>
+                </div>
+                <Link
+                  href={whatsappLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center justify-center rounded-lg bg-green-600 text-white px-4 py-2 text-sm font-medium hover:bg-green-700 transition-colors"
+                >
+                  Ouvrir WhatsApp
+                </Link>
+              </CardContent>
+            </Card>
+          )}
         </div>
 
         <ContactForm />

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -24,6 +24,7 @@ import { generateSubdomain } from "@/lib/generate-subdomain";
 import { logger } from "@/lib/logger";
 import { phoneToWhatsApp } from "@/lib/morocco";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
+import { isAllowedSubdomain } from "@/lib/reserved-subdomains";
 import { createAdminClient } from "@/lib/supabase-server";
 import { normalizeText, safeParse } from "@/lib/validations";
 import { sendTextMessage } from "@/lib/whatsapp";
@@ -370,18 +371,37 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 2. Generate subdomain and check uniqueness
-    let subdomain = generateSubdomain(data.clinic_name);
+    // 2. Generate subdomain — must be unique AND not reserved/malformed.
+    // F-2: generateSubdomain appends a random suffix so the result is
+    // effectively never a bare reserved word, but we validate explicitly as
+    // defense-in-depth (the same rule the DB trigger enforces) and retry on
+    // the rare collision or a pathological clinic name.
+    let subdomain = "";
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const candidate = generateSubdomain(data.clinic_name);
+      if (!isAllowedSubdomain(candidate)) continue;
 
-    const { data: existingClinic } = await supabase
-      .from("clinics")
-      .select("id")
-      .eq("subdomain", subdomain)
-      .maybeSingle();
+      const { data: existingClinic } = await supabase
+        .from("clinics")
+        .select("id")
+        .eq("subdomain", candidate)
+        .maybeSingle();
 
-    if (existingClinic) {
-      // Extremely unlikely with random suffix, but handle it
-      subdomain = generateSubdomain(data.clinic_name);
+      if (!existingClinic) {
+        subdomain = candidate;
+        break;
+      }
+    }
+
+    if (!subdomain) {
+      logger.error("Could not allocate a valid unique subdomain", {
+        context: "register-clinic",
+      });
+      return apiError(
+        "Impossible de générer une adresse pour votre clinique. Veuillez réessayer ou contacter le support.",
+        409,
+        "SUBDOMAIN_ALLOCATION_FAILED",
+      );
     }
 
     // 3. Create the auth user with a random password (user will reset via email)

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,7 @@ import { getAllPosts } from "@/lib/blog";
 import { getDirectoryDoctors } from "@/lib/data/directory";
 import { DIRECTORY_CITIES, TOP_CITY_SPECIALTY_COMBOS } from "@/lib/directory-constants";
 import { logger } from "@/lib/logger";
+import { isAllowedSubdomain } from "@/lib/reserved-subdomains";
 import type { Database } from "@/lib/types/database";
 
 /**
@@ -111,6 +112,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
         for (const clinic of clinics) {
           if (!clinic.subdomain) continue;
+          // F-2: Never emit reserved or malformed subdomains into the public
+          // sitemap, even if a stray row slipped past the DB guard. Keeps junk
+          // / reserved tenants (admin, api, www, …) out of Google's index.
+          if (!isAllowedSubdomain(clinic.subdomain)) continue;
           const clinicBase = `https://${clinic.subdomain}.${rootDomain}`;
           const modified = clinic.updated_at ? new Date(clinic.updated_at) : now;
 

--- a/src/lib/__tests__/reserved-subdomains.test.ts
+++ b/src/lib/__tests__/reserved-subdomains.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression lock-in for Audit F-2.
+ *
+ * These assert the shared reserved/slug rules so a future change can't silently
+ * let `admin.oltigo.com`, punycode homographs, or malformed slugs back in.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  assertAllowedSubdomain,
+  checkSubdomain,
+  isAllowedSubdomain,
+  isReservedSubdomain,
+  isValidSubdomainSlug,
+  OPERATIONAL_SUBDOMAINS,
+  RESERVED_SUBDOMAINS,
+} from "../reserved-subdomains";
+
+describe("isValidSubdomainSlug", () => {
+  it.each([
+    "dr-ahmed",
+    "clinique-dentaire-fes",
+    "dr-ahmed-x7k2p9",
+    "3m-clinique", // RFC 1123: a leading digit is allowed
+    "cabinet123",
+    "abc",
+  ])("accepts valid slug %s", (slug) => {
+    expect(isValidSubdomainSlug(slug)).toBe(true);
+  });
+
+  it.each([
+    ["", "empty"],
+    ["ab", "too short (< 3)"],
+    ["a".repeat(41), "too long (> 40)"],
+    ["-leading", "leading hyphen"],
+    ["trailing-", "trailing hyphen"],
+    ["double--hyphen", "consecutive hyphens"],
+    ["UPPER", "uppercase"],
+    ["café", "non-ASCII"],
+    ["xn--80ak6aa92e", "punycode"],
+    ["has space", "whitespace"],
+    ["under_score", "underscore"],
+  ])("rejects %s (%s)", (slug) => {
+    expect(isValidSubdomainSlug(slug)).toBe(false);
+  });
+});
+
+describe("isReservedSubdomain", () => {
+  it.each(["admin", "api", "www", "staging", "mail", "auth", "oltigo", "webhook", "billing"])(
+    "treats %s as reserved",
+    (slug) => {
+      expect(isReservedSubdomain(slug)).toBe(true);
+    },
+  );
+
+  it("is case-insensitive", () => {
+    expect(isReservedSubdomain("ADMIN")).toBe(true);
+    expect(isReservedSubdomain("Api")).toBe(true);
+  });
+
+  it("never treats operational tenants (demo/test) as reserved", () => {
+    expect(isReservedSubdomain("demo")).toBe(false);
+    expect(isReservedSubdomain("test")).toBe(false);
+  });
+
+  it("does not treat normal clinic slugs as reserved", () => {
+    expect(isReservedSubdomain("dr-ahmed")).toBe(false);
+    expect(isReservedSubdomain("clinique-dentaire-fes")).toBe(false);
+  });
+
+  it("keeps the operational and reserved sets disjoint", () => {
+    for (const op of OPERATIONAL_SUBDOMAINS) {
+      expect(RESERVED_SUBDOMAINS.has(op)).toBe(false);
+    }
+  });
+});
+
+describe("isAllowedSubdomain", () => {
+  it("allows valid, non-reserved slugs", () => {
+    expect(isAllowedSubdomain("dr-ahmed-x7k2p9")).toBe(true);
+  });
+
+  it("allows operational tenants demo/test", () => {
+    expect(isAllowedSubdomain("demo")).toBe(true);
+    expect(isAllowedSubdomain("test")).toBe(true);
+  });
+
+  it("blocks reserved subdomains", () => {
+    for (const slug of ["admin", "api", "www", "mail", "auth"]) {
+      expect(isAllowedSubdomain(slug)).toBe(false);
+    }
+  });
+
+  it("blocks malformed slugs (uppercase, punycode, hyphen abuse)", () => {
+    for (const slug of ["BadCase", "xn--abc", "--bad", "a"]) {
+      expect(isAllowedSubdomain(slug)).toBe(false);
+    }
+  });
+});
+
+describe("checkSubdomain", () => {
+  it("returns 'reserved' for reserved words", () => {
+    expect(checkSubdomain("admin")).toBe("reserved");
+  });
+
+  it("returns 'invalid_format' for malformed slugs", () => {
+    expect(checkSubdomain("xn--abc")).toBe("invalid_format");
+    expect(checkSubdomain("BadCase")).toBe("invalid_format");
+  });
+
+  it("returns null for allowed slugs and operational tenants", () => {
+    expect(checkSubdomain("dr-ahmed-x7k2p9")).toBeNull();
+    expect(checkSubdomain("demo")).toBeNull();
+  });
+});
+
+describe("assertAllowedSubdomain", () => {
+  it("throws for reserved and malformed slugs", () => {
+    expect(() => assertAllowedSubdomain("admin")).toThrow(/reserved/i);
+    expect(() => assertAllowedSubdomain("xn--abc")).toThrow(/valid/i);
+  });
+
+  it("does not throw for allowed slugs or operational tenants", () => {
+    expect(() => assertAllowedSubdomain("dr-ahmed-x7k2p9")).not.toThrow();
+    expect(() => assertAllowedSubdomain("demo")).not.toThrow();
+  });
+});

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -555,6 +555,25 @@ export function validateEnv(): EnvValidationResult {
     });
   }
 
+  // Audit F-1: Frontend error monitoring must be live in production. The
+  // deployed app was shipping `sentry-public_key=placeholder`, silently
+  // dropping every client-side exception. The DSN is a deploy-time secret, so
+  // we enforce at runtime boot (via enforceEnvValidation in instrumentation)
+  // and deliberately skip during `next build` — NEXT_PHASE is
+  // "phase-production-build" there and the secret is legitimately absent in CI.
+  const isBuildPhase = process.env.NEXT_PHASE === "phase-production-build";
+  if (isProduction && !isBuildPhase) {
+    const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+    if (!sentryDsn || /placeholder/i.test(sentryDsn)) {
+      missing.push({
+        name: "NEXT_PUBLIC_SENTRY_DSN",
+        description:
+          "Real Sentry DSN required in production (currently missing or set to a 'placeholder' value) — client-side error monitoring is dead without it",
+        group: "observability",
+      });
+    }
+  }
+
   return { valid: missing.length === 0, missing, warnings };
 }
 

--- a/src/lib/reserved-subdomains.ts
+++ b/src/lib/reserved-subdomains.ts
@@ -1,0 +1,273 @@
+/**
+ * Reserved subdomain blocklist + slug validation (Audit F-2).
+ *
+ * This module is the single source of truth for which subdomains may never
+ * be served as a tenant clinic, and what shape a valid tenant slug must take.
+ * It is intentionally dependency-free (no Next.js / Node-only imports) so it
+ * can run in every context that needs it:
+ *
+ *   - Edge middleware + `extractSubdomain()` (request resolution)
+ *   - The public sitemap (defense-in-depth filtering)
+ *   - The self-service registration endpoint (reject bad slugs)
+ *   - The `scripts/check-orphan-subdomains.mjs` CI guard (Node)
+ *
+ * Why a blocklist matters: without it, `admin.oltigo.com`, `api.oltigo.com`,
+ * `www.oltigo.com`, etc. resolve as if they were tenant clinics. That is an
+ * SEO / duplicate-content problem at best and a phishing / reserved-name
+ * takeover problem at worst.
+ */
+
+/**
+ * Operational subdomains that ARE real, Oltigo-operated tenants and therefore
+ * must keep resolving normally. These are created by seeds / super-admin, not
+ * by public registration, so they are deliberately NOT in the reserved set.
+ *
+ * `demo` in particular backs the public demo site (the "Voir la démo" CTA
+ * points at https://demo.oltigo.com) — blocking it would break that flow.
+ */
+export const OPERATIONAL_SUBDOMAINS: ReadonlySet<string> = new Set(["demo", "test"]);
+
+/**
+ * Subdomains that must never be served as a tenant and must never be
+ * registrable. Grouped only for readability — order is irrelevant.
+ *
+ * Anything added here is enforced at request resolution, in the sitemap, in
+ * the registration endpoint, and by the database trigger (migration 00171).
+ */
+export const RESERVED_SUBDOMAINS: ReadonlySet<string> = new Set([
+  // ── Infrastructure / DNS ──────────────────────────────────────────
+  "www",
+  "api",
+  "app",
+  "cdn",
+  "assets",
+  "static",
+  "media",
+  "uploads",
+  "files",
+  "img",
+  "images",
+  "ns1",
+  "ns2",
+  "ns3",
+  "mx",
+  "mail",
+  "email",
+  "smtp",
+  "imap",
+  "pop",
+  "pop3",
+  "ftp",
+  "sftp",
+  "vpn",
+  "proxy",
+  "gateway",
+  "edge",
+  "origin",
+  "host",
+  "server",
+
+  // ── Environments ──────────────────────────────────────────────────
+  // NB: `demo`/`test` are intentionally NOT here (see OPERATIONAL_SUBDOMAINS).
+  "staging",
+  "stage",
+  "dev",
+  "develop",
+  "development",
+  "preview",
+  "sandbox",
+  "qa",
+  "uat",
+  "prod",
+  "production",
+
+  // ── Platform / brand ──────────────────────────────────────────────
+  "oltigo",
+  "root",
+  "system",
+  "internal",
+  "console",
+  "panel",
+  "portal",
+  "platform",
+  "core",
+
+  // ── Auth / security ───────────────────────────────────────────────
+  "admin",
+  "administrator",
+  "superadmin",
+  "super-admin",
+  "auth",
+  "oauth",
+  "sso",
+  "login",
+  "logout",
+  "signin",
+  "sign-in",
+  "signup",
+  "sign-up",
+  "register",
+  "account",
+  "accounts",
+  "secure",
+  "security",
+  "password",
+  "reset",
+  "verify",
+  "verification",
+
+  // ── Product surfaces ──────────────────────────────────────────────
+  "dashboard",
+  "support",
+  "help",
+  "helpdesk",
+  "docs",
+  "documentation",
+  "blog",
+  "news",
+  "status",
+  "about",
+  "contact",
+  "pricing",
+  "billing",
+  "pay",
+  "payment",
+  "payments",
+  "checkout",
+  "invoice",
+  "invoices",
+  "webhook",
+  "webhooks",
+  "callback",
+  "callbacks",
+  "cron",
+  "jobs",
+  "queue",
+
+  // ── Observability / tooling ───────────────────────────────────────
+  "sentry",
+  "grafana",
+  "metrics",
+  "monitoring",
+  "logs",
+  "git",
+  "ci",
+  "cd",
+
+  // ── Generic role / medical words (squatting / impersonation) ──────
+  "staff",
+  "team",
+  "doctor",
+  "doctors",
+  "patient",
+  "patients",
+  "pharmacy",
+  "pharmacist",
+  "receptionist",
+  "nurse",
+  "clinic",
+  "clinics",
+  "cabinet",
+  "medical",
+  "health",
+  "sante",
+  "hopital",
+  "hospital",
+]);
+
+/**
+ * Maximum length of a tenant subdomain label. DNS labels max out at 63 chars;
+ * we stay well under that to leave room and keep URLs readable.
+ */
+export const MAX_SUBDOMAIN_LENGTH = 40;
+export const MIN_SUBDOMAIN_LENGTH = 3;
+
+/**
+ * True when `slug` is structurally a valid tenant subdomain label.
+ *
+ * Rules (Audit F-2, aligned to the RFC 1123 host-label grammar):
+ *   - lowercase ASCII letters, digits, and single hyphens only
+ *   - must start and end with a letter or digit
+ *   - no leading/trailing hyphen, no consecutive hyphens
+ *   - length between MIN_SUBDOMAIN_LENGTH and MAX_SUBDOMAIN_LENGTH
+ *   - no punycode (`xn--`) — blocks IDN homograph / homoglyph attacks
+ *
+ * Note: the audit suggested `^[a-z]…` (must start with a letter). We allow a
+ * leading digit instead, matching RFC 1123, so legitimate clinics whose name
+ * starts with a number (e.g. "3M Clinique") are not rejected. Every abuse
+ * vector the audit targets (reserved words, hyphen abuse, punycode, uppercase,
+ * non-ASCII) is still blocked.
+ *
+ * This does NOT check the reserved blocklist — use {@link isReservedSubdomain}
+ * or {@link assertAllowedSubdomain} for that.
+ */
+export function isValidSubdomainSlug(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  const value = slug.normalize("NFC");
+  if (value.length < MIN_SUBDOMAIN_LENGTH || value.length > MAX_SUBDOMAIN_LENGTH) {
+    return false;
+  }
+  // Punycode / IDN — reject outright to avoid homograph confusion attacks.
+  if (value.includes("xn--")) return false;
+  // No consecutive hyphens.
+  if (value.includes("--")) return false;
+  // Start/end alphanumeric, hyphens only in the middle.
+  return /^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(value);
+}
+
+/**
+ * True when `slug` is on the reserved blocklist (case-insensitive).
+ * Operational tenants (demo/test) are never treated as reserved.
+ */
+export function isReservedSubdomain(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  const value = slug.trim().toLowerCase();
+  if (OPERATIONAL_SUBDOMAINS.has(value)) return false;
+  return RESERVED_SUBDOMAINS.has(value);
+}
+
+/**
+ * True when `slug` may be served / registered as a tenant: structurally valid
+ * AND not reserved. Operational tenants (demo/test) are allowed.
+ *
+ * Validity is case-sensitive — a tenant slug must already be canonical
+ * lowercase (the DB trigger enforces the same), so `"BadCase"` is rejected
+ * rather than silently normalized. Reserved-ness stays case-insensitive.
+ */
+export function isAllowedSubdomain(slug: string): boolean {
+  if (typeof slug !== "string") return false;
+  const value = slug.trim();
+  if (OPERATIONAL_SUBDOMAINS.has(value.toLowerCase())) return true;
+  return isValidSubdomainSlug(value) && !isReservedSubdomain(value);
+}
+
+/** Reason codes returned by {@link checkSubdomain}. */
+export type SubdomainRejection = "invalid_format" | "reserved";
+
+/**
+ * Validate a subdomain, returning a machine-readable rejection reason or null
+ * when it is allowed. Useful where you want to branch on the reason (API
+ * responses, logging) instead of a thrown error.
+ */
+export function checkSubdomain(slug: string): SubdomainRejection | null {
+  const value = (slug ?? "").trim();
+  if (OPERATIONAL_SUBDOMAINS.has(value.toLowerCase())) return null;
+  if (!isValidSubdomainSlug(value)) return "invalid_format";
+  if (isReservedSubdomain(value)) return "reserved";
+  return null;
+}
+
+/**
+ * Throwing variant for code paths that should hard-fail on a bad slug
+ * (e.g. just before an INSERT). The message is safe to surface to operators
+ * but intentionally generic for end users.
+ */
+export function assertAllowedSubdomain(slug: string): void {
+  const reason = checkSubdomain(slug);
+  if (reason === "reserved") {
+    throw new Error(`Subdomain "${slug}" is reserved and cannot be used.`);
+  }
+  if (reason === "invalid_format") {
+    throw new Error(`Subdomain "${slug}" is not a valid tenant slug.`);
+  }
+}

--- a/src/lib/subdomain.ts
+++ b/src/lib/subdomain.ts
@@ -6,6 +6,8 @@
  * For local dev, subdomains work via "clinicname.localhost:3000".
  */
 
+import { isReservedSubdomain } from "@/lib/reserved-subdomains";
+
 /**
  * Extract the subdomain from a hostname.
  *
@@ -23,7 +25,7 @@ export function extractSubdomain(hostname: string, rootDomain?: string): string 
   // Local development: *.localhost
   if (host.endsWith(".localhost")) {
     const sub = host.replace(".localhost", "");
-    if (sub && sub !== "www") return sub;
+    if (sub && sub !== "www" && !sub.includes(".") && !isReservedSubdomain(sub)) return sub;
     return null;
   }
 
@@ -40,20 +42,13 @@ export function extractSubdomain(hostname: string, rootDomain?: string): string 
   // Ignore empty, "www", or multi-level subdomains (e.g., "a.b")
   if (!sub || sub === "www" || sub.includes(".")) return null;
 
-  // Audit 8.3 — Reserved subdomains that must not be resolved as tenant
-  // clinics. "staging" in particular would conflict with the staging
-  // environment route (staging.oltigo.com) defined in wrangler.toml.
-  const RESERVED_SUBDOMAINS = new Set([
-    "staging",
-    "api",
-    "admin",
-    "app",
-    "mail",
-    "ftp",
-    "ns1",
-    "ns2",
-  ]);
-  if (RESERVED_SUBDOMAINS.has(sub)) return null;
+  // Audit 8.3 / F-2 — Reserved subdomains must not resolve as tenant clinics.
+  // The blocklist (admin, api, www, staging, mail, …) lives in the shared
+  // `reserved-subdomains` module so resolution, the sitemap, the registration
+  // endpoint, and the DB trigger all enforce exactly the same set. "staging"
+  // in particular would otherwise collide with the staging environment route
+  // (staging.oltigo.com) defined in wrangler.toml.
+  if (isReservedSubdomain(sub)) return null;
 
   return sub;
 }

--- a/supabase/migrations/00171_reserved_subdomain_guard.sql
+++ b/supabase/migrations/00171_reserved_subdomain_guard.sql
@@ -1,0 +1,129 @@
+-- ============================================================
+-- Migration 00171: Database-level reserved / malformed subdomain guard
+--
+-- AUDIT F-2
+-- ---------
+-- Self-service registration (`/api/v1/register-clinic`), the request
+-- resolver (`extractSubdomain`), and the public sitemap now all share one
+-- blocklist (`src/lib/reserved-subdomains.ts`). This migration adds the same
+-- rule at the database layer so that NO code path — super-admin onboarding,
+-- a future endpoint, a manual SQL insert, or a seed — can create a clinic on
+-- a reserved (admin, api, www, staging, …) or structurally invalid subdomain.
+--
+-- DESIGN
+-- ------
+-- A BEFORE INSERT OR UPDATE trigger (NOT a CHECK constraint) is used on
+-- purpose: a CHECK is validated against existing rows when added, which would
+-- fail the migration if any pre-existing reserved row (e.g. a stray `admin`
+-- clinic) is already present. The trigger only validates rows as they are
+-- inserted or when `subdomain` actually changes, so historical rows are left
+-- untouched and can be cleaned up as a separate, deliberate data operation.
+--
+-- Operational tenants `demo` and `test` are explicitly allowed — `demo` backs
+-- the public demo site (https://demo.oltigo.com).
+--
+-- KEEP IN SYNC: the reserved set and slug rules below mirror
+-- `src/lib/reserved-subdomains.ts`. If you change one, change the other.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- is_reserved_subdomain(slug): true when the slug must never be a tenant.
+-- IMMUTABLE + no table access so it is safe to call from a trigger / CHECK.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.is_reserved_subdomain(slug text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT lower(coalesce(slug, '')) = ANY (ARRAY[
+    -- Infrastructure / DNS
+    'www','api','app','cdn','assets','static','media','uploads','files','img',
+    'images','ns1','ns2','ns3','mx','mail','email','smtp','imap','pop','pop3',
+    'ftp','sftp','vpn','proxy','gateway','edge','origin','host','server',
+    -- Environments (demo/test intentionally excluded — operational tenants)
+    'staging','stage','dev','develop','development','preview','sandbox','qa',
+    'uat','prod','production',
+    -- Platform / brand
+    'oltigo','root','system','internal','console','panel','portal','platform','core',
+    -- Auth / security
+    'admin','administrator','superadmin','super-admin','auth','oauth','sso',
+    'login','logout','signin','sign-in','signup','sign-up','register','account',
+    'accounts','secure','security','password','reset','verify','verification',
+    -- Product surfaces
+    'dashboard','support','help','helpdesk','docs','documentation','blog','news',
+    'status','about','contact','pricing','billing','pay','payment','payments',
+    'checkout','invoice','invoices','webhook','webhooks','callback','callbacks',
+    'cron','jobs','queue',
+    -- Observability / tooling
+    'sentry','grafana','metrics','monitoring','logs','git','ci','cd',
+    -- Generic role / medical words
+    'staff','team','doctor','doctors','patient','patients','pharmacy','pharmacist',
+    'receptionist','nurse','clinic','clinics','cabinet','medical','health','sante',
+    'hopital','hospital'
+  ]);
+$$;
+
+COMMENT ON FUNCTION public.is_reserved_subdomain(text) IS
+  'AUDIT F-2: true when a subdomain is reserved (infra/security/brand/role). '
+  'Mirrors src/lib/reserved-subdomains.ts. demo/test are NOT reserved.';
+
+-- ------------------------------------------------------------
+-- Trigger: reject reserved or structurally invalid subdomains on write.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enforce_clinic_subdomain_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v text;
+BEGIN
+  -- Nothing to validate when there is no subdomain.
+  IF NEW.subdomain IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- On UPDATE, only validate when the subdomain actually changes so we never
+  -- retroactively break a grandfathered row that is updated for other reasons.
+  IF TG_OP = 'UPDATE' AND NEW.subdomain IS NOT DISTINCT FROM OLD.subdomain THEN
+    RETURN NEW;
+  END IF;
+
+  v := lower(NEW.subdomain);
+
+  -- Operational tenants are always allowed (demo backs the public demo site).
+  IF v IN ('demo', 'test') THEN
+    RETURN NEW;
+  END IF;
+
+  -- Reserved words are never allowed.
+  IF public.is_reserved_subdomain(v) THEN
+    RAISE EXCEPTION 'Subdomain "%" is reserved and cannot be used.', NEW.subdomain
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- Structural rules (mirror isValidSubdomainSlug):
+  --   length 3..40, lowercase, no punycode, no consecutive hyphens,
+  --   start/end alphanumeric, hyphens only in the middle.
+  IF char_length(v) < 3 OR char_length(v) > 40
+     OR NEW.subdomain <> v                  -- must already be lowercase
+     OR v LIKE '%xn--%'                      -- no punycode / IDN homographs
+     OR v LIKE '%--%'                        -- no consecutive hyphens
+     OR v !~ '^[a-z0-9][a-z0-9-]*[a-z0-9]$'  -- RFC 1123 host label
+  THEN
+    RAISE EXCEPTION 'Subdomain "%" is not a valid tenant slug.', NEW.subdomain
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_clinic_subdomain_guard ON public.clinics;
+CREATE TRIGGER trg_enforce_clinic_subdomain_guard
+  BEFORE INSERT OR UPDATE OF subdomain ON public.clinics
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_clinic_subdomain_guard();
+
+COMMENT ON FUNCTION public.enforce_clinic_subdomain_guard() IS
+  'AUDIT F-2: BEFORE INSERT/UPDATE guard rejecting reserved or malformed '
+  'clinic subdomains at the DB layer. See migration 00171.';


### PR DESCRIPTION
Addresses the P0/P1 findings from the Oltigo audit (`oltigo-fixes-remaining.md`). All changes verified locally against the full CI gate (lint at baseline, tsc, vitest, build, bundle budget, migration/i18n/tenant guards).

## F-2 — Subdomain validation (P0, the big one)
The root cause behind junk tenants in the sitemap and `admin.oltigo.com` resolving was the absence of a shared reserved-word/slug rule. This adds one source of truth and enforces it at **every layer**:

- **`src/lib/reserved-subdomains.ts`** (new): the blocklist (`admin`, `api`, `www`, `staging`, `mail`, `auth`, `oltigo`, `billing`, `webhook`, `doctor`, `pharmacy`, … 90+ words) plus an RFC 1123 slug grammar. Rejects punycode (`xn--`), consecutive hyphens, uppercase, non-ASCII, and out-of-range length.
  - `demo` / `test` are **deliberately exempt** — they're real Oltigo-operated tenants (`demo.oltigo.com` backs the "Voir la démo" CTA). Putting them on the blocklist would break the demo site.
  - Validity is case-sensitive (a stored slug must be canonical lowercase, matching the DB trigger); reserved-ness is case-insensitive.
- **`subdomain.ts`**: `extractSubdomain()` now uses the shared list on both the prod and `*.localhost` paths (replacing the inline 8-word set), so reserved hosts never resolve as tenants.
- **`sitemap.ts`**: skips any clinic whose subdomain isn't `isAllowedSubdomain()` — defense-in-depth so reserved/junk rows can't be indexed.
- **`register-clinic` route**: the generated subdomain is validated in a 5-attempt allocate loop (allowed **and** unique), returning `409 SUBDOMAIN_ALLOCATION_FAILED` if it can't allocate.
- **Migration `00171`** (new): a `BEFORE INSERT/UPDATE` trigger on `clinics` enforcing the same blocklist + slug rules at the DB layer — so no code path (super-admin onboarding, seeds, manual SQL) can create a reserved/malformed tenant. A trigger (not a `CHECK`) so existing rows aren't retroactively invalidated.

> Note: the regex was relaxed from the audit's `^[a-z]…` to RFC 1123 (leading digit allowed) so legitimate clinics like "3M Clinique" aren't rejected. Every abuse vector in the audit is still blocked.

## F-1 — Sentry DSN placeholder (P0)
`validateEnv()` now fails in production (at runtime boot, **not** during `next build`) when `NEXT_PUBLIC_SENTRY_DSN` is missing or matches `/placeholder/i`, so a dead frontend Sentry DSN can't silently ship again.

## F-3 — Contact JSON-LD (P1)
Marketing contact page is now `Organization` (not `MedicalBusiness`); placeholder phone/WhatsApp (`+212 5/6 20-000000`) are filtered from the UI and omitted from structured data; JSON-LD is dropped entirely for a clinic tenant with no real contact details.

## F-5 — Duplicate skip links (P1)
Removed the second skip link on auth pages. The root layout's single "skip to content" link now targets the auth form (`#main-content`), fixing the WCAG 2.4.1 two-target ambiguity on `/login/`.

## Tests
`src/lib/__tests__/reserved-subdomains.test.ts` (39 cases): valid/invalid slugs, reserved words, demo/test exemption, punycode rejection, case sensitivity.

---
### Already fixed in `main` (no change needed)
- **F-6** RTL — root layout already renders `<html lang dir>` dynamically via `getDirFromLocale`/`getLocaleFromTenant`.
- **C-8** viewport `maximum-scale` already removed.
- **F-8** password policy — `password-policy.ts` + HIBP k-anonymity (`hibp.ts`) already present; registration endpoint already hardened (disabled by default, DNS-TXT verification, Turnstile, rate limiting, `pending_review`, atomic RPC).

### Deferred (P2)
- **F-4** CLS skeleton sizing and **F-7** chunk/bundle audit — lower priority, not in this PR.

### ⚠️ Infra actions (cannot be done in code — need you)
1. **Set `NEXT_PUBLIC_SENTRY_DSN`** in the production environment (Cloudflare). After this PR, prod will fail-fast at boot until it's set — intended, but coordinate the deploy.
2. **Delete the `admin.oltigo.com` DNS record.** Code now refuses to resolve/register it, but the existing DNS entry should be removed.
3. **Audit the prod DB** for default admin creds (`admin@admin.com` / `123456789`) and rotate if present. Untestable from the codebase.
4. **Zombie tenant cleanup** is a data op — the new trigger blocks *new* bad rows; existing junk rows need a separate cleanup pass (happy to provide the SQL).
