### PR TITLE
refactor(ai): unify dual AI config systems into the router path (Task A1)

### DIFF
--- a/src/lib/__tests__/ai-config.test.ts
+++ b/src/lib/__tests__/ai-config.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for the unified AI config resolution (Task A1).
+ *
+ * `resolveAIConfig()` must delegate provider/model selection to the
+ * DB-backed router path (`loadProviderConfigs()` + `selectAvailableProvider()`)
+ * while preserving its legacy return shape and safety rails:
+ * kill switch (F-AI-01), base-URL allowlist (F-AI-05), model allowlist
+ * (F-AI-07 / W8-S-03), and per-request seed (F-AI-14).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AIProvider, ProviderConfig, RoutingTier } from "@/lib/ai/types";
+
+// ── Mocks ──
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/lib/ai-disclaimer", () => ({
+  AI_DISCLAIMER_FR: "Test disclaimer",
+  getAIDisclaimer: vi.fn(() => "Test disclaimer"),
+}));
+
+vi.mock("@/lib/features", () => ({
+  isAIEnabled: vi.fn(async () => true),
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createUntypedAdminClient: vi.fn(() => ({})),
+}));
+
+const { loadProviderConfigsMock } = vi.hoisted(() => ({
+  loadProviderConfigsMock: vi.fn(),
+}));
+
+// Keep the real selection logic (selectAvailableProvider, priority ordering,
+// availability rules) — only the DB load is mocked.
+vi.mock("@/lib/ai/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/router")>();
+  return { ...actual, loadProviderConfigs: loadProviderConfigsMock };
+});
+
+// ── Helpers ──
+
+function makeConfig(provider: AIProvider, overrides: Partial<ProviderConfig> = {}): ProviderConfig {
+  return {
+    provider,
+    displayName: provider,
+    apiKey: `${provider}-key`,
+    isActive: true,
+    routingTier: 1 as RoutingTier,
+    fallbackProvider: null,
+    monthlyBudgetCents: 0,
+    requestsThisMonth: 0,
+    tokensThisMonth: 0,
+    inputTokensThisMonth: 0,
+    outputTokensThisMonth: 0,
+    costThisMonthCents: 0,
+    rateLimitedUntil: null,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+function makeConfigMap(...configs: ProviderConfig[]): Map<AIProvider, ProviderConfig> {
+  return new Map(configs.map((c) => [c.provider, c]));
+}
+
+const ENV_VARS = [
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+  "OPENAI_MODEL",
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_AI_API_TOKEN",
+  "CLOUDFLARE_AI_TOKEN",
+] as const;
+
+describe("resolveAIConfig (unified path)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of ENV_VARS) vi.stubEnv(key, "");
+    loadProviderConfigsMock.mockResolvedValue(new Map());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 503 when the kill switch is engaged", async () => {
+    const { isAIEnabled } = await import("@/lib/features");
+    vi.mocked(isAIEnabled).mockResolvedValueOnce(false);
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.statusCode).toBe(503);
+      expect(result.reason).toBe("AI features are disabled");
+    }
+    expect(loadProviderConfigsMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves an admin-configured OpenAI provider from the database", async () => {
+    loadProviderConfigsMock.mockResolvedValue(
+      makeConfigMap(makeConfig("openai", { apiKey: "sk-db" })),
+    );
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("openai");
+      expect(result.config.apiKey).toBe("sk-db");
+      expect(result.config.baseUrl).toBe("https://api.openai.com/v1");
+      expect(result.config.model).toBe("gpt-4o-mini-2024-07-18");
+      expect(typeof result.config.seed).toBe("number");
+    }
+  });
+
+  it("registers OPENAI_API_KEY as the openai fallback credential when no DB key exists", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    loadProviderConfigsMock.mockResolvedValue(new Map());
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("openai");
+      expect(result.config.apiKey).toBe("sk-env");
+    }
+  });
+
+  it("returns 503 when no provider is configured at all", async () => {
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.statusCode).toBe(503);
+      expect(result.reason).toContain("not configured");
+    }
+  });
+
+  it("honours admin routing tiers across OpenAI-compatible providers", async () => {
+    const { PROVIDER_MODELS } = await import("@/lib/ai/models");
+    loadProviderConfigsMock.mockResolvedValue(
+      makeConfigMap(
+        makeConfig("openai", { routingTier: 1 as RoutingTier }),
+        makeConfig("groq", { routingTier: 3 as RoutingTier }),
+      ),
+    );
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("groq");
+      expect(result.config.baseUrl).toBe("https://api.groq.com/openai/v1");
+      expect(result.config.model).toBe(PROVIDER_MODELS.groq.model);
+    }
+  });
+
+  it("skips providers that are not OpenAI-wire-compatible (anthropic stays router-only)", async () => {
+    loadProviderConfigsMock.mockResolvedValue(
+      makeConfigMap(
+        makeConfig("anthropic", { routingTier: 3 as RoutingTier }),
+        makeConfig("openai", { routingTier: 0 as RoutingTier }),
+      ),
+    );
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("openai");
+    }
+  });
+
+  it("respects budget ceilings and falls back to Workers AI", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "acc-123");
+    vi.stubEnv("CLOUDFLARE_AI_API_TOKEN", "cf-token");
+    loadProviderConfigsMock.mockResolvedValue(
+      makeConfigMap(makeConfig("openai", { monthlyBudgetCents: 1000, costThisMonthCents: 1000 })),
+    );
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("workers_ai");
+      expect(result.config.apiKey).toBe("cf-token");
+      expect(result.config.baseUrl).toBe(
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/ai/v1",
+      );
+      expect(result.config.model).toBe("@cf/meta/llama-3.1-8b-instruct");
+    }
+  });
+
+  it("skips providers under a persisted rate-limit cooldown", async () => {
+    vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "acc-123");
+    vi.stubEnv("CLOUDFLARE_AI_API_TOKEN", "cf-token");
+    loadProviderConfigsMock.mockResolvedValue(
+      makeConfigMap(makeConfig("openai", { rateLimitedUntil: Date.now() + 60_000 })),
+    );
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("workers_ai");
+    }
+  });
+
+  it("rejects an OPENAI_MODEL override that is not in the allowlist (W8-S-03)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    vi.stubEnv("OPENAI_MODEL", "gpt-4o-mini"); // floating alias — must be rejected
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.statusCode).toBe(500);
+      expect(result.reason).toBe("AI model configuration error");
+    }
+  });
+
+  it("rejects an OPENAI_BASE_URL override outside the allowlist (F-AI-05)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    vi.stubEnv("OPENAI_BASE_URL", "https://evil.example.com/v1");
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.statusCode).toBe(500);
+      expect(result.reason).toBe("AI service configuration error");
+    }
+  });
+
+  it("falls back to the env credential when the database load fails", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    loadProviderConfigsMock.mockRejectedValue(new Error("db down"));
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.provider).toBe("openai");
+      expect(result.config.apiKey).toBe("sk-env");
+    }
+  });
+
+  it("does not mutate the router's shared config cache when overlaying the env fallback", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    const shared = new Map<AIProvider, ProviderConfig>();
+    loadProviderConfigsMock.mockResolvedValue(shared);
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    await resolveAIConfig();
+
+    expect(shared.size).toBe(0);
+  });
+});
+
+describe("ALLOWED_MODELS (single registry)", () => {
+  it("contains every provider default model", async () => {
+    const { ALLOWED_MODELS, PROVIDER_MODELS } = await import("@/lib/ai/models");
+    for (const config of Object.values(PROVIDER_MODELS)) {
+      expect(ALLOWED_MODELS.has(config.model)).toBe(true);
+    }
+  });
+
+  it("retains the legacy pinned snapshot IDs", async () => {
+    const { ALLOWED_MODELS } = await import("@/lib/ai/models");
+    for (const id of [
+      "gpt-4o-mini-2024-07-18",
+      "gpt-4o-2024-08-06",
+      "gpt-4o-2024-11-20",
+      "@cf/meta/llama-3.1-8b-instruct",
+    ]) {
+      expect(ALLOWED_MODELS.has(id)).toBe(true);
+    }
+  });
+});

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -2,17 +2,26 @@
  * Shared AI configuration — centralises kill-switch, URL allowlist,
  * model version pinning, and disclaimer injection.
  *
