### PR TITLE
fix(security): drop debug_request_headers + revoke anon EXECUTE on admin RPCs (00185)

### DIFF
--- a/supabase/migrations/00185_drop_drift_fn_and_revoke_anon_admin_rpcs.sql
+++ b/supabase/migrations/00185_drop_drift_fn_and_revoke_anon_admin_rpcs.sql
@@ -1,0 +1,112 @@
+-- Migration 00185: Drop undocumented prod-only debug function + reconcile
+--                  anon EXECUTE on admin-only SECURITY DEFINER RPCs.
+--
+-- AI-SEC / RLS-bypass + least-privilege hardening.
+--
+-- PROBLEM
+--   A live audit of the production database surfaced two pieces of schema
+--   drift that do NOT exist in version control:
+--
+--   1. public.debug_request_headers() is live in production as a SECURITY
+--      DEFINER function callable by `anon`, yet appears NOWHERE in this repo
+--      (0 occurrences across *.sql and *.ts). It is leftover request-header
+--      debugging from the 00041 / 00042 era. An undocumented, anon-callable,
+--      definer-rights function on a PHI database is attack surface that can
+--      never be code-reviewed because it is not in source control.
+--
+--   2. Four admin-only SECURITY DEFINER RPCs are granted EXECUTE to `anon`
+--      in production, even though each one's DEFINING migration revoked
+--      PUBLIC and granted only authenticated / service_role:
+--        - execute_admin_query(text)          [00157: REVOKE PUBLIC, GRANT authenticated]
+--        - approve_refund(uuid, uuid)         [00151: REVOKE PUBLIC, GRANT authenticated]
+--        - get_super_admin_dashboard_stats()  [00155: REVOKE PUBLIC, GRANT authenticated]
+--        - get_all_clinic_signals()           [00159 + 00169: GRANT service_role only]
+--      Each is protected by an internal is_super_admin() / role guard, so the
+--      stray anon grant is NOT independently exploitable today. But an
+--      anon-callable admin RPC violates least-privilege and is precisely the
+--      drift a pre-launch security review must close. None of the four has any
+--      anon call site in src/ (verified by grep).
+--
+-- FIX
+--   1. Drop every overload of debug_request_headers (signature-agnostic).
+--   2. For each admin RPC, re-assert the intended end state DECLARATIVELY:
+--      REVOKE EXECUTE FROM PUBLIC and FROM anon, then GRANT to the exact role
+--      its defining migration intended. Declaring the end state (rather than
+--      only revoking) is deterministic regardless of the drifted starting
+--      grants and cannot strip a legitimate caller.
+--
+-- SCOPE
+--   No table, no RLS policy, and no function BODY is modified. This is a drop
+--   of an out-of-band function plus EXECUTE-grant reconciliation only. The
+--   public booking / tenant-context surface (booking_atomic_insert,
+--   booking_find_or_create_patient, set_tenant_context, get_request_clinic_id,
+--   get_tenant_context, ...) is deliberately left untouched.
+--
+-- REVERSIBLE: re-GRANT EXECUTE ... TO anon to restore (not advised). The
+--   dropped debug function has no source to restore and should remain gone.
+-- IDEMPOTENT: every statement is guarded by to_regprocedure; safe to re-run.
+
+-- ── 1. Drop the undocumented prod-only debug function (all overloads) ──
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT 'public.' || p.proname || '(' ||
+           pg_get_function_identity_arguments(p.oid) || ')' AS sig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'debug_request_headers'
+  LOOP
+    EXECUTE 'DROP FUNCTION IF EXISTS ' || r.sig;
+    RAISE NOTICE '00185: dropped %', r.sig;
+  END LOOP;
+END $$;
+
+-- ── 2. Reconcile admin-RPC grants to intended least-privilege ──
+-- execute_admin_query(text): authenticated only (internal is_super_admin guard).
+DO $$
+BEGIN
+  IF to_regprocedure('public.execute_admin_query(text)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.execute_admin_query(text) FROM PUBLIC;
+    REVOKE EXECUTE ON FUNCTION public.execute_admin_query(text) FROM anon;
+    GRANT  EXECUTE ON FUNCTION public.execute_admin_query(text) TO authenticated;
+    RAISE NOTICE '00185: reconciled execute_admin_query(text) -> authenticated';
+  END IF;
+END $$;
+
+-- approve_refund(uuid, uuid): authenticated only (super-admin + dual control).
+DO $$
+BEGIN
+  IF to_regprocedure('public.approve_refund(uuid, uuid)') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.approve_refund(uuid, uuid) FROM PUBLIC;
+    REVOKE EXECUTE ON FUNCTION public.approve_refund(uuid, uuid) FROM anon;
+    GRANT  EXECUTE ON FUNCTION public.approve_refund(uuid, uuid) TO authenticated;
+    RAISE NOTICE '00185: reconciled approve_refund(uuid,uuid) -> authenticated';
+  END IF;
+END $$;
+
+-- get_super_admin_dashboard_stats(): authenticated only (super-admin guard).
+DO $$
+BEGIN
+  IF to_regprocedure('public.get_super_admin_dashboard_stats()') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.get_super_admin_dashboard_stats() FROM PUBLIC;
+    REVOKE EXECUTE ON FUNCTION public.get_super_admin_dashboard_stats() FROM anon;
+    GRANT  EXECUTE ON FUNCTION public.get_super_admin_dashboard_stats() TO authenticated;
+    RAISE NOTICE '00185: reconciled get_super_admin_dashboard_stats() -> authenticated';
+  END IF;
+END $$;
+
+-- get_all_clinic_signals(): service_role ONLY. 00169 deliberately revoked
+-- authenticated; do NOT re-grant it here.
+DO $$
+BEGIN
+  IF to_regprocedure('public.get_all_clinic_signals()') IS NOT NULL THEN
+    REVOKE EXECUTE ON FUNCTION public.get_all_clinic_signals() FROM PUBLIC;
+    REVOKE EXECUTE ON FUNCTION public.get_all_clinic_signals() FROM anon;
+    REVOKE EXECUTE ON FUNCTION public.get_all_clinic_signals() FROM authenticated;
+    GRANT  EXECUTE ON FUNCTION public.get_all_clinic_signals() TO service_role;
+    RAISE NOTICE '00185: reconciled get_all_clinic_signals() -> service_role';
+  END IF;
+END $$;

--- a/supabase/tests/admin_rpc_grants_hardening.test.sql
+++ b/supabase/tests/admin_rpc_grants_hardening.test.sql
@@ -1,0 +1,136 @@
+-- ============================================================================
+-- 00185: Pin the drop of debug_request_headers and the anon-grant
+--        reconciliation on admin-only SECURITY DEFINER RPCs.
+-- ============================================================================
+--
+-- Migration 00185 removes an undocumented prod-only function
+-- (debug_request_headers) and revokes the stray `anon` EXECUTE grant from four
+-- admin RPCs, while preserving each function's intended caller:
+--   - execute_admin_query(text)            -> authenticated
+--   - approve_refund(uuid, uuid)           -> authenticated
+--   - get_super_admin_dashboard_stats()    -> authenticated
+--   - get_all_clinic_signals()             -> service_role ONLY (00169)
+--
+-- This test pins the resulting privilege state so a regression (re-granting
+-- anon, or accidentally stripping a legitimate caller) fails loudly. It also
+-- pins a no-regression invariant: the public booking RPC stays anon-callable.
+--
+-- Run locally with pgTAP (https://pgtap.org/) installed:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/admin_rpc_grants_hardening.test.sql
+--
+-- Wrapped in a transaction that rolls back; safe to run repeatedly against any
+-- database where migration 00185 has been applied.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
+SELECT plan(11);
+
+-- 1. The undocumented debug function is gone (all overloads).
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'debug_request_headers'
+  ),
+  'debug_request_headers is fully removed from the public schema'
+);
+
+-- 2-5. anon cannot EXECUTE any of the four admin RPCs (any overload).
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'execute_admin_query'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE execute_admin_query'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'approve_refund'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE approve_refund'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_super_admin_dashboard_stats'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE get_super_admin_dashboard_stats'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_all_clinic_signals'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE get_all_clinic_signals'
+);
+
+-- 6-8. The intended authenticated callers retain EXECUTE.
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'execute_admin_query'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated retains EXECUTE on execute_admin_query'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'approve_refund'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated retains EXECUTE on approve_refund'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_super_admin_dashboard_stats'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated retains EXECUTE on get_super_admin_dashboard_stats'
+);
+
+-- 9. service_role retains EXECUTE on get_all_clinic_signals.
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_all_clinic_signals'
+      AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+  ),
+  'service_role retains EXECUTE on get_all_clinic_signals'
+);
+
+-- 10. authenticated must NOT regain EXECUTE on get_all_clinic_signals (00169).
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_all_clinic_signals'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated does NOT have EXECUTE on get_all_clinic_signals (00169 intent preserved)'
+);
+
+-- 11. No-regression: the public booking RPC stays anon-callable.
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'booking_atomic_insert'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'no-regression: anon can still EXECUTE booking_atomic_insert'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## What

