### PR TITLE
fix(security): enable RLS on patient_files with clinic-scoped policy (audit Task 1, P0)

### DIFF
--- a/src/lib/__tests__/integration/rls-real-postgres.test.ts
+++ b/src/lib/__tests__/integration/rls-real-postgres.test.ts
@@ -89,6 +89,9 @@ const CORE_PHI_TABLES = [
   "family_members",
   "installments",
   "users",
+  // Audit 2026-06-09 Task 1: PHI uploads system of record.
+  // RLS enabled in migration 00180_patient_files_rls.sql.
+  "patient_files",
 ] as const;
 
 describe.skipIf(SKIP)("RLS Real Postgres Tests", () => {
@@ -180,6 +183,51 @@ describe.skipIf(SKIP)("RLS Real Postgres Tests", () => {
         }
       },
     );
+  });
+
+  describe("patient_files RLS (audit 2026-06-09 Task 1)", () => {
+    it("anon client for clinic A cannot read clinic B patient_files", async () => {
+      const clientA = createAnonClientForClinic(CLINIC_A_ID);
+
+      const { data, error } = await clientA
+        .from("patient_files")
+        .select("id, clinic_id, r2_key")
+        .eq("clinic_id", CLINIC_B_ID)
+        .limit(5);
+
+      // Either an empty array (RLS blocked) or a permission error is
+      // acceptable. What is NOT acceptable: clinic B PHI file records
+      // (R2 keys, encryption IVs) leaking through.
+      if (!error) {
+        expect(data ?? []).toHaveLength(0);
+      } else {
+        expect(error.message).toMatch(/does not exist|permission denied|relation/i);
+      }
+    });
+
+    it("anon client cannot insert a patient_files record for another clinic", async () => {
+      const clientA = createAnonClientForClinic(CLINIC_A_ID);
+      const marker = "rls-test/injected-patient-file";
+
+      const { error } = await clientA.from("patient_files").insert({
+        clinic_id: CLINIC_B_ID,
+        patient_id: "33333333-3333-3333-3333-333333333333",
+        file_name: "injected.pdf",
+        file_type: "application/pdf",
+        file_size: 1,
+        r2_key: marker,
+      });
+
+      // RLS should block this — either a policy/permission error or the
+      // insert silently affects 0 rows.
+      if (error) {
+        expect(error.message).toMatch(/policy|permission|violates|denied/i);
+      }
+      // Backstop: verify the row was NOT actually created.
+      const admin = createAdminClient();
+      const { data } = await admin.from("patient_files").select("id").eq("r2_key", marker).limit(1);
+      expect(data ?? []).toHaveLength(0);
+    });
   });
 
   describe("Cross-tenant INSERT isolation", () => {

--- a/supabase/migrations/00180_patient_files_rls.sql
+++ b/supabase/migrations/00180_patient_files_rls.sql
@@ -1,0 +1,39 @@
+-- 00180: Enable Row-Level Security on patient_files (audit 2026-06-09, Task 1 / P0)
+--
+-- patient_files is the system of record for PHI uploads (R2 object keys,
+-- encryption IVs, patient/clinic linkage). It was the only one of the
+-- 261 tables without ENABLE ROW LEVEL SECURITY: 00165 created it (as a
+-- guard for environments where it was historically provisioned
+-- out-of-band) and gave its sibling medical_alerts a clinic-scoped
+-- policy in the same file, but never enabled RLS on patient_files itself.
+--
+-- This migration applies the exact defense-in-depth pattern used for
+-- medical_alerts in 00165:
+--   * RLS enabled on the table
+--   * one clinic-scoped policy keyed on get_request_clinic_id()
+--     (see 00041_fix_rls_use_request_headers.sql) for authenticated users
+--
+-- Impact on existing code paths (verified at time of writing):
+--   * supabase/functions/parse-medical-document uses the service-role key
+--     and bypasses RLS — unaffected.
+--   * api/files/download and api/files/extraction-status run with an
+--     authenticated session client plus tenant context set by with-auth,
+--     so same-clinic access continues to work; cross-clinic access is now
+--     also blocked at the database layer, not just in route code.
+--
+-- All operations are idempotent (safe to re-run; safe on environments
+-- where the table predates the migration chain).
+
+ALTER TABLE patient_files ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users may access file records for their own clinic only.
+-- For a FOR ALL policy the USING clause also serves as the WITH CHECK
+-- clause, so cross-clinic INSERT/UPDATE/DELETE is denied as well.
+DO $$ BEGIN
+  CREATE POLICY "patient_files_clinic_access"
+    ON patient_files FOR ALL
+    USING (
+      clinic_id = get_request_clinic_id()
+      AND auth.role() = 'authenticated'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
## Audit 2026-06-09 — Task 1 (P0 launch blocker)

`patient_files` is the system of record for PHI uploads (R2 object keys, encryption IVs, patient/clinic linkage) and was the **only one of 261 tables** created without `ENABLE ROW LEVEL SECURITY`. Migration 00165 created it and gave its sibling `medical_alerts` a clinic-scoped policy in the same file, but never enabled RLS on `patient_files` itself.

### Changes
- **`supabase/migrations/00180_patient_files_rls.sql`** — enables RLS on `patient_files` and adds one clinic-scoped `FOR ALL` policy using the same `get_request_clinic_id()` + `auth.role() = 'authenticated'` pattern as `medical_alerts` (00165). Idempotent, safe on environments where the table was provisioned out-of-band.
- **`rls-real-postgres.test.ts`** — adds `patient_files` to `CORE_PHI_TABLES` (cross-tenant SELECT + no-context SELECT matrix) and a dedicated describe block with a cross-tenant SELECT denial case and a cross-clinic INSERT denial case backed by a service-role backstop check.

### Verified impact on live code paths
- `supabase/functions/parse-medical-document` uses the service-role key → bypasses RLS, unaffected.
- `api/files/download` and `api/files/extraction-status` run with an authenticated session client + tenant context set by `with-auth` → same-clinic access keeps working; cross-clinic access is now also blocked at the DB layer (defense-in-depth, both layers agree).

### Acceptance criteria (from the audit plan)
- [x] Migration enabling RLS + clinic-scoped policy for `patient_files`
- [x] `patient_files` cross-tenant denial cases in the RLS integration tests
- [ ] **Operator action after merge:** confirm staging and production actually have the policy applied (`select relrowsecurity from pg_class where relname = 'patient_files';` + `select * from pg_policies where tablename = 'patient_files';`) — the table was historically created out-of-band, so verify live state, not just migrations.