- * Phase 2 bridge: `resolveAIConfig()` now checks the `ai_provider_configs`
- * table first (database-backed routing) and falls back to the
- * `OPENAI_API_KEY` environment variable for backward compatibility.
- * This means every route that calls `resolveAIConfig()` automatically
- * uses the admin-managed provider keys from the superadmin UI when
- * available, without requiring route-by-route rewrites.
+ * Task A1 (unified config): `resolveAIConfig()` is a thin compatibility
+ * wrapper over the DB-backed router. Provider/model selection delegates to
+ * `loadProviderConfigs()` + `selectAvailableProvider()` — the exact ordering
+ * and availability rules `routeAIRequest()` uses (admin routing tier, active
+ * flag, monthly budget ceiling, persisted 429 cooldowns). There is no longer
+ * a parallel env-driven resolution path: the `OPENAI_API_KEY` environment
+ * variable is registered as a fallback credential for the `openai` provider
+ * when the admin has not configured a usable key in `ai_provider_configs`.
+ *
+ * Because legacy callers POST raw OpenAI wire format to
+ * `${baseUrl}/chat/completions`, only providers with OpenAI-compatible
+ * endpoints are eligible here (see OPENAI_COMPAT_BASE_URLS in models.ts).
+ * `anthropic`/`google` remain reachable through `routeAIRequest()` and join
+ * the unified path with the AI SDK migration (Task A3).
  *
  * Findings addressed:
  *   F-AI-01: Kill switch enforcement across all AI routes
