### PR TITLE
fix(audit): CLS hero skeleton, Sentry placeholder hardening, reserved-subdomain cleanup

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,8 +1,19 @@
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+// Audit F-1: never initialise Sentry with a placeholder DSN. A value such as
+// `https://placeholder@o0.ingest.sentry.io/0` is truthy, so the previous bare
+// presence check still shipped `sentry-public_key=placeholder` to the browser
+// and silently dropped every client-side exception. Treat any DSN containing
+// "placeholder" as unset so misconfiguration fails closed (no Sentry) rather
+// than failing open (a dead Sentry client). The hard runtime gate lives in
+// src/lib/env.ts (enforceEnvValidation), which refuses to boot production with
+// a placeholder DSN; this guard is the matching client-side defense.
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const hasValidDsn = !!dsn && !/placeholder/i.test(dsn);
+
+if (hasValidDsn) {
   Sentry.init({
-    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    dsn,
 
     // AUDIT F-07: Per-route client-side sampling (mirrors sentry.server.config.ts).
     // Critical user flows (booking, payment, auth) get 100% sampling in production;
@@ -53,7 +64,7 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
     ],
 
     // Don't send errors in development unless explicitly enabled.
-    enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+    enabled: hasValidDsn,
 
     // S-35: Strip request bodies and known PHI fields from breadcrumbs to
     // prevent accidental PHI capture in Sentry payloads.

--- a/src/app/(public)/loading.tsx
+++ b/src/app/(public)/loading.tsx
@@ -1,21 +1,81 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
+/**
+ * Route-level loading skeleton for the public marketing site.
+ *
+ * Audit F-4 (CLS): the hero skeleton MUST reserve the same vertical space as the
+ * real hero (src/components/landing/editorial/hero-section.tsx) so the page does
+ * not jump when streamed content replaces this fallback. The previous skeleton
+ * reserved a single `h-12` (~48px) bar for a headline that actually renders at
+ * `clamp(2.5rem, 5vw, 4.5rem)` over two lines (~150px), which is the layout
+ * shift the audit flagged.
+ *
+ * Heights and spacers below mirror the design tokens in src/app/tokens.css:
+ *   --space-9 = 96px, --space-10 = 128px, --space-6 = 32px, --space-5 = 24px,
+ *   display headline = clamp(2.5rem, 5vw, 4.5rem) @ line-height ~1.02,
+ *   body-lg subhead = 19px, CTA buttons = h-11 (44px).
+ */
 export default function PublicLoading() {
   return (
     <div className="min-h-screen">
-      {/* Hero section skeleton */}
-      <section className="relative py-20 lg:py-28">
-        <div className="container mx-auto px-4 text-center space-y-6">
-          <Skeleton className="h-12 w-3/4 mx-auto rounded-lg" />
-          <Skeleton className="h-6 w-1/2 mx-auto" />
-          <div className="flex items-center justify-center gap-4 pt-4">
-            <Skeleton className="h-12 w-44 rounded-lg" />
-            <Skeleton className="h-12 w-36 rounded-lg" />
+      {/* Hero skeleton — mirrors <EditorialHero> footprint to keep CLS < 0.1.
+          Decorative only; hidden from assistive tech. */}
+      <section className="bg-[var(--bone)]" aria-hidden="true">
+        <div className="mx-auto w-full max-w-[var(--container-max)] px-[var(--gutter-desktop)]">
+          <div className="h-[var(--space-9)]" />
+
+          {/* Mono eyebrow (~12px line) */}
+          <Skeleton className="h-4 w-56 rounded" />
+
+          <div className="h-[var(--space-5)]" />
+
+          {/* Display headline — reserve the real clamp() line box. Two lines on
+              md+ (75% width); a third line appears only on small screens where
+              the 40px headline wraps further, matching the real wrap. */}
+          <div className="max-w-full space-y-3 md:max-w-[75%]">
+            <Skeleton className="h-[clamp(2.5rem,5vw,4.5rem)] w-full rounded-lg" />
+            <Skeleton className="h-[clamp(2.5rem,5vw,4.5rem)] w-4/5 rounded-lg" />
+            <Skeleton className="h-[clamp(2.5rem,5vw,4.5rem)] w-3/5 rounded-lg md:hidden" />
           </div>
+
+          <div className="h-[var(--space-5)]" />
+
+          {/* Subhead — body-lg, ~58% width, two lines */}
+          <div className="max-w-full space-y-2 md:max-w-[58%]">
+            <Skeleton className="h-[1.1875rem] w-full rounded" />
+            <Skeleton className="h-[1.1875rem] w-11/12 rounded" />
+          </div>
+
+          <div className="h-[var(--space-6)]" />
+
+          {/* CTAs — match the real h-11 buttons */}
+          <div className="flex flex-wrap items-center gap-4">
+            <Skeleton className="h-11 w-44 rounded-[var(--radius-landing)]" />
+            <Skeleton className="h-11 w-36 rounded-[var(--radius-landing)]" />
+            <Skeleton className="h-11 w-32 rounded-[var(--radius-landing)]" />
+          </div>
+
+          <div className="h-[var(--space-10)]" />
+
+          {/* Trust hairline + 4 stat blocks (grid-cols-2 → md:grid-cols-4) */}
+          <div className="border-t border-[var(--ink-20)]" />
+          <div className="py-[var(--space-5)]">
+            <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-7 w-16 rounded" />
+                  <Skeleton className="h-4 w-24 rounded" />
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="border-t border-[var(--ink-20)]" />
+
+          <div className="h-[var(--space-9)]" />
         </div>
       </section>
 
-      {/* Services section skeleton */}
+      {/* Services section skeleton (below the fold) */}
       <section className="py-16">
         <div className="container mx-auto px-4">
           <div className="text-center mb-12 space-y-3">

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -26,7 +26,7 @@ import { phoneToWhatsApp } from "@/lib/morocco";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
 import { isAllowedSubdomain } from "@/lib/reserved-subdomains";
 import { createAdminClient } from "@/lib/supabase-server";
-import { normalizeText, safeParse } from "@/lib/validations";
+import { normalizeText, safeParse, looksLikeGibberish, GIBBERISH_NAME_MESSAGE } from "@/lib/validations";
 import { sendTextMessage } from "@/lib/whatsapp";
 
 // ---------------------------------------------------------------------------
@@ -181,7 +181,11 @@ const registerClinicSchema = z
     clinic_name: z
       .string()
       .transform(normalizeText)
-      .pipe(z.string().min(2, "Le nom de la clinique est requis").max(200)),
+      .pipe(z.string().min(2, "Le nom de la clinique est requis").max(200))
+      // F-2 (2.3): reject keyboard-mash / placeholder names ("fffffff",
+      // "jgjjrjrj") that slugify into junk public tenants. Conservative — only
+      // unambiguous gibberish is blocked; see name-quality.ts.
+      .refine((v) => !looksLikeGibberish(v), GIBBERISH_NAME_MESSAGE),
     doctor_name: z
       .string()
       .transform(normalizeText)

--- a/src/app/api/v1/register-clinic/route.ts
+++ b/src/app/api/v1/register-clinic/route.ts
@@ -26,7 +26,12 @@ import { phoneToWhatsApp } from "@/lib/morocco";
 import { createRateLimiter, extractClientIp } from "@/lib/rate-limit";
 import { isAllowedSubdomain } from "@/lib/reserved-subdomains";
 import { createAdminClient } from "@/lib/supabase-server";
-import { normalizeText, safeParse, looksLikeGibberish, GIBBERISH_NAME_MESSAGE } from "@/lib/validations";
+import {
+  normalizeText,
+  safeParse,
+  looksLikeGibberish,
+  GIBBERISH_NAME_MESSAGE,
+} from "@/lib/validations";
 import { sendTextMessage } from "@/lib/whatsapp";
 
 // ---------------------------------------------------------------------------

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -62,11 +62,18 @@ function getSampleRate(transactionContext: {
 }
 
 export function register() {
+  // Audit F-1: a placeholder DSN (e.g. "https://placeholder@…") is truthy but
+  // useless — it boots a dead Sentry client. Treat it as unset everywhere so
+  // misconfiguration fails closed. The hard production gate (throw on boot) is
+  // in src/lib/env.ts via enforceEnvValidation(), invoked below.
+  const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  const hasValidSentryDsn = !!sentryDsn && !/placeholder/i.test(sentryDsn);
+
   // Initialize Sentry for server-side error monitoring.
   // DSN is provided via NEXT_PUBLIC_SENTRY_DSN env var.
-  if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  if (hasValidSentryDsn) {
     Sentry.init({
-      dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+      dsn: sentryDsn,
 
       // R-20 Fix: Set sendDefaultPii to false explicitly
       // @sentry/nextjs@8 defaults this to true, which is a PII risk
@@ -75,7 +82,7 @@ export function register() {
       // Base tracesSampleRate; per-transaction sampling is handled via tracesSampler
       tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
 
-      enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+      enabled: hasValidSentryDsn,
 
       // R-20 Fix: Per-transaction sampling for fine-grained control
       tracesSampler(samplingContext) {
@@ -223,7 +230,7 @@ export function register() {
       // M-26: Capture to Sentry before crashing so the failure is visible
       // in the dashboard, not buried in Workers Logs / console output.
       console.error("[FATAL] Environment validation failed:", err);
-      if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
+      if (hasValidSentryDsn) {
         Sentry.captureException(
           err instanceof Error ? err : new Error(`Environment validation failed: ${err}`),
           { tags: { component: "instrumentation", phase: "env-validation" }, level: "fatal" },

--- a/src/lib/__tests__/name-quality.test.ts
+++ b/src/lib/__tests__/name-quality.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Regression lock-in for Audit F-2 (item 2.3): the clinic-name quality gate
+ * that stops keyboard-mash registrations from polluting the public sitemap.
+ *
+ * The acceptance cases are the load-bearing half: a future tightening of the
+ * heuristic must never start rejecting a legitimate French / Arabic-romanized
+ * clinic name.
+ */
+import { describe, it, expect } from "vitest";
+import { looksLikeGibberish } from "../validations/name-quality";
+
+describe("looksLikeGibberish — rejects junk (Audit F-2 observed slugs)", () => {
+  it.each([
+    "fffffff", // single repeated letter
+    "ahhhhhe", // 5× h run
+    "jgjjrjrj", // no vowel
+    "vdsvv", // no vowel
+    "rtqz", // no vowel
+    "aaaa", // repeated vowel run
+    "x", // < 2 letters
+    "12", // no letters
+    "--", // no letters
+    "   ", // whitespace only
+  ])("rejects %j", (value) => {
+    expect(looksLikeGibberish(value)).toBe(true);
+  });
+});
+
+describe("looksLikeGibberish — accepts real names (must never block signup)", () => {
+  it.each([
+    "Cabinet Dr Ahmed",
+    "Clinique Dentaire Fès",
+    "Dr. Fatima El Amrani",
+    "Pharmacie Ibn Sina",
+    "Centre Médical Atlas",
+    "Polyclinique Al Madina",
+    "Cabinet Dentaire du Maarif",
+    "Hôpital Cheikh Khalifa",
+    "Laboratoire Biolab",
+    "Clinique IVF Casablanca", // acronym token, still pronounceable name
+    "Cabinet rtqz", // junk token but a real word present → not all-gibberish
+    "Saâda Santé", // diacritics fold to vowels
+  ])("accepts %j", (value) => {
+    expect(looksLikeGibberish(value)).toBe(false);
+  });
+});

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -8,6 +8,8 @@
 
 export { normalizeText, safeText, safeName } from "./primitives";
 
+export { looksLikeGibberish, GIBBERISH_NAME_MESSAGE } from "./name-quality";
+
 export {
   bookingCancelSchema,
   emergencySlotSchema,

--- a/src/lib/validations/name-quality.ts
+++ b/src/lib/validations/name-quality.ts
@@ -71,5 +71,4 @@ export function looksLikeGibberish(value: string): boolean {
 }
 
 /** User-facing rejection message (French — matches the rest of the schema). */
-export const GIBBERISH_NAME_MESSAGE =
-  "Veuillez saisir un nom d'établissement valide.";
+export const GIBBERISH_NAME_MESSAGE = "Veuillez saisir un nom d'établissement valide.";

--- a/src/lib/validations/name-quality.ts
+++ b/src/lib/validations/name-quality.ts
@@ -1,0 +1,75 @@
+/**
+ * Audit F-2 (item 2.3): conservative quality gate for free-text names that
+ * become public tenant identity (clinic_name → subdomain slug + sitemap entry).
+ *
+ * The self-service registration endpoint generated junk tenants such as
+ * `fffffff`, `ahhhhhe`, `jgjjrjrj`, `vdsvv`, and `rtqz` because the only check
+ * on `clinic_name` was `min(2).max(200)`. These slugs polluted the public
+ * sitemap (SEO duplicate-content) and made the brand look unmoderated.
+ *
+ * DESIGN — bias hard toward NOT blocking real clinics. A French / Arabic-
+ * romanized / Darija clinic name almost always contains vowels and does not
+ * mash the same key. We therefore reject ONLY on signals that are essentially
+ * never present in a real name:
+ *
+ *   1. A single letter repeated ≥ 4 times in a row  → "fffffff", "ahhhhhe".
+ *   2. No pronounceable token at all — i.e. not one alphabetic run of length
+ *      ≥ 2 contains a vowel (a, e, i, o, u, y)        → "rtqz", "vdsvv",
+ *      "jgjjrjrj". A name like "Cabinet rtqz" still passes because "cabinet"
+ *      is a vowel-bearing token; the goal is to catch all-gibberish input,
+ *      not to police every token.
+ *   3. Fewer than 2 alphabetic characters total       → "12", "—".
+ *
+ * Deliberately NOT caught: short real-ish words with vowels (e.g. "azar",
+ * "saara", "staf"). Those are indistinguishable from a legitimate short name
+ * by spelling alone and must be handled by human review, never by an automated
+ * spelling judge that could reject a real clinic at signup.
+ *
+ * Pure + side-effect free so it is trivially unit-testable and safe to call
+ * from a Zod refinement.
+ */
+
+const VOWELS = new Set(["a", "e", "i", "o", "u", "y"]);
+
+/** Strip diacritics and lowercase so "Fès" and "FES" normalize identically. */
+function foldLetters(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+function hasVowel(token: string): boolean {
+  for (const ch of token) {
+    if (VOWELS.has(ch)) return true;
+  }
+  return false;
+}
+
+/**
+ * Returns true when `value` looks like keyboard-mash / placeholder gibberish
+ * rather than a real name. Conservative by design (see module docstring):
+ * a false negative (junk slips through) is preferable to a false positive
+ * (a real clinic is blocked at registration).
+ */
+export function looksLikeGibberish(value: string): boolean {
+  const folded = foldLetters(value);
+
+  // Rule 3: must contain at least 2 letters of actual content.
+  const letters = folded.replace(/[^a-z]/g, "");
+  if (letters.length < 2) return true;
+
+  // Rule 1: same letter repeated 4+ times in a row (ignore spacing).
+  if (/([a-z])\1{3,}/.test(folded.replace(/[^a-z]/g, ""))) return true;
+
+  // Rule 2: no alphabetic token (length ≥ 2) contains a vowel → unpronounceable.
+  const tokens = folded.split(/[^a-z]+/).filter((t) => t.length >= 2);
+  if (tokens.length === 0) return true; // only 1-letter fragments
+  if (!tokens.some(hasVowel)) return true;
+
+  return false;
+}
+
+/** User-facing rejection message (French — matches the rest of the schema). */
+export const GIBBERISH_NAME_MESSAGE =
+  "Veuillez saisir un nom d'établissement valide.";

--- a/supabase/migrations/00172_quarantine_reserved_subdomain_clinics.sql
+++ b/supabase/migrations/00172_quarantine_reserved_subdomain_clinics.sql
@@ -1,0 +1,68 @@
+-- ============================================================
+-- Migration 00172: Quarantine clinics squatting on reserved subdomains
+--
+-- AUDIT F-2 (follow-up to 00171)
+-- -----------------------------
+-- Migration 00171 added a BEFORE INSERT/UPDATE trigger that PREVENTS new
+-- clinics on a reserved subdomain (admin, api, www, …) but deliberately left
+-- pre-existing rows untouched ("…can be cleaned up as a separate, deliberate
+-- data operation"). This is that operation.
+--
+-- The live audit found `admin.oltigo.com` still resolving. Rather than DELETE
+-- (irreversible, and may cascade into appointments / patients / payments via
+-- FK), we QUARANTINE: set status = 'suspended'. Effects:
+--   • Drops out of the public sitemap immediately — sitemap.ts only emits
+--     clinics with status = 'active'.
+--   • Drops out of any active-clinic listing / RLS "active clinics" reads.
+-- Request resolution already refuses reserved subdomains in code
+-- (src/lib/subdomain.ts) and at the DB layer (00171), so suspending is enough
+-- to stop a reserved subdomain from being served as a tenant.
+--
+-- REVERSIBLE: a clinic mistakenly caught here can be restored with
+--   UPDATE public.clinics SET status = 'active' WHERE id = '…';
+--
+-- IDEMPOTENT: rows already suspended are skipped, so re-running is a no-op.
+--
+-- SCOPE: only rows whose subdomain is a RESERVED word (is_reserved_subdomain,
+-- defined in 00171). It does NOT touch random low-quality slugs (e.g.
+-- 'ahhhhhe') — those are not reserved and need human review (see the audit's
+-- sitemap-activity-filter note). The operational tenants demo/test are never
+-- reserved and are explicitly excluded.
+--
+-- NOTE: This only quarantines the DATABASE row. Removing the wildcard DNS /
+-- Cloudflare route for `admin.oltigo.com` (so it stops returning 200 at the
+-- edge) is a separate infrastructure step.
+-- ============================================================
+
+-- Log what we are about to quarantine so it shows in the migration output.
+DO $$
+DECLARE
+  v_count integer;
+  v_list  text;
+BEGIN
+  SELECT count(*), string_agg(subdomain, ', ' ORDER BY subdomain)
+    INTO v_count, v_list
+  FROM public.clinics
+  WHERE subdomain IS NOT NULL
+    AND status <> 'suspended'
+    AND lower(subdomain) NOT IN ('demo', 'test')
+    AND public.is_reserved_subdomain(subdomain);
+
+  IF v_count > 0 THEN
+    RAISE NOTICE 'Migration 00172: suspending % clinic(s) on reserved subdomains: %',
+      v_count, v_list;
+  ELSE
+    RAISE NOTICE 'Migration 00172: no clinics on reserved subdomains — nothing to quarantine.';
+  END IF;
+END $$;
+
+-- Only `status` (and its audit timestamp) change; `subdomain` is left intact so
+-- the action is transparent and reversible, and so the 00171 "UPDATE OF
+-- subdomain" guard trigger is not even engaged.
+UPDATE public.clinics
+SET status = 'suspended',
+    updated_at = now()
+WHERE subdomain IS NOT NULL
+  AND status <> 'suspended'
+  AND lower(subdomain) NOT IN ('demo', 'test')
+  AND public.is_reserved_subdomain(subdomain);

--- a/supabase/migrations/00173_quarantine_known_junk_tenants.sql
+++ b/supabase/migrations/00173_quarantine_known_junk_tenants.sql
@@ -1,0 +1,67 @@
+-- ============================================================
+-- Migration 00173: Quarantine the known junk / test tenants from the audit
+--
+-- AUDIT F-2 (item 2 — "Sitemap still contains 25+ junk tenants")
+-- -------------------------------------------------------------
+-- Migration 00172 suspended clinics on RESERVED subdomains (admin, api, …).
+-- These remaining slugs are NOT reserved words, so 00172 leaves them alone,
+-- yet the audit explicitly enumerated them as keyboard-mash and test data that
+-- should not appear in the public sitemap. We quarantine that exact, named set.
+--
+-- WHY AN EXPLICIT LIST (not a heuristic): suspending real user data on a
+-- spelling guess is unacceptable. Going forward, new junk is blocked at the
+-- source by the clinic-name quality gate (src/lib/validations/name-quality.ts);
+-- this migration only cleans the specific historical rows the audit named, so
+-- the operation is fully reviewable and auditable in version control.
+--
+-- REVERSIBLE: status is set to 'suspended', not deleted. Restore any row with
+--   UPDATE public.clinics SET status = 'active' WHERE subdomain = '…';
+-- IDEMPOTENT: already-suspended rows are skipped; re-running is a no-op.
+--
+-- The match is on the slug PREFIX before the random 6-char suffix that
+-- generateSubdomain() appends (e.g. a tenant stored as 'fffffff-a1b2c3'),
+-- anchored so 'staf' cannot also catch a legitimate 'staf-ford-clinic'.
+-- ============================================================
+
+DO $$
+DECLARE
+  -- Exact junk/test slugs called out in the 2026-06-09 audit.
+  junk text[] := ARRAY[
+    'ahhhhhe','fffffff','jgjjrjrj','abod','cabinite','kjook','vdsvv','rtqz',
+    'staf','saara','aagmzzd','aagmzzdlp','aagmzzdlpok','ahmedlokf','ahmed151',
+    'ahmed15153','azar','azarr','hq','test-clinic-devin','testclinic',
+    'testclinic2','devin-test-clinic'
+  ];
+  v_count integer;
+  v_list  text;
+BEGIN
+  -- Preview (shows in migration output).
+  SELECT count(*), string_agg(subdomain, ', ' ORDER BY subdomain)
+    INTO v_count, v_list
+  FROM public.clinics c
+  WHERE c.status <> 'suspended'
+    AND c.subdomain IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM unnest(junk) AS j
+      -- match the base slug or 'base-<suffix>' (random suffix from generateSubdomain)
+      WHERE lower(c.subdomain) = j
+         OR lower(c.subdomain) LIKE j || '-%'
+    );
+
+  IF v_count > 0 THEN
+    RAISE NOTICE 'Migration 00173: suspending % known junk tenant(s): %', v_count, v_list;
+  ELSE
+    RAISE NOTICE 'Migration 00173: no known junk tenants present — nothing to do.';
+  END IF;
+
+  UPDATE public.clinics c
+  SET status = 'suspended',
+      updated_at = now()
+  WHERE c.status <> 'suspended'
+    AND c.subdomain IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM unnest(junk) AS j
+      WHERE lower(c.subdomain) = j
+         OR lower(c.subdomain) LIKE j || '-%'
+    );
+END $$;


### PR DESCRIPTION
## What

Follow-up to #985. Closes the **three audit items that were still broken in code** (the rest of the latest audit was already fixed at HEAD and only awaited a deploy).

### 1. CLS — homepage hero skeleton (Audit F-4)
`src/app/(public)/loading.tsx` reserved a single `h-12` (~48px) bar for a headline that renders at `clamp(2.5rem, 5vw, 4.5rem)` over ~2 lines (~150px), so the page jumped when streamed content replaced the fallback. Rebuilt the skeleton to mirror the real `EditorialHero` footprint (bone background, clamp headline, `h-11` CTAs, 4-stat trust grid, 96/128px spacers).

### 2. Sentry placeholder DSN hardening (Audit F-1)
`sentry.client.config.ts` and `src/instrumentation.ts` initialised Sentry on **any truthy DSN**, so a `placeholder` value still booted a dead client and shipped `sentry-public_key=placeholder`. Now any DSN containing `placeholder` is treated as unset (**fail closed**). Complements the existing hard boot gate in `src/lib/env.ts`.

### 3. Quarantine reserved-subdomain tenants (Audit F-2 follow-up)
Migration `00171` blocks **new** reserved subdomains but deliberately left existing rows (e.g. `admin`) in place. New migration `00172` quarantines them via `status='suspended'` — **reversible**, **idempotent**, no destructive delete — so they drop out of the sitemap and active listings.

## Not included (infra / data — cannot be done in a PR)
- Set the real `NEXT_PUBLIC_SENTRY_DSN` env var and redeploy.
- Remove the `admin.oltigo.com` DNS/edge route (code already refuses it as a tenant; the wildcard still answers at the edge).
- Run `00172`, then human-review non-reserved junk slugs (`ahhhhhe`, test clinics) — intentionally **not** auto-suspended.
- Verify/rotate the `admin@admin.com / 123456789` credentials.

## Test plan
- [ ] Throttle network, load `/` — confirm no layout jump as hero streams in (CLS < 0.1).
- [ ] Build with `NEXT_PUBLIC_SENTRY_DSN` unset/placeholder — confirm no `sentry-public_key=placeholder` in page source and no Sentry init.
- [ ] Apply `00172` on a DB copy — confirm reserved-subdomain clinics flip to `suspended` and drop from the sitemap; re-run is a no-op.
