### PR TITLE
Fix Semgrep findings from PR #1005 review (env-access + tenant-scoping false positives)

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -6,24 +6,24 @@ rules:
   # defense-in-depth — application-level scoping is required even with RLS.
   #
   # This rule rewrites the previous version so that .eq("clinic_id", ...) is
-  # recognised anywhere in the method chain (the previous pattern-not-regex
-  # approach silently failed because semgrep's matched range only spanned
-  # `from().method()` and the regex never saw subsequent .eq() calls).
+  # recognised anywhere in the method chain. The previous version combined
+  # `pattern-inside: $EXPR` with a `pattern-not-regex`, but the regex only
+  # ever evaluated against the `from().method()` sub-range, and the auxiliary
+  # `pattern-not` clauses only suppressed chains where .eq("clinic_id") was
+  # the terminal call (within at most two trailing calls). Both silently
+  # failed for real-world chains, producing false positives on queries that
+  # are correctly scoped, e.g.:
   #
-  # Two correctness changes vs the previous rule:
+  #   .from("t").select(...).eq("clinic_id", id).order(...).limit(n)
+  #   .from("t").update(data).eq("id", x).eq("clinic_id", id)
   #
-  #   1. Use a `pattern-inside` over the full expression statement, so the
-  #      pattern-not-regex evaluates against the entire chain text.
-  #
-  #   2. Whitelist a fixed list of service-level / non-clinic-keyed tables
-  #      that the project uses (see migrations 00092 processed_stripe_events,
-  #      00094 processed_whatsapp_messages, 00101 webhook_retry_queue,
-  #      notification_queue from monetization batch, and the `users` table
-  #      which is keyed by id rather than clinic_id). For these tables an
-  #      `.eq("id", ...)` filter is the tenant-equivalent scoping.
+  # The fix: `pattern-not-inside` with method-chain ellipsis. It is
+  # containment-based — any from().crud() match that sits inside a chain
+  # which eventually calls .eq("clinic_id", ...) is excluded, regardless of
+  # chain depth or calls following the .eq().
   #
   # False positives this rule deliberately allows:
-  #   - Queries on the whitelisted service tables above
+  #   - Queries on the whitelisted service tables below
   #   - Queries in cron jobs that intentionally iterate over all clinics
   #     (callers should still annotate these with `// nosemgrep: tenant-scoping`
   #     for documentation purposes — the rule cannot detect cron context)
@@ -32,17 +32,12 @@ rules:
   #
   - id: tenant-scoping
     patterns:
-      # Match any chain that starts with .from(<table>).<crud>(...) — the
-      # matched range is the full expression so subsequent .eq("clinic_id")
-      # calls show up to the pattern-not-regex below.
       - pattern: |
           $CLIENT.from($TABLE).$METHOD(...)