- *   F-AI-05: OPENAI_BASE_URL allowlist (prevents operator-overridable exfil)
- *   F-AI-07: Model version pinning (no floating alias)
+ *   F-AI-05: Base-URL allowlist (prevents operator-overridable exfil)
+ *   F-AI-07 / W8-S-03: Model version pinning via the shared allowlist
+ *   F-AI-14: Per-request seed for reproducibility
  *   F-A199:  AI medical-advice disclaimer in response payloads
  */
 
@@ -20,16 +29,22 @@ import { AI_DISCLAIMER_FR } from "@/lib/ai-disclaimer";
 import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
-import { loadProviderConfigs } from "./router";
+import { ALLOWED_MODELS, OPENAI_COMPAT_BASE_URLS, PROVIDER_MODELS } from "./models";
+import { loadProviderConfigs, selectAvailableProvider } from "./router";
+import type { AIProvider, ProviderConfig } from "./types";
 
 // ── URL Allowlist (F-AI-05) ──
 
 /**
- * Only these base URLs are permitted for OPENAI_BASE_URL.
+ * Only these base URLs are permitted for OpenAI-compatible chat calls.
  * Prevents an operator from redirecting AI calls to a rogue endpoint
- * that could exfiltrate PHI sent in prompts.
+ * that could exfiltrate PHI sent in prompts. Seeded from the single
+ * provider registry so the allowlist cannot drift from the router.
  */
-const ALLOWED_AI_BASE_URLS = new Set(["https://api.openai.com/v1", "https://api.openai.com"]);
+const ALLOWED_AI_BASE_URLS = new Set<string>([
+  "https://api.openai.com",
+  ...Object.values(OPENAI_COMPAT_BASE_URLS),
+]);
 
 // W8-S-02: Pin Azure OpenAI to an explicit resource name rather than
 // accepting any *.openai.azure.com subdomain. Set AZURE_OPENAI_RESOURCE_NAME
