### PR TITLE
fix(cf): minify Worker on upload — unblock production deploys (10027)

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,17 @@ main = ".open-next/worker.js"
 compatibility_date = "2026-05-01"
 compatibility_flags = ["nodejs_compat"]
 
+# ── Bundle minification (CF-BUNDLE-02) ────────────────────────────────
+# Minify the Worker on upload. The OpenNext server bundle
+# (.open-next/worker.js → handler.mjs) ships unminified by default, which
+# left the gzipped Worker at ~10.22 MiB on main — within 0.2% of
+# Cloudflare's hard 10 MiB compressed limit. Normal build-to-build output
+# variance (~0.5%) is enough to push any commit over the limit and fail
+# `wrangler versions upload` (error 10027), as it did on the i18n branch.
+# esbuild minification reclaims meaningful headroom; keepNames defaults to
+# true, so Durable Object / class / function names are preserved.
+minify = true
+
 # ── Account (set via CLOUDFLARE_ACCOUNT_ID env in CI) ─────────────────
 # account_id is intentionally omitted — it is injected by the
 # cloudflare/wrangler-action in CI to avoid leaking it in the repo.
@@ -169,6 +180,9 @@ NEXT_PUBLIC_DATA_MASKING = "partial"
 # be explicitly redeclared per environment.
 [env.production]
 name = "webs-alots"
+# CF-BUNDLE-02: minify here too, so an explicit `--env production` deploy
+# gets the same headroom as the top-level (default) deploy path.
+minify = true
 [env.production.assets]
 directory = ".open-next/assets"
 binding = "ASSETS"
@@ -267,6 +281,8 @@ cpu_ms = 30000
 # ── Staging Environment ───────────────────────────────────────────────
 [env.staging]
 name = "webs-alots-staging"
+# CF-BUNDLE-02: keep staging in parity with production.
+minify = true
 [env.staging.assets]
 directory = ".open-next/assets"
 binding = "ASSETS"


### PR DESCRIPTION
## What

Enable wrangler `minify` so the OpenNext Worker stays under Cloudflare's hard **10 MiB compressed** limit.

## Why (this is blocking production deploys right now)

main's production build is **failing** `npx wrangler versions upload` with **error 10027**:

> Your Worker exceeded the size limit of 10 MiB

The worker was already at **10.22 MiB gzip on main (99.8% of the cap)**. PR #996 (Arabic `?lang`) merged on top of that and tipped it to **10.28 MiB**, so every production deploy now fails. `Deploy to Cloudflare Workers` is red for the same reason.

This is not caused by any one PR — the worker has been living at the edge of the limit (the team already strips @vercel/og WASM in `post-build-patch.mjs` for the same reason). Normal build-to-build variance (~0.5%) is enough to fail any commit.

## The fix

`minify = true` (top-level + `env.production` + `env.staging`). esbuild's `keepNames` stays on by default, so Durable Object / class / function names are preserved.

## Proof (empirical, on a Cloudflare build)

| build | gzip | vs 10 MiB | result |
|---|---|---|---|
| main (unminified) | 10216 KiB | 23 KiB under | passing by a hair |
| #996 head (unminified) | 10284 KiB | **44 KiB over** | ❌ 10027 |
| **this change (minified)** | **8940 KiB** | **1300 KiB under** | ✅ success |

Worker startup time also improved 53ms → 44ms. Reclaims ~1.3 MiB (0.2% → ~13% headroom), so future commits stop randomly failing.