### PR TITLE
fix(auth): repair signup + add guardrails so it cannot silently break again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,17 @@ jobs:
           # Deploy to `production` on main, `staging` on the staging branch.
           command: deploy --env ${{ github.ref_name == 'main' && 'production' || 'staging' }}
 
+      # Post-deploy smoke test against the LIVE site. Catches a broken deploy
+      # (e.g. signup failing because Supabase creds were not inlined into the
+      # client bundle) within ~30s instead of waiting for a user report.
+      # Allow a short propagation window before asserting.
+      - name: Post-deploy smoke test
+        env:
+          SMOKE_BASE_URL: ${{ github.ref_name == 'main' && 'https://oltigo.com' || 'https://staging.oltigo.com' }}
+        run: |
+          sleep 15
+          node scripts/smoke-post-deploy.mjs
+
       # ─── Second Worker: webs-alots-ai (AI routes) ─────────────────────
       # Lives in workers/ai/ as a separate npm package. Plain fetch handler
       # (no Next.js / OpenNext) so the bundle stays small. Holds CopilotKit

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -106,6 +106,10 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+          # PR previews build with placeholder Supabase creds (signup is not
+          # exercised here), so downgrade the build-env guard to a warning.
+          # Real deploys (deploy.yml) run the guard strictly with live secrets.
+          ALLOW_MISSING_PUBLIC_ENV: "1"
 
       # Verify the Worker entry point was actually emitted — catches
       # silent OpenNext misconfigurations where the build "succeeds"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:e2e": "playwright test",
     "test:db": "supabase test db",
     "typecheck": "tsc --noEmit",
-    "build:cf": "node scripts/patch-opennext.mjs && opennextjs-cloudflare build && node scripts/post-build-patch.mjs",
+    "build:cf": "node scripts/check-build-env.mjs && node scripts/patch-opennext.mjs && opennextjs-cloudflare build && node scripts/post-build-patch.mjs",
     "deploy": "npm run build:cf && wrangler deploy",
     "docs:generate": "typedoc",
     "analyze": "ANALYZE=true next build",

--- a/scripts/check-build-env.mjs
+++ b/scripts/check-build-env.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Build-time guard for client-inlined public environment variables.
+ *
+ * Next.js inlines `NEXT_PUBLIC_*` variables into the **client bundle** at
+ * build time. If they are missing/empty during `build:cf`, the browser
+ * Supabase client (`src/lib/supabase-client.ts`) initialises with empty
+ * credentials and throws "Missing Supabase environment variables" at
+ * runtime — which surfaces to users as the generic "Une erreur inattendue"
+ * on /register (signup) while server-side flows (login, password reset)
+ * keep working because they read the value at runtime on the Worker.
+ *
+ * This is exactly the failure mode that shipped to production once: the
+ * Worker runtime secrets were set (server-side login worked) but the
+ * GitHub Actions build secrets were never set, so the client bundle was
+ * built with empty Supabase credentials and signup broke silently.
+ *
+ * This guard makes that failure LOUD at build time instead of silent in
+ * production. The existing "Verify build output" CI step only checks that
+ * a worker entrypoint exists — it does not check that public env vars were
+ * actually inlined. This closes that gap.
+ *
+ * Escape hatch: set ALLOW_MISSING_PUBLIC_ENV=1 to downgrade to a warning
+ * (e.g. a local structural build where signup is not exercised).
+ *
+ * Usage:
+ *   node scripts/check-build-env.mjs
+ */
+
+/** Public vars that MUST be present (non-empty) in the build environment. */
+const REQUIRED_PUBLIC_VARS = ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+
+/** Lightweight shape checks so an obviously-wrong value also fails fast. */
+const VALIDATORS = {
+  NEXT_PUBLIC_SUPABASE_URL: (v) =>
+    /^https:\/\/[a-z0-9-]+\.supabase\.(co|in|net)$/i.test(v) ||
+    `expected a https://<project>.supabase.co URL, got "${v.slice(0, 32)}…"`,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: (v) =>
+    // Legacy JWT anon key (eyJ...) OR new publishable key (sb_publishable_...)
+    /^eyJ[\w-]+\.[\w-]+\.[\w-]+$/.test(v) ||
+    /^sb_publishable_[\w-]{20,}$/.test(v) ||
+    `expected a Supabase anon/publishable key (JWT "eyJ…" or "sb_publishable_…"), got "${v.slice(0, 16)}…"`,
+};
+
+const allowMissing = process.env.ALLOW_MISSING_PUBLIC_ENV === "1";
+const problems = [];
+
+for (const name of REQUIRED_PUBLIC_VARS) {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    problems.push(`  ✗ ${name} is missing or empty`);
+    continue;
+  }
+  const validate = VALIDATORS[name];
+  if (validate) {
+    const result = validate(value);
+    if (result !== true) problems.push(`  ✗ ${name}: ${result}`);
+  }
+}
+
+if (problems.length === 0) {
+  console.log("✓ check-build-env: all required NEXT_PUBLIC_* build vars are present.");
+  process.exit(0);
+}
+
+const header =
+  "\n✗ check-build-env: client bundle would ship WITHOUT valid Supabase public credentials.\n" +
+  "  These are inlined into the browser bundle at build time. Without them, signup\n" +
+  "  (the browser Supabase client) breaks while server-side login still works.\n\n";
+const fix =
+  "\n  Fix: set these as **GitHub Actions repository secrets** (Settings → Secrets and\n" +
+  "  variables → Actions). Note: these are SEPARATE from the Cloudflare Worker runtime\n" +
+  "  secrets (`wrangler secret put`) — the build needs its own copy to inline them.\n" +
+  "  Values come from Supabase → Project Settings → API.\n";
+
+if (allowMissing) {
+  console.warn(header + problems.join("\n") + fix);
+  console.warn("\n  ALLOW_MISSING_PUBLIC_ENV=1 set → continuing with a WARNING.\n");
+  process.exit(0);
+}
+
+console.error(header + problems.join("\n") + fix);
+process.exit(1);