@@ -57,45 +72,42 @@ function isAllowedBaseUrl(url: string): boolean {
 // ── Pinned Model Version (F-AI-07) ──
 
 /**
- * Default model version. Pinned to a dated snapshot to prevent
- * unexpected behaviour changes when OpenAI updates the alias.
+ * Default model for the legacy OpenAI path. Pinned to a dated snapshot to
+ * prevent unexpected behaviour changes when OpenAI updates the alias.
+ * (Reconciling this with the router's registry default is Task A2.)
  */
 const DEFAULT_MODEL = "gpt-4o-mini-2024-07-18";
 
-// W8-S-03: Only dated snapshot model names are allowed. Floating aliases
-// (e.g. "gpt-4o-mini") are rejected to prevent silent safety regressions.
-const ALLOWED_MODELS = new Set([
-  "gpt-4o-mini-2024-07-18",
-  "gpt-4o-2024-08-06",
-  "gpt-4o-2024-11-20",
-  "@cf/meta/llama-3.1-8b-instruct",
-]);
+const NOT_CONFIGURED_REASON =
+  "AI service not configured. Set OPENAI_API_KEY or configure a provider in the admin dashboard.";
 
 // ── Public API ──
 
 export interface AIConfig {
+  /** Provider the unified router selected for this request. */
+  provider: AIProvider;
   apiKey: string;
   baseUrl: string;
   model: string;
-  /** F-AI-14: Deterministic seed for reproducibility. Log with audit events. */
+  /** F-AI-14: Per-request seed for reproducibility. Log with audit events. */
   seed: number;
 }
 
 /**
  * Resolve and validate AI configuration.
  *
- * Resolution order:
+ * Resolution order (single path — Task A1):
  *   1. F-AI-01: Global kill-switch (KV + env)
- *   2. Database — load active provider configs from `ai_provider_configs`.
- *      Uses the first active provider that has an API key (OpenAI preferred
- *      for backward compatibility with routes that call the OpenAI chat
- *      completions API directly).
- *   3. Environment fallback — `OPENAI_API_KEY` from Cloudflare secrets.
- *   4. F-AI-05: OPENAI_BASE_URL allowlist (only for OpenAI / env fallback)
- *   5. F-AI-07: Model pinning
- *
- * This bridge lets all existing routes transparently use admin-managed
- * keys from the superadmin settings UI without per-route rewrites.
+ *   2. Load provider configs from `ai_provider_configs` via the router's
+ *      `loadProviderConfigs()` (30s cache). On DB failure, continue with an
+ *      empty set so the env fallback below still works.
+ *   3. Register `OPENAI_API_KEY` as the `openai` provider's fallback
+ *      credential when no usable admin-managed key exists.
+ *   4. `selectAvailableProvider()` picks the best available
+ *      OpenAI-wire-compatible provider using the router's tier/budget/
+ *      cooldown rules. Workers AI stays the always-last free fallback.
+ *   5. F-AI-05 base-URL allowlist + F-AI-07/W8-S-03 model allowlist
+ *      validation on the selected provider.
  */
 export async function resolveAIConfig(): Promise<
   { ok: true; config: AIConfig } | { ok: false; reason: string; statusCode: number }
@@ -105,128 +117,144 @@ export async function resolveAIConfig(): Promise<
     return { ok: false, reason: "AI features are disabled", statusCode: 503 };
   }
 
-  // ── Try database-backed config first ──
-  const dbResult = await resolveFromDatabase();
-  if (dbResult) {
-    return { ok: true, config: dbResult };
+  const configs = await loadEffectiveConfigs();
+
+  // One selection path: same rules as routeAIRequest(), restricted to
+  // providers the legacy OpenAI-wire-format callers can actually talk to.
+  const provider = selectAvailableProvider(
+    configs,
+    (p) => p === "workers_ai" || p in OPENAI_COMPAT_BASE_URLS,
+  );
+
+  if (!provider) {
+    return { ok: false, reason: NOT_CONFIGURED_REASON, statusCode: 503 };
   }
 
-  // ── Fallback to environment variables ──
-  return resolveFromEnv();
+  return buildProviderConfig(provider, configs);
 }
 
