### PR TITLE
fix(deps): resolve Dependabot alerts for uuid and prismjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,12 +466,12 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex": {
-      "version": "3.0.140",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.140.tgz",
-      "integrity": "sha512-didlWnjTRvTM+yEoHNi/I+WnwlxpWcLMZtylFodVzuUOLhmQltoP46RgKG5hfXsGYwbnfBJbKcf6rvhOzYHSWQ==",
+      "version": "3.0.141",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.141.tgz",
+      "integrity": "sha512-+PjbZu63x+7RABQpAnNcJ0+EEZjKt3nQESQszA4Gyv9rLajob+FvxRJWeiLcKDsGIQdEFBknDrI5KLLSm7Doeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "2.0.80",
+        "@ai-sdk/anthropic": "2.0.81",
         "@ai-sdk/google": "2.0.74",
         "@ai-sdk/openai-compatible": "1.0.39",
         "@ai-sdk/provider": "2.0.3",
@@ -486,9 +486,9 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.80",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.80.tgz",
-      "integrity": "sha512-7HPgFv91YFFYyZapM/Vy3tRbBq/hL44omh0vz/WikiU7fJFxdOjCeg6Nb089lxM7+qBe7blZsoSRJ7gfAkEo1w==",
+      "version": "2.0.81",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.81.tgz",
+      "integrity": "sha512-0iqx9hZc9xqdhxOdZkYJAKuCs9o+5a86gStYl0M7IBZzmx6jTDrynXiOigDjH3SQrmLclLCspTjW5E6YFrlyHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
@@ -3820,20 +3820,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/@copilotkit/runtime/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@copilotkit/runtime/node_modules/zod": {
@@ -28455,15 +28441,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/refractor/node_modules/property-information": {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,12 @@
   "overrides": {
     "postcss": "^8.5.10",
     "@hono/node-server": "^1.19.13",
-    "react-copy-to-clipboard": "^5.1.1"
+    "react-copy-to-clipboard": "^5.1.1",
+    "@copilotkit/runtime": {
+      "uuid": "^11.1.1"
+    },
+    "refractor": {
+      "prismjs": "^1.30.0"
+    }
   }
 }

--- a/workers/ai/package-lock.json
+++ b/workers/ai/package-lock.json
@@ -57,19 +57,6 @@
         "zod": "^3.22.4"
       }
     },
-    "node_modules/@ag-ui/client/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@ag-ui/client/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -190,19 +177,6 @@
         "@protobuf-ts/protoc": "^2.11.1"
       }
     },
-    "node_modules/@ag-ui/mcp-middleware/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@ag-ui/mcp-middleware/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -272,12 +246,12 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex": {
-      "version": "3.0.140",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.140.tgz",
-      "integrity": "sha512-didlWnjTRvTM+yEoHNi/I+WnwlxpWcLMZtylFodVzuUOLhmQltoP46RgKG5hfXsGYwbnfBJbKcf6rvhOzYHSWQ==",
+      "version": "3.0.141",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google-vertex/-/google-vertex-3.0.141.tgz",
+      "integrity": "sha512-+PjbZu63x+7RABQpAnNcJ0+EEZjKt3nQESQszA4Gyv9rLajob+FvxRJWeiLcKDsGIQdEFBknDrI5KLLSm7Doeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "2.0.80",
+        "@ai-sdk/anthropic": "2.0.81",
         "@ai-sdk/google": "2.0.74",
         "@ai-sdk/openai-compatible": "1.0.39",
         "@ai-sdk/provider": "2.0.3",
@@ -292,9 +266,9 @@
       }
     },
     "node_modules/@ai-sdk/google-vertex/node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.80",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.80.tgz",
-      "integrity": "sha512-7HPgFv91YFFYyZapM/Vy3tRbBq/hL44omh0vz/WikiU7fJFxdOjCeg6Nb089lxM7+qBe7blZsoSRJ7gfAkEo1w==",
+      "version": "2.0.81",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.81.tgz",
+      "integrity": "sha512-0iqx9hZc9xqdhxOdZkYJAKuCs9o+5a86gStYl0M7IBZzmx6jTDrynXiOigDjH3SQrmLclLCspTjW5E6YFrlyHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.3",
@@ -762,19 +736,6 @@
       },
       "peerDependencies": {
         "@ag-ui/core": ">=0.0.48"
-      }
-    },
-    "node_modules/@copilotkit/shared/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@copilotkit/shared/node_modules/zod": {
@@ -5766,17 +5727,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/workers/ai/package.json
+++ b/workers/ai/package.json
@@ -25,5 +25,10 @@
     "@cloudflare/workers-types": "^4.20250501.0",
     "typescript": "^5.6.0",
     "wrangler": "^4.98.0"
+  },
+  "overrides": {
+    "@copilotkit/runtime": {
+      "uuid": "^11.1.1"
+    }
   }
 }


### PR DESCRIPTION
Fixes 3 of the 5 open Dependabot alerts. Lockfile-only changes via scoped npm overrides — no code changes, no API changes.

## Fixed
- **#88 + #90 (medium)** — `uuid` 10.0.0 under `@copilotkit/runtime` bumped to 11.1.1 in both `package-lock.json` and `workers/ai/package-lock.json` (CVE-2026-41907, missing buffer bounds check in v3/v5/v6). Scoped override, so langgraph's `uuid@14` line is untouched.
- **#15 (medium)** — `prismjs` 1.27.0 under `refractor` bumped to 1.30.0 (CVE-2024-53382, DOM clobbering). Same major, patch-level risk only.

## Not fixable yet
- **#89 + #91 (low)** — `@ai-sdk/provider-utils` 3.0.25 (CVE-2026-8769, uncontrolled resource consumption). `@ai-sdk/google-vertex` 3.0.141 (pulled in by `@copilotkit/runtime`) pins `provider-utils` 3.0.25 **exactly**, and no patched release exists in the v3 line. These will clear automatically once CopilotKit or the AI SDK bump that dependency. Low severity (DoS-class, not data exposure); reasonable to dismiss as tolerable risk in the meantime if you want a clean alerts page.

## Verify after merge
`npm install` from a clean tree, then `npm ls uuid prismjs` — no copy of uuid below 11.1.1 or prismjs below 1.30.0 should remain.