### PR TITLE
fix(admin): surface AI model management UI and fix access roles

### DIFF
--- a/src/app/(admin)/admin/ai-config/page.tsx
+++ b/src/app/(admin)/admin/ai-config/page.tsx
@@ -203,6 +203,11 @@ export default function AIConfigAdminPage() {
         credentials: "include",
         body: JSON.stringify({ feature_key: featureKey, is_enabled: !currentEnabled }),
       });
+      if (res.status === 403) {
+        throw new Error(
+          "Seul le super admin peut activer/désactiver les fonctionnalités IA (réglage global de la plateforme).",
+        );
+      }
       if (!res.ok) throw new Error("Échec de la mise à jour");
       await loadConfig();
     } catch (err) {

--- a/src/app/(super-admin)/super-admin/settings/page.tsx
+++ b/src/app/(super-admin)/super-admin/settings/page.tsx
@@ -1,7 +1,17 @@
 /* eslint-disable i18next/no-literal-string -- Admin/super-admin internal surface: French UI strings are the intended output language; adding them to the i18n keyset would inflate the translation backlog for internal-only tooling. */
 "use client";
 
-import { Globe, Clock, Bell, RefreshCw, Info, Save, Loader2, Bot, ChevronRight } from "lucide-react";
+import {
+  Globe,
+  Clock,
+  Bell,
+  RefreshCw,
+  Info,
+  Save,
+  Loader2,
+  Bot,
+  ChevronRight,
+} from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";

--- a/src/app/(super-admin)/super-admin/settings/page.tsx
+++ b/src/app/(super-admin)/super-admin/settings/page.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable i18next/no-literal-string -- Admin/super-admin internal surface: French UI strings are the intended output language; adding them to the i18n keyset would inflate the translation backlog for internal-only tooling. */
 "use client";
 
-import { Globe, Clock, Bell, RefreshCw, Info, Save, Loader2 } from "lucide-react";
+import { Globe, Clock, Bell, RefreshCw, Info, Save, Loader2, Bot, ChevronRight } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -80,6 +81,25 @@ export default function SettingsPage() {
       </div>
 
       <div className="grid gap-6">
+        {/* AI model management shortcut */}
+        <Link href="/super-admin/settings/ai" className="block group">
+          <Card className="transition-colors group-hover:border-violet-400">
+            <CardContent className="flex items-center justify-between py-4">
+              <div className="flex items-center gap-3">
+                <Bot className="h-5 w-5 text-violet-600" />
+                <div>
+                  <p className="font-medium text-sm">AI Models &amp; Routing</p>
+                  <p className="text-xs text-muted-foreground">
+                    Provider API keys, working status, monthly spend, budgets, task routing
+                    (chatbot, summaries, translation…) and the emergency kill switch.
+                  </p>
+                </div>
+              </div>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            </CardContent>
+          </Card>
+        </Link>
+
         {/* Language & Timezone */}
         <Card>
           <CardHeader>

--- a/src/app/api/admin/ai-config/route.ts
+++ b/src/app/api/admin/ai-config/route.ts
@@ -5,7 +5,12 @@
  * PATCH — update a provider config (API key, active state, budget)
  * POST — update feature toggles
  *
- * Super admin only. API keys are encrypted with AES-256-GCM (PHI_ENCRYPTION_KEY)
+ * GET is readable by super_admin and clinic_admin (the clinic admin AI pages
+ * at /admin/ai-config and /admin/ai-routing render status, spend, and budget
+ * data from it). Writes (PATCH/POST) stay super_admin only because provider
+ * configs and feature toggles are platform-global, not per-clinic.
+ *
+ * API keys are encrypted with AES-256-GCM (PHI_ENCRYPTION_KEY)
  * before insert/update via `encryptProviderKey`. Keys are never returned in
  * the GET response — only a `has_api_key` boolean.
  *
@@ -245,7 +250,7 @@ async function handlePost(req: NextRequest, _auth: AuthContext) {
   return apiSuccess({ updated: true, feature_key: featureKey, is_enabled: isEnabled });
 }
 
-export const GET = withAuth((req, auth) => handleGet(req, auth), ["super_admin"]);
+export const GET = withAuth((req, auth) => handleGet(req, auth), ["super_admin", "clinic_admin"]);
 
 export const PATCH = withAuth((req, auth) => handlePatch(req, auth), ["super_admin"]);
 

--- a/src/components/layouts/admin-layout-shell.tsx
+++ b/src/components/layouts/admin-layout-shell.tsx
@@ -26,6 +26,8 @@ import {
   Boxes,
   FileText,
   Brain,
+  Cpu,
+  Route,
   ScrollText,
   DatabaseZap,
   Gift,
@@ -129,6 +131,8 @@ const navItems: NavItem[] = [
   },
   // AI-powered features (Professional+ plan)
   { href: "/admin/ai-manager", label: "AI Manager", icon: Brain, requiredFeature: "ai_manager" },
+  { href: "/admin/ai-config", label: "AI Models", icon: Cpu },
+  { href: "/admin/ai-routing", label: "AI Routing", icon: Route },
   // Security & Compliance
   { href: "/admin/audit-logs", label: "Audit Logs", icon: ScrollText },
   { href: "/admin/data-retention", label: "Data Retention", icon: DatabaseZap },


### PR DESCRIPTION
## Problem
There was no visible place in the app to manage AI models, check whether providers are working, see monthly spend, or choose which model handles which feature (chatbot, summaries, etc.).

It turns out all of this was already built, but unreachable:

- `/admin/ai-config` (providers, status, budgets, spend, traces, memories) and `/admin/ai-routing` (provider health, fallback chains, cost per task) had **no link in any menu**.
- Both pages call `GET /api/admin/ai-config`, which was restricted to `super_admin`, so clinic admins got a 403 even with the direct URL.
- The per-task model routing UI (incl. the **Chatbot** row) lives in `/super-admin/settings/ai` but was easy to miss from the Settings hub.

## Changes
- Add **AI Models** and **AI Routing** entries to the clinic admin sidebar
- Allow `clinic_admin` on `GET /api/admin/ai-config` (read-only view of status/spend). Writes (`PATCH`/`POST`) stay `super_admin`-only because provider configs and feature toggles are platform-global
- Add an **AI Models & Routing** shortcut card at the top of `/super-admin/settings` linking to `/super-admin/settings/ai`
- Show a clear French permission message when a clinic admin tries to flip a platform-global AI feature toggle

## Verification
- `tsc --noEmit`: clean
- `eslint` on all 4 changed files: clean
- `vitest run` on `ai-config` + `ai-models` tests: 27/27 passing