### PR TITLE
fix(security): caller-clinic guard on match_documents / match_memories (RLS bypass)

### DIFF
--- a/supabase/migrations/00184_match_fns_tenant_guard.sql
+++ b/supabase/migrations/00184_match_fns_tenant_guard.sql
@@ -1,0 +1,156 @@
+-- Migration 00184: Caller-clinic guard for RAG SECURITY DEFINER match functions
+--
+-- AI-SEC / RLS-bypass hardening.
+--
+-- PROBLEM
+--   match_documents (00174) and match_memories (00175) are SECURITY DEFINER
+--   and therefore bypass RLS. They accept p_clinic_id as a parameter but only
+--   validate that it IS NOT NULL. Any caller that can EXECUTE the function can
+--   pass an ARBITRARY p_clinic_id and read another clinic's embedded documents
+--   or memories — a cross-tenant read bypass on PHI-adjacent data.
+--
+-- FIX
+--   Add the same caller-clinic guard already used by increment_clinic_ai_usage
+--   (00181): resolve the caller's clinic from the JWT profile
+--   (get_user_clinic_id) and/or the request header (get_request_clinic_id) and
+--   reject any call whose p_clinic_id does not match. Service-role / cron
+--   callers have neither context and remain allowed for cross-tenant backfill
+--   and consolidation jobs (which is required by ai-embed-faqs and
+--   ai-memory-consolidate).
+--
+-- SCOPE
+--   CREATE OR REPLACE only — function signatures, return types, ownership and
+--   existing GRANTs are preserved unchanged. No RLS policy is modified. No
+--   existing migration file is edited.
+--
+-- REVERSIBLE: re-apply 00174 / 00175 definitions to drop the guard.
+-- IDEMPOTENT: CREATE OR REPLACE is safe to run repeatedly.
+
+-- ── match_documents ────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION match_documents(
+  p_clinic_id uuid,
+  p_query_embedding vector(1536),
+  p_match_count int DEFAULT 8,
+  p_source_type text DEFAULT NULL,
+  p_keyword text DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  clinic_id uuid,
+  source_type text,
+  source_id uuid,
+  language text,
+  content text,
+  metadata jsonb,
+  similarity float
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_clinic    uuid := get_user_clinic_id();
+  v_request_clinic uuid := get_request_clinic_id();
+BEGIN
+  -- Validate clinic_id parameter (defense in depth).
+  IF p_clinic_id IS NULL THEN
+    RAISE EXCEPTION 'clinic_id parameter is required';
+  END IF;
+
+  -- Caller-clinic guard (mirrors increment_clinic_ai_usage, 00181).
+  -- This function is SECURITY DEFINER and bypasses RLS, so the parameter is
+  -- the ONLY tenant boundary. A caller bound to a clinic (by JWT profile or by
+  -- the x-clinic-id request header) may only query their own clinic.
+  -- Service-role / cron callers have neither context and are allowed.
+  IF v_user_clinic IS NOT NULL OR v_request_clinic IS NOT NULL THEN
+    IF p_clinic_id IS DISTINCT FROM v_user_clinic
+       AND p_clinic_id IS DISTINCT FROM v_request_clinic THEN
+      RAISE EXCEPTION 'match_documents: clinic mismatch';
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    d.id,
+    d.clinic_id,
+    d.source_type,
+    d.source_id,
+    d.language,
+    d.content,
+    d.metadata,
+    1 - (d.embedding <=> p_query_embedding) AS similarity
+  FROM ai_documents d
+  WHERE d.clinic_id = p_clinic_id
+    AND d.embedding IS NOT NULL
+    AND (p_source_type IS NULL OR d.source_type = p_source_type)
+    AND (
+      p_keyword IS NULL
+      OR to_tsvector('french', d.content) @@ plainto_tsquery('french', p_keyword)
+    )
+  ORDER BY d.embedding <=> p_query_embedding
+  LIMIT p_match_count;
+END;
+$$;
+
+COMMENT ON FUNCTION match_documents(uuid, vector, int, text, text) IS
+  'RLS-bypass hardened (00184): SECURITY DEFINER cosine search; rejects callers whose clinic context does not match p_clinic_id. Service-role/cron callers allowed.';
+
+-- ── match_memories ─────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION match_memories(
+  p_clinic_id uuid,
+  p_agent_type text,
+  p_query_embedding vector(1536),
+  p_match_count int DEFAULT 5
+)
+RETURNS TABLE (
+  id uuid,
+  clinic_id uuid,
+  agent_type text,
+  content text,
+  confidence real,
+  last_used_at timestamptz,
+  created_at timestamptz,
+  similarity float
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_clinic    uuid := get_user_clinic_id();
+  v_request_clinic uuid := get_request_clinic_id();
+BEGIN
+  IF p_clinic_id IS NULL THEN
+    RAISE EXCEPTION 'clinic_id parameter is required';
+  END IF;
+
+  -- Caller-clinic guard (see match_documents above).
+  IF v_user_clinic IS NOT NULL OR v_request_clinic IS NOT NULL THEN
+    IF p_clinic_id IS DISTINCT FROM v_user_clinic
+       AND p_clinic_id IS DISTINCT FROM v_request_clinic THEN
+      RAISE EXCEPTION 'match_memories: clinic mismatch';
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    m.id,
+    m.clinic_id,
+    m.agent_type,
+    m.content,
+    m.confidence,
+    m.last_used_at,
+    m.created_at,
+    1 - (m.embedding <=> p_query_embedding) AS similarity
+  FROM ai_memories m
+  WHERE m.clinic_id = p_clinic_id
+    AND m.agent_type = p_agent_type
+    AND m.embedding IS NOT NULL
+    AND m.confidence >= 0.4
+  ORDER BY m.embedding <=> p_query_embedding
+  LIMIT p_match_count;
+END;
+$$;
+
+COMMENT ON FUNCTION match_memories(uuid, text, vector, int) IS
+  'RLS-bypass hardened (00184): SECURITY DEFINER cosine search; rejects callers whose clinic context does not match p_clinic_id. Service-role/cron callers allowed.';

--- a/supabase/tests/match_fns_tenant_guard.test.sql
+++ b/supabase/tests/match_fns_tenant_guard.test.sql
@@ -1,0 +1,96 @@
+-- ============================================================================
+-- Pin the caller-clinic guard in match_documents / match_memories (00184).
+-- ============================================================================
+--
+-- Both RPCs are SECURITY DEFINER (defined in 00174 / 00175) and bypass RLS.
+-- Migration 00184 added a caller-clinic guard so a clinic-bound caller cannot
+-- pass another clinic's id and exfiltrate that clinic's embedded documents or
+-- memories. A hostile or careless author could regress this by dropping the
+-- guard. This test pins each scenario so a regression fails loudly.
+--
+-- Caller clinic context is resolved by get_request_clinic_id(), which falls
+-- back to the `app.current_clinic_id` session GUC — we set it here to simulate
+-- a request bound to clinic A without needing a live PostgREST request.
+--
+-- Run locally with pgTAP (https://pgtap.org/) installed:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/match_fns_tenant_guard.test.sql
+--
+-- Wrapped in a transaction that rolls back, so it is safe to run repeatedly.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
+SELECT plan(10);
+
+-- A zero embedding so the function calls are well-typed. The guard fires before
+-- the vector search in the cross-tenant cases, so the value is irrelevant there.
+CREATE FUNCTION pg_temp.zv() RETURNS vector LANGUAGE sql AS
+$f$ SELECT ('[' || array_to_string(array_fill(0::float4, ARRAY[1536]), ',') || ']')::vector $f$;
+
+-- ── Structure: both functions exist and are still SECURITY DEFINER ──────────
+SELECT has_function(
+  'public', 'match_documents',
+  ARRAY['uuid','vector','integer','text','text'],
+  'match_documents(...) is defined in the public schema'
+);
+SELECT is(
+  (SELECT prosecdef FROM pg_proc
+     WHERE proname = 'match_documents' AND pronamespace = 'public'::regnamespace),
+  true,
+  'match_documents is SECURITY DEFINER'
+);
+SELECT has_function(
+  'public', 'match_memories',
+  ARRAY['uuid','text','vector','integer'],
+  'match_memories(...) is defined in the public schema'
+);
+SELECT is(
+  (SELECT prosecdef FROM pg_proc
+     WHERE proname = 'match_memories' AND pronamespace = 'public'::regnamespace),
+  true,
+  'match_memories is SECURITY DEFINER'
+);
+
+-- ── Behaviour: caller bound to clinic A ─────────────────────────────────────
+SELECT set_config('app.current_clinic_id', '11111111-1111-1111-1111-111111111111', true);
+
+-- A caller bound to clinic A must NOT be able to query clinic B.
+SELECT throws_like(
+  $$ SELECT public.match_documents('22222222-2222-2222-2222-222222222222'::uuid, pg_temp.zv()) $$,
+  '%clinic mismatch%',
+  'match_documents rejects a clinic-A caller querying clinic B'
+);
+SELECT throws_like(
+  $$ SELECT public.match_memories('22222222-2222-2222-2222-222222222222'::uuid, 'general', pg_temp.zv()) $$,
+  '%clinic mismatch%',
+  'match_memories rejects a clinic-A caller querying clinic B'
+);
+
+-- A caller bound to clinic A querying clinic A is allowed (returns 0 rows, no raise).
+SELECT lives_ok(
+  $$ SELECT public.match_documents('11111111-1111-1111-1111-111111111111'::uuid, pg_temp.zv()) $$,
+  'match_documents allows a clinic-A caller querying clinic A'
+);
+SELECT lives_ok(
+  $$ SELECT public.match_memories('11111111-1111-1111-1111-111111111111'::uuid, 'general', pg_temp.zv()) $$,
+  'match_memories allows a clinic-A caller querying clinic A'
+);
+
+-- ── Behaviour: service-role / cron caller (no clinic context) ───────────────
+-- Backfill and consolidation jobs run without a user or request clinic and
+-- must remain able to query any clinic.
+SELECT set_config('app.current_clinic_id', '', true);
+
+SELECT lives_ok(
+  $$ SELECT public.match_documents('22222222-2222-2222-2222-222222222222'::uuid, pg_temp.zv()) $$,
+  'match_documents allows a service-role caller (no clinic context) for any clinic'
+);
+SELECT lives_ok(
+  $$ SELECT public.match_memories('22222222-2222-2222-2222-222222222222'::uuid, 'general', pg_temp.zv()) $$,
+  'match_memories allows a service-role caller (no clinic context) for any clinic'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
## Summary

`match_documents` (00174) and `match_memories` (00175) are `SECURITY DEFINER` RPCs, so they **bypass RLS**. They accepted `p_clinic_id` as a parameter but only validated `p_clinic_id IS NOT NULL`. Any caller that can `EXECUTE` them could pass an **arbitrary** `p_clinic_id` and read another clinic's embedded documents / memories — a cross-tenant read bypass on PHI-adjacent data.

This PR adds the **caller-clinic guard** already used by `increment_clinic_ai_usage` (00181).

## The exploit (before)

```
-- caller bound to clinic A (JWT profile or x-clinic-id header)
select * from match_documents('<CLINIC_B>', <embedding>);  -- returned clinic B's rows
```

## The fix

`CREATE OR REPLACE` on both functions. Resolve the caller's clinic from `get_user_clinic_id()` (JWT profile) and `get_request_clinic_id()` (x-clinic-id header / session GUC); reject when `p_clinic_id` matches neither:

```sql
IF v_user_clinic IS NOT NULL OR v_request_clinic IS NOT NULL THEN
  IF p_clinic_id IS DISTINCT FROM v_user_clinic
     AND p_clinic_id IS DISTINCT FROM v_request_clinic THEN
    RAISE EXCEPTION 'match_documents: clinic mismatch';
  END IF;
END IF;
```

Service-role / cron callers have **neither** context and remain allowed — required by `ai-embed-faqs` and `ai-memory-consolidate` cross-tenant backfill. This is identical to the established 00181 pattern.

## Verification

A pgTAP test (`supabase/tests/match_fns_tenant_guard.test.sql`) pins each scenario, mirroring `booking_atomic_insert.test.sql`. Verified in an isolated Postgres 17 + pgvector harness (helpers + tables reproduced from 00002/00042/00174/00175):

- **Original functions:** the two cross-tenant assertions **fail** (the bug is real and caught).
- **After 00184:** **10/10 pass** — `CREATE OR REPLACE` is signature-compatible; cross-clinic rejected; same-clinic and no-context (service-role) paths still succeed.

> Note: verified in isolation, not against the full migration set. CI should run `npm run test:db` (`supabase test db`) for full-schema confirmation — the new test is auto-discovered there.

## Scope & safety

- `CREATE OR REPLACE` only — **signatures, return types, ownership and existing GRANTs preserved**.
- **No RLS policy modified. No existing migration file edited.** New files only (additive), per `.ai/TASK-ROUTER.md`.
- Service-role / cron behaviour unchanged.
- Reversible: re-apply the 00174 / 00175 bodies to drop the guard.

## Files

- `supabase/migrations/00184_match_fns_tenant_guard.sql`
- `supabase/tests/match_fns_tenant_guard.test.sql`

---

## Audit context (the rest of the RLS-bypass review)

While auditing the "service role / SECURITY DEFINER bypass" surface:

- **Service-role centralization — already solid.** `createScopedAdminClient(purpose, clinicId)` + the typed `AdminPurpose` union force every admin call site to declare intent; `semgrep.admin-client-guard` enforces it in CI. The AI crons correctly use the scoped client per clinic.
- **No `NEXT_PUBLIC` service-key leak.** Clean.
- **`FORCE ROW LEVEL SECURITY`: 0 of ~100+ RLS-enabled tables.** Recommended as defense-in-depth follow-up (closes the table-owner / SECURITY-DEFINER owner bypass). Held out of this PR because its effect depends on the prod role attributes (whether the table owner has `BYPASSRLS`) and several existing `SECURITY DEFINER` RPCs are granted to `anon` and intentionally rely on bypass — it needs `supabase test db` against the real role setup before shipping. Happy to open it as a separate PR.

## Reviewer checklist

- [ ] `npm run test:db` green (new pgTAP test picked up)
- [ ] Confirm `match_documents` / `match_memories` callers always run with clinic context (JWT or `x-clinic-id`) so legitimate calls aren't blocked
- [ ] Decide on the `FORCE ROW LEVEL SECURITY` follow-up