-      - pattern-inside: |
-          $EXPR
-      # Any .eq("clinic_id", ...) anywhere in the surrounding expression
-      # makes this query tenant-scoped.
-      - pattern-not-regex: |
-          \.eq\(\s*["']clinic_id["']
+      # CRUD methods only — ignore .from(...).rpc(...), etc.
+      - metavariable-regex:
+          metavariable: $METHOD
+          regex: ^(select|insert|update|delete|upsert)$
       # Service-level / non-clinic-keyed tables.
       - metavariable-regex:
           metavariable: $TABLE
@@ -69,31 +64,20 @@ rules:
           # .from("users").select("*") still triggers a warning.
           regex: |-
             ^(?!["'](clinics|ai_provider_configs)["']).*$
-      # CRUD methods only — ignore .from(...).rpc(...), etc.
-      - metavariable-regex:
-          metavariable: $METHOD
-          regex: ^(select|insert|update|delete|upsert)$
-      # Belt-and-suspenders AST patterns for shallow chains where
-      # .eq("clinic_id") is the terminal call. Kept from the previous
-      # version so the rule does not regress on common shapes.
-      - pattern-not: |
-          $CLIENT.from($TABLE).$METHOD(...).eq("clinic_id", ...)
-      - pattern-not: |
-          $CLIENT.from($TABLE).$METHOD(...).eq('clinic_id', ...)
-      - pattern-not: |
-          $CLIENT.from($TABLE).$METHOD(...).$CHAIN1(...).eq("clinic_id", ...)
-      - pattern-not: |
-          $CLIENT.from($TABLE).$METHOD(...).$CHAIN1(...).eq('clinic_id', ...)
-      - pattern-not: |
-          $CLIENT.from($TABLE).$METHOD(...).$C1(...).$C2(...).eq("clinic_id", ...)
-      - pattern-not: |
-          $CLIENT.from($TABLE).$METHOD(...).$C1(...).$C2(...).eq('clinic_id', ...)
+      # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
+      # makes this query tenant-scoped. Semgrep normalises JS string quotes,
+      # but both variants are kept for belt-and-suspenders parity with the
+      # codebase's mixed quoting.
+      - pattern-not-inside: |
+          $CLIENT.from($TABLE).$METHOD(...). ... .eq("clinic_id", ...)
+      - pattern-not-inside: |
+          $CLIENT.from($TABLE).$METHOD(...). ... .eq('clinic_id', ...)
       # insert/upsert with clinic_id in the data object.
-      - pattern-not: |
+      - pattern-not-inside: |
           $CLIENT.from($TABLE).insert({clinic_id: ..., ...})
-      - pattern-not: |
+      - pattern-not-inside: |
           $CLIENT.from($TABLE).upsert({clinic_id: ..., ...})
-      - pattern-not: |
+      - pattern-not-inside: |
           $CLIENT.from($TABLE).insert([..., {clinic_id: ..., ...}, ...])
     message: >
       Supabase query on `$TABLE` missing `.eq("clinic_id", ...)` — every

--- a/src/lib/ai/providers.ts
+++ b/src/lib/ai/providers.ts
@@ -19,6 +19,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createXai } from "@ai-sdk/xai";
 import { generateText, streamText, type LanguageModel, type ToolSet } from "ai";
+import { getWorkersAiConfig } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { PROVIDER_MODELS } from "./models";
 import type { AIProvider, AIRequest } from "./types";
@@ -95,9 +96,8 @@ export function createModel(provider: AIProvider, apiKey: string | null): Langua
 
     case "workers_ai": {
       // Workers AI uses the OpenAI-compatible endpoint via @ai-sdk/openai-compatible.
-      const accountId = process.env.CLOUDFLARE_ACCOUNT_ID; // nosemgrep: semgrep.env-access — Workers AI runtime cred
-      const aiToken =
-        process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN ?? apiKey; // nosemgrep: semgrep.env-access — Workers AI runtime cred
+      const { accountId, apiToken } = getWorkersAiConfig();
+      const aiToken = apiToken ?? apiKey;
 
       if (!accountId || !aiToken) {
         throw new ProviderError(

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -503,8 +503,9 @@ async function getPlatformStats(input: ToolInput, ctx: AgentToolContext): Promis
       .from("clinics")
       .select("id", { count: "exact", head: true })
       .gte("created_at", since),
-    ctx.supabase.from("users").select("id", { count: "exact", head: true }),
-    ctx.supabase
+    // Platform-wide aggregates: super_admin-gated, count-only (head: true), no row data.
+    ctx.supabase.from("users").select("id", { count: "exact", head: true }), // nosemgrep: semgrep.tenant-scoping
+    ctx.supabase // nosemgrep: semgrep.tenant-scoping
       .from("appointments")
       .select("id", { count: "exact", head: true })
       .gte("created_at", since),
@@ -600,7 +601,8 @@ async function runAnalyticsQuery(input: ToolInput, ctx: AgentToolContext): Promi
 
   if (queryType === "busiest_hours_today") {
     const today = getLocalDateStr();
-    const { data, error } = await ctx.supabase
+    // Platform-wide hour histogram: super_admin-gated, aggregatedOnly output.
+    const { data, error } = await ctx.supabase // nosemgrep: semgrep.tenant-scoping
       .from("appointments")
       .select("start_time")
       .eq("appointment_date", today)

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1224,6 +1224,22 @@ export function getCloudflareApiConfig(): {
   };
 }
 
+/**
+ * Cloudflare Workers AI credentials (OpenAI-compatible endpoint used by
+ * src/lib/ai/providers.ts).
+ */
+export function getWorkersAiConfig(): {
+  accountId: string | undefined;
+  apiToken: string | undefined;
+} {
+  return {
+    accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+    // CLOUDFLARE_AI_TOKEN is the legacy variable name — kept as a fallback
+    // for deployments configured before CLOUDFLARE_AI_API_TOKEN existed.
+    apiToken: process.env.CLOUDFLARE_AI_API_TOKEN ?? process.env.CLOUDFLARE_AI_TOKEN,
+  };
+}
+
 /** Booking token HMAC secret. */
 export function getBookingTokenSecret(): string | undefined {
   return process.env.BOOKING_TOKEN_SECRET;


### PR DESCRIPTION
## Summary

Follow-up to #1005, resolving the GitHub Advanced Security / Semgrep review findings.

### 1. `semgrep.env-access` in `src/lib/ai/providers.ts`
- Added `getWorkersAiConfig()` to `src/lib/env.ts` (keeps the legacy `CLOUDFLARE_AI_TOKEN` fallback, documented).
- `providers.ts` now reads Workers AI credentials through the centralized env module. The `nosemgrep` annotations are removed instead of suppressed.

### 2. `semgrep.tenant-scoping` review comments (8 findings)
All 8 flagged queries were **already correctly scoped** with `.eq("clinic_id", ...)` - the rule itself was broken:
- `pattern-not-regex` only ever evaluated against the `from().method()` sub-range, so it never saw subsequent `.eq()` calls.
- The auxiliary `pattern-not` clauses only suppressed chains where `.eq("clinic_id")` was the *terminal* call.

Chains like `.from("t").select().eq("clinic_id", id).order().limit()` or `.from("t").update(d).eq("id", x).eq("clinic_id", id)` were all false positives. The rule is rewritten using `pattern-not-inside` with method-chain ellipsis, which is containment-based and recognises `.eq("clinic_id", ...)` anywhere in the chain.

### 3. Remaining true positives in `src/lib/ai/tools.ts`
With the fixed rule, 3 findings remain in the files from the #1005 review: `getPlatformStats` and `runAnalyticsQuery` platform-wide analytics. Both are `super_admin`-gated and aggregate-only, i.e. intentionally cross-tenant. Annotated with `// nosemgrep: semgrep.tenant-scoping` plus justification comments, per the rule's documented convention.

## Verification (semgrep 1.165.0, run locally)

| Scan | Old rule | New rule |
| --- | --- | --- |
| tenant-scoping on the 6 files flagged in #1005 | 55 findings | 0 findings |
| Synthetic unscoped queries (regression check) | flagged | still flagged (lines with missing clinic_id) |
| Full `.semgrep/` config on all 4 changed files | - | 0 findings |

The rule fix strictly reduces findings (the new suppression set is a superset of the old), so no new alerts are introduced anywhere in the repo; existing false-positive alerts will auto-close on the next default-branch scan.
