### PR TITLE
fix(security): lock cron SECURITY DEFINER fns to service_role (00186)

### DIFF
--- a/supabase/migrations/00186_lock_cron_fns_to_service_role.sql
+++ b/supabase/migrations/00186_lock_cron_fns_to_service_role.sql
@@ -1,0 +1,88 @@
+-- Migration 00186: Lock maintenance / cron SECURITY DEFINER functions to
+--                  service_role only (revoke the implicit anon/authenticated
+--                  EXECUTE grant).
+--
+-- AI-SEC / RLS-bypass + least-privilege hardening.
+--
+-- PROBLEM
+--   Postgres grants EXECUTE on every new function to PUBLIC by default, and in
+--   Supabase the `anon` and `authenticated` roles are members of PUBLIC. A
+--   per-role `REVOKE ... FROM anon` therefore does NOTHING unless PUBLIC is
+--   also revoked. A live audit confirmed this: a prod query filtered on
+--   grantee IN ('anon','authenticated') reported these five maintenance
+--   functions as anon/authenticated-callable, because their defining
+--   migrations never revoked PUBLIC.
+--
+--   All five are SECURITY DEFINER (they run with owner rights and BYPASS RLS),
+--   have NO internal authorization guard, and are invoked exclusively as
+--   out-of-band pg_cron jobs / service-role workers (0 call sites in src/ as
+--   `anon` or `authenticated`). They were never meant to be reachable from a
+--   browser session:
+--
+--     - claim_notification_batch(integer)        [00135]  *** PHI / DoS ***
+--     - try_cron_advisory_lock(text)             [00135]
+--     - cleanup_expired_rate_limit_entries()     [00068]
+--     - expire_stale_refund_requests()           [00125]
+--     - refresh_ai_usage_monthly()               [00139]
+--
+--   The standout is claim_notification_batch: it RETURNS SETOF
+--   notification_queue (recipient phone/email + message body + clinic_id) and,
+--   being SECURITY DEFINER, bypasses RLS, so ANY authenticated user could call
+--   it to read other clinics' patient contact details and appointment content
+--   (PHI under HIPAA). As a side effect it also flips the claimed rows to
+--   'processing', so a malicious or accidental call silently drops real
+--   notification sends -- a cross-tenant integrity / DoS bug on top of the read
+--   leak.
+--
+-- FIX
+--   For every overload of each function, re-assert the intended end state
+--   DECLARATIVELY: REVOKE EXECUTE FROM PUBLIC, anon, and authenticated, then
+--   GRANT EXECUTE TO service_role. Declaring the end state (rather than only
+--   revoking anon) is the whole point: PUBLIC is the actual source of the
+--   grant, so revoking anon alone would leave the hole open. service_role and
+--   the function owner (pg_cron context) retain access, so every legitimate
+--   invocation path is preserved.
+--
+-- SCOPE
+--   No table, no RLS policy, and no function BODY is modified. EXECUTE-grant
+--   reconciliation only, on five named maintenance functions. The public
+--   booking / tenant-context surface (booking_atomic_insert,
+--   booking_find_or_create_patient, set_tenant_context, get_request_clinic_id,
+--   ...) is deliberately left untouched and stays anon-callable.
+--
+--   NOTE (root cause, intentionally NOT changed here): the systemic fix would
+--   be `ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS
+--   FROM PUBLIC`. That is deliberately omitted -- it is a broad change that
+--   would also strip the legitimately anon-callable booking/tenant RPCs and
+--   must be evaluated on its own. This migration closes the five proven holes.
+--
+-- REVERSIBLE: re-GRANT EXECUTE ... TO anon/authenticated to restore (not
+--   advised).
+-- IDEMPOTENT: signature-agnostic loop over live overloads; safe to re-run.
+
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT 'public.' || p.proname || '(' ||
+           pg_get_function_identity_arguments(p.oid) || ')' AS sig,
+           p.proname AS name
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = ANY (ARRAY[
+        'claim_notification_batch',
+        'try_cron_advisory_lock',
+        'cleanup_expired_rate_limit_entries',
+        'expire_stale_refund_requests',
+        'refresh_ai_usage_monthly'
+      ])
+  LOOP
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION ' || r.sig || ' FROM PUBLIC';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION ' || r.sig || ' FROM anon';
+    EXECUTE 'REVOKE EXECUTE ON FUNCTION ' || r.sig || ' FROM authenticated';
+    EXECUTE 'GRANT  EXECUTE ON FUNCTION ' || r.sig || ' TO service_role';
+    RAISE NOTICE '00186: locked % -> service_role only', r.sig;
+  END LOOP;
+END $$;

