### PR TITLE
fix(security): force build-time inline of NEXT_PUBLIC_DATA_MASKING (follow-up to #1016)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -55,6 +55,27 @@ function getSupabaseImageHostname(): string {
 // consistency. See @/lib/middleware/security-headers for the implementation.
 
 const nextConfig: NextConfig = {
+  // Audit 2026-06-09 Task 2 (P0) — follow-up to #1016.
+  // The build step in deploy.yml sets NEXT_PUBLIC_DATA_MASKING=partial, but
+  // SWC's automatic process.env.NEXT_PUBLIC_* inlining did not reach
+  // src/lib/mask.ts in the Cloudflare Workers build: the deployed chunk
+  // contained `t.default.env.NEXT_PUBLIC_DATA_MASKING || "unset"` (a runtime
+  // read against the Workers process polyfill) instead of the literal
+  // "partial". In the browser that polyfill carries no NEXT_PUBLIC_DATA_MASKING,
+  // so MASKING_BUILD_LEVEL evaluated to "unset" and getMaskLevel() returned
+  // "none" — exactly the audit failure mode. The post-deploy smoke test then
+  // also reported "none" (its regex picked up the nearest "none" literal,
+  // which lives inside mask.ts's own comparisons).
+  //
+  // The `env` config field forces a static, AST-level replacement of
+  // process.env.NEXT_PUBLIC_DATA_MASKING with the build-time value across
+  // BOTH client and server bundles, regardless of how SWC happens to treat
+  // the source file. Keep "partial" as the fallback so local builds without
+  // the env var still ship a safe default.
+  env: {
+    NEXT_PUBLIC_DATA_MASKING: process.env.NEXT_PUBLIC_DATA_MASKING || "partial",
+  },
+
   // E2E suite (login-flow / registration-flow / pricing / mobile-flows specs)
   // asserts `<Link>` hrefs in their canonical form (e.g. href="/login/").
   // Removing this flag drops the trailing slash from rendered hrefs and breaks

--- a/scripts/smoke-post-deploy.mjs
+++ b/scripts/smoke-post-deploy.mjs
@@ -42,9 +42,31 @@ const SUPABASE_URL_RE = /https:\/\/[a-z0-9-]+\.supabase\.(co|in|net)/i;
 const SUPABASE_KEY_RE = /eyJ[\w-]+\.[\w-]+\.[\w-]+|sb_publishable_[\w-]{20,}/;
 
 // Audit Task 2: marker emitted by src/components/masking-build-sentinel.tsx.
-// Matches both the minifier-folded form ("__OLTIGO_MASKING_BUILD__partial")
-// and the unfolded concatenation the bundler may leave behind.
-const MASKING_SENTINEL_RE = /__OLTIGO_MASKING_BUILD__[\s\S]{0,300}?(partial|full|none|unset)/;
+// Two recognised shapes:
+//   1. Minifier-folded literal:        "__OLTIGO_MASKING_BUILD__partial"
+//   2. Unfolded concat (variable):     "__OLTIGO_MASKING_BUILD__" + r   where
+//      r is a same-module export bound to MASKING_BUILD_LEVEL.
+//
+// The previous "[\s\S]{0,300}?(partial|full|none|unset)" form was a foot-gun:
+// when the build did NOT inline NEXT_PUBLIC_DATA_MASKING (the exact failure
+// mode this check exists to detect), mask.ts's own `=== "none"` / `=== "full"`
+// comparisons sit only a few dozen chars after the marker in the bundled
+// chunk, and the non-greedy match would lock onto one of those — reporting
+// e.g. "none" while the true MASKING_BUILD_LEVEL value at runtime was
+// "unset". The fix below requires the level to be either immediately glued
+// to the marker (folded case) or to appear in a sentinel-binding initializer
+// of the form `<var> = ... NEXT_PUBLIC_DATA_MASKING || "<level>"` within a
+// short window. Anything else returns null and the report stays honest.
+const MASKING_SENTINEL_RE_FOLDED = /__OLTIGO_MASKING_BUILD__(partial|full|none|unset)/;
+const MASKING_SENTINEL_RE_BINDING =
+  /NEXT_PUBLIC_DATA_MASKING\s*\|\|\s*["'](partial|full|none|unset)["']/;
+function extractMaskingLevel(text) {
+  return (
+    text.match(MASKING_SENTINEL_RE_FOLDED)?.[1] ??
+    text.match(MASKING_SENTINEL_RE_BINDING)?.[1] ??
+    null
+  );
+}
 const EXPECTED_MASKING = process.env.SMOKE_EXPECTED_MASKING || "partial";
 
 let failures = 0;
@@ -111,7 +133,7 @@ async function checkSignupIntegrity() {
       const { text } = await fetchText(BASE + chunk);
       if (!urlFound && SUPABASE_URL_RE.test(text)) urlFound = true;
       if (!keyFound && SUPABASE_KEY_RE.test(text)) keyFound = true;
-      if (!maskingLevel) maskingLevel = text.match(MASKING_SENTINEL_RE)?.[1] ?? null;
+      if (!maskingLevel) maskingLevel = extractMaskingLevel(text);
     } catch {
       // ignore individual chunk fetch errors; absence is what we test for
     }


### PR DESCRIPTION
## Summary

Follow-up to #1016. The failed Deploy run on main (https://github.com/groupsmix/webs-alots/actions/runs/27360091080) traced to a real masking regression, not a smoke-test flake.

## Root cause

PR #1016 set `NEXT_PUBLIC_DATA_MASKING=partial` on the deploy build step. That should be enough — Next.js inlines `process.env.NEXT_PUBLIC_*` at build time. For `src/lib/supabase-client.ts` it does (verified: the deployed chunk has the literal `https://xxxlygxysprrghqojvvz.supabase.co`).

For `src/lib/mask.ts` it does **not**. The deployed chunk `/_next/static/chunks/1_s7kw-ar3nl4.js` contains:

```
let r = t.default.env.NEXT_PUBLIC_DATA_MASKING || "unset";
function n() { let e = t.default.env.NEXT_PUBLIC_DATA_MASKING;
               return "full" === e || "partial" === e ? e : "none" }
```

Both `MASKING_BUILD_LEVEL` and `getMaskLevel()` survived as runtime reads against the Workers `process` polyfill (`t = e.i(247167)`). In the browser, that polyfill carries no `NEXT_PUBLIC_DATA_MASKING`, so:

- `MASKING_BUILD_LEVEL` → `"unset"`
- `getMaskLevel()` → `"none"` (the audit failure mode)

Why SWC's auto-inlining skipped this one file and not `supabase-client.ts` — same access pattern, no obvious difference — is opaque from the outside, but reproducible: the bundle on prod right now reads runtime, not literal.

## Fix

**`next.config.ts`** — add an `env` field for `NEXT_PUBLIC_DATA_MASKING`. The `env` config performs a deterministic AST-level replacement across both client and server bundles, independent of SWC's auto-inlining heuristics. Fallback `"partial"` so local builds without the env var still ship a safe default.

## Smoke test was also lying

The post-deploy smoke reported `masking integrity: client bundle masking level is "none"`. The actual bundle value at runtime is `"unset"`. The regex `__OLTIGO_MASKING_BUILD__[\s\S]{0,300}?(partial|full|none|unset)` non-greedy matched the `"none"` literal sitting inside `mask.ts`'s own comparison `if ("none" === t…`, ~80 chars after the marker.

**`scripts/smoke-post-deploy.mjs`** — tighten the extractor to two unambiguous shapes:
- Folded literal: `__OLTIGO_MASKING_BUILD__<level>`
- Unfolded binding: `NEXT_PUBLIC_DATA_MASKING || "<level>"`

Verified against the current production chunk: now reports `"unset"` instead of `"none"`.

## Verification

- Prettier clean.
- Replayed the new extractor against the live broken chunk → reports `unset` (the truth) instead of `none` (a lie that pointed at the wrong cause).
- After this PR, the deploy.yml build env (`NEXT_PUBLIC_DATA_MASKING=partial`) will flow through `next.config.ts.env` and inline as the literal `"partial"` in `mask.ts`, fixing both the smoke check and the underlying PHI exposure.