--- a/scripts/smoke-post-deploy.mjs
+++ b/scripts/smoke-post-deploy.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Post-deploy smoke test — runs against the LIVE deployed site.
+ *
+ * Purpose: catch a broken deploy within ~30s instead of waiting for a user
+ * to report it. This is the check that would have caught the signup outage:
+ * the homepage and login rendered fine, but the /register client bundle had
+ * no Supabase credentials inlined, so signup threw for every visitor.
+ *
+ * Two layers:
+ *   1. Route liveness — key public routes + /api/health respond < 400.
+ *   2. Signup integrity — the deployed /register page's client JS bundle
+ *      actually contains a Supabase URL and an anon/publishable key. This is
+ *      the build-time-inlining failure mode that server-side checks miss.
+ *
+ * Usage:
+ *   SMOKE_BASE_URL=https://oltigo.com node scripts/smoke-post-deploy.mjs
+ *   (defaults to https://oltigo.com)
+ *
+ * Exit code 0 = all pass, 1 = at least one failure.
+ */
+
+const BASE = (process.env.SMOKE_BASE_URL || "https://oltigo.com").replace(/\/$/, "");
+const TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS || 20000);
+
+/** Routes that must respond with a status below `maxStatus`. */
+const ROUTES = [
+  { path: "/", maxStatus: 400 },
+  { path: "/login", maxStatus: 400 },
+  { path: "/register", maxStatus: 400 },
+  { path: "/pricing", maxStatus: 400 },
+  { path: "/api/health", maxStatus: 400 },
+];
+
+const SUPABASE_URL_RE = /https:\/\/[a-z0-9-]+\.supabase\.(co|in|net)/i;
+const SUPABASE_KEY_RE = /eyJ[\w-]+\.[\w-]+\.[\w-]+|sb_publishable_[\w-]{20,}/;
+
+let failures = 0;
+const log = (ok, msg) => {
+  console.log(`${ok ? "✓" : "✗"} ${msg}`);
+  if (!ok) failures++;
+};
+
+async function fetchText(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, redirect: "follow" });
+    const text = await res.text();
+    return { status: res.status, text };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function checkRoutes() {
+  for (const { path, maxStatus } of ROUTES) {
+    try {
+      const { status } = await fetchText(BASE + path);
+      log(status < maxStatus, `${path} → HTTP ${status} (expected < ${maxStatus})`);
+    } catch (err) {
+      log(false, `${path} → request failed: ${err?.message || err}`);
+    }
+  }
+}
+
+/**
+ * Verify the deployed /register page ships a usable Supabase client. The
+ * credentials are inlined into one of the referenced /_next/static chunks,
+ * so we fetch the page, then scan its JS bundles for a URL + key.
+ */
+async function checkSignupIntegrity() {
+  let html;
+  try {
+    ({ text: html } = await fetchText(BASE + "/register"));
+  } catch (err) {
+    log(false, `signup integrity: could not load /register (${err?.message || err})`);
+    return;
+  }
+
+  const chunks = [...html.matchAll(/\/_next\/static\/[^"']+\.js/g)].map((m) => m[0]);
+  const unique = [...new Set(chunks)].slice(0, 60);
+  if (unique.length === 0) {
+    log(false, "signup integrity: no client JS chunks referenced by /register");
+    return;
+  }
+
+  let urlFound = SUPABASE_URL_RE.test(html);
+  let keyFound = SUPABASE_KEY_RE.test(html);
+
+  for (const chunk of unique) {
+    if (urlFound && keyFound) break;
+    try {
+      const { text } = await fetchText(BASE + chunk);
+      if (!urlFound && SUPABASE_URL_RE.test(text)) urlFound = true;
+      if (!keyFound && SUPABASE_KEY_RE.test(text)) keyFound = true;
+    } catch {
+      // ignore individual chunk fetch errors; absence is what we test for
+    }
+  }
+
+  log(urlFound, "signup integrity: Supabase URL inlined in client bundle");
+  log(
+    keyFound,
+    keyFound
+      ? "signup integrity: Supabase anon/publishable key inlined in client bundle"
+      : "signup integrity: Supabase anon key MISSING from client bundle — signup will fail " +
+          "(set NEXT_PUBLIC_SUPABASE_ANON_KEY as a GitHub Actions build secret)",
+  );
+}
+
+(async () => {
+  console.log(`Post-deploy smoke test → ${BASE}\n`);
+  await checkRoutes();
+  await checkSignupIntegrity();
+  console.log("");
+  if (failures > 0) {
+    console.error(`✗ smoke test FAILED with ${failures} problem(s).`);
+    process.exit(1);
+  }
+  console.log("✓ smoke test passed.");
+})();

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -230,7 +230,7 @@ export default function ForgotPasswordPage() {
             {sent ? t(locale, "forgot.emailSent") : t(locale, "forgot.title")}
           </CardTitle>
           <CardDescription>
-            {sent ? `${t(locale, "forgot.emailSentDesc")} ${email}` : t(locale, "forgot.desc")}
+            {sent ? t(locale, "forgot.emailSentDesc", { email }) : t(locale, "forgot.desc")}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Sentry from "@sentry/nextjs";
 import { UserPlus, ShieldCheck, ArrowLeft, Eye, EyeOff, HeartPulse, Mail } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
@@ -97,6 +98,7 @@ export default function RegisterPage() {
       setLoading(false);
     } catch (err) {
       logger.warn("Registration failed", { context: "register", error: err });
+      Sentry.captureException(err, { tags: { flow: "register", method: "phone" } });
       setError(t(locale, "error.unexpected"));
       setLoading(false);
     }
@@ -151,6 +153,11 @@ export default function RegisterPage() {
       setLoading(false);
     } catch (err) {
       logger.warn("Email registration failed", { context: "register", error: err });
+      // A thrown error here (vs. a returned result.error) means the browser
+      // Supabase client itself failed to initialise/call — most often because
+      // NEXT_PUBLIC_SUPABASE_* were not inlined into the client bundle at build
+      // time. That is invisible server-side, so capture it explicitly.
+      Sentry.captureException(err, { tags: { flow: "register", method: "email" } });
       setError(t(locale, "error.unexpected"));
       setLoading(false);
     }
@@ -169,6 +176,7 @@ export default function RegisterPage() {
       }
     } catch (err) {
       logger.warn("OTP verification failed", { context: "register", error: err });
+      Sentry.captureException(err, { tags: { flow: "register", method: "otp" } });
       setError(t(locale, "error.unexpected"));
       setLoading(false);
     }

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { t, type Locale } from "@/lib/i18n";
+
+// 403 page is never something we want indexed.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+/**
+ * 403 — Access denied.
+ *
+ * Several server components (e.g. the super-admin AI Builder) call
+ * `redirect("/unauthorized")` when a role check fails. Before this page
+ * existed, that redirect resolved to a non-existent route and rendered a
+ * confusing 404. This gives those redirects a proper destination.
+ *
+ * Mirrors the locale handling of the root `not-found.tsx`: the active locale
+ * is read from the `x-tenant-locale` header set by middleware, falling back
+ * to French.
+ */
+export default async function UnauthorizedPage() {
+  const h = await headers();
+  const locale: Locale = (h.get("x-tenant-locale") as Locale) || "fr";
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <div className="w-full max-w-md text-center">
+        <p className="text-6xl font-bold text-muted-foreground">403</p>
+        <h1 className="mt-4 text-xl font-semibold">{t(locale, "unauthorized.title")}</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t(locale, "unauthorized.description")}
+        </p>
+        <div className="mt-6 flex items-center justify-center gap-3">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            {t(locale, "notFound.backHome")}
+          </Link>
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center rounded-lg border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            {t(locale, "auth.signIn")}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1120,6 +1120,8 @@
   "terms.toutePersonneAccedantA": "أي شخص يصل إلى المنصة، سواء كان مهنيًا صحيًا (طبيب، طبيب أسنان، صيدلي) أو مريضًا.",
   "terms.toutePersonneUtilisantLa": "أي شخص يستخدم المنصة لحجز المواعيد أو الاطلاع على معلوماته الطبية.",
   "ui.data-mask.constMaskedMaskvalueType": "; } const masked = mask(value, type, effectiveLevel); const defaultLabel = type === \"phone\" ? \"هاتف\" : type === \"email\" ? \"بريد إلكتروني\" : \"بطاقة التعريف\"; const a11yLabel = label ?? defaultLabel; return (",
+  "unauthorized.description": "ليس لديك الأذونات اللازمة للوصول إلى هذه الصفحة. إذا كنت تعتقد أن هذا خطأ، فاتصل بالمسؤول.",
+  "unauthorized.title": "تم رفض الوصول",
   "vet.addPet": "إضافة حيوان",
   "vet.appointment": "استشارة",
   "vet.breed": "السلالة",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1120,6 +1120,8 @@
   "terms.toutePersonneAccedantA": "any person accessing the Platform, whether a healthcare professional (doctor, dentist, pharmacist) or a patient.",
   "terms.toutePersonneUtilisantLa": "any person using the Platform to book appointments or view their medical information.",
   "ui.data-mask.constMaskedMaskvalueType": "; } const masked = mask(value, type, effectiveLevel); const defaultLabel = type === \"phone\" ? \"Phone\" : type === \"email\" ? \"Email\" : \"CIN\"; const a11yLabel = label ?? defaultLabel; return (",
+  "unauthorized.description": "You do not have the necessary permissions to access this page. If you believe this is an error, contact an administrator.",
+  "unauthorized.title": "Access denied",
   "vet.addPet": "Add Pet",
   "vet.appointment": "Consultation",
   "vet.breed": "Breed",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1120,6 +1120,8 @@
   "terms.toutePersonneAccedantA": "toute personne accédant à la Plateforme, qu&apos;il s&apos;agisse d&apos;un professionnel de santé (médecin, dentiste, pharmacien) ou d&apos;un patient.",
   "terms.toutePersonneUtilisantLa": "toute personne utilisant la Plateforme pour prendre rendez-vous ou consulter ses informations médicales.",
   "ui.data-mask.constMaskedMaskvalueType": "; } const masked = mask(value, type, effectiveLevel); const defaultLabel = type === \"phone\" ? \"Téléphone\" : type === \"email\" ? \"Email\" : \"CIN\"; const a11yLabel = label ?? defaultLabel; return (",
+  "unauthorized.description": "Vous n'avez pas les autorisations nécessaires pour accéder à cette page. Si vous pensez qu'il s'agit d'une erreur, contactez un administrateur.",
+  "unauthorized.title": "Accès non autorisé",
   "vet.addPet": "Ajouter un animal",
   "vet.appointment": "Consultation",
   "vet.breed": "Race",


### PR DESCRIPTION
## What & why

Email signup on `/register` has been failing in production with a generic "Une erreur inattendue". 

**Root cause (confirmed):** signup runs in the **browser** via `supabase-client.ts`, which needs `NEXT_PUBLIC_SUPABASE_*` inlined into the client bundle **at build time**. Those were set as Cloudflare Worker *runtime* secrets (so server-side login/password-reset kept working) but never as **GitHub Actions build secrets**, so the deployed client bundle ships with no anon key and the browser Supabase client throws. Verified live: the `/register` bundle contains the Supabase URL but no anon key.

The actual fix is operational (set the two GitHub Actions secrets, see below). This PR makes that failure mode **impossible to ship silently again** and fixes a few adjacent bugs found during an end-to-end test sweep.

## Required follow-up by a maintainer (the actual signup fix)

This PR does **not** contain secrets. To restore signup:

1. Supabase → Project Settings → API. Copy **Project URL** and **anon/public key**.
2. GitHub → repo → Settings → Secrets and variables → Actions → add repository secrets:
   - `NEXT_PUBLIC_SUPABASE_URL`
   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
   
   ⚠️ These are **separate** from the Cloudflare Worker runtime secrets (`wrangler secret put`). The build needs its own copy to inline them.
3. Merge + deploy. The new post-deploy smoke step confirms the fix (or fails the deploy).

## Changes

**Guardrails**
- `scripts/check-build-env.mjs` (new) — fails `build:cf` if the public Supabase vars are missing/empty/malformed. Escape hatch `ALLOW_MISSING_PUBLIC_ENV=1` for placeholder-cred builds (wired into `pr-preview.yml`).
- `scripts/smoke-post-deploy.mjs` (new) — post-deploy check against the **live** site: key routes respond `<400` **and** the `/register` bundle actually contains a Supabase URL + anon key. Wired into `deploy.yml` after the main Worker deploys.
- `register/page.tsx` — signup failures now `Sentry.captureException` (were only `logger.warn`), so an outage pages someone.

**Adjacent fixes**
- `/super-admin/builder` **404**: the page `redirect("/unauthorized")` on a failed role check, but that route never existed → root 404. Added `src/app/unauthorized/page.tsx` (403, i18n via `x-tenant-locale`) + `unauthorized.*` keys in FR/EN/AR.
- `forgot-password`: confirmation showed a literal `{email}` — now passes the param to `t()` so it interpolates.

## Verified locally
- `check-build-env.mjs`: 5 cases (missing / empty / malformed / valid / escape-hatch) all correct.
- `smoke-post-deploy.mjs`: run against oltigo.com — passes all routes, correctly flags the missing anon key today.
- `scripts/check-translations.mjs`: passes (0 gaps, baseline 0). Locale JSON valid, full FR/EN/AR parity, sorted, no empty strings.
- CI (`typecheck` / `lint` / `test`) is the authoritative gate — the dev sandbox couldn't run the full Next.js toolchain.

## Left untouched (needs a maintainer decision)
The AI Builder has deeper issues beyond the 404: it runs its **own** `users` role query (unlike sibling pages that trust the middleware-verified header), which likely fails for super-admins under RLS; and its backend (`webs-alots-ai` Worker / CopilotKit) is unprovisioned per the HOTFIX note in `(super-admin)/layout.tsx`. Either provision the AI Worker or hide the nav link. Not changed unilaterally since the nav code says AI links are "always rendered post-launch".