Closes two pieces of **production schema drift** found during the pre-launch security audit. Neither exists in version control.

### 1. Drop `debug_request_headers()`
Live in production as a `SECURITY DEFINER` function callable by `anon`, but absent from this repo (0 occurrences across `*.sql` / `*.ts`). Leftover request-header debugging from the 00041/00042 era. An undocumented, anon-callable, definer-rights function on a PHI database is un-reviewable attack surface.

### 2. Revoke stray `anon` EXECUTE on four admin RPCs
`execute_admin_query`, `approve_refund`, `get_super_admin_dashboard_stats`, and `get_all_clinic_signals` carry an `anon` EXECUTE grant in production that **no committed migration applied**. Each is protected by an internal `is_super_admin()` / role guard, so the stray grant is **not independently exploitable today** — but anon-callable admin RPCs violate least-privilege and are exactly the drift a pre-launch review must close. None has an anon call site in `src/` (verified by grep).

## How

`00185` drops every overload of `debug_request_headers`, then **declaratively** reconciles each RPC's grants to its intended caller:

| function | intended caller (per defining migration) |
|---|---|
| `execute_admin_query(text)` | authenticated (00157) |
| `approve_refund(uuid,uuid)` | authenticated (00151) |
| `get_super_admin_dashboard_stats()` | authenticated (00155) |
| `get_all_clinic_signals()` | **service_role only** (00159 + 00169) |

