### PR TITLE
feat(audit-task-11): add error boundaries for demo/lab/specialist route groups

### DIFF
--- a/src/app/(demo)/error.tsx
+++ b/src/app/(demo)/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
+
+export default function DemoError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ClinicErrorBoundary error={error} reset={reset} context="demo" variant="page" />;
+}

--- a/src/app/(lab)/error.tsx
+++ b/src/app/(lab)/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
+
+export default function LabError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ClinicErrorBoundary error={error} reset={reset} context="lab" variant="page" />;
+}

--- a/src/app/(specialist)/error.tsx
+++ b/src/app/(specialist)/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ClinicErrorBoundary from "@/components/error-boundaries/clinic-error-boundary";
+
+export default function SpecialistError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <ClinicErrorBoundary error={error} reset={reset} context="specialist" variant="page" />;
+}


### PR DESCRIPTION
## Summary

Adds error.tsx to three uncovered route groups that previously fell back to the generic root error page with no role-aware recovery:

- (demo) — demo tenant surfaces
- (lab) — lab technician / results surfaces
- (specialist) — specialist consultation surfaces

Each uses the same ClinicErrorBoundary pattern already established in (receptionist), (doctor), and (clinic-public).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact (UI error handling only)

Closes audit 2026-06-09 Task 11 (P2).