### PR TITLE
fix(ai): refresh model registry to current provider IDs with deprecated-alias resolution (A2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -166,7 +166,9 @@ CLOUDFLARE_AI_API_TOKEN=
 # ---- AI Chatbot — Advanced level [Optional — OpenAI-compatible, paid] ----
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1
-OPENAI_MODEL=gpt-4o-mini
+# Must be in the model allowlist (src/lib/ai/models.ts). Floating aliases
+# (e.g. gpt-4o-mini) are rejected; deprecated pins auto-resolve with a warning.
+OPENAI_MODEL=gpt-5.4-mini
 
 # A107-03: Set to "true" to disable all AI features immediately (kill switch).
 # Takes precedence over the KV-based flag.

--- a/src/lib/__tests__/ai-config.test.ts
+++ b/src/lib/__tests__/ai-config.test.ts
@@ -114,7 +114,7 @@ describe("resolveAIConfig (unified path)", () => {
       expect(result.config.provider).toBe("openai");
       expect(result.config.apiKey).toBe("sk-db");
       expect(result.config.baseUrl).toBe("https://api.openai.com/v1");
-      expect(result.config.model).toBe("gpt-4o-mini-2024-07-18");
+      expect(result.config.model).toBe("gpt-5.4-mini");
       expect(typeof result.config.seed).toBe("number");
     }
   });
@@ -218,6 +218,25 @@ describe("resolveAIConfig (unified path)", () => {
     }
   });
 
+  it("auto-resolves a deprecated OPENAI_MODEL pin to its replacement (Task A2)", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-env");
+    // Previously-valid dated snapshot, superseded in the A2 registry refresh.
+    vi.stubEnv("OPENAI_MODEL", "gpt-4o-mini-2024-07-18");
+
+    const { resolveAIConfig } = await import("@/lib/ai/config");
+    const result = await resolveAIConfig();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.config.model).toBe("gpt-5.4-mini");
+    }
+    const { logger } = await import("@/lib/logger");
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      "Deprecated AI model auto-resolved to its replacement",
+      expect.objectContaining({ original: "gpt-4o-mini-2024-07-18", model: "gpt-5.4-mini" }),
+    );
+  });
+
   it("rejects an OPENAI_MODEL override that is not in the allowlist (W8-S-03)", async () => {
     vi.stubEnv("OPENAI_API_KEY", "sk-env");
     vi.stubEnv("OPENAI_MODEL", "gpt-4o-mini"); // floating alias — must be rejected
@@ -280,15 +299,17 @@ describe("ALLOWED_MODELS (single registry)", () => {
     }
   });
 
-  it("retains the legacy pinned snapshot IDs", async () => {
+  it("contains the explicitly pinned operator-selectable IDs", async () => {
     const { ALLOWED_MODELS } = await import("@/lib/ai/models");
-    for (const id of [
-      "gpt-4o-mini-2024-07-18",
-      "gpt-4o-2024-08-06",
-      "gpt-4o-2024-11-20",
-      "@cf/meta/llama-3.1-8b-instruct",
-    ]) {
+    for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "@cf/meta/llama-3.1-8b-instruct"]) {
       expect(ALLOWED_MODELS.has(id)).toBe(true);
+    }
+  });
+
+  it("no longer allowlists retired snapshot IDs directly (Task A2)", async () => {
+    const { ALLOWED_MODELS } = await import("@/lib/ai/models");
+    for (const id of ["gpt-4o-mini-2024-07-18", "gpt-4o-2024-08-06", "gpt-4o-2024-11-20"]) {
+      expect(ALLOWED_MODELS.has(id)).toBe(false);
     }
   });
 });