--- a/supabase/tests/cron_fns_service_role_lockdown.test.sql
+++ b/supabase/tests/cron_fns_service_role_lockdown.test.sql
@@ -1,0 +1,182 @@
+-- ============================================================================
+-- 00186: Pin the service_role-only lockdown of maintenance / cron
+--        SECURITY DEFINER functions.
+-- ============================================================================
+--
+-- Migration 00186 revokes the implicit PUBLIC/anon/authenticated EXECUTE grant
+-- from five SECURITY DEFINER maintenance functions and grants EXECUTE to
+-- service_role only:
+--   - claim_notification_batch(integer)       (PHI/DoS: SETOF notification_queue)
+--   - try_cron_advisory_lock(text)
+--   - cleanup_expired_rate_limit_entries()
+--   - expire_stale_refund_requests()
+--   - refresh_ai_usage_monthly()
+--
+-- These run exclusively as pg_cron / service-role jobs and must never be
+-- reachable from a browser session. This test pins the privilege state so a
+-- regression (Postgres' default PUBLIC grant re-exposing them, or an explicit
+-- re-grant) fails loudly. It also pins a no-regression invariant: the public
+-- booking RPC stays anon-callable.
+--
+-- Run locally with pgTAP (https://pgtap.org/) installed:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/cron_fns_service_role_lockdown.test.sql
+--
+-- Wrapped in a transaction that rolls back; safe to run repeatedly against any
+-- database where migration 00186 has been applied.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
+SELECT plan(16);
+
+-- 1-5. anon cannot EXECUTE any overload of the five cron functions.
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'claim_notification_batch'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE claim_notification_batch'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'try_cron_advisory_lock'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE try_cron_advisory_lock'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'cleanup_expired_rate_limit_entries'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE cleanup_expired_rate_limit_entries'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'expire_stale_refund_requests'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE expire_stale_refund_requests'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'refresh_ai_usage_monthly'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'anon cannot EXECUTE refresh_ai_usage_monthly'
+);
+
+-- 6-10. authenticated cannot EXECUTE any overload either (service_role only).
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'claim_notification_batch'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated cannot EXECUTE claim_notification_batch (PHI leak path closed)'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'try_cron_advisory_lock'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated cannot EXECUTE try_cron_advisory_lock'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'cleanup_expired_rate_limit_entries'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated cannot EXECUTE cleanup_expired_rate_limit_entries'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'expire_stale_refund_requests'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated cannot EXECUTE expire_stale_refund_requests'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'refresh_ai_usage_monthly'
+      AND has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'authenticated cannot EXECUTE refresh_ai_usage_monthly'
+);
+
+-- 11-15. service_role retains EXECUTE on every cron function (cron path intact).
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'claim_notification_batch'
+      AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+  ),
+  'service_role retains EXECUTE on claim_notification_batch'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'try_cron_advisory_lock'
+      AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+  ),
+  'service_role retains EXECUTE on try_cron_advisory_lock'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'cleanup_expired_rate_limit_entries'
+      AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+  ),
+  'service_role retains EXECUTE on cleanup_expired_rate_limit_entries'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'expire_stale_refund_requests'
+      AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+  ),
+  'service_role retains EXECUTE on expire_stale_refund_requests'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'refresh_ai_usage_monthly'
+      AND has_function_privilege('service_role', p.oid, 'EXECUTE')
+  ),
+  'service_role retains EXECUTE on refresh_ai_usage_monthly'
+);
+
+-- 16. No-regression: the public booking RPC stays anon-callable.
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'booking_atomic_insert'
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'no-regression: anon can still EXECUTE booking_atomic_insert'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## What