For each: `REVOKE EXECUTE FROM PUBLIC, anon` → `GRANT` to the intended role. Declaring the end state (rather than only revoking) is deterministic regardless of the drifted starting grants and cannot strip a legitimate caller. Idempotent (guarded by `to_regprocedure`). No table, no RLS policy, and no function **body** is modified.

## Verification

Built a PG17 + pgTAP harness simulating the drifted production grants:

- **Before 00185:** 5 failing assertions — debug fn present; `anon` can call all four RPCs.
- **After 00185:** **11/11 pass** — `anon` locked out, `authenticated`/`service_role` retained, `get_all_clinic_signals` stays service_role-only (00169 intent preserved), and a **no-regression** assertion confirms `booking_atomic_insert` is still anon-callable (i.e. the public booking surface is untouched).

Test added: `supabase/tests/admin_rpc_grants_hardening.test.sql` (runs under `npm run test:db`).

## Not included: `FORCE ROW LEVEL SECURITY`

Investigated and **deliberately skipped**. Proven in the same harness with a non-superuser owner: a booking-style `SECURITY DEFINER` validator returns `1` normally but **`0` under FORCE** — i.e. `booking_atomic_insert` would fail every public booking with "doctor not found in clinic." FORCE also cannot stop the real cross-tenant risk (`service_role` has `BYPASSRLS`, which FORCE does not affect). Net: it breaks the sealed booking RPC for zero security benefit on the path that actually matters.

## Scope

Additive only: one new migration + one new test. No existing migration edited; no sealed-layer file touched.

---
🤖 Drafted by Iris. Follow-up to #1058.