--- a/src/lib/__tests__/ai-models.test.ts
+++ b/src/lib/__tests__/ai-models.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the single model registry (Task A2).
+ *
+ * Guards the registry refresh invariants:
+ *  - every default model ID is in the generated allowlist (acceptance A2)
+ *  - the deprecated-alias map never widens the allowlist, never chains,
+ *    and always resolves to an allowed model
+ *  - floating aliases stay rejected (W8-S-03)
+ *  - pricing/context metadata stays sane for cost accounting
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ALLOWED_MODELS,
+  DEPRECATED_MODEL_ALIASES,
+  PINNED_SNAPSHOT_MODELS,
+  PROVIDER_MODELS,
+  PROVIDER_PRIORITY,
+  resolveModelAlias,
+} from "@/lib/ai/models";
+
+describe("model registry (Task A2)", () => {
+  it("every provider default model ID is in the allowlist", () => {
+    for (const config of Object.values(PROVIDER_MODELS)) {
+      expect(ALLOWED_MODELS.has(config.model)).toBe(true);
+    }
+  });
+
+  it("every pinned snapshot ID is in the allowlist", () => {
+    for (const id of PINNED_SNAPSHOT_MODELS) {
+      expect(ALLOWED_MODELS.has(id)).toBe(true);
+    }
+  });
+
+  it("every provider in the priority list has a registry entry", () => {
+    for (const provider of PROVIDER_PRIORITY) {
+      expect(PROVIDER_MODELS[provider]).toBeDefined();
+      expect(PROVIDER_MODELS[provider].provider).toBe(provider);
+    }
+  });
+
+  it("no decommissioned ID appears as a default or pinned model", () => {
+    const current = new Set([
+      ...Object.values(PROVIDER_MODELS).map((m) => m.model),
+      ...PINNED_SNAPSHOT_MODELS,
+    ]);
+    for (const deprecated of Object.keys(DEPRECATED_MODEL_ALIASES)) {
+      expect(current.has(deprecated)).toBe(false);
+    }
+  });
+
+  it("has sane pricing and context metadata for cost accounting", () => {
+    for (const config of Object.values(PROVIDER_MODELS)) {
+      expect(config.maxContextTokens).toBeGreaterThan(0);
+      expect(config.rpmLimit).toBeGreaterThan(0);
+      expect(config.costPerInputToken).toBeGreaterThanOrEqual(0);
+      expect(config.costPerOutputToken).toBeGreaterThanOrEqual(0);
+      if (config.provider !== "workers_ai") {
+        // Paid providers must have non-zero pricing or cost caps go blind.
+        expect(config.costPerInputToken).toBeGreaterThan(0);
+        expect(config.costPerOutputToken).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("DEPRECATED_MODEL_ALIASES (Task A2)", () => {
+  it("every alias target is in the allowlist", () => {
+    for (const target of Object.values(DEPRECATED_MODEL_ALIASES)) {
+      expect(ALLOWED_MODELS.has(target)).toBe(true);
+    }
+  });
+
+  it("never chains: no target is itself a deprecated key", () => {
+    for (const target of Object.values(DEPRECATED_MODEL_ALIASES)) {
+      expect(DEPRECATED_MODEL_ALIASES[target]).toBeUndefined();
+    }
+  });
+
+  it("no deprecated key is in the allowlist (resolution, not widening)", () => {
+    for (const deprecated of Object.keys(DEPRECATED_MODEL_ALIASES)) {
+      expect(ALLOWED_MODELS.has(deprecated)).toBe(false);
+    }
+  });
+
+  it("resolves known decommissioned IDs to their replacements", () => {
+    expect(resolveModelAlias("llama-3.1-70b-versatile")).toEqual({
+      model: "llama-3.3-70b-versatile",
+      deprecated: true,
+      original: "llama-3.1-70b-versatile",
+    });
+    expect(resolveModelAlias("claude-sonnet-4-20250514").model).toBe("claude-sonnet-4-6");
+    expect(resolveModelAlias("gemini-2.0-flash").model).toBe("gemini-3.5-flash");
+    expect(resolveModelAlias("deepseek-chat").model).toBe("deepseek-v4-flash");
+    expect(resolveModelAlias("mistral-small-latest").model).toBe("mistral-small-2603");
+    expect(resolveModelAlias("grok-3-mini").model).toBe("grok-4.3");
+    expect(resolveModelAlias("gpt-4.1-mini").model).toBe("gpt-5.4-mini");
+  });
+
+  it("passes current model IDs through untouched", () => {
+    for (const config of Object.values(PROVIDER_MODELS)) {
+      expect(resolveModelAlias(config.model)).toEqual({
+        model: config.model,
+        deprecated: false,
+      });
+    }
+  });
+
+  it("does not rescue never-allowed floating aliases (W8-S-03)", () => {
+    for (const floating of ["gpt-4o-mini", "chat-latest", "gemini-flash-latest"]) {
+      const resolution = resolveModelAlias(floating);
+      expect(resolution.deprecated).toBe(false);
+      expect(ALLOWED_MODELS.has(resolution.model)).toBe(false);
+    }
+  });
+});

--- a/src/lib/ai/config.ts
+++ b/src/lib/ai/config.ts
@@ -29,7 +29,12 @@ import { AI_DISCLAIMER_FR } from "@/lib/ai-disclaimer";
 import { isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
-import { ALLOWED_MODELS, OPENAI_COMPAT_BASE_URLS, PROVIDER_MODELS } from "./models";
+import {
+  ALLOWED_MODELS,
+  OPENAI_COMPAT_BASE_URLS,
+  PROVIDER_MODELS,
+  resolveModelAlias,
+} from "./models";
 import { loadProviderConfigs, selectAvailableProvider } from "./router";
 import type { AIProvider, ProviderConfig } from "./types";
 
@@ -72,11 +77,10 @@ function isAllowedBaseUrl(url: string): boolean {
 // ── Pinned Model Version (F-AI-07) ──
 
 /**
- * Default model for the legacy OpenAI path. Pinned to a dated snapshot to
- * prevent unexpected behaviour changes when OpenAI updates the alias.
- * (Reconciling this with the router's registry default is Task A2.)
+ * Default model for the legacy OpenAI path (Task A2: reconciled with the
+ * router's registry default — single source of truth in models.ts).
  */
-const DEFAULT_MODEL = "gpt-4o-mini-2024-07-18";
+const DEFAULT_MODEL = PROVIDER_MODELS.openai.model;
 
 const NOT_CONFIGURED_REASON =
   "AI service not configured. Set OPENAI_API_KEY or configure a provider in the admin dashboard.";
@@ -243,6 +247,21 @@ function buildProviderConfig(
   if (provider === "openai") {
     // nosemgrep: semgrep.env-access — operator-configurable model, validated below against allowlist
     model = process.env.OPENAI_MODEL || DEFAULT_MODEL;
+  }
+  // Task A2: a stale-but-previously-valid operator pin auto-resolves to its
+  // current replacement (with a warning) instead of 404ing at the provider.
+  // Never-allowed floating aliases are not in the map and still fail below.
+  if (model) {
+    const resolution = resolveModelAlias(model);
+    if (resolution.deprecated) {
+      logger.warn("Deprecated AI model auto-resolved to its replacement", {
+        context: "ai-config",
+        provider,
+        original: resolution.original,
+        model: resolution.model,
+      });
+    }
+    model = resolution.model;
   }
   if (!model || !ALLOWED_MODELS.has(model)) {
     logger.error("AI model is not in the allowlist", {

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -120,11 +120,7 @@ export const RATE_LIMIT_WINDOW_MS = 60_000;
  * published for this line). Floating aliases (e.g. "gpt-4o-mini",
  * "chat-latest") are still rejected to prevent silent safety regressions.
  */
-export const PINNED_SNAPSHOT_MODELS: readonly string[] = [
-  "gpt-5.5",
-  "gpt-5.4",
-  "gpt-5.4-nano",
-];
+export const PINNED_SNAPSHOT_MODELS: readonly string[] = ["gpt-5.5", "gpt-5.4", "gpt-5.4-nano"];
 
 /**
  * F-AI-07 / W8-S-03: The model allowlist, generated from the single provider

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -3,6 +3,13 @@
  *
  * Pricing is in cents per 1M tokens. RPM limits are conservative defaults;
  * actual limits depend on the user's API tier.
+ *
+ * Task A2: model IDs and pricing verified against official provider
+ * documentation on 2026-06-10 (Groq console docs, Google AI pricing,
+ * Anthropic models overview, OpenAI platform pricing, xAI models page,
+ * DeepSeek pricing, Mistral model cards). Superseded IDs are mapped in
+ * `DEPRECATED_MODEL_ALIASES` below so stale operator pins auto-resolve to
+ * their replacement instead of failing at the provider.
  */
 
 import type { AIProvider, ModelConfig } from "./types";
@@ -19,58 +26,67 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
   },
   groq: {
     provider: "groq",
-    model: "llama-3.1-70b-versatile",
+    // llama-3.1-70b-versatile was decommissioned; 3.3 is Groq's drop-in replacement.
+    model: "llama-3.3-70b-versatile",
     maxContextTokens: 131072,
-    costPerInputToken: 59,
-    costPerOutputToken: 79,
+    costPerInputToken: 59, // $0.59 / 1M
+    costPerOutputToken: 79, // $0.79 / 1M
     rpmLimit: 30,
   },
   deepseek: {
     provider: "deepseek",
-    model: "deepseek-chat",
-    maxContextTokens: 65536,
-    costPerInputToken: 14,
-    costPerOutputToken: 28,
+    // deepseek-chat retires 2026-07-24; V4 Flash is its designated successor.
+    model: "deepseek-v4-flash",
+    maxContextTokens: 1_000_000,
+    costPerInputToken: 14, // $0.14 / 1M (cache miss)
+    costPerOutputToken: 28, // $0.28 / 1M
     rpmLimit: 300,
   },
   google: {
     provider: "google",
-    model: "gemini-2.0-flash",
+    // gemini-2.0-flash is shut down; 3.5 Flash is the current stable Flash tier.
+    model: "gemini-3.5-flash",
     maxContextTokens: 1048576,
-    costPerInputToken: 15,
-    costPerOutputToken: 60,
+    costPerInputToken: 150, // $1.50 / 1M (standard paid tier)
+    costPerOutputToken: 900, // $9.00 / 1M (incl. thinking tokens)
     rpmLimit: 1500,
   },
   mistral: {
     provider: "mistral",
-    model: "mistral-small-latest",
-    maxContextTokens: 32768,
-    costPerInputToken: 10,
-    costPerOutputToken: 30,
+    // Replaces the floating "mistral-small-latest" alias (W8-S-03) with the
+    // dated Mistral Small 4 snapshot (v26.03).
+    model: "mistral-small-2603",
+    maxContextTokens: 262144,
+    costPerInputToken: 15, // $0.15 / 1M
+    costPerOutputToken: 60, // $0.60 / 1M
     rpmLimit: 120,
   },
   openai: {
     provider: "openai",
-    model: "gpt-4.1-mini",
-    maxContextTokens: 1047576,
-    costPerInputToken: 40,
-    costPerOutputToken: 160,
+    // gpt-4.1-mini is superseded; 5.4 mini is the current mini-tier model.
+    model: "gpt-5.4-mini",
+    maxContextTokens: 400000,
+    costPerInputToken: 75, // $0.75 / 1M
+    costPerOutputToken: 450, // $4.50 / 1M
     rpmLimit: 500,
   },
   anthropic: {
     provider: "anthropic",
-    model: "claude-sonnet-4-20250514",
-    maxContextTokens: 200000,
-    costPerInputToken: 300,
-    costPerOutputToken: 1500,
+    // claude-sonnet-4-20250514 retires 2026-06-15. Sonnet 4.6 IDs are
+    // dateless but still pinned snapshots per Anthropic's versioning docs.
+    model: "claude-sonnet-4-6",
+    maxContextTokens: 1_000_000,
+    costPerInputToken: 300, // $3.00 / 1M
+    costPerOutputToken: 1500, // $15.00 / 1M
     rpmLimit: 50,
   },
   xai: {
     provider: "xai",
-    model: "grok-3-mini",
-    maxContextTokens: 131072,
-    costPerInputToken: 30,
-    costPerOutputToken: 50,
+    // grok-3-mini is superseded; grok-4.3 is xAI's current general model.
+    model: "grok-4.3",
+    maxContextTokens: 1_000_000,
+    costPerInputToken: 125, // $1.25 / 1M
+    costPerOutputToken: 250, // $2.50 / 1M
     rpmLimit: 60,
   },
 };
@@ -82,31 +98,32 @@ export const PROVIDER_MODELS: Record<string, ModelConfig> = {
  * providers share the same tier. Workers AI is always pinned last.
  */
 export const PROVIDER_PRIORITY: AIProvider[] = [
-  "anthropic", // best quality (Claude Sonnet 4)
-  "openai", // GPT-4.1-mini
-  "google", // Gemini 2.0 Flash
-  "xai", // Grok 3 Mini
-  "mistral", // Mistral Small
-  "deepseek", // DeepSeek Chat
-  "groq", // Fast inference (Llama 70B)
+  "anthropic", // best quality (Claude Sonnet 4.6)
+  "openai", // GPT-5.4 mini
+  "google", // Gemini 3.5 Flash
+  "xai", // Grok 4.3
+  "mistral", // Mistral Small 4
+  "deepseek", // DeepSeek V4 Flash
+  "groq", // Fast inference (Llama 3.3 70B)
   "workers_ai", // free fallback — always last
 ];
 
 /** Rate limit window duration (ms) */
 export const RATE_LIMIT_WINDOW_MS = 60_000;
 
-// ── Single-registry model allowlist (Task A1) ──
+// ── Single-registry model allowlist (Tasks A1 + A2) ──
 
 /**
- * W8-S-03: Dated snapshot model IDs that operators may pin via `OPENAI_MODEL`
- * in addition to the per-provider defaults above. Floating aliases
- * (e.g. "gpt-4o-mini") are rejected to prevent silent safety regressions.
- * (Registry refresh with current provider IDs is Task A2.)
+ * W8-S-03: Additional pinned model IDs that operators may select via
+ * `OPENAI_MODEL` beyond the per-provider defaults above. OpenAI's current
+ * 5.x version IDs are pinned releases (no dated public snapshots are
+ * published for this line). Floating aliases (e.g. "gpt-4o-mini",
+ * "chat-latest") are still rejected to prevent silent safety regressions.
  */
 export const PINNED_SNAPSHOT_MODELS: readonly string[] = [
-  "gpt-4o-mini-2024-07-18",
-  "gpt-4o-2024-08-06",
-  "gpt-4o-2024-11-20",
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.4-nano",
 ];
 
 /**
@@ -118,6 +135,67 @@ export const ALLOWED_MODELS: ReadonlySet<string> = new Set<string>([
   ...Object.values(PROVIDER_MODELS).map((m) => m.model),
   ...PINNED_SNAPSHOT_MODELS,
 ]);
+
+// ── Deprecated alias resolution (Task A2) ──
+
+/**
+ * Decommissioned or superseded model IDs mapped to their current
+ * replacement. When an operator-saved pin (e.g. `OPENAI_MODEL` set before a
+ * registry refresh) references one of these, it auto-resolves to the
+ * replacement — with a logged warning — instead of 404ing at the provider.
+ *
+ * Deliberately NOT included: floating aliases that were never allowed
+ * (e.g. "gpt-4o-mini"). Those must keep failing the allowlist (W8-S-03).
+ * Targets must always be members of `ALLOWED_MODELS` and must never appear
+ * as keys themselves (no alias chains) — enforced by unit tests.
+ */
+export const DEPRECATED_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  // Groq decommissioned the 3.1 70B; 3.3 70B is its documented replacement.
+  "llama-3.1-70b-versatile": "llama-3.3-70b-versatile",
+  // Google shut down the Gemini 2.0 family.
+  "gemini-2.0-flash": "gemini-3.5-flash",
+  // Anthropic retires Claude Sonnet 4 on 2026-06-15.
+  "claude-sonnet-4-20250514": "claude-sonnet-4-6",
+  // OpenAI 4.x line superseded by the 5.4 family (former registry default
+  // and former PINNED_SNAPSHOT_MODELS entries).
+  "gpt-4.1-mini": "gpt-5.4-mini",
+  "gpt-4o-mini-2024-07-18": "gpt-5.4-mini",
+  "gpt-4o-2024-08-06": "gpt-5.4",
+  "gpt-4o-2024-11-20": "gpt-5.4",
+  // DeepSeek retires deepseek-chat / deepseek-reasoner on 2026-07-24.
+  "deepseek-chat": "deepseek-v4-flash",
+  "deepseek-reasoner": "deepseek-v4-flash",
+  // Former floating registry default (W8-S-03) and retiring dated versions.
+  "mistral-small-latest": "mistral-small-2603",
+  "mistral-small-2506": "mistral-small-2603",
+  "mistral-small-2503": "mistral-small-2603",
+  // xAI superseded the grok-3 line.
+  "grok-3-mini": "grok-4.3",
+};
+
+/** Result of resolving a (possibly deprecated) model ID. */
+export interface ModelAliasResolution {
+  /** The ID to actually send to the provider. */
+  model: string;
+  /** True when the input was a deprecated ID rewritten to its replacement. */
+  deprecated: boolean;
+  /** The original deprecated ID, present when `deprecated` is true. */
+  original?: string;
+}
+
+/**
+ * Resolve a model ID through the deprecated-alias map. Unknown IDs pass
+ * through untouched (and will then fail the `ALLOWED_MODELS` check as
+ * before — this function never widens the allowlist). Callers are
+ * responsible for logging a warning when `deprecated` is true.
+ */
+export function resolveModelAlias(model: string): ModelAliasResolution {
+  const replacement = DEPRECATED_MODEL_ALIASES[model];
+  if (replacement) {
+    return { model: replacement, deprecated: true, original: model };
+  }
+  return { model, deprecated: false };
+}
 
 /**
  * Providers whose chat APIs are OpenAI-wire-compatible, with their base URLs.

--- a/src/lib/builder/models.ts
+++ b/src/lib/builder/models.ts
@@ -7,14 +7,15 @@ export interface BuilderModel {
 
 export const BUILDER_MODELS: BuilderModel[] = [
   {
-    id: "claude-sonnet-4-20250514",
-    name: "Claude Sonnet 4",
+    // Task A2: claude-sonnet-4-20250514 retires 2026-06-15.
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
     provider: "anthropic",
     description: "Best balance of speed and quality",
   },
   {
-    id: "claude-opus-4-5",
-    name: "Claude Opus 4.5",
+    id: "claude-opus-4-8",
+    name: "Claude Opus 4.8",
     provider: "anthropic",
     description: "Most capable, slower",
   },


### PR DESCRIPTION
## Task A2 — Refresh the model registry

Follows A1 (#1000). Scope is strictly A2; no other masterplan tasks touched.

### Model defaults (verified against official provider docs, 2026-06-10)

| Provider | Before | After | Why |
|---|---|---|---|
| groq | `llama-3.1-70b-versatile` | `llama-3.3-70b-versatile` | decommissioned by Groq |
| google | `gemini-2.0-flash` | `gemini-3.5-flash` | 2.0 family shut down |
| anthropic | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` | retires **2026-06-15** |
| openai | `gpt-4.1-mini` | `gpt-5.4-mini` | superseded (5.x line) |
| mistral | `mistral-small-latest` | `mistral-small-2603` | floating alias → dated pin (W8-S-03) |
| deepseek | `deepseek-chat` | `deepseek-v4-flash` | retires 2026-07-24 |
| xai | `grok-3-mini` | `grok-4.3` | superseded |
| workers_ai | `@cf/meta/llama-3.1-8b-instruct` | unchanged | still listed |

Pricing (cents/1M) and context windows updated to current published values. `PROVIDER_PRIORITY` comments refreshed.

### Deprecated-alias safety net
- `DEPRECATED_MODEL_ALIASES` + `resolveModelAlias()`: a stale-but-previously-valid operator pin (e.g. `OPENAI_MODEL=gpt-4o-mini-2024-07-18`, old admin-saved IDs) auto-resolves to its replacement with a logged warning instead of 404ing at the provider.
- Never-allowed floating aliases (`gpt-4o-mini`, `chat-latest`, …) are **not** rescued — they still fail the allowlist (W8-S-03 preserved).
- Alias map invariants are test-enforced: targets always allowed, no chains, no allowlist widening.

### Other changes
- `config.ts` `DEFAULT_MODEL` now points at the registry (single source of truth, completes the A1 direction).
- `PINNED_SNAPSHOT_MODELS` refreshed to `gpt-5.5` / `gpt-5.4` / `gpt-5.4-nano`; retired 4o snapshots moved to the alias map.
- `builder/models.ts`: Sonnet 4.6 / Opus 4.8 (Sonnet 4 ID retires in 5 days).
- `.env.example`: current model + allowlist note.

### Tests & verification
- New `src/lib/__tests__/ai-models.test.ts` (registry + alias invariants, pricing sanity) — acceptance criterion: every default model ID is in the allowlist ✔
- `ai-config.test.ts`: new deprecated-pin auto-resolution case; updated default-model expectations.
- `lint` 0 errors · `tsc --noEmit` clean · `vitest` 159 files / 1897 passed · eval runners exit green locally (skip without `EVAL_AUTH_TOKEN`; CI runs the full suite on this PR since `src/lib/ai/**` is touched).

### Sealed layers
No changes to middleware, auth, tenant, encryption, PHI files, RLS, or booking/payment routes.

_Note for the admin `test provider` acceptance check: run `/api/admin/ai-config/test` against each configured provider in dev after merge — needs live keys not available in this environment._