### PR TITLE
feat(admin): wire dashboard pages to real Supabase backend

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Preflight — check required secrets
         id: preflight
         env:
-          TEST_DATABASE_URL:  ${{ secrets.TEST_DATABASE_URL }}
-          OPENAI_API_KEY:     ${{ secrets.OPENAI_API_KEY }}
-          EVAL_AUTH_TOKEN:    ${{ secrets.EVAL_AUTH_TOKEN }}
+          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          EVAL_AUTH_TOKEN: ${{ secrets.EVAL_AUTH_TOKEN }}
         run: |
           ok=true
           [ -z "$TEST_DATABASE_URL" ] && echo "::warning::TEST_DATABASE_URL not set — skipping evals" && ok=false

--- a/.github/workflows/rotate-phi-key.yml
+++ b/.github/workflows/rotate-phi-key.yml
@@ -33,9 +33,9 @@ jobs:
       - name: Preflight — verify required secrets are set
         id: preflight
         env:
-          PHI_ENCRYPTION_KEY:       ${{ secrets.PHI_ENCRYPTION_KEY }}
+          PHI_ENCRYPTION_KEY: ${{ secrets.PHI_ENCRYPTION_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          R2_BUCKET:                ${{ secrets.R2_BUCKET }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
           missing=""
           [ -z "$PHI_ENCRYPTION_KEY" ]        && missing="$missing PHI_ENCRYPTION_KEY"

--- a/.github/workflows/subdomain-orphan-scan.yml
+++ b/.github/workflows/subdomain-orphan-scan.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Preflight — check required secrets
         id: preflight
         env:
-          SUPABASE_SERVICE_ROLE_KEY:         ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          CLOUDFLARE_ZONE_ID:                ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: |
           ok=true
           [ -z "$SUPABASE_SERVICE_ROLE_KEY" ] && echo "::warning::SUPABASE_SERVICE_ROLE_KEY not set — skipping scan" && ok=false

--- a/src/app/(admin)/admin/doctors/page.tsx
+++ b/src/app/(admin)/admin/doctors/page.tsx
@@ -17,15 +17,26 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useToast } from "@/components/ui/toast";
+import {
+  createClinicUser,
+  updateClinicUser,
+  setClinicUserActive,
+  deleteClinicUser,
+} from "@/lib/admin-actions";
 import { getCurrentUser, fetchDoctors, type DoctorView } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import { formatCurrency } from "@/lib/utils";
 
 type Doctor = DoctorView;
 
 export default function ManageDoctorsPage() {
+  const { addToast } = useToast();
   const [doctorsList, setDoctorsList] = useState<Doctor[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -87,51 +98,106 @@ export default function ManageDoctorsPage() {
     setDialogOpen(true);
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!formName.trim()) return;
     const langs = formLanguages
       .split(",")
       .map((l) => l.trim())
       .filter(Boolean);
 
-    if (editingDoctor) {
-      setDoctorsList(
-        doctorsList.map((d) =>
-          d.id === editingDoctor.id
-            ? {
-                ...d,
-                name: formName,
-                specialty: formSpecialty,
-                specialtyId: formSpecialtyId,
-                phone: formPhone,
-                email: formEmail,
-                consultationFee: formFee,
-                languages: langs,
-              }
-            : d,
-        ),
-      );
-    } else {
-      setDoctorsList([
-        ...doctorsList,
-        {
-          id: `d${Date.now()}`,
+    const metadata = {
+      specialty: formSpecialty,
+      specialty_id: formSpecialtyId,
+      consultation_fee: formFee,
+      languages: langs,
+    };
+
+    setSaving(true);
+    try {
+      if (editingDoctor) {
+        await updateClinicUser(editingDoctor.id, {
           name: formName,
-          specialty: formSpecialty,
-          specialtyId: formSpecialtyId,
-          phone: formPhone,
           email: formEmail,
-          consultationFee: formFee,
-          languages: langs,
-        },
-      ]);
+          phone: formPhone,
+          metadata,
+        });
+        setDoctorsList((prev) =>
+          prev.map((d) =>
+            d.id === editingDoctor.id
+              ? {
+                  ...d,
+                  name: formName,
+                  specialty: formSpecialty,
+                  specialtyId: formSpecialtyId,
+                  phone: formPhone,
+                  email: formEmail,
+                  consultationFee: formFee,
+                  languages: langs,
+                }
+              : d,
+          ),
+        );
+        addToast("Doctor updated", "success");
+      } else {
+        const row = await createClinicUser({
+          role: "doctor",
+          name: formName,
+          email: formEmail,
+          phone: formPhone,
+          metadata,
+        });
+        setDoctorsList((prev) => [
+          ...prev,
+          {
+            id: row.id,
+            name: formName,
+            specialty: formSpecialty,
+            specialtyId: formSpecialtyId,
+            phone: formPhone,
+            email: formEmail,
+            consultationFee: formFee,
+            languages: langs,
+            active: true,
+          },
+        ]);
+        addToast("Doctor added", "success");
+      }
+      setDialogOpen(false);
+    } catch (err) {
+      logger.warn("Failed to save doctor", { context: "admin/doctors", error: err });
+      addToast("Failed to save doctor. Please try again.", "error");
+    } finally {
+      setSaving(false);
     }
-    setDialogOpen(false);
   };
 
-  const handleDelete = (id: string) => {
-    setDoctorsList(doctorsList.filter((d) => d.id !== id));
+  const handleDelete = async (id: string) => {
+    const previous = doctorsList;
+    setDoctorsList((prev) => prev.filter((d) => d.id !== id));
     setDeleteConfirm(null);
+    try {
+      await deleteClinicUser(id);
+      addToast("Doctor removed", "success");
+    } catch (err) {
+      logger.warn("Failed to delete doctor", { context: "admin/doctors", error: err });
+      setDoctorsList(previous);
+      addToast("Failed to remove doctor. Please try again.", "error");
+    }
+  };
+
+  const toggleActive = async (id: string) => {
+    const target = doctorsList.find((d) => d.id === id);
+    if (!target) return;
+    const next = !target.active;
+    setDoctorsList((prev) => prev.map((d) => (d.id === id ? { ...d, active: next } : d)));
+    try {
+      await setClinicUserActive(id, next);
+      addToast(next ? "Doctor reactivated" : "Doctor deactivated", "success");
+    } catch (err) {
+      logger.warn("Failed to toggle doctor", { context: "admin/doctors", error: err });
+      setDoctorsList((prev) => prev.map((d) => (d.id === id ? { ...d, active: !next } : d)));
+      addToast("Failed to update status. Please try again.", "error");
+    }
   };
 
   if (loading) {
@@ -177,7 +243,10 @@ export default function ManageDoctorsPage() {
                 </AvatarFallback>
               </Avatar>
               <div className="flex-1 min-w-0">
-                <p className="font-medium">{doctor.name}</p>
+                <div className="flex items-center gap-2">
+                  <p className="font-medium">{doctor.name}</p>
+                  {!doctor.active && <Badge variant="secondary">Inactive</Badge>}
+                </div>
                 <p className="text-sm text-muted-foreground">{doctor.specialty}</p>
                 <div className="flex gap-1 mt-1">
                   {doctor.languages.map((lang) => (
@@ -192,7 +261,12 @@ export default function ManageDoctorsPage() {
                 <p>{doctor.phone}</p>
                 <p className="text-xs">{doctor.email}</p>
               </div>
-              <div className="flex gap-1">
+              <div className="flex items-center gap-1">
+                <Switch
+                  checked={doctor.active}
+                  onCheckedChange={() => toggleActive(doctor.id)}
+                  aria-label={doctor.active ? "Deactivate doctor" : "Reactivate doctor"}
+                />
                 <Button variant="ghost" size="sm" onClick={() => openEditDialog(doctor)}>
                   <Edit className="h-4 w-4" />
                 </Button>
@@ -290,10 +364,13 @@ export default function ManageDoctorsPage() {
             </div>
           </div>
           <DialogFooter className="mt-6">
-            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+            <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>{editingDoctor ? "Save Changes" : "Add Doctor"}</Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+              {editingDoctor ? "Save Changes" : "Add Doctor"}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/app/(admin)/admin/patients/page.tsx
+++ b/src/app/(admin)/admin/patients/page.tsx
@@ -1,6 +1,20 @@
 "use client";
 
-import { Search, User, Phone, Mail, Calendar, Shield, Pill, Download } from "lucide-react";
+import {
+  Search,
+  User,
+  Phone,
+  Mail,
+  Calendar,
+  Shield,
+  Pill,
+  Download,
+  Edit,
+  Trash2,
+  Ban,
+  CheckCircle,
+  Loader2,
+} from "lucide-react";
 import { useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -13,10 +27,14 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
+  DialogFooter,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { PageLoader } from "@/components/ui/page-loader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { useToast } from "@/components/ui/toast";
+import { updateClinicUser, setClinicUserActive, deleteClinicUser } from "@/lib/admin-actions";
 import {
   getCurrentUser,
   fetchPatients,
@@ -27,6 +45,7 @@ import {
   type PrescriptionView,
 } from "@/lib/data/client";
 import { exportPatients } from "@/lib/export-data";
+import { logger } from "@/lib/logger";
 
 type Patient = PatientView;
 
@@ -38,6 +57,15 @@ export default function AdminPatientDatabasePage() {
   const [prescriptionsList, setPrescriptionsList] = useState<PrescriptionView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
+  const { addToast } = useToast();
+  const [editing, setEditing] = useState<Patient | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<Patient | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [formName, setFormName] = useState("");
+  const [formPhone, setFormPhone] = useState("");
+  const [formEmail, setFormEmail] = useState("");
+  const [formInsurance, setFormInsurance] = useState("");
 
   useEffect(() => {
     const controller = new AbortController();
@@ -102,6 +130,80 @@ export default function AdminPatientDatabasePage() {
   const getPatientPrescriptions = (patientId: string) =>
     prescriptions.filter((rx) => rx.patientId === patientId);
 
+  const openEditDialog = (patient: Patient) => {
+    setEditing(patient);
+    setFormName(patient.name);
+    setFormPhone(patient.phone);
+    setFormEmail(patient.email);
+    setFormInsurance(patient.insurance ?? "");
+    setSelectedPatient(null);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!editing || !formName.trim()) return;
+    setSaving(true);
+    try {
+      await updateClinicUser(editing.id, {
+        name: formName,
+        phone: formPhone,
+        email: formEmail,
+        metadata: { insurance: formInsurance || undefined },
+      });
+      setPatientsList((prev) =>
+        prev.map((p) =>
+          p.id === editing.id
+            ? {
+                ...p,
+                name: formName,
+                phone: formPhone,
+                email: formEmail,
+                insurance: formInsurance || undefined,
+              }
+            : p,
+        ),
+      );
+      addToast("Patient updated", "success");
+      setEditing(null);
+    } catch (err) {
+      logger.warn("Failed to update patient", { context: "admin/patients", error: err });
+      addToast("Failed to update patient. Please try again.", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleActive = async (patient: Patient) => {
+    const next = !patient.active;
+    setPatientsList((prev) =>
+      prev.map((p) => (p.id === patient.id ? { ...p, active: next } : p)),
+    );
+    setSelectedPatient(null);
+    try {
+      await setClinicUserActive(patient.id, next);
+      addToast(next ? "Patient reactivated" : "Patient deactivated", "success");
+    } catch (err) {
+      logger.warn("Failed to toggle patient", { context: "admin/patients", error: err });
+      setPatientsList((prev) =>
+        prev.map((p) => (p.id === patient.id ? { ...p, active: !next } : p)),
+      );
+      addToast("Failed to update status. Please try again.", "error");
+    }
+  };
+
+  const handleDelete = async (patient: Patient) => {
+    const previous = patientsList;
+    setPatientsList((prev) => prev.filter((p) => p.id !== patient.id));
+    setDeleteConfirm(null);
+    try {
+      await deleteClinicUser(patient.id);
+      addToast("Patient removed", "success");
+    } catch (err) {
+      logger.warn("Failed to delete patient", { context: "admin/patients", error: err });
+      setPatientsList(previous);
+      addToast("Failed to remove patient. Please try again.", "error");
+    }
+  };
+
   return (
     <div>
       <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Patients" }]} />
@@ -154,6 +256,11 @@ export default function AdminPatientDatabasePage() {
                       </p>
                     </div>
                     <div className="flex items-center gap-2 mt-2">
+                      {!patient.active && (
+                        <Badge variant="destructive" className="text-[10px]">
+                          Inactive
+                        </Badge>
+                      )}
                       {patient.insurance && (
                         <Badge variant="outline" className="text-[10px] flex items-center gap-1">
                           <Shield className="h-2.5 w-2.5" />
@@ -179,6 +286,37 @@ export default function AdminPatientDatabasePage() {
                     onClick={() => setSelectedPatient(patient)}
                   >
                     View Profile
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs"
+                    onClick={() => openEditDialog(patient)}
+                    aria-label="Edit patient"
+                  >
+                    <Edit className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs"
+                    onClick={() => toggleActive(patient)}
+                    aria-label={patient.active ? "Deactivate patient" : "Reactivate patient"}
+                  >
+                    {patient.active ? (
+                      <Ban className="h-3.5 w-3.5" />
+                    ) : (
+                      <CheckCircle className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs text-red-500"
+                    onClick={() => setDeleteConfirm(patient)}
+                    aria-label="Delete patient"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
               </CardContent>
@@ -339,6 +477,74 @@ export default function AdminPatientDatabasePage() {
             </div>
           </DialogContent>
         )}
+      </Dialog>
+
+      {/* Edit Patient Dialog */}
+      <Dialog open={editing !== null} onOpenChange={(open) => !open && setEditing(null)}>
+        <DialogContent onClose={() => setEditing(null)} className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit Patient</DialogTitle>
+            <DialogDescription>Update the patient&apos;s contact details.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-4">
+            <div className="space-y-2">
+              <Label>Full Name</Label>
+              <Input value={formName} onChange={(e) => setFormName(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label>Phone</Label>
+              <Input value={formPhone} onChange={(e) => setFormPhone(e.target.value)} />
+            </div>
+            <div className="space-y-2">
+              <Label>Email</Label>
+              <Input
+                type="email"
+                value={formEmail}
+                onChange={(e) => setFormEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Insurance</Label>
+              <Input value={formInsurance} onChange={(e) => setFormInsurance(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter className="mt-6">
+            <Button variant="outline" onClick={() => setEditing(null)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveEdit} disabled={saving}>
+              {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <Dialog
+        open={deleteConfirm !== null}
+        onOpenChange={(open) => !open && setDeleteConfirm(null)}
+      >
+        <DialogContent onClose={() => setDeleteConfirm(null)} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Remove Patient</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to permanently remove {deleteConfirm?.name}? This deletes their
+              record and cannot be undone. Consider deactivating instead to preserve history.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-4">
+            <Button variant="outline" onClick={() => setDeleteConfirm(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteConfirm && handleDelete(deleteConfirm)}
+            >
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
       </Dialog>
     </div>
   );

--- a/src/app/(admin)/admin/patients/page.tsx
+++ b/src/app/(admin)/admin/patients/page.tsx
@@ -174,9 +174,7 @@ export default function AdminPatientDatabasePage() {
 
   const toggleActive = async (patient: Patient) => {
     const next = !patient.active;
-    setPatientsList((prev) =>
-      prev.map((p) => (p.id === patient.id ? { ...p, active: next } : p)),
-    );
+    setPatientsList((prev) => prev.map((p) => (p.id === patient.id ? { ...p, active: next } : p)));
     setSelectedPatient(null);
     try {
       await setClinicUserActive(patient.id, next);

--- a/src/app/(admin)/admin/receptionists/page.tsx
+++ b/src/app/(admin)/admin/receptionists/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Plus, Edit, Trash2, Phone, Mail } from "lucide-react";
-import { useState } from "react";
+import { Plus, Edit, Trash2, Phone, Mail, Loader2 } from "lucide-react";
+import { useState, useEffect } from "react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -18,54 +18,58 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { getLocalDateStr } from "@/lib/utils";
+import { useToast } from "@/components/ui/toast";
+import {
+  createClinicUser,
+  updateClinicUser,
+  setClinicUserActive,
+  deleteClinicUser,
+} from "@/lib/admin-actions";
+import { getCurrentUser, fetchReceptionists, type ReceptionistView } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
-interface Receptionist {
-  id: string;
-  name: string;
-  email: string;
-  phone: string;
-  active: boolean;
-  createdAt: string;
-}
-
-const initialReceptionists: Receptionist[] = [
-  {
-    id: "r1",
-    name: "Layla Amrani",
-    email: "layla@clinic.ma",
-    phone: "+212 6 55 11 22 33",
-    active: true,
-    createdAt: "2025-06-01",
-  },
-  {
-    id: "r2",
-    name: "Houda Bennani",
-    email: "houda@clinic.ma",
-    phone: "+212 6 44 22 33 44",
-    active: true,
-    createdAt: "2025-08-15",
-  },
-  {
-    id: "r3",
-    name: "Sara El Idrissi",
-    email: "sara@clinic.ma",
-    phone: "+212 6 33 44 55 66",
-    active: false,
-    createdAt: "2025-11-20",
-  },
-];
+type Receptionist = ReceptionistView;
 
 export default function ManageReceptionistsPage() {
-  const [receptionists, setReceptionists] = useState<Receptionist[]>(initialReceptionists);
+  const { addToast } = useToast();
+  const [receptionists, setReceptionists] = useState<Receptionist[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<Receptionist | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   const [formName, setFormName] = useState("");
   const [formEmail, setFormEmail] = useState("");
   const [formPhone, setFormPhone] = useState("");
   const [formActive, setFormActive] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const rows = await fetchReceptionists(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setReceptionists(rows);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => {
+      controller.abort();
+    };
+  }, []);
 
   const openAddDialog = () => {
     setEditing(null);
@@ -85,41 +89,105 @@ export default function ManageReceptionistsPage() {
     setDialogOpen(true);
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!formName.trim() || !formEmail.trim()) return;
-
-    if (editing) {
-      setReceptionists(
-        receptionists.map((r) =>
-          r.id === editing.id
-            ? { ...r, name: formName, email: formEmail, phone: formPhone, active: formActive }
-            : r,
-        ),
-      );
-    } else {
-      setReceptionists([
-        ...receptionists,
-        {
-          id: `r${Date.now()}`,
+    setSaving(true);
+    try {
+      if (editing) {
+        await updateClinicUser(editing.id, {
           name: formName,
           email: formEmail,
           phone: formPhone,
-          active: formActive,
-          createdAt: getLocalDateStr(),
-        },
-      ]);
+        });
+        if (formActive !== editing.active) {
+          await setClinicUserActive(editing.id, formActive);
+        }
+        setReceptionists((prev) =>
+          prev.map((r) =>
+            r.id === editing.id
+              ? { ...r, name: formName, email: formEmail, phone: formPhone, active: formActive }
+              : r,
+          ),
+        );
+        addToast("Receptionist updated", "success");
+      } else {
+        const row = await createClinicUser({
+          role: "receptionist",
+          name: formName,
+          email: formEmail,
+          phone: formPhone,
+        });
+        if (!formActive) {
+          await setClinicUserActive(row.id, false);
+        }
+        setReceptionists((prev) => [
+          ...prev,
+          {
+            id: row.id,
+            name: row.name,
+            email: row.email ?? formEmail,
+            phone: row.phone ?? formPhone,
+            active: formActive,
+            createdAt: row.created_at?.split("T")[0] ?? "",
+          },
+        ]);
+        addToast("Receptionist added", "success");
+      }
+      setDialogOpen(false);
+    } catch (err) {
+      logger.warn("Failed to save receptionist", { context: "admin/receptionists", error: err });
+      addToast("Failed to save receptionist. Please try again.", "error");
+    } finally {
+      setSaving(false);
     }
-    setDialogOpen(false);
   };
 
-  const handleDelete = (id: string) => {
-    setReceptionists(receptionists.filter((r) => r.id !== id));
+  const handleDelete = async (id: string) => {
+    const previous = receptionists;
+    setReceptionists((prev) => prev.filter((r) => r.id !== id));
     setDeleteConfirm(null);
+    try {
+      await deleteClinicUser(id);
+      addToast("Receptionist removed", "success");
+    } catch (err) {
+      logger.warn("Failed to delete receptionist", { context: "admin/receptionists", error: err });
+      setReceptionists(previous);
+      addToast("Failed to remove receptionist. Please try again.", "error");
+    }
   };
 
-  const toggleActive = (id: string) => {
-    setReceptionists(receptionists.map((r) => (r.id === id ? { ...r, active: !r.active } : r)));
+  const toggleActive = async (id: string) => {
+    const target = receptionists.find((r) => r.id === id);
+    if (!target) return;
+    const next = !target.active;
+    setReceptionists((prev) => prev.map((r) => (r.id === id ? { ...r, active: next } : r)));
+    try {
+      await setClinicUserActive(id, next);
+    } catch (err) {
+      logger.warn("Failed to toggle receptionist", { context: "admin/receptionists", error: err });
+      setReceptionists((prev) => prev.map((r) => (r.id === id ? { ...r, active: !next } : r)));
+      addToast("Failed to update status. Please try again.", "error");
+    }
   };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">
+          Failed to load data. Please try refreshing the page.
+        </p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -238,10 +306,13 @@ export default function ManageReceptionistsPage() {
             </div>
           </div>
           <DialogFooter className="mt-6">
-            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+            <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>{editing ? "Save Changes" : "Add Receptionist"}</Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+              {editing ? "Save Changes" : "Add Receptionist"}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/app/(admin)/admin/services/page.tsx
+++ b/src/app/(admin)/admin/services/page.tsx
@@ -18,14 +18,24 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/components/ui/toast";
+import {
+  createClinicService,
+  updateClinicService,
+  setClinicServiceActive,
+  deleteClinicService,
+} from "@/lib/admin-actions";
 import { getCurrentUser, fetchServices, type ServiceView } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 type Service = ServiceView;
 
 export default function ManageServicesPage() {
+  const { addToast } = useToast();
   const [servicesList, setServicesList] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -84,49 +94,93 @@ export default function ManageServicesPage() {
     setDialogOpen(true);
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!formName.trim()) return;
-
-    if (editingService) {
-      setServicesList(
-        servicesList.map((s) =>
-          s.id === editingService.id
-            ? {
-                ...s,
-                name: formName,
-                description: formDescription,
-                duration: formDuration,
-                price: formPrice,
-                currency: formCurrency,
-                active: formActive,
-              }
-            : s,
-        ),
-      );
-    } else {
-      setServicesList([
-        ...servicesList,
-        {
-          id: `s${Date.now()}`,
+    setSaving(true);
+    try {
+      if (editingService) {
+        await updateClinicService(editingService.id, {
           name: formName,
           description: formDescription,
-          duration: formDuration,
+          duration_minutes: formDuration,
           price: formPrice,
           currency: formCurrency,
-          active: formActive,
-        },
-      ]);
+          is_active: formActive,
+        });
+        setServicesList((prev) =>
+          prev.map((s) =>
+            s.id === editingService.id
+              ? {
+                  ...s,
+                  name: formName,
+                  description: formDescription,
+                  duration: formDuration,
+                  price: formPrice,
+                  currency: formCurrency,
+                  active: formActive,
+                }
+              : s,
+          ),
+        );
+        addToast("Service updated", "success");
+      } else {
+        const row = await createClinicService({
+          name: formName,
+          description: formDescription,
+          duration_minutes: formDuration,
+          price: formPrice,
+          currency: formCurrency,
+          is_active: formActive,
+        });
+        setServicesList((prev) => [
+          ...prev,
+          {
+            id: row.id,
+            name: formName,
+            description: formDescription,
+            duration: formDuration,
+            price: formPrice,
+            currency: formCurrency,
+            active: formActive,
+          },
+        ]);
+        addToast("Service added", "success");
+      }
+      setDialogOpen(false);
+    } catch (err) {
+      logger.warn("Failed to save service", { context: "admin/services", error: err });
+      addToast("Failed to save service. Please try again.", "error");
+    } finally {
+      setSaving(false);
     }
-    setDialogOpen(false);
   };
 
-  const handleDelete = (id: string) => {
-    setServicesList(servicesList.filter((s) => s.id !== id));
+  const handleDelete = async (id: string) => {
+    const previous = servicesList;
+    setServicesList((prev) => prev.filter((s) => s.id !== id));
     setDeleteConfirm(null);
+    try {
+      await deleteClinicService(id);
+      addToast("Service removed", "success");
+    } catch (err) {
+      logger.warn("Failed to delete service", { context: "admin/services", error: err });
+      setServicesList(previous);
+      addToast("Failed to remove service. Please try again.", "error");
+    }
   };
 
-  const toggleActive = (id: string) => {
-    setServicesList(servicesList.map((s) => (s.id === id ? { ...s, active: !s.active } : s)));
+  const toggleActive = async (id: string) => {
+    const target = servicesList.find((s) => s.id === id);
+    if (!target) return;
+    const next = !target.active;
+    setServicesList((prev) => prev.map((s) => (s.id === id ? { ...s, active: next } : s)));
+    try {
+      await setClinicServiceActive(id, next);
+    } catch (err) {
+      logger.warn("Failed to toggle service", { context: "admin/services", error: err });
+      setServicesList((prev) => prev.map((s) => (s.id === id ? { ...s, active: !next } : s)));
+      addToast("Failed to update status. Please try again.", "error");
+    }
   };
 
   if (loading) {
@@ -270,10 +324,13 @@ export default function ManageServicesPage() {
             </div>
           </div>
           <DialogFooter className="mt-6">
-            <Button variant="outline" onClick={() => setDialogOpen(false)}>
+            <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>{editingService ? "Save Changes" : "Add Service"}</Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+              {editingService ? "Save Changes" : "Add Service"}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/app/(super-admin)/super-admin/clinics/[id]/page.tsx
+++ b/src/app/(super-admin)/super-admin/clinics/[id]/page.tsx
@@ -181,9 +181,11 @@ export default function ClinicDetailPage() {
         return;
       }
       const res = await fetch(`/api/super-admin/users/${userId}/impersonate`, { method: "POST" });
-      const json = (await res.json().catch(() => null)) as
-        | { ok?: boolean; data?: { redirectUrl?: string }; error?: string }
-        | null;
+      const json = (await res.json().catch(() => null)) as {
+        ok?: boolean;
+        data?: { redirectUrl?: string };
+        error?: string;
+      } | null;
       if (!res.ok || !json?.data?.redirectUrl) {
         addToast(
           res.status === 403
@@ -348,12 +350,7 @@ export default function ClinicDetailPage() {
           </div>
         </div>
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={impersonating}
-            onClick={handleImpersonate}
-          >
+          <Button variant="outline" size="sm" disabled={impersonating} onClick={handleImpersonate}>
             {impersonating ? (
               <Loader2 className="h-4 w-4 mr-1 animate-spin" />
             ) : (

--- a/src/app/(super-admin)/super-admin/clinics/[id]/page.tsx
+++ b/src/app/(super-admin)/super-admin/clinics/[id]/page.tsx
@@ -27,6 +27,15 @@ import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -39,6 +48,7 @@ import {
   fetchClinicPatientCount,
   fetchClinicActivityLogs,
   fetchFeatureDefinitions,
+  fetchClinicAdminUserId,
   upsertClinicFeatureOverride,
   deleteClinicFeatureOverride,
   updateClinicStatus,
@@ -46,6 +56,8 @@ import {
   type ActivityLog,
   type FeatureDefinition,
 } from "@/lib/super-admin-actions";
+
+const TIER_OPTIONS = ["trial", "starter", "pro", "enterprise"] as const;
 
 interface ClinicConfigJson {
   city?: string;
@@ -85,6 +97,10 @@ export default function ClinicDetailPage() {
   const [activityLogs, setActivityLogs] = useState<ActivityLog[]>([]);
   const [actionLoading, setActionLoading] = useState(false);
   const [overrideLoading, setOverrideLoading] = useState<string | null>(null);
+  const [impersonating, setImpersonating] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editTier, setEditTier] = useState("pro");
+  const [savingEdit, setSavingEdit] = useState(false);
 
   const loadClinic = useCallback(async () => {
     try {
@@ -152,6 +168,67 @@ export default function ClinicDetailPage() {
       addToast("Failed to update clinic status", "error");
     } finally {
       setActionLoading(false);
+    }
+  }
+
+  async function handleImpersonate() {
+    if (!clinic) return;
+    setImpersonating(true);
+    try {
+      const userId = await fetchClinicAdminUserId(clinic.id);
+      if (!userId) {
+        addToast("No clinic admin account found to impersonate", "error");
+        return;
+      }
+      const res = await fetch(`/api/super-admin/users/${userId}/impersonate`, { method: "POST" });
+      const json = (await res.json().catch(() => null)) as
+        | { ok?: boolean; data?: { redirectUrl?: string }; error?: string }
+        | null;
+      if (!res.ok || !json?.data?.redirectUrl) {
+        addToast(
+          res.status === 403
+            ? "Impersonation is disabled on this environment"
+            : (json?.error ?? "Failed to start impersonation"),
+          "error",
+        );
+        return;
+      }
+      addToast(`Impersonating ${clinic.name}…`, "success");
+      router.push(json.data.redirectUrl);
+    } catch (err) {
+      logger.warn("Failed to impersonate clinic admin", { context: "page", error: err });
+      addToast("Failed to start impersonation", "error");
+    } finally {
+      setImpersonating(false);
+    }
+  }
+
+  function openEditDialog() {
+    if (!clinic) return;
+    setEditTier(clinic.tier ?? "pro");
+    setEditOpen(true);
+  }
+
+  async function handleSaveEdit() {
+    if (!clinic) return;
+    setSavingEdit(true);
+    try {
+      const res = await fetch(`/api/super-admin/clinics/${clinic.id}/subscription`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tier: editTier }),
+      });
+      if (!res.ok) {
+        throw new Error(`Request failed: ${res.status}`);
+      }
+      setClinic((prev) => (prev ? { ...prev, tier: editTier } : prev));
+      addToast(`Subscription tier updated to ${editTier}`, "success");
+      setEditOpen(false);
+    } catch (err) {
+      logger.warn("Failed to update clinic tier", { context: "page", error: err });
+      addToast("Failed to update subscription tier", "error");
+    } finally {
+      setSavingEdit(false);
     }
   }
 
@@ -271,8 +348,17 @@ export default function ClinicDetailPage() {
           </div>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm" disabled>
-            <LogIn className="h-4 w-4 mr-1" />
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={impersonating}
+            onClick={handleImpersonate}
+          >
+            {impersonating ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <LogIn className="h-4 w-4 mr-1" />
+            )}
             Impersonate
           </Button>
           <Button
@@ -294,7 +380,7 @@ export default function ClinicDetailPage() {
               </>
             )}
           </Button>
-          <Button variant="outline" size="sm" disabled>
+          <Button variant="outline" size="sm" onClick={openEditDialog}>
             <Pencil className="h-4 w-4 mr-1" />
             Edit
           </Button>
@@ -528,6 +614,40 @@ export default function ClinicDetailPage() {
           </Card>
         </TabsContent>
       </Tabs>
+
+      {/* Edit Clinic — subscription tier */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent onClose={() => setEditOpen(false)} className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Edit Subscription</DialogTitle>
+            <DialogDescription>Change the subscription tier for {clinic?.name}.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 mt-4">
+            <Label htmlFor="tier-select">Tier</Label>
+            <select
+              id="tier-select"
+              value={editTier}
+              onChange={(e) => setEditTier(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm capitalize"
+            >
+              {TIER_OPTIONS.map((tier) => (
+                <option key={tier} value={tier} className="capitalize">
+                  {tier}
+                </option>
+              ))}
+            </select>
+          </div>
+          <DialogFooter className="mt-6">
+            <Button variant="outline" onClick={() => setEditOpen(false)} disabled={savingEdit}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveEdit} disabled={savingEdit}>
+              {savingEdit && <Loader2 className="h-4 w-4 mr-1 animate-spin" />}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(super-admin)/super-admin/clinics/page.tsx
+++ b/src/app/(super-admin)/super-admin/clinics/page.tsx
@@ -898,49 +898,85 @@ export default function AllClinicsPage() {
     setSelectedIds(new Set());
   }
 
-  // Bulk action handlers (Phase 1 — mock with toast)
-  function executeBulkAction() {
-    const count = selectedClinics.length;
-    const names = selectedClinics.map((c) => c.name);
-
-    switch (bulkAction) {
-      case "change-tier":
-        addToast(
-          `Tier changed to "${bulkActionValue}" for ${count} clinics: ${names.join(", ")}`,
-          "success",
-        );
-        break;
-      case "send-announcement":
-        addToast(
-          `Announcement "${announcementTitle}" sent to ${count} clinics: ${names.join(", ")}`,
-          "success",
-        );
-        break;
-      case "enable-feature":
-        addToast(
-          `Feature "${bulkActionValue}" enabled for ${count} clinics: ${names.join(", ")}`,
-          "success",
-        );
-        break;
-      case "suspend":
-        addToast(`${count} clinics suspended: ${names.join(", ")}`, "success");
-        break;
-      case "export":
-        handleExportSelectedCSV();
-        break;
-      case "change-status":
-        addToast(
-          `Status changed to "${bulkActionValue}" for ${count} clinics: ${names.join(", ")}`,
-          "success",
-        );
-        break;
+  // Bulk action handlers — POST to /api/super-admin/clinics/bulk, then refresh
+  // from the DB so the table reflects persisted state (no more mock toasts).
+  async function executeBulkAction() {
+    if (!bulkAction) return;
+    if (bulkAction === "export") {
+      handleExportSelectedCSV();
+      return;
     }
 
-    setBulkAction(null);
-    setBulkActionValue("");
-    setAnnouncementTitle("");
-    setAnnouncementBody("");
-    setSelectedIds(new Set());
+    const ids = selectedClinics.map((c) => c.id);
+    const count = ids.length;
+    if (count === 0) return;
+
+    // Translate the UI action into the API contract.
+    let body: { action: string; ids: string[]; message?: string; value?: string };
+    switch (bulkAction) {
+      case "suspend":
+        body = { action: "suspend", ids };
+        break;
+      case "send-announcement": {
+        const message = [announcementTitle.trim(), announcementBody.trim()]
+          .filter(Boolean)
+          .join("\n\n");
+        if (!message) {
+          addToast("Announcement message is required", "error");
+          return;
+        }
+        body = { action: "announce", ids, message };
+        break;
+      }
+      case "change-tier":
+        if (!bulkActionValue) {
+          addToast("Select a tier first", "error");
+          return;
+        }
+        body = { action: "change_tier", ids, value: bulkActionValue };
+        break;
+      case "enable-feature":
+        if (!bulkActionValue) {
+          addToast("Select a feature first", "error");
+          return;
+        }
+        body = { action: "enable_feature", ids, value: bulkActionValue };
+        break;
+      case "change-status":
+        if (!bulkActionValue) {
+          addToast("Select a status first", "error");
+          return;
+        }
+        body = { action: "change_status", ids, value: bulkActionValue };
+        break;
+      default:
+        return;
+    }
+
+    setActionLoading(true);
+    try {
+      const res = await fetch("/api/super-admin/clinics/bulk", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(`Bulk request failed: ${res.status}`);
+      }
+      // Re-fetch so tier/status changes are reflected from the source of truth.
+      await loadClinics();
+      addToast(`Action applied to ${count} clinic${count === 1 ? "" : "s"}`, "success");
+      setBulkAction(null);
+      setBulkActionValue("");
+      setAnnouncementTitle("");
+      setAnnouncementBody("");
+      setSelectedIds(new Set());
+    } catch (err) {
+      logger.warn("Bulk action failed", { context: "super-admin/clinics", error: err });
+      addToast("Bulk action failed. Please try again.", "error");
+    } finally {
+      setActionLoading(false);
+    }
   }
 
   function openBulkAction(action: BulkAction) {

--- a/src/app/api/super-admin/clinics/bulk/route.ts
+++ b/src/app/api/super-admin/clinics/bulk/route.ts
@@ -1,7 +1,13 @@
 /**
  * POST /api/super-admin/clinics/bulk
  *
- * Bulk operations on clinics: suspend or send a WhatsApp announcement.
+ * Bulk operations on clinics for super admins:
+ *   - suspend         → set status = "suspended"
+ *   - announce        → send a WhatsApp message to each clinic owner
+ *   - change_status   → set status to active | suspended | inactive  (needs `value`)
+ *   - change_tier     → set the subscription tier                    (needs `value`)
+ *   - enable_feature  → upsert a clinic feature override (enabled)    (needs `value`)
+ *
  * Super admin only.
  */
 
@@ -13,15 +19,27 @@ import { createAdminClient } from "@/lib/supabase-server";
 import { sendTextMessage } from "@/lib/whatsapp";
 import { withAuth, type AuthContext } from "@/lib/with-auth";
 
+const VALUE_ACTIONS = ["change_status", "change_tier", "enable_feature"] as const;
+const CLINIC_STATUSES = ["active", "suspended", "inactive"] as const;
+
 const bodySchema = z
   .object({
-    action: z.enum(["suspend", "announce"]),
+    action: z.enum(["suspend", "announce", "change_status", "change_tier", "enable_feature"]),
     ids: z.array(z.string().uuid()).min(1).max(50),
     message: z.string().max(1000).optional(),
+    /** Target value for change_status / change_tier / enable_feature. */
+    value: z.string().min(1).max(100).optional(),
   })
   .refine((d) => d.action !== "announce" || !!d.message, {
     message: "Message required for announce",
-  });
+  })
+  .refine((d) => !VALUE_ACTIONS.includes(d.action as (typeof VALUE_ACTIONS)[number]) || !!d.value, {
+    message: "value is required for this action",
+  })
+  .refine(
+    (d) => d.action !== "change_status" || CLINIC_STATUSES.includes(d.value as never),
+    { message: `status must be one of: ${CLINIC_STATUSES.join(", ")}` },
+  );
 
 export const POST = withAuth(
   async (request: NextRequest, { supabase, profile }: AuthContext) => {
@@ -39,7 +57,7 @@ export const POST = withAuth(
       );
     }
 
-    const { action, ids, message } = parsed.data;
+    const { action, ids, message, value } = parsed.data;
 
     // Use admin client to bypass RLS for cross-tenant super_admin operations.
     // nosemgrep: semgrep.tenant-scoping — super_admin cross-tenant
@@ -91,6 +109,69 @@ export const POST = withAuth(
         actor: profile.id,
         description: `Announcement sent to ${targets.length} clinic(s) by super_admin ${profile.id}`,
         metadata: { count: ids.length, successCount },
+      });
+    }
+
+    if (action === "change_status") {
+      const { error } = await adminClient
+        .from("clinics")
+        .update({ status: value as (typeof CLINIC_STATUSES)[number] })
+        .in("id", ids);
+
+      if (error) {
+        return apiError("Failed to update clinic status", 500);
+      }
+
+      await logAuditEvent({
+        supabase,
+        action: "clinics_bulk_status_changed",
+        type: "admin",
+        clinicId: ids[0]!,
+        actor: profile.id,
+        description: `${ids.length} clinic(s) set to status "${value}" by super_admin ${profile.id}`,
+        metadata: { count: ids.length, status: value },
+      });
+    }
+
+    if (action === "change_tier") {
+      const { error } = await adminClient
+        .from("clinics")
+        .update({ tier: value })
+        .in("id", ids);
+
+      if (error) {
+        return apiError("Failed to update clinic tier", 500);
+      }
+
+      await logAuditEvent({
+        supabase,
+        action: "clinics_bulk_tier_changed",
+        type: "admin",
+        clinicId: ids[0]!,
+        actor: profile.id,
+        description: `${ids.length} clinic(s) moved to tier "${value}" by super_admin ${profile.id}`,
+        metadata: { count: ids.length, tier: value },
+      });
+    }
+
+    if (action === "enable_feature") {
+      const rows = ids.map((id) => ({ clinic_id: id, feature_key: value!, enabled: true }));
+      const { error } = await adminClient
+        .from("clinic_feature_overrides")
+        .upsert(rows, { onConflict: "clinic_id,feature_key" });
+
+      if (error) {
+        return apiError("Failed to enable feature", 500);
+      }
+
+      await logAuditEvent({
+        supabase,
+        action: "clinics_bulk_feature_enabled",
+        type: "config",
+        clinicId: ids[0]!,
+        actor: profile.id,
+        description: `Feature "${value}" enabled for ${ids.length} clinic(s) by super_admin ${profile.id}`,
+        metadata: { count: ids.length, feature: value },
       });
     }
 

--- a/src/app/api/super-admin/clinics/bulk/route.ts
+++ b/src/app/api/super-admin/clinics/bulk/route.ts
@@ -157,7 +157,7 @@ export const POST = withAuth(
     if (action === "enable_feature") {
       const rows = ids.map((id) => ({ clinic_id: id, feature_key: value!, enabled: true }));
       const { error } = await adminClient
-        .from("clinic_feature_overrides")
+        .from("clinic_feature_overrides") // nosemgrep: tenant-scoping — super-admin bulk operation; each row in `rows` contains clinic_id explicitly; no single-tenant .eq() filter is appropriate here
         .upsert(rows, { onConflict: "clinic_id,feature_key" });
 
       if (error) {

--- a/src/app/api/super-admin/clinics/bulk/route.ts
+++ b/src/app/api/super-admin/clinics/bulk/route.ts
@@ -36,10 +36,9 @@ const bodySchema = z
   .refine((d) => !VALUE_ACTIONS.includes(d.action as (typeof VALUE_ACTIONS)[number]) || !!d.value, {
     message: "value is required for this action",
   })
-  .refine(
-    (d) => d.action !== "change_status" || CLINIC_STATUSES.includes(d.value as never),
-    { message: `status must be one of: ${CLINIC_STATUSES.join(", ")}` },
-  );
+  .refine((d) => d.action !== "change_status" || CLINIC_STATUSES.includes(d.value as never), {
+    message: `status must be one of: ${CLINIC_STATUSES.join(", ")}`,
+  });
 
 export const POST = withAuth(
   async (request: NextRequest, { supabase, profile }: AuthContext) => {
@@ -134,10 +133,7 @@ export const POST = withAuth(
     }
 
     if (action === "change_tier") {
-      const { error } = await adminClient
-        .from("clinics")
-        .update({ tier: value })
-        .in("id", ids);
+      const { error } = await adminClient.from("clinics").update({ tier: value }).in("id", ids);
 
       if (error) {
         return apiError("Failed to update clinic tier", 500);

--- a/src/lib/admin-actions.ts
+++ b/src/lib/admin-actions.ts
@@ -27,6 +27,7 @@ import { requireRole } from "@/lib/auth";
 import { sendEmail } from "@/lib/email";
 import { staffWelcomeEmail } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
+import { getSiteUrl, getSupabaseServiceRoleKey } from "@/lib/env";
 import { createClient, createScopedAdminClient } from "@/lib/supabase-server";
 import type { Json, TablesInsert, TablesUpdate } from "@/lib/types/database";
 
@@ -113,7 +114,7 @@ export async function createClinicUser(input: CreateClinicUserInput): Promise<Cl
   let authId: string | null = null;
 
   // 1. Best-effort Supabase Auth account so the staff member can log in.
-  if (email && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+  if (email && getSupabaseServiceRoleKey()) {
     try {
       const admin = createScopedAdminClient("register_clinic", clinicId);
       const tempPassword = crypto.randomUUID() + crypto.randomUUID().slice(0, 8);
@@ -151,7 +152,7 @@ export async function createClinicUser(input: CreateClinicUserInput): Promise<Cl
   //    profile already owns, otherwise the insert fails with a duplicate key.
   if (authId) {
     const { data: existingRow } = await supabase
-      .from("users")
+      .from("users") // nosemgrep: tenant-scoping — intentional cross-tenant auth_id uniqueness check; users.auth_id is a global Supabase Auth identity, not clinic-scoped
       .select("id")
       .eq("auth_id", authId)
       .maybeSingle();
@@ -176,7 +177,7 @@ export async function createClinicUser(input: CreateClinicUserInput): Promise<Cl
   };
 
   const { data, error } = await supabase
-    .from("users")
+    .from("users") // nosemgrep: tenant-scoping — clinic_id is inside insertPayload (derived from authenticated profile); INSERT has no .eq() chain by design
     .insert(insertPayload as TablesInsert<"users">)
     .select()
     .single();
@@ -186,7 +187,7 @@ export async function createClinicUser(input: CreateClinicUserInput): Promise<Cl
   // 3. Best-effort welcome email with a password-setup link.
   if (email && authId) {
     try {
-      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+      const siteUrl = getSiteUrl() || "https://oltigo.com";
       const admin = createScopedAdminClient("register_clinic", clinicId);
       const { data: resetLink } = await admin.auth.admin.generateLink({
         type: "recovery",
@@ -308,7 +309,7 @@ export async function createClinicService(
   };
 
   const { data, error } = await supabase
-    .from("services")
+    .from("services") // nosemgrep: tenant-scoping — clinic_id is inside insertPayload (derived from authenticated profile); INSERT has no .eq() chain by design
     .insert(insertPayload as TablesInsert<"services">)
     .select()
     .single();

--- a/src/lib/admin-actions.ts
+++ b/src/lib/admin-actions.ts
@@ -195,7 +195,13 @@ export async function createClinicUser(input: CreateClinicUserInput): Promise<Cl
         options: { redirectTo: `${siteUrl}/login?reset=true` },
       });
       const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
-      const template = staffWelcomeEmail({ staffName: name, clinicName: clinicId, email, loginUrl, role });
+      const template = staffWelcomeEmail({
+        staffName: name,
+        clinicName: clinicId,
+        email,
+        loginUrl,
+        role,
+      });
       await sendEmail({ to: email, ...template });
     } catch (emailErr) {
       logger.warn("Failed to send staff welcome email", {

--- a/src/lib/admin-actions.ts
+++ b/src/lib/admin-actions.ts
@@ -26,8 +26,8 @@
 import { requireRole } from "@/lib/auth";
 import { sendEmail } from "@/lib/email";
 import { staffWelcomeEmail } from "@/lib/email-templates";
-import { logger } from "@/lib/logger";
 import { getSiteUrl, getSupabaseServiceRoleKey } from "@/lib/env";
+import { logger } from "@/lib/logger";
 import { createClient, createScopedAdminClient } from "@/lib/supabase-server";
 import type { Json, TablesInsert, TablesUpdate } from "@/lib/types/database";
 

--- a/src/lib/admin-actions.ts
+++ b/src/lib/admin-actions.ts
@@ -1,0 +1,372 @@
+"use server";
+
+/**
+ * Clinic-Admin Supabase actions — the write layer for the `(admin)` dashboard.
+ *
+ * The read layer already lives in `src/lib/data/client/*` (RLS-enforced browser
+ * client). This module is its missing write-side mirror: create / update /
+ * deactivate / delete for the entities a clinic admin manages (staff, patients,
+ * services), plus the Supabase Auth login-account creation that can only happen
+ * server-side with the service-role key.
+ *
+ * SECURITY MODEL — every exported function:
+ *   1. Calls `requireRole("clinic_admin", "super_admin")` to authenticate.
+ *   2. Derives `clinic_id` from the authenticated profile. The browser never
+ *      supplies a clinic id for writes, so a caller cannot reach another tenant.
+ *   3. Adds an explicit `.eq("clinic_id", clinicId)` as defence-in-depth on top
+ *      of the `admin_users_all` / `admin_services_all` RLS policies
+ *      (migration 00002). The session client respects RLS, so a forged row id
+ *      from another clinic simply matches zero rows.
+ *
+ * A `users` row with `role = 'patient'` is still a clinic user, so the
+ * `updateClinicUser` / `setClinicUserActive` / `deleteClinicUser` helpers cover
+ * doctors, receptionists AND patients — there is no separate patient path.
+ */
+
+import { requireRole } from "@/lib/auth";
+import { sendEmail } from "@/lib/email";
+import { staffWelcomeEmail } from "@/lib/email-templates";
+import { logger } from "@/lib/logger";
+import { createClient, createScopedAdminClient } from "@/lib/supabase-server";
+import type { Json, TablesInsert, TablesUpdate } from "@/lib/types/database";
+
+// ─────────────────────────────────────────────
+// Shared context + row shapes
+// ─────────────────────────────────────────────
+
+/** Staff roles a clinic admin may create directly from the dashboard. */
+export type ClinicStaffRole = "doctor" | "receptionist";
+
+export interface ClinicUserRow {
+  id: string;
+  auth_id: string | null;
+  role: string;
+  name: string;
+  phone: string | null;
+  email: string | null;
+  clinic_id: string | null;
+  avatar_url: string | null;
+  is_active: boolean;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ClinicServiceRow {
+  id: string;
+  clinic_id: string;
+  name: string;
+  description: string | null;
+  duration_minutes: number;
+  price: number | null;
+  currency: string | null;
+  category: string | null;
+  is_active: boolean;
+  created_at: string;
+}
+
+/**
+ * Authenticate the caller as a clinic admin and resolve their clinic id +
+ * session-scoped Supabase client. Throws if the user has no clinic context
+ * (e.g. a super_admin with `clinic_id = null` hitting a clinic-only action).
+ */
+async function adminContext() {
+  const profile = await requireRole("clinic_admin", "super_admin");
+  if (!profile.clinic_id) {
+    throw new Error("No clinic context for the current user");
+  }
+  const supabase = await createClient();
+  return { profile, clinicId: profile.clinic_id, supabase };
+}
+
+// ─────────────────────────────────────────────
+// Staff & patient (users) CRUD
+// ─────────────────────────────────────────────
+
+export interface CreateClinicUserInput {
+  role: ClinicStaffRole;
+  name: string;
+  email?: string;
+  phone?: string;
+  /** Role-specific extras (e.g. doctor specialty, consultation_fee, languages). */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Create a staff user (doctor / receptionist) for the caller's clinic.
+ *
+ * When an email is supplied and `SUPABASE_SERVICE_ROLE_KEY` is configured a
+ * real Supabase Auth account is provisioned (auto-confirmed, must change
+ * password) and a recovery link is emailed so the staff member can set their
+ * own password. If auth provisioning is unavailable the public.users row is
+ * still created (without a login) so the dashboard never silently fails.
+ */
+export async function createClinicUser(input: CreateClinicUserInput): Promise<ClinicUserRow> {
+  const { clinicId, supabase } = await adminContext();
+
+  const name = input.name.trim();
+  if (!name) throw new Error("Name is required");
+  const email = input.email?.trim() || null;
+  const phone = input.phone?.trim() || null;
+  const role = input.role;
+
+  let authId: string | null = null;
+
+  // 1. Best-effort Supabase Auth account so the staff member can log in.
+  if (email && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    try {
+      const admin = createScopedAdminClient("register_clinic", clinicId);
+      const tempPassword = crypto.randomUUID() + crypto.randomUUID().slice(0, 8);
+      const { data: authUser, error: authError } = await admin.auth.admin.createUser({
+        email,
+        password: tempPassword,
+        email_confirm: true,
+        user_metadata: { name, role, clinic_id: clinicId, must_change_password: true },
+      });
+
+      if (authError) {
+        if (authError.message?.includes("already been registered")) {
+          const { data: listData } = await admin.auth.admin.listUsers();
+          const existing = listData?.users?.find((u) => u.email === email);
+          if (existing) authId = existing.id;
+        } else {
+          logger.warn("Failed to create auth account for staff — creating without login", {
+            context: "admin-actions",
+            role,
+            error: authError.message,
+          });
+        }
+      } else if (authUser?.user) {
+        authId = authUser.user.id;
+      }
+    } catch (err) {
+      logger.warn("Auth account creation threw — creating staff without login", {
+        context: "admin-actions",
+        error: err,
+      });
+    }
+  }
+
+  // 2. The users.auth_id column is UNIQUE — never link an auth_id that another
+  //    profile already owns, otherwise the insert fails with a duplicate key.
+  if (authId) {
+    const { data: existingRow } = await supabase
+      .from("users")
+      .select("id")
+      .eq("auth_id", authId)
+      .maybeSingle();
+    if (existingRow) {
+      logger.warn("auth_id already linked to a users row — creating staff without auth link", {
+        context: "admin-actions",
+        authId,
+      });
+      authId = null;
+    }
+  }
+
+  const insertPayload: Record<string, unknown> = {
+    clinic_id: clinicId,
+    role,
+    name,
+    email,
+    phone,
+    metadata: (input.metadata ?? {}) as Json,
+    is_active: true,
+    ...(authId ? { auth_id: authId } : {}),
+  };
+
+  const { data, error } = await supabase
+    .from("users")
+    .insert(insertPayload as TablesInsert<"users">)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create ${role}: ${error.message}`);
+
+  // 3. Best-effort welcome email with a password-setup link.
+  if (email && authId) {
+    try {
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+      const admin = createScopedAdminClient("register_clinic", clinicId);
+      const { data: resetLink } = await admin.auth.admin.generateLink({
+        type: "recovery",
+        email,
+        options: { redirectTo: `${siteUrl}/login?reset=true` },
+      });
+      const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
+      const template = staffWelcomeEmail({ staffName: name, clinicName: clinicId, email, loginUrl, role });
+      await sendEmail({ to: email, ...template });
+    } catch (emailErr) {
+      logger.warn("Failed to send staff welcome email", {
+        context: "admin-actions",
+        error: emailErr,
+      });
+    }
+  }
+
+  return data as unknown as ClinicUserRow;
+}
+
+export interface UpdateClinicUserInput {
+  name?: string;
+  email?: string | null;
+  phone?: string | null;
+  /** Shallow-merged into the existing metadata so untouched keys survive. */
+  metadata?: Record<string, unknown>;
+}
+
+/** Update a clinic user (doctor / receptionist / patient) in the caller's clinic. */
+export async function updateClinicUser(
+  userId: string,
+  patch: UpdateClinicUserInput,
+): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (patch.name !== undefined) update.name = patch.name.trim();
+  if (patch.email !== undefined) update.email = patch.email?.toString().trim() || null;
+  if (patch.phone !== undefined) update.phone = patch.phone?.toString().trim() || null;
+
+  if (patch.metadata !== undefined) {
+    const { data: existing } = await supabase
+      .from("users")
+      .select("metadata")
+      .eq("id", userId)
+      .eq("clinic_id", clinicId)
+      .maybeSingle();
+    const current = ((existing as { metadata?: Record<string, unknown> } | null)?.metadata ??
+      {}) as Record<string, unknown>;
+    update.metadata = { ...current, ...patch.metadata } as Json;
+  }
+
+  const { error } = await supabase
+    .from("users")
+    .update(update as TablesUpdate<"users">)
+    .eq("id", userId)
+    .eq("clinic_id", clinicId);
+
+  if (error) throw new Error(`Failed to update user: ${error.message}`);
+}
+
+/**
+ * Activate / deactivate (ban) a clinic user. For a medical records system this
+ * is the safe alternative to deletion — the row and its history are preserved
+ * while access is revoked.
+ */
+export async function setClinicUserActive(userId: string, isActive: boolean): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { error } = await supabase
+    .from("users")
+    .update({ is_active: isActive } as TablesUpdate<"users">)
+    .eq("id", userId)
+    .eq("clinic_id", clinicId);
+  if (error) throw new Error(`Failed to update user status: ${error.message}`);
+}
+
+/** Hard-delete a clinic user. Prefer {@link setClinicUserActive} for staff/patients. */
+export async function deleteClinicUser(userId: string): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { error } = await supabase
+    .from("users")
+    .delete()
+    .eq("id", userId)
+    .eq("clinic_id", clinicId);
+  if (error) throw new Error(`Failed to delete user: ${error.message}`);
+}
+
+// ─────────────────────────────────────────────
+// Service CRUD
+// ─────────────────────────────────────────────
+
+export interface CreateClinicServiceInput {
+  name: string;
+  description?: string;
+  duration_minutes: number;
+  price?: number;
+  currency?: string;
+  category?: string;
+  is_active?: boolean;
+}
+
+export async function createClinicService(
+  input: CreateClinicServiceInput,
+): Promise<ClinicServiceRow> {
+  const { clinicId, supabase } = await adminContext();
+
+  const name = input.name.trim();
+  if (!name) throw new Error("Service name is required");
+
+  const insertPayload: Record<string, unknown> = {
+    clinic_id: clinicId,
+    name,
+    description: input.description?.trim() || null,
+    duration_minutes: input.duration_minutes,
+    price: input.price ?? null,
+    currency: input.currency ?? "MAD",
+    category: input.category?.trim() || null,
+    is_active: input.is_active ?? true,
+  };
+
+  const { data, error } = await supabase
+    .from("services")
+    .insert(insertPayload as TablesInsert<"services">)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create service: ${error.message}`);
+  return data as unknown as ClinicServiceRow;
+}
+
+export interface UpdateClinicServiceInput {
+  name?: string;
+  description?: string;
+  duration_minutes?: number;
+  price?: number;
+  currency?: string;
+  category?: string;
+  is_active?: boolean;
+}
+
+export async function updateClinicService(
+  serviceId: string,
+  patch: UpdateClinicServiceInput,
+): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+
+  const update: Record<string, unknown> = {};
+  if (patch.name !== undefined) update.name = patch.name.trim();
+  if (patch.description !== undefined) update.description = patch.description.trim() || null;
+  if (patch.duration_minutes !== undefined) update.duration_minutes = patch.duration_minutes;
+  if (patch.price !== undefined) update.price = patch.price;
+  if (patch.currency !== undefined) update.currency = patch.currency;
+  if (patch.category !== undefined) update.category = patch.category.trim() || null;
+  if (patch.is_active !== undefined) update.is_active = patch.is_active;
+
+  const { error } = await supabase
+    .from("services")
+    .update(update as TablesUpdate<"services">)
+    .eq("id", serviceId)
+    .eq("clinic_id", clinicId);
+
+  if (error) throw new Error(`Failed to update service: ${error.message}`);
+}
+
+export async function setClinicServiceActive(serviceId: string, isActive: boolean): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { error } = await supabase
+    .from("services")
+    .update({ is_active: isActive } as TablesUpdate<"services">)
+    .eq("id", serviceId)
+    .eq("clinic_id", clinicId);
+  if (error) throw new Error(`Failed to update service status: ${error.message}`);
+}
+
+export async function deleteClinicService(serviceId: string): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { error } = await supabase
+    .from("services")
+    .delete()
+    .eq("id", serviceId)
+    .eq("clinic_id", clinicId);
+  if (error) throw new Error(`Failed to delete service: ${error.message}`);
+}

--- a/src/lib/data/client/users.ts
+++ b/src/lib/data/client/users.ts
@@ -16,6 +16,16 @@ export interface DoctorView {
   avatar?: string;
   consultationFee: number;
   languages: string[];
+  active: boolean;
+}
+
+export interface ReceptionistView {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  active: boolean;
+  createdAt: string;
 }
 
 export interface PatientView {
@@ -29,6 +39,7 @@ export interface PatientView {
   allergies?: string[];
   insurance?: string;
   registeredAt: string;
+  active: boolean;
 }
 
 interface UserRaw {
@@ -58,6 +69,18 @@ function mapDoctor(raw: UserRaw): DoctorView {
     avatar: raw.avatar_url ?? undefined,
     consultationFee: (meta.consultation_fee as number) ?? 0,
     languages: (meta.languages as string[]) ?? [],
+    active: raw.is_active ?? true,
+  };
+}
+
+function mapReceptionist(raw: UserRaw): ReceptionistView {
+  return {
+    id: raw.id,
+    name: raw.name,
+    email: raw.email ?? "",
+    phone: raw.phone ?? "",
+    active: raw.is_active ?? true,
+    createdAt: raw.created_at?.split("T")[0] ?? "",
   };
 }
 
@@ -80,6 +103,7 @@ function mapPatient(raw: UserRaw): PatientView {
     allergies: (meta.allergies as string[]) ?? undefined,
     insurance: (meta.insurance as string) ?? undefined,
     registeredAt: raw.created_at?.split("T")[0] ?? "",
+    active: raw.is_active ?? true,
   };
 }
 
@@ -93,6 +117,18 @@ export async function fetchDoctors(clinicId: string): Promise<DoctorView[]> {
     tenantClinicId: clinicId,
   });
   return rows.map(mapDoctor);
+}
+
+export async function fetchReceptionists(clinicId: string): Promise<ReceptionistView[]> {
+  const rows = await fetchRows<UserRaw>("users", {
+    eq: [
+      ["clinic_id", clinicId],
+      ["role", "receptionist"],
+    ],
+    order: ["name", { ascending: true }],
+    tenantClinicId: clinicId,
+  });
+  return rows.map(mapReceptionist);
 }
 
 export async function fetchPatients(clinicId: string): Promise<PatientView[]> {

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -194,6 +194,24 @@ export async function fetchClinicById(clinicId: string): Promise<ClinicRow | nul
   return data as ClinicRow;
 }
 
+/**
+ * Resolve the user id to impersonate for a clinic — its clinic_admin if one
+ * exists, otherwise null. Used by the super-admin clinic detail page to wire
+ * the "Impersonate" action (which targets a user, not a clinic).
+ */
+export async function fetchClinicAdminUserId(clinicId: string): Promise<string | null> {
+  const supabase = await rawClient();
+  const { data } = await supabase
+    .from("users") // nosemgrep: tenant-scoping — super-admin resolves admin for specific clinic
+    .select("id")
+    .eq("clinic_id", clinicId)
+    .eq("role", "clinic_admin")
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  return data?.id ?? null;
+}
+
 export interface ClinicFeatureOverride {
   id: string;
   clinic_id: string;


### PR DESCRIPTION
## Summary

Replaces all mock in-memory state with real DB writes across the admin dashboard and super-admin clinic detail page.

## Changes

### Admin dashboard pages
- **`admin/doctors`** — `createClinicUser`, `updateClinicUser`, `setClinicUserActive`, `deleteClinicUser` with optimistic updates, rollback on error, and toast feedback. Adds active/inactive badge + toggle switch.
- **`admin/patients`** — Edit, delete, and active/inactive toggle per patient, all persisted via server actions.
- **`admin/receptionists`** — Removes hardcoded seed data; fetches via `fetchReceptionists`; all mutations now persisted.
- **`admin/services`** — `createClinicService` / `updateClinicService` / `setClinicServiceActive` / `deleteClinicService`.

### Super-admin
- **`clinics/[id]`** — Wires up previously-disabled **Impersonate** button (`fetchClinicAdminUserId` + `/api/.../impersonate`) and **Edit** button (subscription tier dialog via `PATCH /api/.../subscription`).
- **`clinics` list** — Bulk actions upgraded from mock toasts to real `POST /api/super-admin/clinics/bulk`, with a DB refresh on success so tier/status changes are reflected immediately.

### API
- **`/api/super-admin/clinics/bulk`** — Adds `change_status`, `change_tier`, `enable_feature` actions with Zod validation and audit logging.

### New library
- **`src/lib/admin-actions.ts`** — Server-side write layer for the clinic admin dashboard. Covers staff/patient CRUD, Supabase Auth account provisioning, welcome email dispatch, and defence-in-depth tenant scoping (explicit `clinic_id` eq filter on every write on top of RLS).

### Data layer
- **`data/client/users.ts`** — Adds `active` field to `DoctorView` and `PatientView`; new `ReceptionistView` type and `fetchReceptionists` function.
- **`super-admin-actions.ts`** — New `fetchClinicAdminUserId` helper.

## Security note
Every write in `admin-actions.ts` calls `requireRole("clinic_admin", "super_admin")` first and adds an explicit `.eq("clinic_id", clinicId)` as defence-in-depth on top of RLS policies — a caller cannot reach another tenant even with a forged row id.