### PR TITLE
fix(db): correct 00099 FK index columns + add auto-migration workflow

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,63 @@
+# =============================================================================
+# DB Migrate — apply Supabase migrations to the remote database
+# =============================================================================
+#
+# Triggers on push to `main` (→ production) or `staging` (→ staging) when
+# anything under supabase/migrations/ changes.
+#
+# Required GitHub secrets:
+#   SUPABASE_ACCESS_TOKEN        — personal access token (already used by
+#                                  migration-check.yml)
+#   SUPABASE_DB_PASSWORD_PROD    — database password of the production project
+#   SUPABASE_DB_PASSWORD_STAGING — database password of the staging project
+#
+# Project refs are not secrets (they're visible in every client URL).
+# =============================================================================
+
+name: DB Migrate
+
+on:
+  push:
+    branches: [main, staging]
+    paths:
+      - "supabase/migrations/**"
+
+concurrency:
+  group: db-migrate-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    name: Push migrations to ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
+        with:
+          version: 2.101.0
+
+      - name: Link project
+        run: |
+          supabase link --project-ref "$PROJECT_REF"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_REF: ${{ github.ref_name == 'main' && 'xxxlygxysprrghqojvvz' || 'ranstbjbvgalaosqnvmg' }}
+          SUPABASE_DB_PASSWORD: ${{ github.ref_name == 'main' && secrets.SUPABASE_DB_PASSWORD_PROD || secrets.SUPABASE_DB_PASSWORD_STAGING }}
+
+      - name: Push migrations
+        run: supabase db push --include-all
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ github.ref_name == 'main' && secrets.SUPABASE_DB_PASSWORD_PROD || secrets.SUPABASE_DB_PASSWORD_STAGING }}
+
+      - name: Verify migration state
+        run: supabase migration list --linked
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ github.ref_name == 'main' && secrets.SUPABASE_DB_PASSWORD_PROD || secrets.SUPABASE_DB_PASSWORD_STAGING }}

--- a/supabase/migrations/00099_add_missing_fk_indexes.sql
+++ b/supabase/migrations/00099_add_missing_fk_indexes.sql
@@ -17,13 +17,13 @@ BEGIN;
 
 -- Clinical tables ------------------------------------------------------------
 CREATE INDEX IF NOT EXISTS idx_admissions_doctor_id
-  ON admissions (doctor_id);
+  ON admissions (admitting_doctor_id);
 
-CREATE INDEX IF NOT EXISTS idx_beds_department_id
-  ON beds (department_id);
+CREATE INDEX IF NOT EXISTS idx_beds_room_id
+  ON beds (room_id);
 
-CREATE INDEX IF NOT EXISTS idx_beds_patient_id
-  ON beds (patient_id);
+CREATE INDEX IF NOT EXISTS idx_beds_current_patient_id
+  ON beds (current_patient_id);
 
 CREATE INDEX IF NOT EXISTS idx_ivf_cycles_partner_id
   ON ivf_cycles (partner_id);


### PR DESCRIPTION
## What

**1. Fix `00099_add_missing_fk_indexes.sql`** - three indexes referenced columns that don't exist in the schema:

| Was | Now |
|---|---|
| `admissions (doctor_id)` | `admissions (admitting_doctor_id)` |
| `beds (department_id)` | `beds (room_id)` |
| `beds (patient_id)` | `beds (current_patient_id)` |

Any fresh environment (`supabase start`, CI local stack) failed at this file. Remote prod/staging already carry the corrected indexes (applied manually on 2026-06-11 during the schema-drift recovery), so `db push` will skip 00099 there - this fix is for fresh DBs only.

**2. Add `.github/workflows/db-migrate.yml`** - until now nothing ever applied migrations to the remote databases: `migration-check.yml` and `ci.yml` only validate against a throwaway local stack. That's how prod sat at 00042 while the repo reached 00179. This workflow runs `supabase db push` on every push to `main` (production) / `staging` (staging) touching `supabase/migrations/`.

## Required repo secrets

- `SUPABASE_DB_PASSWORD_PROD`
- `SUPABASE_DB_PASSWORD_STAGING`
- `SUPABASE_ACCESS_TOKEN` (already configured)

## Context

Both databases were brought from ~00042 to 00179 on 2026-06-11 after rehearsing all migrations on staging first (full prod data backup taken beforehand). Migration history table is consistent on both projects, so this workflow picks up cleanly from 00179.