### PR TITLE
fix: resolve Semgrep findings from PR #1009 review (env-access + tenant-scoping)

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -49,6 +49,7 @@ rules:
           #   - `clinics`            — the tenant table itself; querying it
           #                             directly is the service-level pattern.
           #   - `ai_provider_configs`— global provider config; no clinic_id.
+          #   - `ai_task_configs`    — global per-task model routing pins; no clinic_id.
           #
           # All other queue / processed-events tables (notification_queue,
           # processed_stripe_events, processed_whatsapp_messages,
@@ -63,7 +64,7 @@ rules:
           # annotated rather than whitelisted, so a future bare
           # .from("users").select("*") still triggers a warning.
           regex: |-
-            ^(?!["'](clinics|ai_provider_configs)["']).*$
+            ^(?!["'](clinics|ai_provider_configs|ai_task_configs)["']).*$
       # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
       # makes this query tenant-scoped. Semgrep normalises JS string quotes,
       # but both variants are kept for belt-and-suspenders parity with the

--- a/scripts/check-tenant-scoping.mjs
+++ b/scripts/check-tenant-scoping.mjs
@@ -60,6 +60,9 @@ const ALLOWLIST = new Set([
   "src/app/api/admin/ai-config/route.ts",
   // Admin AI connection test — super_admin only, no tenant-scoped tables touched
   "src/app/api/admin/ai-config/test/route.ts",
+  // Admin AI task routing — super_admin per-task model pins; ai_task_configs
+  // is a platform-global table with no clinic_id column (migration 00179)
+  "src/app/api/admin/ai-task-config/route.ts",
   // AI route — unified AI endpoint with cross-tenant usage logging
   "src/app/api/ai/route.ts",
   // AI router/feature-toggles helpers — cross-tenant reads of ai_* tables

--- a/src/app/api/admin/ai-kill-switch/route.ts
+++ b/src/app/api/admin/ai-kill-switch/route.ts
@@ -20,6 +20,7 @@
 
 import { NextRequest } from "next/server";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api-response";
+import { isAiDisabledByEnv } from "@/lib/env";
 import { getKVBinding, isAIEnabled } from "@/lib/features";
 import { logger } from "@/lib/logger";
 import { withAuth } from "@/lib/with-auth";
@@ -30,7 +31,7 @@ const KILL_SWITCH_KEY = "ai.enabled";
 // ── GET: current state ──
 
 async function handleGet(_req: NextRequest, _auth: AuthContext) {
-  const envLocked = process.env.AI_DISABLED === "true"; // nosemgrep: semgrep.env-access — kill-switch status read
+  const envLocked = isAiDisabledByEnv();
 
   let kvAvailable = false;
   try {
@@ -67,8 +68,7 @@ async function handlePost(req: NextRequest, auth: AuthContext) {
     return apiValidationError("confirm: true is required to change the AI kill switch");
   }
 
-  if (enabled && process.env.AI_DISABLED === "true") {
-    // nosemgrep: semgrep.env-access — kill-switch guard
+  if (enabled && isAiDisabledByEnv()) {
     return apiError(
       "AI is disabled via the AI_DISABLED environment variable. Remove the env override to re-enable from the dashboard.",
       409,

--- a/src/app/api/admin/ai-task-config/route.ts
+++ b/src/app/api/admin/ai-task-config/route.ts
@@ -55,7 +55,7 @@ const PROVIDERS: readonly AIProvider[] = [
 async function handleGet(_req: NextRequest, _auth: AuthContext) {
   const supabase = createUntypedAdminClient("ai-task-config-list");
 
-  const { data, error } = await supabase // nosemgrep: semgrep.tenant-scoping
+  const { data, error } = await supabase
     .from("ai_task_configs")
     .select("id, task_type, pinned_provider, pinned_model, is_active, updated_at")
     .order("task_type");
@@ -150,10 +150,7 @@ async function handlePatch(req: NextRequest, auth: AuthContext) {
 
   const supabase = createUntypedAdminClient("ai-task-config-update");
 
-  const { error } = await supabase // nosemgrep: semgrep.tenant-scoping
-    .from("ai_task_configs")
-    .update(update)
-    .eq("task_type", taskType);
+  const { error } = await supabase.from("ai_task_configs").update(update).eq("task_type", taskType);
 
   if (error) {
     logger.error("Failed to update AI task config", {

--- a/src/lib/ai/task-config.ts
+++ b/src/lib/ai/task-config.ts
@@ -52,7 +52,7 @@ export async function loadTaskConfigs(supabase?: any): Promise<Map<AITaskType, T
 
   try {
     const client = supabase ?? createUntypedAdminClient("ai-task-config");
-    const { data, error } = await client // nosemgrep: semgrep.tenant-scoping
+    const { data, error } = await client
       .from("ai_task_configs")
       .select("task_type, pinned_provider, pinned_model, is_active");
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -407,6 +407,13 @@ export const ENV_RULES: EnvRule[] = [
     description: "Enable FHIR and complex CRM integrations. Default: false.",
     group: "feature-flags",
   },
+  {
+    name: "AI_DISABLED",
+    required: false,
+    description:
+      "Emergency AI kill switch override. When 'true', all AI features are disabled and the dashboard toggle is locked. Default: unset.",
+    group: "feature-flags",
+  },
 ];
 
 /**
@@ -422,6 +429,15 @@ export function isAiFeaturesEnabled(): boolean {
 
 export function isFhirEnabled(): boolean {
   return process.env.NEXT_PUBLIC_FHIR_ENABLED === "true";
+}
+
+/**
+ * Emergency AI kill switch env override (AI-KS). When AI_DISABLED=true the
+ * environment always wins over the dashboard KV toggle: AI stays off and the
+ * super-admin UI shows the switch as env-locked.
+ */
+export function isAiDisabledByEnv(): boolean {
+  return process.env.AI_DISABLED === "true";
 }
 
 /**


### PR DESCRIPTION
Properly addresses the 5 Semgrep findings the security bot raised on #1009, following each rule's prescribed fix instead of inline suppressions.

## env-access — `src/app/api/admin/ai-kill-switch/route.ts` (alerts 2032, 2033)
- Added `AI_DISABLED` to `ENV_RULES` and a documented `isAiDisabledByEnv()` helper in `src/lib/env.ts` (the canonical env reader).
- Replaced both direct `process.env.AI_DISABLED` reads with the helper.
- Note: the suppression at line 70 had been moved off the matched line by formatting, so it no longer suppressed anything — routing through `env.ts` fixes the finding for real.

## tenant-scoping — `ai-task-config/route.ts` + `lib/ai/task-config.ts` (alerts 2034–2036)
- `ai_task_configs` is a platform-global table (per-task model routing pins, no `clinic_id` column — see `00179_ai_task_configs.sql`).
- Per the rule's own guidance, added it to the whitelist in `.semgrep/tenant-scoping.yml` alongside `clinics` and `ai_provider_configs`, and removed the three inline suppressions.

No behavior change.