### PR TITLE
fix(security): inline PHI masking into client bundle + per-branch Supabase creds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,8 +71,12 @@ jobs:
         run: npm run build:cf
         env:
           # Supabase URL/key are baked into the client bundle at build time.
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          # Per-branch credentials: staging must NOT ship with the production
+          # Supabase project baked into its client bundle (cross-env PHI risk).
+          # `main` uses NEXT_PUBLIC_SUPABASE_*; `staging` (and any other branch)
+          # uses STAGING_SUPABASE_*. Both pairs must be set in repo secrets.
+          NEXT_PUBLIC_SUPABASE_URL: ${{ github.ref_name == 'main' && secrets.NEXT_PUBLIC_SUPABASE_URL || secrets.STAGING_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ github.ref_name == 'main' && secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || secrets.STAGING_SUPABASE_ANON_KEY }}
           # Feature flag: show AI Agents / AI Team / Website Builder in super-admin.
           # Baked into client bundle at build time (NEXT_PUBLIC_*).
           NEXT_PUBLIC_AI_FEATURES_ENABLED: ${{ secrets.NEXT_PUBLIC_AI_FEATURES_ENABLED }}


### PR DESCRIPTION
## Why every deploy has been red since last night

The post-deploy smoke test (added in the June 11 audit commit) is correctly failing: the shipped client bundle reads `NEXT_PUBLIC_DATA_MASKING` through a runtime process shim (`t.default.env.NEXT_PUBLIC_DATA_MASKING` in chunk `1_s7kw-*.js`) instead of an inlined literal. In a browser that's always `undefined`, so `getMaskLevel()` compiles to **"none" - PHI renders unmasked in client components on production right now**.

### Fix 1: `next.config.ts`
Declare `NEXT_PUBLIC_DATA_MASKING` in the `env` map, which guarantees static replacement in client chunks under the OpenNext build. Fail-closed default of `"partial"` when the variable is absent.

### Fix 2: `deploy.yml` - staging was baking PRODUCTION credentials
The build step used `secrets.NEXT_PUBLIC_SUPABASE_URL` / `ANON_KEY` for **both** branches. A staging deploy would ship a client bundle pointing at the production database (cross-env PHI contamination). `STAGING_SUPABASE_URL` existed as a secret but was never referenced. Staging now uses `STAGING_SUPABASE_URL` + `STAGING_SUPABASE_ANON_KEY` (the latter just added to repo secrets).

## Verification
After merge, the Deploy run should go green end-to-end: the smoke test asserts the bundle carries `__OLTIGO_MASKING_BUILD__partial`.

## Note
The `staging` branch was force-updated to this branch's HEAD (it was 90 commits behind with one obsolete TOML fix, running March-era code against the freshly migrated DB - the cause of staging.oltigo.com's 500s).