### PR TITLE
perf: single-RPC admin stats and server-rendered receptionist dashboard

### DIFF
--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -1,376 +1,42 @@
-"use client";
+import { ReceptionistDashboardView } from "@/components/receptionist/receptionist-dashboard-view";
+import { requireAuth } from "@/lib/auth";
+import { getReceptionistDashboardData } from "@/lib/data/dashboard";
 
-import { Calendar, Users, UserPlus, Clock, CreditCard, FileText } from "lucide-react";
-import { useState, useEffect } from "react";
-import { AppointmentCard } from "@/components/receptionist/appointment-card";
-import { CashRegister } from "@/components/receptionist/cash-register";
-import { EndOfDayReportButton } from "@/components/receptionist/end-of-day-report-button";
-import { ManualBookingDialog } from "@/components/receptionist/manual-booking-dialog";
-import { PaymentDialog } from "@/components/receptionist/payment-dialog";
-import { QuickPatientRegistration } from "@/components/receptionist/quick-patient-registration";
-import { RealtimeWaitingRoom } from "@/components/receptionist/realtime-waiting-room";
-import { ReceptionistAIWidget } from "@/components/receptionist/receptionist-ai-widget";
-import { WalkInDialog } from "@/components/receptionist/walk-in-dialog";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { EmptyState } from "@/components/ui/empty-state";
-import { PageLoader } from "@/components/ui/page-loader";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import {
-  getCurrentUser,
-  fetchAppointments,
-  fetchInvoices,
-  fetchPatients,
-  type AppointmentView,
-  type PatientView,
-} from "@/lib/data/client";
-import { formatCurrency } from "@/lib/utils";
+/**
+ * PERF-LAT-07: Server Component entry point for the receptionist dashboard.
+ *
+ * Previously this page was entirely client-side: it shipped a spinner,
+ * hydrated, then ran getCurrentUser() (a browser→Supabase auth round trip)
+ * followed by three data fetches — every visit paid a full client-side
+ * waterfall before anything useful rendered. Data is now fetched during the
+ * server render (one parallel query batch; see getReceptionistDashboardData)
+ * and streamed with the HTML, with the route group's loading.tsx skeleton
+ * as the streaming fallback. Role access is enforced by middleware
+ * (ROLE_ROUTE_MAP) and requireAuth.
+ */
+export default async function ReceptionistDashboardPage() {
+  const profile = await requireAuth();
 
-export default function ReceptionistDashboardPage() {
-  const [todayAppts, setTodayAppts] = useState<AppointmentView[]>([]);
-  const [patientMap, setPatientMap] = useState<Map<string, PatientView>>(new Map());
-  const [totalRevenue, setTotalRevenue] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [checkedInIds, setCheckedInIds] = useState<Set<string>>(new Set());
-  const [clinicId, setClinicId] = useState("");
-
-  useEffect(() => {
-    const controller = new AbortController();
-    async function load() {
-      const user = await getCurrentUser();
-      if (controller.signal.aborted) return;
-      if (!user?.clinic_id) {
-        setLoading(false);
-        return;
-      }
-      setClinicId(user.clinic_id);
-      // PERF-LAT-05: this dashboard only renders today/tomorrow lists,
-      // recent status tabs and monthly revenue — fetch a 30-day lookback
-      // plus future rows instead of the clinic's full history (which was
-      // oldest-first and capped at 1000 rows, so busy clinics could even
-      // lose today's schedule).
-      const lookback = new Date();
-      lookback.setDate(lookback.getDate() - 30);
-      const [appts, invoices, patients] = await Promise.all([
-        fetchAppointments(user.clinic_id, {
-          sinceDate: lookback.toISOString().split("T")[0],
-        }),
-        fetchInvoices(user.clinic_id, { sinceDate: lookback.toISOString() }),
-        fetchPatients(user.clinic_id),
-      ]);
-      if (controller.signal.aborted) return;
-      setTodayAppts(appts);
-      setPatientMap(new Map(patients.map((p) => [p.id, p])));
-      const revenue = invoices
-        .filter((inv) => inv.status === "paid")
-        .reduce((sum, inv) => sum + inv.amount, 0);
-      setTotalRevenue(revenue);
-      setLoading(false);
-    }
-    load().catch((err) => {
-      if (!controller.signal.aborted) {
-        setError(err instanceof Error ? err : new Error(String(err)));
-        setLoading(false);
-      }
-    });
-    return () => {
-      controller.abort();
-    };
-  }, []);
-
-  const todayDateStr = new Date().toISOString().split("T")[0];
-  const tomorrowDate = new Date();
-  tomorrowDate.setDate(tomorrowDate.getDate() + 1);
-  const tomorrowDateStr = tomorrowDate.toISOString().split("T")[0];
-
-  const todayApptsFiltered = todayAppts.filter((a) => a.date === todayDateStr);
-  const tomorrowAppts = todayAppts.filter((a) => a.date === tomorrowDateStr);
-  const checkedInAppts = todayAppts.filter(
-    (a) => checkedInIds.has(a.id) || a.status === "in-progress",
-  );
-  const waitingAppts = todayApptsFiltered.filter(
-    (a) => checkedInIds.has(a.id) && a.status !== "completed",
-  );
-  const completedAppts = todayAppts.filter((a) => a.status === "completed");
-  const cancelledAppts = todayAppts.filter((a) => a.status === "cancelled");
-  const noShowAppts = todayAppts.filter((a) => a.status === "no-show");
-
-  const checkedInCount = todayApptsFiltered.filter(
-    (a) => a.status === "confirmed" || a.status === "in-progress",
-  ).length;
-
-  const stats = [
-    {
-      icon: Calendar,
-      label: "Today's Bookings",
-      value: todayApptsFiltered.length.toString(),
-      color: "text-blue-600",
-    },
-    {
-      icon: Users,
-      label: "Checked In",
-      value: (checkedInCount + checkedInIds.size).toString(),
-      color: "text-green-600",
-    },
-    { icon: UserPlus, label: "Walk-ins Today", value: "0", color: "text-purple-600" },
-    {
-      icon: CreditCard,
-      label: "Revenue (Month)",
-      value: `${formatCurrency(totalRevenue)}`,
-      color: "text-orange-600",
-    },
-  ];
-
-  const handleCheckIn = (id: string) => {
-    setCheckedInIds((prev) => new Set(prev).add(id));
-  };
-
-  const handleConfirm = (id: string) => {
-    setTodayAppts((prev) => prev.map((a) => (a.id === id ? { ...a, status: "confirmed" } : a)));
-  };
-
-  const handleCancel = (id: string) => {
-    setTodayAppts((prev) => prev.map((a) => (a.id === id ? { ...a, status: "cancelled" } : a)));
-  };
-
-  const handleNoShow = (id: string) => {
-    setTodayAppts((prev) => prev.map((a) => (a.id === id ? { ...a, status: "no-show" } : a)));
-  };
-
-  const handleReschedule = (_id: string) => {
-    // TODO: Implement reschedule flow (open reschedule dialog)
-  };
-
-  const renderApptList = (appointments: AppointmentView[], emptyMessage: string) => {
-    if (appointments.length === 0) {
-      return (
-        <EmptyState
-          icon={Calendar}
-          title={emptyMessage}
-          description="Click Manual Booking or Walk-in Registration to add an appointment."
-        />
-      );
-    }
+  // Mirror the legacy behavior for a receptionist with no clinic assigned:
+  // render the dashboard shell with empty data instead of erroring.
+  if (!profile.clinic_id) {
     return (
-      <div className="space-y-2 max-h-[500px] overflow-y-auto pr-1">
-        {appointments.map((apt) => (
-          <AppointmentCard
-            key={apt.id}
-            appointment={apt}
-            patient={patientMap.get(apt.patientId)}
-            isCheckedIn={checkedInIds.has(apt.id)}
-            onCheckIn={handleCheckIn}
-            onConfirm={handleConfirm}
-            onCancel={handleCancel}
-            onNoShow={handleNoShow}
-            onReschedule={handleReschedule}
-          />
-        ))}
-      </div>
-    );
-  };
-
-  if (loading) {
-    return <PageLoader message="Loading dashboard..." />;
-  }
-
-  if (error) {
-    return (
-      <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
-        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
-      </div>
+      <ReceptionistDashboardView
+        clinicId=""
+        initialAppointments={[]}
+        patients={[]}
+        totalRevenue={0}
+      />
     );
   }
 
+  const data = await getReceptionistDashboardData(profile.clinic_id);
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Reception Dashboard</h1>
-        <div className="flex gap-2">
-          <ManualBookingDialog
-            trigger={
-              <Button variant="outline" size="sm">
-                <Calendar className="h-4 w-4 mr-1" />
-                Manual Booking
-              </Button>
-            }
-          />
-          <EndOfDayReportButton />
-        </div>
-      </div>
-
-      {/* Stats Row */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
-        {stats.map((stat) => (
-          <Card key={stat.label}>
-            <CardContent className="flex items-center gap-4 p-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
-                <stat.icon className={`h-5 w-5 ${stat.color}`} />
-              </div>
-              <div>
-                <p className="text-2xl font-bold">{stat.value}</p>
-                <p className="text-xs text-muted-foreground">{stat.label}</p>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {/* Three-column layout: Schedule | Waiting Room | Quick Actions */}
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* Column 1: Appointment Board */}
-        <Card className="lg:col-span-1">
-          <CardHeader>
-            <CardTitle className="text-base flex items-center gap-2">
-              <Calendar className="h-4 w-4" />
-              Appointment Board
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <Tabs defaultValue="today" className="w-full">
-              <TabsList className="w-full justify-start overflow-x-auto h-auto flex-wrap mb-4 bg-transparent p-0 gap-1">
-                <TabsTrigger
-                  value="today"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  Today
-                </TabsTrigger>
-                <TabsTrigger
-                  value="tomorrow"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  Tomorrow
-                </TabsTrigger>
-                <TabsTrigger
-                  value="checked-in"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  Checked In
-                </TabsTrigger>
-                <TabsTrigger
-                  value="waiting"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  Waiting
-                </TabsTrigger>
-                <TabsTrigger
-                  value="completed"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  Completed
-                </TabsTrigger>
-                <TabsTrigger
-                  value="cancelled"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  Cancelled
-                </TabsTrigger>
-                <TabsTrigger
-                  value="no-show"
-                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
-                >
-                  No-show
-                </TabsTrigger>
-              </TabsList>
-
-              <TabsContent value="today" className="m-0">
-                {renderApptList(todayApptsFiltered, "No appointments scheduled for today.")}
-              </TabsContent>
-              <TabsContent value="tomorrow" className="m-0">
-                {renderApptList(tomorrowAppts, "No appointments scheduled for tomorrow.")}
-              </TabsContent>
-              <TabsContent value="checked-in" className="m-0">
-                {renderApptList(checkedInAppts, "No patients currently checked in.")}
-              </TabsContent>
-              <TabsContent value="waiting" className="m-0">
-                {renderApptList(waitingAppts, "No patients waiting.")}
-              </TabsContent>
-              <TabsContent value="completed" className="m-0">
-                {renderApptList(completedAppts, "No completed appointments yet.")}
-              </TabsContent>
-              <TabsContent value="cancelled" className="m-0">
-                {renderApptList(cancelledAppts, "No cancelled appointments.")}
-              </TabsContent>
-              <TabsContent value="no-show" className="m-0">
-                {renderApptList(noShowAppts, "No no-shows recorded.")}
-              </TabsContent>
-            </Tabs>
-          </CardContent>
-        </Card>
-
-        {/* Column 2: Waiting Room (Real-time via Supabase) */}
-        {clinicId ? (
-          <RealtimeWaitingRoom clinicId={clinicId} onCallIn={(id) => handleCheckIn(id)} />
-        ) : (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base flex items-center gap-2">
-                <Clock className="h-4 w-4" />
-                Waiting Room
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-sm text-muted-foreground">Loading...</p>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Column 3: Quick Actions */}
-        <div className="space-y-4">
-          {/* Walk-in Registration */}
-          <WalkInDialog
-            trigger={
-              <Button className="w-full">
-                <UserPlus className="h-4 w-4 mr-1" />
-                Walk-in Registration
-              </Button>
-            }
-          />
-
-          {/* Quick Patient Registration */}
-          {clinicId && <QuickPatientRegistration clinicId={clinicId} />}
-
-          {/* Cash Register */}
-          <CashRegister />
-
-          {/* Quick Links */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <FileText className="h-4 w-4" />
-                Quick Links
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              <a href="/receptionist/daily-report" className="block">
-                <Button variant="outline" size="sm" className="w-full justify-start">
-                  <FileText className="h-3.5 w-3.5 mr-2" />
-                  Full Daily Report
-                </Button>
-              </a>
-              <PaymentDialog
-                trigger={
-                  <Button variant="outline" size="sm" className="w-full justify-start">
-                    <CreditCard className="h-3.5 w-3.5 mr-2" />
-                    Advanced Payment
-                  </Button>
-                }
-              />
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      {/* Receptionist AI Widget */}
-      {clinicId && (
-        <div className="mt-6">
-          <ReceptionistAIWidget clinicId={clinicId} />
-        </div>
-      )}
-    </div>
+    <ReceptionistDashboardView
+      clinicId={profile.clinic_id}
+      initialAppointments={data.appointments}
+      patients={data.patients}
+      totalRevenue={data.totalRevenue}
+    />
   );
 }

--- a/src/components/receptionist/receptionist-dashboard-view.tsx
+++ b/src/components/receptionist/receptionist-dashboard-view.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import { Calendar, Users, UserPlus, Clock, CreditCard, FileText } from "lucide-react";
+import { useMemo, useState } from "react";
+import { AppointmentCard } from "@/components/receptionist/appointment-card";
+import { CashRegister } from "@/components/receptionist/cash-register";
+import { EndOfDayReportButton } from "@/components/receptionist/end-of-day-report-button";
+import { ManualBookingDialog } from "@/components/receptionist/manual-booking-dialog";
+import { PaymentDialog } from "@/components/receptionist/payment-dialog";
+import { QuickPatientRegistration } from "@/components/receptionist/quick-patient-registration";
+import { RealtimeWaitingRoom } from "@/components/receptionist/realtime-waiting-room";
+import { ReceptionistAIWidget } from "@/components/receptionist/receptionist-ai-widget";
+import { WalkInDialog } from "@/components/receptionist/walk-in-dialog";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import type { AppointmentView } from "@/lib/data/client/appointments";
+import type { PatientView } from "@/lib/data/client/users";
+import { formatCurrency } from "@/lib/utils";
+
+/**
+ * PERF-LAT-07: Client view for the receptionist dashboard.
+ *
+ * Extracted from the former all-client page so the data can be fetched
+ * during the server render (see getReceptionistDashboardData) instead of
+ * via a post-hydration getCurrentUser → fetch waterfall. This component
+ * keeps all the interactive behavior (tabs, check-in state, optimistic
+ * status updates, dialogs, realtime waiting room) but receives its initial
+ * data as props.
+ */
+interface ReceptionistDashboardViewProps {
+  clinicId: string;
+  initialAppointments: AppointmentView[];
+  patients: PatientView[];
+  totalRevenue: number;
+}
+
+export function ReceptionistDashboardView({
+  clinicId,
+  initialAppointments,
+  patients,
+  totalRevenue,
+}: ReceptionistDashboardViewProps) {
+  const [todayAppts, setTodayAppts] = useState<AppointmentView[]>(initialAppointments);
+  const [checkedInIds, setCheckedInIds] = useState<Set<string>>(new Set());
+  const patientMap = useMemo(
+    () => new Map<string, PatientView>(patients.map((p) => [p.id, p])),
+    [patients],
+  );
+
+  const todayDateStr = new Date().toISOString().split("T")[0];
+  const tomorrowDate = new Date();
+  tomorrowDate.setDate(tomorrowDate.getDate() + 1);
+  const tomorrowDateStr = tomorrowDate.toISOString().split("T")[0];
+
+  const todayApptsFiltered = todayAppts.filter((a) => a.date === todayDateStr);
+  const tomorrowAppts = todayAppts.filter((a) => a.date === tomorrowDateStr);
+  const checkedInAppts = todayAppts.filter(
+    (a) => checkedInIds.has(a.id) || a.status === "in-progress",
+  );
+  const waitingAppts = todayApptsFiltered.filter(
+    (a) => checkedInIds.has(a.id) && a.status !== "completed",
+  );
+  const completedAppts = todayAppts.filter((a) => a.status === "completed");
+  const cancelledAppts = todayAppts.filter((a) => a.status === "cancelled");
+  const noShowAppts = todayAppts.filter((a) => a.status === "no-show");
+
+  const checkedInCount = todayApptsFiltered.filter(
+    (a) => a.status === "confirmed" || a.status === "in-progress",
+  ).length;
+
+  const stats = [
+    {
+      icon: Calendar,
+      label: "Today's Bookings",
+      value: todayApptsFiltered.length.toString(),
+      color: "text-blue-600",
+    },
+    {
+      icon: Users,
+      label: "Checked In",
+      value: (checkedInCount + checkedInIds.size).toString(),
+      color: "text-green-600",
+    },
+    { icon: UserPlus, label: "Walk-ins Today", value: "0", color: "text-purple-600" },
+    {
+      icon: CreditCard,
+      label: "Revenue (Month)",
+      value: `${formatCurrency(totalRevenue)}`,
+      color: "text-orange-600",
+    },
+  ];
+
+  const handleCheckIn = (id: string) => {
+    setCheckedInIds((prev) => new Set(prev).add(id));
+  };
+
+  const handleConfirm = (id: string) => {
+    setTodayAppts((prev) => prev.map((a) => (a.id === id ? { ...a, status: "confirmed" } : a)));
+  };
+
+  const handleCancel = (id: string) => {
+    setTodayAppts((prev) => prev.map((a) => (a.id === id ? { ...a, status: "cancelled" } : a)));
+  };
+
+  const handleNoShow = (id: string) => {
+    setTodayAppts((prev) => prev.map((a) => (a.id === id ? { ...a, status: "no-show" } : a)));
+  };
+
+  const handleReschedule = (_id: string) => {
+    // TODO: Implement reschedule flow (open reschedule dialog)
+  };
+
+  const renderApptList = (appointments: AppointmentView[], emptyMessage: string) => {
+    if (appointments.length === 0) {
+      return (
+        <EmptyState
+          icon={Calendar}
+          title={emptyMessage}
+          description="Click Manual Booking or Walk-in Registration to add an appointment."
+        />
+      );
+    }
+    return (
+      <div className="space-y-2 max-h-[500px] overflow-y-auto pr-1">
+        {appointments.map((apt) => (
+          <AppointmentCard
+            key={apt.id}
+            appointment={apt}
+            patient={patientMap.get(apt.patientId)}
+            isCheckedIn={checkedInIds.has(apt.id)}
+            onCheckIn={handleCheckIn}
+            onConfirm={handleConfirm}
+            onCancel={handleCancel}
+            onNoShow={handleNoShow}
+            onReschedule={handleReschedule}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Reception Dashboard</h1>
+        <div className="flex gap-2">
+          <ManualBookingDialog
+            trigger={
+              <Button variant="outline" size="sm">
+                <Calendar className="h-4 w-4 mr-1" />
+                Manual Booking
+              </Button>
+            }
+          />
+          <EndOfDayReportButton />
+        </div>
+      </div>
+
+      {/* Stats Row */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-6">
+        {stats.map((stat) => (
+          <Card key={stat.label}>
+            <CardContent className="flex items-center gap-4 p-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
+                <stat.icon className={`h-5 w-5 ${stat.color}`} />
+              </div>
+              <div>
+                <p className="text-2xl font-bold">{stat.value}</p>
+                <p className="text-xs text-muted-foreground">{stat.label}</p>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Three-column layout: Schedule | Waiting Room | Quick Actions */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Column 1: Appointment Board */}
+        <Card className="lg:col-span-1">
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Calendar className="h-4 w-4" />
+              Appointment Board
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Tabs defaultValue="today" className="w-full">
+              <TabsList className="w-full justify-start overflow-x-auto h-auto flex-wrap mb-4 bg-transparent p-0 gap-1">
+                <TabsTrigger
+                  value="today"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  Today
+                </TabsTrigger>
+                <TabsTrigger
+                  value="tomorrow"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  Tomorrow
+                </TabsTrigger>
+                <TabsTrigger
+                  value="checked-in"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  Checked In
+                </TabsTrigger>
+                <TabsTrigger
+                  value="waiting"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  Waiting
+                </TabsTrigger>
+                <TabsTrigger
+                  value="completed"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  Completed
+                </TabsTrigger>
+                <TabsTrigger
+                  value="cancelled"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  Cancelled
+                </TabsTrigger>
+                <TabsTrigger
+                  value="no-show"
+                  className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border"
+                >
+                  No-show
+                </TabsTrigger>
+              </TabsList>
+
+              <TabsContent value="today" className="m-0">
+                {renderApptList(todayApptsFiltered, "No appointments scheduled for today.")}
+              </TabsContent>
+              <TabsContent value="tomorrow" className="m-0">
+                {renderApptList(tomorrowAppts, "No appointments scheduled for tomorrow.")}
+              </TabsContent>
+              <TabsContent value="checked-in" className="m-0">
+                {renderApptList(checkedInAppts, "No patients currently checked in.")}
+              </TabsContent>
+              <TabsContent value="waiting" className="m-0">
+                {renderApptList(waitingAppts, "No patients waiting.")}
+              </TabsContent>
+              <TabsContent value="completed" className="m-0">
+                {renderApptList(completedAppts, "No completed appointments yet.")}
+              </TabsContent>
+              <TabsContent value="cancelled" className="m-0">
+                {renderApptList(cancelledAppts, "No cancelled appointments.")}
+              </TabsContent>
+              <TabsContent value="no-show" className="m-0">
+                {renderApptList(noShowAppts, "No no-shows recorded.")}
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+
+        {/* Column 2: Waiting Room (Real-time via Supabase) */}
+        {clinicId ? (
+          <RealtimeWaitingRoom clinicId={clinicId} onCallIn={(id) => handleCheckIn(id)} />
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Waiting Room
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">Loading...</p>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Column 3: Quick Actions */}
+        <div className="space-y-4">
+          {/* Walk-in Registration */}
+          <WalkInDialog
+            trigger={
+              <Button className="w-full">
+                <UserPlus className="h-4 w-4 mr-1" />
+                Walk-in Registration
+              </Button>
+            }
+          />
+
+          {/* Quick Patient Registration */}
+          {clinicId && <QuickPatientRegistration clinicId={clinicId} />}
+
+          {/* Cash Register */}
+          <CashRegister />
+
+          {/* Quick Links */}
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm flex items-center gap-2">
+                <FileText className="h-4 w-4" />
+                Quick Links
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <a href="/receptionist/daily-report" className="block">
+                <Button variant="outline" size="sm" className="w-full justify-start">
+                  <FileText className="h-3.5 w-3.5 mr-2" />
+                  Full Daily Report
+                </Button>
+              </a>
+              <PaymentDialog
+                trigger={
+                  <Button variant="outline" size="sm" className="w-full justify-start">
+                    <CreditCard className="h-3.5 w-3.5 mr-2" />
+                    Advanced Payment
+                  </Button>
+                }
+              />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Receptionist AI Widget */}
+      {clinicId && (
+        <div className="mt-6">
+          <ReceptionistAIWidget clinicId={clinicId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/data/dashboard.ts
+++ b/src/lib/data/dashboard.ts
@@ -1,8 +1,13 @@
 "use server";
 
+import type { AppointmentView } from "@/lib/data/client/appointments";
+import type { PatientView } from "@/lib/data/client/users";
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase-server";
 import { getLocalDateStr } from "@/lib/utils";
+// Type-only imports from the client data layer (erased at compile time, so
+// no "use client" module is pulled into this server module). The receptionist
+// view components consume these exact shapes.
 
 /** Default upper-bound limit for list queries to prevent unbounded result sets. */
 const DEFAULT_QUERY_LIMIT = 1000;
@@ -106,11 +111,59 @@ export interface DashboardStats {
 }
 
 export async function getDashboardStats(clinicId: string): Promise<DashboardStats> {
-  // Reuse shared base queries (audit DRY-02)
-  const [base, supabase] = await Promise.all([fetchBaseDashboardStats(clinicId), createClient()]);
+  const supabase = await createClient();
 
-  // Fetch dashboard-specific data in parallel
-  const [insurancePatientsRes, recentActivity] = await Promise.all([
+  // PERF-LAT-06: Single-round-trip aggregates via RPC (migration 00180).
+  // The legacy path below issues 9 queries — five head-only counts plus
+  // three UNBOUNDED row fetches (every completed payment, every review,
+  // every patient row) just to compute sums/averages the database can
+  // produce itself. The RPC returns one row of aggregates; RLS still
+  // applies (SECURITY INVOKER). Falls back to the legacy multi-query path
+  // until the migration is applied (same pattern as avg_clinic_rating).
+  try {
+    // get_clinic_dashboard_stats is a DB function not yet in the generated
+    // Supabase types. Use a targeted cast instead of blanket `as any`.
+    type UntypedRpc = (
+      fn: string,
+      args: Record<string, unknown>,
+    ) => ReturnType<typeof supabase.rpc>;
+    const rpc = supabase.rpc.bind(supabase) as unknown as UntypedRpc;
+    const [rpcRes, rpcRecentActivity] = await Promise.all([
+      rpc("get_clinic_dashboard_stats", { cid: clinicId }),
+      getRecentActivity(supabase, clinicId),
+    ]);
+    const row = (Array.isArray(rpcRes.data) ? rpcRes.data[0] : rpcRes.data) as Record<
+      string,
+      unknown
+    > | null;
+    if (!rpcRes.error && row) {
+      return {
+        totalPatients: Number(row.total_patients ?? 0),
+        totalAppointments: Number(row.total_appointments ?? 0),
+        completedAppointments: Number(row.completed_appointments ?? 0),
+        noShowCount: Number(row.no_show_count ?? 0),
+        totalRevenue: Number(row.total_revenue ?? 0),
+        averageRating: Number(row.average_rating ?? 0),
+        doctorCount: Number(row.doctor_count ?? 0),
+        insurancePatients: Number(row.insurance_patients ?? 0),
+        recentActivity: rpcRecentActivity,
+      };
+    }
+    logger.warn("get_clinic_dashboard_stats RPC unavailable, using fallback", {
+      context: "data/dashboard",
+      error: rpcRes.error,
+    });
+  } catch (err) {
+    logger.warn("get_clinic_dashboard_stats RPC failed, using fallback", {
+      context: "data/dashboard",
+      error: err,
+    });
+  }
+
+  // Fallback: legacy multi-query path (audit DRY-02). Remove once
+  // migration 00180 is deployed everywhere.
+  const [base, insurancePatientsRes, recentActivity] = await Promise.all([
+    fetchBaseDashboardStats(clinicId),
     supabase.from("users").select("id, metadata").eq("clinic_id", clinicId).eq("role", "patient"),
     getRecentActivity(supabase, clinicId),
   ]);
@@ -582,4 +635,168 @@ export async function getPatientDashboardData(
   );
 
   return { userName, appointments, prescriptions, invoices, notifications };
+}
+
+// ────────────────────────────────────────────
+// Receptionist Dashboard Data (server-side)
+// ────────────────────────────────────────────
+
+export interface ReceptionistDashboardData {
+  appointments: AppointmentView[];
+  patients: PatientView[];
+  /** Sum of completed payments within the lookback window ("Revenue (Month)"). */
+  totalRevenue: number;
+}
+
+/**
+ * PERF-LAT-07: Server-side loader for the receptionist dashboard.
+ *
+ * The page was previously a Client Component that rendered a spinner, then
+ * after hydration ran getCurrentUser() (a browser→Supabase auth round trip)
+ * followed by three more fetches — a full client-side waterfall on every
+ * visit. This loader runs during the server render (auth context already
+ * resolved by middleware/requireAuth), issues all queries in one parallel
+ * batch over the server's connection, and streams the finished HTML.
+ *
+ * Scoped to a 30-day lookback + future rows: the dashboard renders
+ * today/tomorrow lists, recent status tabs and monthly revenue — never
+ * deep history.
+ */
+export async function getReceptionistDashboardData(
+  clinicId: string,
+): Promise<ReceptionistDashboardData> {
+  const supabase = await createClient();
+
+  const lookbackDate = new Date();
+  lookbackDate.setDate(lookbackDate.getDate() - 30);
+  const sinceDate = getLocalDateStr(lookbackDate);
+
+  const [apptsRes, patientsRes, doctorsRes, servicesRes, paymentsRes] = await Promise.all([
+    supabase
+      .from("appointments")
+      .select(
+        "id, patient_id, doctor_id, service_id, appointment_date, start_time, status, is_first_visit, insurance_flag, is_emergency, notes, cancelled_at, cancellation_reason, rescheduled_from, recurrence_group_id, recurrence_pattern",
+      )
+      .eq("clinic_id", clinicId)
+      .gte("appointment_date", sinceDate)
+      .order("appointment_date", { ascending: true })
+      .limit(DEFAULT_QUERY_LIMIT),
+    supabase
+      .from("users")
+      .select("id, name, phone, email, metadata, created_at")
+      .eq("clinic_id", clinicId)
+      .eq("role", "patient")
+      .order("name", { ascending: true })
+      .limit(DEFAULT_QUERY_LIMIT),
+    supabase
+      .from("users")
+      .select("id, name")
+      .eq("clinic_id", clinicId)
+      .eq("role", "doctor")
+      .limit(DEFAULT_QUERY_LIMIT),
+    supabase
+      .from("services")
+      .select("id, name")
+      .eq("clinic_id", clinicId)
+      .limit(DEFAULT_QUERY_LIMIT),
+    supabase
+      .from("payments")
+      .select("amount")
+      .eq("clinic_id", clinicId)
+      .eq("status", "completed")
+      .gte("created_at", lookbackDate.toISOString())
+      .limit(DEFAULT_QUERY_LIMIT),
+  ]);
+
+  type PatientRaw = {
+    id: string;
+    name: string;
+    phone: string | null;
+    email: string | null;
+    metadata: Record<string, unknown> | null;
+    created_at: string | null;
+  };
+  const patientRows = (patientsRes.data ?? []) as PatientRaw[];
+
+  // Mirrors mapPatient() in src/lib/data/client/users.ts so the client view
+  // receives identical shapes whether data came from server or browser.
+  const patients: PatientView[] = patientRows.map((raw) => {
+    const meta = raw.metadata ?? {};
+    const dob = (meta.date_of_birth as string) ?? "";
+    let age = 0;
+    if (dob) {
+      const diff = Date.now() - new Date(dob).getTime();
+      age = Math.floor(diff / (365.25 * 24 * 60 * 60 * 1000));
+    }
+    return {
+      id: raw.id,
+      name: raw.name,
+      phone: raw.phone ?? "",
+      email: raw.email ?? "",
+      age: (meta.age as number) ?? age,
+      gender: ((meta.gender as string) ?? "M") as "M" | "F",
+      dateOfBirth: dob,
+      allergies: (meta.allergies as string[]) ?? undefined,
+      insurance: (meta.insurance as string) ?? undefined,
+      registeredAt: raw.created_at?.split("T")[0] ?? "",
+    };
+  });
+
+  const nameMap = new Map<string, { name: string; phone: string }>();
+  for (const p of patientRows) nameMap.set(p.id, { name: p.name, phone: p.phone ?? "" });
+  for (const d of (doctorsRes.data ?? []) as { id: string; name: string }[]) {
+    nameMap.set(d.id, { name: d.name, phone: "" });
+  }
+  const serviceMap = new Map(
+    ((servicesRes.data ?? []) as { id: string; name: string }[]).map((s) => [s.id, s.name]),
+  );
+
+  type ApptRaw = {
+    id: string;
+    patient_id: string;
+    doctor_id: string;
+    service_id: string | null;
+    appointment_date: string;
+    start_time: string | null;
+    status: string | null;
+    is_first_visit: boolean | null;
+    insurance_flag: boolean | null;
+    is_emergency: boolean | null;
+    notes: string | null;
+    cancelled_at: string | null;
+    cancellation_reason: string | null;
+    rescheduled_from: string | null;
+    recurrence_group_id: string | null;
+    recurrence_pattern: string | null;
+  };
+  // Mirrors mapAppointment() in src/lib/data/client/appointments.ts.
+  const appointments: AppointmentView[] = ((apptsRes.data ?? []) as ApptRaw[]).map((raw) => ({
+    id: raw.id,
+    patientId: raw.patient_id,
+    patientName: nameMap.get(raw.patient_id)?.name ?? "Unknown",
+    patientPhone: nameMap.get(raw.patient_id)?.phone || undefined,
+    doctorId: raw.doctor_id,
+    doctorName: nameMap.get(raw.doctor_id)?.name ?? "Unknown",
+    serviceId: raw.service_id ?? "",
+    serviceName: (raw.service_id ? serviceMap.get(raw.service_id) : null) ?? "Consultation",
+    date: raw.appointment_date,
+    time: raw.start_time?.slice(0, 5) ?? "",
+    status: raw.status?.replaceAll("_", "-") ?? "scheduled",
+    isFirstVisit: raw.is_first_visit ?? false,
+    hasInsurance: raw.insurance_flag ?? false,
+    cancelledAt: raw.cancelled_at ?? undefined,
+    cancellationReason: raw.cancellation_reason ?? undefined,
+    rescheduledFrom: raw.rescheduled_from ?? undefined,
+    isEmergency: raw.is_emergency ?? false,
+    notes: raw.notes ?? undefined,
+    recurrenceGroupId: raw.recurrence_group_id ?? undefined,
+    recurrencePattern: raw.recurrence_pattern ?? undefined,
+  }));
+
+  const totalRevenue = ((paymentsRes.data ?? []) as { amount: number }[]).reduce(
+    (sum, p) => sum + (p.amount ?? 0),
+    0,
+  );
+
+  return { appointments, patients, totalRevenue };
 }

--- a/supabase/migrations/00180_clinic_dashboard_stats_rpc.sql
+++ b/supabase/migrations/00180_clinic_dashboard_stats_rpc.sql
@@ -1,0 +1,67 @@
+-- 00180_clinic_dashboard_stats_rpc.sql
+-- PERF-LAT-06: Single-round-trip dashboard aggregates.
+--
+-- The admin dashboard (getDashboardStats in src/lib/data/dashboard.ts)
+-- previously issued 9 PostgREST queries per render: five head-only counts
+-- plus THREE unbounded row fetches — every completed payment row (to sum
+-- revenue in JS), every review row (to average stars in JS) and every
+-- patient row with metadata (to count insurance flags in JS). For a mature
+-- clinic that is thousands of rows over the wire to produce eight numbers.
+--
+-- This function computes all eight aggregates in one database call.
+--
+-- Security:
+--   * SECURITY INVOKER (the default) is used deliberately. RLS policies on
+--     users / appointments / payments / reviews apply to the caller exactly
+--     as they did for the individual PostgREST queries this replaces, so
+--     the function cannot widen data access or leak cross-tenant rows.
+--   * EXECUTE is revoked from PUBLIC and anon; dashboard stats are for
+--     signed-in staff only. (Even if invoked by anon, RLS would return
+--     zeros — the revoke is defense in depth.)
+--
+-- The application falls back to the legacy multi-query path when this
+-- function does not exist yet, so deploying code before this migration is
+-- safe (same pattern as avg_clinic_rating).
+
+CREATE OR REPLACE FUNCTION public.get_clinic_dashboard_stats(cid uuid)
+RETURNS TABLE (
+  total_patients         bigint,
+  total_appointments     bigint,
+  completed_appointments bigint,
+  no_show_count          bigint,
+  total_revenue          numeric,
+  average_rating         numeric,
+  doctor_count           bigint,
+  insurance_patients     bigint
+)
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT
+    (SELECT count(*) FROM users
+       WHERE clinic_id = cid AND role = 'patient')                  AS total_patients,
+    (SELECT count(*) FROM appointments
+       WHERE clinic_id = cid)                                       AS total_appointments,
+    (SELECT count(*) FROM appointments
+       WHERE clinic_id = cid AND status = 'completed')              AS completed_appointments,
+    (SELECT count(*) FROM appointments
+       WHERE clinic_id = cid AND status = 'no_show')                AS no_show_count,
+    (SELECT COALESCE(sum(amount), 0) FROM payments
+       WHERE clinic_id = cid AND status = 'completed')              AS total_revenue,
+    (SELECT COALESCE(avg(stars), 0) FROM reviews
+       WHERE clinic_id = cid)                                       AS average_rating,
+    (SELECT count(*) FROM users
+       WHERE clinic_id = cid AND role = 'doctor')                   AS doctor_count,
+    -- Matches the JS truthy check `metadata?.insurance`: both a JSON
+    -- boolean true and the string "true" serialize to 'true' via ->>.
+    -- The ->> operator never throws on other value types, unlike a
+    -- ::boolean cast.
+    (SELECT count(*) FROM users
+       WHERE clinic_id = cid AND role = 'patient'
+         AND metadata->>'insurance' = 'true')                       AS insurance_patients;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_clinic_dashboard_stats(uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_clinic_dashboard_stats(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_clinic_dashboard_stats(uuid) TO authenticated;


### PR DESCRIPTION
Follow-up to #1012 (stacked on that branch since both touch the receptionist dashboard — GitHub will retarget this to `main` automatically when #1012 merges).

## PERF-LAT-06: Admin dashboard stats — 9 queries → 1 RPC
`getDashboardStats` issued **9 PostgREST round trips per render**: five head-only counts plus three *unbounded* row fetches — every completed payment row (to sum revenue in JS), every review row (to average stars in JS), and every patient row with metadata (to count insurance flags in JS). For a mature clinic that is thousands of rows over the wire to produce eight numbers.

- New migration `00180_clinic_dashboard_stats_rpc.sql`: `get_clinic_dashboard_stats(cid)` returns all eight aggregates in one call.
- **SECURITY INVOKER** (deliberate): RLS on `users`/`appointments`/`payments`/`reviews` applies to the caller exactly as it did for the individual queries — no widened access, no cross-tenant leak surface. `EXECUTE` revoked from `PUBLIC`/`anon`, granted to `authenticated`.
- The loader tries the RPC first and **falls back to the legacy multi-query path** when the function doesn't exist yet (same pattern as `avg_clinic_rating`), so code can deploy before the migration. The fallback itself is also slightly improved (base stats now fetched in parallel with the rest).
- Insurance count uses `metadata->>'insurance' = 'true'`, matching the JS truthy check for both JSON `true` and `"true"` without a throwing `::boolean` cast.

## PERF-LAT-07: Receptionist dashboard — client waterfall → server render
The page was 100% client-side: ship spinner → hydrate → `getCurrentUser()` (browser→Supabase auth round trip) → three more fetches. Every visit paid a full post-hydration waterfall before anything useful appeared.

Now split into:
- `getReceptionistDashboardData()` — server loader, one parallel query batch: appointments (30-day lookback + future), patients, doctor/service name lookups, completed payments in window. Output shapes mirror the client mappers exactly (`AppointmentView`/`PatientView`).
- `ReceptionistDashboardView` — client component keeping all interactivity (tabs, check-in state, optimistic status updates, dialogs, realtime waiting room), fed by props.
- `page.tsx` — thin Server Component using `requireAuth` (which after PERF-LAT-02 reuses the middleware's signed profile headers, so no extra auth round trip).

The existing `(receptionist)/loading.tsx` skeleton becomes the streaming fallback: users see a structured skeleton then the finished dashboard, with **zero** client-side data round trips. Legacy no-clinic behavior (empty shell) preserved.

## Deployment note
Apply migration 00180 (`supabase db push`) to get the admin-stats win; until then the dashboard transparently uses the fallback path, so ordering is safe in either direction.

## Verification
- `tsc --noEmit` clean
- Full `vitest` suite: **164 files, 1981 tests passed** (80 skipped, pre-existing)
- `eslint` 0 errors (i18n literal-string warnings carried over from the original page file), `prettier --check` clean