Migration **00186** locks five maintenance / cron `SECURITY DEFINER` functions to `service_role` only, closing an implicit `anon` / `authenticated` EXECUTE grant. Follows #1058 (match-fn tenant guard) and #1059 (admin-RPC grant reconciliation) in the pre-launch tenant-isolation sweep.

## Why (root cause)

Postgres grants `EXECUTE` to **PUBLIC** on every `CREATE FUNCTION`, and in Supabase `anon` / `authenticated` are members of PUBLIC. A per-role `REVOKE ... FROM anon` does **nothing** unless PUBLIC is also revoked. A live prod audit (filtered on `grantee IN ('anon','authenticated')`) surfaced five maintenance functions as browser-reachable for exactly this reason, none of which has any internal authorization guard:

| function | source | risk |
|---|---|---|
| `claim_notification_batch(integer)` | 00135 | **PHI + DoS** |
| `try_cron_advisory_lock(text)` | 00135 | integrity |
| `cleanup_expired_rate_limit_entries()` | 00068 | integrity |
| `expire_stale_refund_requests()` | 00125 | integrity |
| `refresh_ai_usage_monthly()` | 00139 | integrity |

The standout is **`claim_notification_batch`**: it `RETURNS SETOF notification_queue` (recipient phone/email + message body + `clinic_id`) and, being `SECURITY DEFINER`, **bypasses RLS**. Any authenticated user could call it to read *other clinics'* patient contact details and appointment content (PHI under HIPAA), and as a side effect it flips claimed rows to `processing` — silently dropping real notification sends (cross-tenant integrity / DoS).

All five run exclusively as out-of-band pg_cron / service-role jobs (0 `anon`/`authenticated` call sites in `src/`), so they were never meant to be reachable from a session.

## Fix

For every overload of each function, declaratively re-assert the intended end state: `REVOKE EXECUTE FROM PUBLIC, anon, authenticated` then `GRANT EXECUTE TO service_role`. Revoking **PUBLIC** (not just `anon`) is the whole point — PUBLIC is the actual source of the grant. `service_role` and the function owner (pg_cron context) keep access, so every legitimate path is preserved.

## Scope / safety

- **No** table, RLS policy, or function **body** modified — EXECUTE-grant reconciliation only.
- Public booking / tenant-context surface (`booking_atomic_insert`, `set_tenant_context`, …) deliberately untouched and stays anon-callable.
- The systemic root-cause fix (`ALTER DEFAULT PRIVILEGES ... REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC`) is intentionally **not** included here — it would also strip the legitimately anon-callable booking RPCs and must be evaluated on its own. This PR closes the five proven holes.
- Migration is additive and idempotent (signature-agnostic loop over live overloads).

## Verification (PG17 + pgTAP, isolated harness)

Faithful harness reproducing the drifted/default grant state, with `notification_queue` under RLS and two clinics' rows seeded:

1. **PHI leak demonstrated (pre-fix):** an `authenticated` user scoped to Clinic A sees only their row via a direct RLS-checked `SELECT`, but through `claim_notification_batch` receives **both** clinics — incl. `patientB@example.ma / "Clinic B: lab results ready"`. RLS bypassed.
2. **Test:** `cron_fns_service_role_lockdown.test.sql` — **10 failures** against the drifted state → **16/16 pass** after 00186.
3. **Leak closed (post-fix):** `authenticated` calling `claim_notification_batch` now gets `permission denied`; `service_role` (cron path) still executes. No regression on `booking_atomic_insert` (still anon-callable).

## Files

- `supabase/migrations/00186_lock_cron_fns_to_service_role.sql`
- `supabase/tests/cron_fns_service_role_lockdown.test.sql`

🤖 Draft — opened for review. Run `npm run test:db` on your side to confirm against the real schema before merge.