-/** Try to load an active OpenAI-compatible provider from `ai_provider_configs`. */
-async function resolveFromDatabase(): Promise<AIConfig | null> {
+/**
+ * Load admin-managed provider configs and overlay the environment fallback.
+ *
+ * The returned map is a copy — never mutate the router's shared 30s cache.
+ */
+async function loadEffectiveConfigs(): Promise<Map<AIProvider, ProviderConfig>> {
+  let configs: Map<AIProvider, ProviderConfig>;
   try {
     const supabase = createUntypedAdminClient("ai-config-resolve");
-    const configs = await loadProviderConfigs(supabase);
-
-    if (configs.size === 0) return null;
-
-    // Prefer OpenAI provider since callers use the OpenAI chat completions API
-    const openaiConfig = configs.get("openai");
-    if (openaiConfig?.isActive && openaiConfig.apiKey) {
-      logger.debug("AI config resolved from database (openai)", { context: "ai-config" });
-      return {
-        apiKey: openaiConfig.apiKey,
-        baseUrl: "https://api.openai.com/v1",
-        model: DEFAULT_MODEL,
-        seed: Date.now(),
-      };
-    }
-
-    // Fall back to Workers AI via OpenAI-compatible endpoint (free, no API key purchase needed)
-    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID; // nosemgrep: semgrep.env-access — runtime cred for Workers AI fallback
-    const aiToken = process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN; // nosemgrep: semgrep.env-access — runtime cred for Workers AI fallback
-    if (accountId && aiToken) {
-      logger.debug("AI config resolved from Workers AI (free fallback)", { context: "ai-config" });
-      return {
-        apiKey: aiToken,
-        baseUrl: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
-        model: "@cf/meta/llama-3.1-8b-instruct",
-        seed: Date.now(),
-      };
-    }
-
-    return null;
+    configs = await loadProviderConfigs(supabase);
   } catch (err) {
-    logger.warn("Failed to load AI config from database, falling back to env", {
+    logger.warn("Failed to load AI provider configs from database, using env fallback", {
       context: "ai-config",
       error: err instanceof Error ? err.message : String(err),
     });
-    return null;
+    configs = new Map();
   }
+
+  const effective = new Map(configs);
+
+  // Router-registered provider credential fallback: when the admin has not
+  // configured a usable OpenAI key, the environment key keeps legacy
+  // deployments working. This is the only place the env secret is read.
+  const dbOpenAI = effective.get("openai");
+  if (!dbOpenAI?.isActive || !dbOpenAI.apiKey) {
+    // nosemgrep: semgrep.env-access — secret read at runtime; registered as the openai provider's fallback credential
+    const envKey = process.env.OPENAI_API_KEY;
+    if (envKey) {
+      effective.set("openai", {
+        provider: "openai",
+        displayName: dbOpenAI?.displayName ?? "OpenAI (env fallback)",
+        apiKey: envKey,
+        isActive: true,
+        routingTier: dbOpenAI?.routingTier ?? 0,
+        fallbackProvider: dbOpenAI?.fallbackProvider ?? null,
+        monthlyBudgetCents: dbOpenAI?.monthlyBudgetCents ?? 0,
+        requestsThisMonth: dbOpenAI?.requestsThisMonth ?? 0,
+        tokensThisMonth: dbOpenAI?.tokensThisMonth ?? 0,
+        inputTokensThisMonth: dbOpenAI?.inputTokensThisMonth ?? 0,
+        outputTokensThisMonth: dbOpenAI?.outputTokensThisMonth ?? 0,
+        costThisMonthCents: dbOpenAI?.costThisMonthCents ?? 0,
+        rateLimitedUntil: dbOpenAI?.rateLimitedUntil ?? null,
+        lastError: dbOpenAI?.lastError ?? null,
+      });
+    }
+  }
+
+  return effective;
 }
 
-/** Original env-based resolution (backward compatible). */
-function resolveFromEnv():
-  | { ok: true; config: AIConfig }
-  | { ok: false; reason: string; statusCode: number } {
-  // nosemgrep: semgrep.env-access — secret read at runtime; not in env.ts to avoid eager import
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    // Try Workers AI as last resort (free, no API key purchase needed)
-    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID; // nosemgrep: semgrep.env-access — runtime cred for Workers AI fallback
-    const aiToken = process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN; // nosemgrep: semgrep.env-access — runtime cred for Workers AI fallback
-    if (accountId && aiToken) {
-      logger.debug("AI config resolved from Workers AI env fallback", { context: "ai-config" });
-      return {
-        ok: true,
-        config: {
-          apiKey: aiToken,
-          baseUrl: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
-          model: "@cf/meta/llama-3.1-8b-instruct",
-          seed: Date.now(),
-        },
-      };
-    }
-
-    return {
-      ok: false,
-      reason:
-        "AI service not configured. Set OPENAI_API_KEY or configure a provider in the admin dashboard.",
-      statusCode: 503,
-    };
-  }
-
-  // F-AI-05: Validate base URL
-  // nosemgrep: semgrep.env-access — operator-configurable base URL, validated below
-  const baseUrl = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
-  if (!isAllowedBaseUrl(baseUrl)) {
-    logger.error("OPENAI_BASE_URL is not in the allowlist", {
-      context: "ai-config",
-      baseUrl,
-    });
-    return {
-      ok: false,
-      reason: "AI service configuration error",
-      statusCode: 500,
-    };
-  }
-
-  // F-AI-07: Pinned model version
-  // W8-S-03: Reject models not in the allowlist to prevent operators from
-  // switching to a floating alias or a less safety-tuned model.
-  // nosemgrep: semgrep.env-access — operator-configurable model, validated below against allowlist
-  const model = process.env.OPENAI_MODEL || DEFAULT_MODEL;
-  if (!ALLOWED_MODELS.has(model)) {
-    logger.error("OPENAI_MODEL is not in the allowlist", {
-      context: "ai-config",
-      model,
-    });
-    return {
-      ok: false,
-      reason: "AI model configuration error",
-      statusCode: 500,
-    };
-  }
-
-  // F-AI-14: Generate a per-request seed for OpenAI reproducibility.
-  // Callers should pass this as `seed` in the API request and log it
-  // in audit events so any problematic output can be reproduced.
+/** Build the validated AIConfig for the provider the router selected. */
+function buildProviderConfig(
+  provider: AIProvider,
+  configs: Map<AIProvider, ProviderConfig>,
+): { ok: true; config: AIConfig } | { ok: false; reason: string; statusCode: number } {
+  // F-AI-14: Per-request seed for OpenAI-compatible reproducibility.
+  // Callers should pass this as `seed` in the API request and log it in
+  // audit events so any problematic output can be reproduced.
   const seed = Date.now();
 
-  return { ok: true, config: { apiKey, baseUrl, model, seed } };
+  if (provider === "workers_ai") {
+    // Free always-last fallback via the Workers AI OpenAI-compatible endpoint.
+    const accountId = process.env.CLOUDFLARE_ACCOUNT_ID; // nosemgrep: semgrep.env-access — runtime cred for Workers AI fallback
+    const aiToken = process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN; // nosemgrep: semgrep.env-access — runtime cred for Workers AI fallback
+    if (!accountId || !aiToken) {
+      // selectAvailableProvider() only returns workers_ai when configured;
+      // this guards against env changes between check and build.
+      return { ok: false, reason: NOT_CONFIGURED_REASON, statusCode: 503 };
+    }
+    logger.debug("AI config resolved (workers_ai fallback)", { context: "ai-config" });
+    return {
+      ok: true,
+      config: {
+        provider,
+        apiKey: aiToken,
+        baseUrl: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+        model: PROVIDER_MODELS.workers_ai.model,
+        seed,
+      },
+    };
+  }
+
+  const config = configs.get(provider);
+  if (!config?.apiKey) {
+    return { ok: false, reason: NOT_CONFIGURED_REASON, statusCode: 503 };
+  }
+
+  // Base URL comes from the single registry. The OPENAI_BASE_URL override is
+  // kept for the openai provider (Azure / approved proxy deployments) and
+  // remains allowlist-validated (F-AI-05).
+  let baseUrl = OPENAI_COMPAT_BASE_URLS[provider];
+  if (provider === "openai") {
+    // nosemgrep: semgrep.env-access — operator-configurable base URL, validated below
+    baseUrl = process.env.OPENAI_BASE_URL || baseUrl;
+  }
+  if (!baseUrl || !isAllowedBaseUrl(baseUrl)) {
+    logger.error("AI base URL is not in the allowlist", {
+      context: "ai-config",
+      provider,
+      baseUrl,
+    });
+    return { ok: false, reason: "AI service configuration error", statusCode: 500 };
+  }
+
+  // F-AI-07 / W8-S-03: Model pinning against the generated allowlist.
+  // Rejects floating aliases and models outside the single registry.
+  let model: string | undefined = PROVIDER_MODELS[provider]?.model;
+  if (provider === "openai") {
+    // nosemgrep: semgrep.env-access — operator-configurable model, validated below against allowlist
+    model = process.env.OPENAI_MODEL || DEFAULT_MODEL;
+  }
+  if (!model || !ALLOWED_MODELS.has(model)) {
+    logger.error("AI model is not in the allowlist", {
+      context: "ai-config",
+      provider,
+      model,
+    });
+    return { ok: false, reason: "AI model configuration error", statusCode: 500 };
+  }
+
+  logger.debug("AI config resolved", { context: "ai-config", provider, model });
+  return { ok: true, config: { provider, apiKey: config.apiKey, baseUrl, model, seed } };
 }
 
 /**

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -94,3 +94,46 @@ export const PROVIDER_PRIORITY: AIProvider[] = [
 
 /** Rate limit window duration (ms) */
 export const RATE_LIMIT_WINDOW_MS = 60_000;
+
+// ── Single-registry model allowlist (Task A1) ──
+
+/**
+ * W8-S-03: Dated snapshot model IDs that operators may pin via `OPENAI_MODEL`
+ * in addition to the per-provider defaults above. Floating aliases
+ * (e.g. "gpt-4o-mini") are rejected to prevent silent safety regressions.
+ * (Registry refresh with current provider IDs is Task A2.)
+ */
+export const PINNED_SNAPSHOT_MODELS: readonly string[] = [
+  "gpt-4o-mini-2024-07-18",
+  "gpt-4o-2024-08-06",
+  "gpt-4o-2024-11-20",
+];
+
+/**
+ * F-AI-07 / W8-S-03: The model allowlist, generated from the single provider
+ * registry plus explicitly pinned snapshot IDs. Previously a hand-maintained
+ * duplicate set inside config.ts (the dual-config problem, Task A1).
+ */
+export const ALLOWED_MODELS: ReadonlySet<string> = new Set<string>([
+  ...Object.values(PROVIDER_MODELS).map((m) => m.model),
+  ...PINNED_SNAPSHOT_MODELS,
+]);
+
+/**
+ * Providers whose chat APIs are OpenAI-wire-compatible, with their base URLs.
+ *
+ * Legacy `resolveAIConfig()` consumers POST raw OpenAI-format JSON to
+ * `${baseUrl}/chat/completions` (including `response_format: json_object`),
+ * so the compatibility wrapper may only select these providers. `anthropic`
+ * and `google` use native adapters (providers.ts) and stay reachable through
+ * `routeAIRequest()` until the AI SDK migration (Task A3). `workers_ai` is
+ * also OpenAI-compatible but its base URL depends on the Cloudflare account
+ * ID, so it is assembled in config.ts.
+ */
+export const OPENAI_COMPAT_BASE_URLS: Partial<Record<AIProvider, string>> = {
+  openai: "https://api.openai.com/v1",
+  groq: "https://api.groq.com/openai/v1",
+  deepseek: "https://api.deepseek.com",
+  mistral: "https://api.mistral.ai/v1",
+  xai: "https://api.x.ai/v1",
+};

--- a/src/lib/ai/router.ts
+++ b/src/lib/ai/router.ts
@@ -160,6 +160,28 @@ function buildPriorityList(configs: Map<AIProvider, ProviderConfig>): AIProvider
   return [...sorted.filter((p) => p !== "workers_ai"), "workers_ai"];
 }
 
+/**
+ * Select the first available provider in routing-tier order — the exact
+ * ordering and availability rules `routeAIRequest()` applies (admin tier,
+ * active flag, API key presence, monthly budget ceiling, persisted and
+ * in-memory rate-limit cooldowns).
+ *
+ * Task A1: exported so the legacy `resolveAIConfig()` compatibility wrapper
+ * resolves through this single path instead of maintaining a parallel
+ * selection system. `isEligible` lets callers restrict candidates (e.g. to
+ * OpenAI-wire-compatible providers).
+ */
+export function selectAvailableProvider(
+  configs: Map<AIProvider, ProviderConfig>,
+  isEligible: (provider: AIProvider) => boolean = () => true,
+): AIProvider | null {
+  for (const provider of buildPriorityList(configs)) {
+    if (!isEligible(provider)) continue;
+    if (checkProviderAvailable(provider, configs).available) return provider;
+  }
+  return null;
+}
+
 // ── Router ──
 
 export async function routeAIRequest(


### PR DESCRIPTION
## Task A1 — Unify the dual AI config systems

Implements **Task A1** from `AI-FIX-MASTERPLAN.md` (problem **P3**): the legacy `resolveAIConfig()` path and the DB-backed router no longer form two parallel AI config systems. There is now one source of truth for provider/model selection.

### What changed

**`src/lib/ai/config.ts`** — `resolveAIConfig()` is now a thin compatibility wrapper over the router:
- Provider selection delegates to `loadProviderConfigs()` + the router's own ordering/availability rules (admin `routing_tier`, active flag, monthly budget ceiling, persisted 429 cooldowns). The old hardcoded "prefer OpenAI, ignore everything else" logic is gone.
- The env-only resolution branch (`resolveFromEnv`) is deleted. `OPENAI_API_KEY` is now read in exactly one place, registered as a **fallback credential for the `openai` provider** when no usable admin-managed key exists in `ai_provider_configs` (acceptance: `grep -rn "OPENAI_API_KEY" src/lib/ai/` shows only that registration).
- Return shape preserved (`apiKey`, `baseUrl`, `model`, `seed`) so none of the 13 callers change. A `provider` field is added for observability.
- Safety rails kept and moved into the unified path: kill switch (F-AI-01), base-URL allowlist incl. pinned Azure resource (F-AI-05 / W8-S-02), model allowlist (F-AI-07 / W8-S-03), per-request seed (F-AI-14), disclaimer export (F-A199).
- DB failure resilience preserved: if the config load throws, resolution continues with the env fallback credential.

**`src/lib/ai/models.ts`** — single model registry:
- `ALLOWED_MODELS` moved here and is **generated** from `PROVIDER_MODELS` + `PINNED_SNAPSHOT_MODELS` instead of being a hand-maintained duplicate set in config.ts.
- New `OPENAI_COMPAT_BASE_URLS` registry: providers whose chat APIs are OpenAI-wire-compatible (`openai`, `groq`, `deepseek`, `mistral`, `xai`). Legacy callers POST raw OpenAI-format JSON (incl. `response_format: json_object`) to `${baseUrl}/chat/completions`, so the wrapper only hands out these providers plus `workers_ai`. `anthropic`/`google` keep using their native adapters via `routeAIRequest()` until the AI SDK migration (Task A3).

**`src/lib/ai/router.ts`** — exports `selectAvailableProvider()`, the exact selection logic `routeAIRequest()` uses, so the wrapper and the router can never drift.

**`src/lib/__tests__/ai-config.test.ts`** — new test suite (13 cases): kill switch, DB-config resolution, env fallback registration, tier-honoring selection, OpenAI-compat eligibility filtering, budget ceiling fallback, persisted cooldown skip, W8-S-03 floating-alias rejection, F-AI-05 rogue-URL rejection, DB-failure resilience, cache non-mutation, and allowlist generation (every registry default is allowlisted — pre-seeds Task A2's acceptance test).

### Intentional behavior changes (consequences of unification)

1. Legacy routes now **respect budget ceilings, cooldowns, and the active flag** for OpenAI — previously the bridge ignored all three and only checked key presence.
2. If an admin configures an OpenAI-compatible provider (e.g. groq) at a higher routing tier than OpenAI, legacy routes now **honor that tier** instead of silently ignoring it.
3. `OPENAI_BASE_URL`/`OPENAI_MODEL` env overrides are now honored (and allowlist-validated) on the DB-credential path too, not only on the env-credential path.

### Out of scope (deliberately)

- Stale model IDs in `PROVIDER_MODELS` (e.g. `llama-3.1-70b-versatile`) — **Task A2** refreshes the registry; the allowlist generation here already gives A2 a single place to do it.
- Replacing hand-rolled adapters / adding anthropic+google to the unified path — **Task A3**.
- No route handlers, sealed Layer 1–2 files, migrations, or PHI paths touched.

### Verification

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] `npm run eval:ai` — runs in CI on this PR (touches `src/lib/ai/**`)
