### PR TITLE
perf: eliminate duplicate auth round trips and bound dashboard queries

### DIFF
--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -45,9 +45,18 @@ export default function ReceptionistDashboardPage() {
         return;
       }
       setClinicId(user.clinic_id);
+      // PERF-LAT-05: this dashboard only renders today/tomorrow lists,
+      // recent status tabs and monthly revenue — fetch a 30-day lookback
+      // plus future rows instead of the clinic's full history (which was
+      // oldest-first and capped at 1000 rows, so busy clinics could even
+      // lose today's schedule).
+      const lookback = new Date();
+      lookback.setDate(lookback.getDate() - 30);
       const [appts, invoices, patients] = await Promise.all([
-        fetchAppointments(user.clinic_id),
-        fetchInvoices(user.clinic_id),
+        fetchAppointments(user.clinic_id, {
+          sinceDate: lookback.toISOString().split("T")[0],
+        }),
+        fetchInvoices(user.clinic_id, { sinceDate: lookback.toISOString() }),
         fetchPatients(user.clinic_id),
       ]);
       if (controller.signal.aborted) return;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,6 +6,7 @@ import { logAuthEvent } from "@/lib/audit-log";
 import { checkPasswordPwned } from "@/lib/hibp";
 import { logger } from "@/lib/logger";
 import { ROLE_DASHBOARD_MAP } from "@/lib/middleware/routes";
+import { verifyProfileHeader, PROFILE_HEADER_NAMES } from "@/lib/profile-header-hmac";
 import {
   loginLimiter,
   accountLockoutLimiter,
@@ -504,6 +505,42 @@ export async function signOut(): Promise<void> {
  */
 export async function getUserProfile(): Promise<UserProfile | null> {
   const supabase = await createClient();
+
+  // PERF-LAT-02: The middleware has ALREADY validated this session with
+  // Supabase Auth (getUser) and looked up the user's row, forwarding
+  // (id, role, clinic_id) via HMAC-signed x-auth-profile-* request headers
+  // (see middleware.ts / profile-header-hmac.ts — inbound copies are
+  // stripped, signatures expire after 5 minutes, and verification fails
+  // closed when PROFILE_HEADER_HMAC_KEY is unset). Re-running getUser()
+  // here added a second Supabase Auth network round trip to every page
+  // render. When the signed headers verify, skip it and fetch the full
+  // profile row directly by primary key — same trust model `withAuth`
+  // already uses for API routes. RLS still applies: the Supabase client
+  // carries the session cookies, and users can only read their own row.
+  let verified: Awaited<ReturnType<typeof verifyProfileHeader>> = null;
+  try {
+    const hdrs = await headers();
+    verified = await verifyProfileHeader({
+      id: hdrs.get(PROFILE_HEADER_NAMES.id),
+      role: hdrs.get(PROFILE_HEADER_NAMES.role),
+      clinic_id: hdrs.get(PROFILE_HEADER_NAMES.clinic),
+      signature: hdrs.get(PROFILE_HEADER_NAMES.sig),
+      iat: hdrs.get(PROFILE_HEADER_NAMES.iat),
+    });
+  } catch {
+    // headers() is unavailable outside a request scope (background jobs,
+    // unit tests) — fall back to the authoritative lookup below.
+  }
+
+  if (verified) {
+    const { data: profile } = await supabase
+      .from("users")
+      .select("id, auth_id, clinic_id, role, name, phone, email, avatar_url, is_active, metadata")
+      .eq("id", verified.id)
+      .single();
+    // Fall through to the authoritative path only if the row lookup failed.
+    if (profile) return profile as UserProfile;
+  }
 
   const {
     data: { user },

--- a/src/lib/data/client/appointments.ts
+++ b/src/lib/data/client/appointments.ts
@@ -86,10 +86,21 @@ function mapAppointment(raw: AppointmentRaw): AppointmentView {
   };
 }
 
-export async function fetchAppointments(clinicId: string): Promise<AppointmentView[]> {
+export async function fetchAppointments(
+  clinicId: string,
+  // PERF-LAT-05: optional lower bound (YYYY-MM-DD). Without it this query
+  // ships the clinic's entire appointment history to the browser, oldest
+  // first — and the 1000-row cap means busy clinics could miss today's
+  // rows entirely. Callers that only render recent/upcoming data should
+  // pass a sinceDate to bound payload size and query time.
+  options?: { sinceDate?: string },
+): Promise<AppointmentView[]> {
   await ensureLookups(clinicId);
   const rows = await fetchRows<AppointmentRaw>("appointments", {
     eq: [["clinic_id", clinicId]],
+    ...(options?.sinceDate
+      ? { gte: ["appointment_date", options.sinceDate] as [string, unknown] }
+      : {}),
     order: ["appointment_date", { ascending: true }],
   });
   return rows.map(mapAppointment);

--- a/src/lib/data/client/invoices.ts
+++ b/src/lib/data/client/invoices.ts
@@ -32,10 +32,17 @@ interface PaymentRaw {
   created_at: string;
 }
 
-export async function fetchInvoices(clinicId: string): Promise<InvoiceView[]> {
+export async function fetchInvoices(
+  clinicId: string,
+  // PERF-LAT-05: optional ISO timestamp lower bound. Without it this query
+  // ships the clinic's entire payment history to the browser. Callers that
+  // only aggregate recent revenue should pass a sinceDate.
+  options?: { sinceDate?: string },
+): Promise<InvoiceView[]> {
   await ensureLookups(clinicId);
   const rows = await fetchRows<PaymentRaw>("payments", {
     eq: [["clinic_id", clinicId]],
+    ...(options?.sinceDate ? { gte: ["created_at", options.sinceDate] as [string, unknown] } : {}),
     order: ["created_at", { ascending: false }],
   });
   return rows.map((r) => ({

--- a/src/lib/data/dashboard.ts
+++ b/src/lib/data/dashboard.ts
@@ -231,6 +231,19 @@ export async function getDoctorDashboardData(
 
   // Fetch doctor's appointments, patients, waiting room, invoices in parallel
   const today = getLocalDateStr();
+
+  // PERF-LAT-03: The dashboard view only renders current week/month stats,
+  // today's schedule, upcoming appointments and recent-history follow-ups.
+  // Previously this pulled the doctor's ENTIRE appointment history ordered
+  // ASCENDING with limit 1000 — so a busy clinic shipped its 1000 OLDEST
+  // rows over the wire (slow) and could miss today's schedule entirely
+  // once history exceeded the limit (wrong). Scope to a 90-day lookback
+  // (covers the week/month windows and follow-up detection) plus all
+  // future appointments.
+  const lookbackDate = new Date();
+  lookbackDate.setDate(lookbackDate.getDate() - 90);
+  const recentCutoff = getLocalDateStr(lookbackDate);
+
   const [apptsRes, patientsRes, waitingRes, invoicesRes] = await Promise.all([
     supabase
       .from("appointments")
@@ -239,6 +252,7 @@ export async function getDoctorDashboardData(
       )
       .eq("clinic_id", clinicId)
       .eq("doctor_id", doctorId)
+      .gte("appointment_date", recentCutoff)
       .order("appointment_date", { ascending: true })
       .limit(DEFAULT_QUERY_LIMIT),
     supabase
@@ -260,6 +274,9 @@ export async function getDoctorDashboardData(
       .from("payments")
       .select("id, appointment_id, amount, status, created_at")
       .eq("clinic_id", clinicId)
+      // PERF-LAT-03: the view only aggregates week/month revenue, so only
+      // payments within the lookback window can ever match.
+      .gte("created_at", lookbackDate.toISOString())
       .order("created_at", { ascending: false })
       .limit(DEFAULT_QUERY_LIMIT),
   ]);
@@ -445,8 +462,11 @@ export async function getPatientDashboardData(
   const supabase = await createClient();
 
   // Resolve clinic currency from DB config (DAL-04: was hardcoded to "MAD")
+  // PERF-LAT-04: kick off the config lookup without awaiting so it runs in
+  // parallel with the dashboard queries below instead of serially before
+  // them (saves one full DB round trip per patient dashboard render).
   const { getClinicConfig } = await import("@/lib/tenant");
-  const clinicCfg = await getClinicConfig(clinicId);
+  const clinicCfgPromise = getClinicConfig(clinicId);
 
   const [apptsRes, rxRes, invoicesRes, notifsRes] = await Promise.all([
     supabase
@@ -541,6 +561,8 @@ export async function getPatientDashboardData(
     date: r.created_at?.split("T")[0] ?? "",
     medications: Array.isArray(r.items) ? r.items : [],
   }));
+
+  const clinicCfg = await clinicCfgPromise;
 
   type InvRaw = { id: string; amount: number; status: string; created_at: string };
   const invoices: PatientInvoiceView[] = ((invoicesRes.data ?? []) as InvRaw[]).map((r) => ({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,7 @@
  * This file orchestrates the modules and handles Supabase auth.
  */
 import { createServerClient } from "@supabase/ssr";
+import type { User } from "@supabase/supabase-js";
 import { NextResponse, type NextRequest } from "next/server";
 import { getWorkerBinding } from "@/lib/cf-bindings";
 import { verifyCronSecret } from "@/lib/cron-auth";
@@ -435,11 +436,26 @@ export async function middleware(request: NextRequest) {
     requestHeaders.set("x-tenant-locale", tenantLocale);
   }
 
-  // IMPORTANT: Do NOT use getSession() here — it reads from cookies and
-  // can be tampered with. Use getUser() which validates with Supabase.
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // PERF-LAT-01: Anonymous fast path. supabase.auth.getUser() performs a
+  // network round trip to Supabase Auth on EVERY request that reaches this
+  // point — including all anonymous traffic on the public marketing site,
+  // crawlers and uptime probes. When the request carries no Supabase auth
+  // cookies there is no session to validate or refresh, so the call is pure
+  // added TTFB (typically 100–300ms from the edge). Skip it entirely and
+  // treat the request as unauthenticated; requests that DO carry
+  // sb-*-auth-token cookies still go through the authoritative getUser()
+  // validation below (never getSession() — cookies can be tampered with).
+  const hasSupabaseAuthCookies = request.cookies
+    .getAll()
+    .some((c) => c.name.startsWith("sb-") && c.name.includes("-auth-token"));
+
+  let user: User | null = null;
+  if (hasSupabaseAuthCookies) {
+    const {
+      data: { user: validatedUser },
+    } = await supabase.auth.getUser();
+    user = validatedUser;
+  }
 
   // SEED-01: Block seed users from accessing any route in production.
   // Sign them out and redirect to login with an error.


### PR DESCRIPTION
## Why
Dashboard and public site feel slow. Profiling the request path found the latency is dominated by redundant network round trips, not rendering.

## What was happening per page view
1. **Middleware** called `supabase.auth.getUser()` (network round trip to Supabase Auth) on **every** request — including all anonymous traffic on the public marketing site, where no session can exist.
2. **Every server-rendered page** then called `requireAuth()` → `getUserProfile()`, which ran a **second** `getUser()` round trip plus a **second** profile query — duplicating work the middleware had just done and already forwarded via HMAC-signed `x-auth-profile-*` headers.
3. **Doctor dashboard** fetched the clinic's *entire* appointment history **ascending** with `limit 1000` — busy clinics shipped their 1000 *oldest* rows and could literally lose today's schedule once history passed 1000 rows. Payments likewise unbounded.
4. **Receptionist dashboard** pulled the clinic's full appointment + payment history into the browser to render today/tomorrow lists and monthly revenue.
5. **Patient dashboard** awaited `getClinicConfig()` serially before its parallel query batch.

## Changes
- **PERF-LAT-01** `middleware.ts`: anonymous fast path — skip `getUser()` when the request has no `sb-*-auth-token` cookies. Sessions that do exist still go through the authoritative `getUser()` (never `getSession()`).
- **PERF-LAT-02** `lib/auth.ts`: `getUserProfile()` verifies the signed profile headers (same trust model as `withAuth`: stripped inbound, HMAC + 5-min iat expiry, fails closed without `PROFILE_HEADER_HMAC_KEY`) and fetches the profile row by primary key, removing the duplicate auth round trip. Authoritative fallback path unchanged.
- **PERF-LAT-03** `lib/data/dashboard.ts`: doctor dashboard scoped to a 90-day lookback + future appointments; payments scoped to the same window (the view only aggregates week/month). Also fixes the missing-today correctness bug above.
- **PERF-LAT-04** patient dashboard: `getClinicConfig()` now runs in parallel with the query batch.
- **PERF-LAT-05** `fetchAppointments`/`fetchInvoices` accept an optional `sinceDate`; receptionist dashboard passes a 30-day lookback. Other callers unchanged.

## Expected impact
- Public site TTFB: one full Supabase Auth round trip removed from every anonymous request (~100–300ms from the edge, also reduces Worker CPU/wall time toward the 50ms budget noted in AUDIT-25).
- Authenticated pages: one auth round trip + duplicate logic removed per render.
- Dashboards: payloads drop from up-to-1000 historical rows per table to the actual working set; today's schedule can no longer be crowded out.

## Verification
- `tsc --noEmit` clean
- `vitest`: auth + middleware suites + public-api-surface + route-inventory — 98 tests passing
- `eslint` 0 errors, `prettier --check` clean on all changed files

## Follow-ups worth considering (not in this PR)
- `getDashboardStats` (admin) fetches all payment amounts and reviews unbounded to compute aggregates — should move to a SQL aggregate/RPC.
- Receptionist dashboard is fully client-side (`getCurrentUser` → fetch waterfall after hydration); converting initial data to a Server Component would remove another visible loading stage.