### PR TITLE
fix: wire live DB reads and writes across all empty-shell dashboard pages

### DIFF
--- a/src/app/(admin)/admin/beds/page.tsx
+++ b/src/app/(admin)/admin/beds/page.tsx
@@ -1,17 +1,81 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BedManagement } from "@/components/polyclinic/bed-management";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { useToast } from "@/components/ui/toast";
+import { createClinicRoom } from "@/lib/admin-actions";
+import { fetchBedManagementRooms, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function AdminBedsPage() {
-  const [rooms] = useState<Parameters<typeof BedManagement>[0]["rooms"]>([]);
+  const { addToast } = useToast();
+  const [rooms, setRooms] = useState<Parameters<typeof BedManagement>[0]["rooms"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchBedManagementRooms(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setRooms(data);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  async function reloadRooms() {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) return;
+    setRooms(await fetchBedManagementRooms(user.clinic_id));
+  }
+
+  async function handleAddRoom(room: {
+    roomNumber: string;
+    roomType: string;
+    floor: string;
+    totalBeds: number;
+  }) {
+    try {
+      await createClinicRoom(room);
+      await reloadRooms();
+      addToast("Room created", "success");
+    } catch (err) {
+      logger.warn("Failed to create room", { context: "admin/beds", error: err });
+      addToast("Failed to create room", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading bed management..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load bed management data.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
       <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Beds" }]} />
       <h1 className="text-2xl font-bold">Bed Management</h1>
-      <BedManagement rooms={rooms} editable />
+      <BedManagement rooms={rooms} editable onAddRoom={handleAddRoom} />
     </div>
   );
 }

--- a/src/app/(admin)/admin/departments/page.tsx
+++ b/src/app/(admin)/admin/departments/page.tsx
@@ -1,14 +1,100 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DepartmentDashboard } from "@/components/polyclinic/department-dashboard";
 import { DepartmentManagement } from "@/components/polyclinic/department-management";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { useToast } from "@/components/ui/toast";
+import { createClinicDepartment, setClinicDepartmentActive } from "@/lib/admin-actions";
+import { fetchDepartmentOverview, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function AdminDepartmentsPage() {
-  const [departments] = useState<Parameters<typeof DepartmentManagement>[0]["departments"]>([]);
-  const [stats] = useState<Parameters<typeof DepartmentDashboard>[0]["stats"]>([]);
+  const { addToast } = useToast();
+  const [departments, setDepartments] = useState<
+    Parameters<typeof DepartmentManagement>[0]["departments"]
+  >([]);
+  const [stats, setStats] = useState<Parameters<typeof DepartmentDashboard>[0]["stats"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchDepartmentOverview(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setDepartments(data.departments);
+      setStats(data.stats);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  async function reloadData() {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) return;
+    const data = await fetchDepartmentOverview(user.clinic_id);
+    setDepartments(data.departments);
+    setStats(data.stats);
+  }
+
+  async function handleAddDepartment(department: {
+    name: string;
+    nameAr: string;
+    floor: string;
+    description: string;
+  }) {
+    try {
+      await createClinicDepartment(department);
+      await reloadData();
+      addToast("Department created", "success");
+    } catch (err) {
+      logger.warn("Failed to create department", { context: "admin/departments", error: err });
+      addToast("Failed to create department", "error");
+    }
+  }
+
+  async function handleToggleActive(id: string, active: boolean) {
+    const previous = departments;
+    setDepartments((current) =>
+      current.map((department) =>
+        department.id === id ? { ...department, isActive: active } : department,
+      ),
+    );
+    try {
+      await setClinicDepartmentActive(id, active);
+      addToast(active ? "Department activated" : "Department deactivated", "success");
+    } catch (err) {
+      logger.warn("Failed to update department", { context: "admin/departments", error: err });
+      setDepartments(previous);
+      addToast("Failed to update department", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading departments..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load department data.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -22,7 +108,12 @@ export default function AdminDepartmentsPage() {
           <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
         </TabsList>
         <TabsContent value="departments" className="mt-4">
-          <DepartmentManagement departments={departments} editable />
+          <DepartmentManagement
+            departments={departments}
+            editable
+            onAdd={handleAddDepartment}
+            onToggleActive={handleToggleActive}
+          />
         </TabsContent>
         <TabsContent value="dashboard" className="mt-4">
           <DepartmentDashboard stats={stats} />

--- a/src/app/(admin)/admin/lab-invoices/page.tsx
+++ b/src/app/(admin)/admin/lab-invoices/page.tsx
@@ -1,12 +1,142 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DeliveryInvoicing } from "@/components/dental-lab/delivery-invoicing";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { useToast } from "@/components/ui/toast";
+import { createClinicLabInvoice, updateClinicLabInvoiceStatus } from "@/lib/admin-actions";
+import { fetchLabDeliveriesAndInvoices, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
+import type { LabInvoiceStatus } from "@/lib/types/database";
+
+function parseInvoiceItems(input: string) {
+  return input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [description = "", quantityRaw = "0", unitPriceRaw = "0"] = line
+        .split("|")
+        .map((part) => part.trim());
+      const quantity = Number(quantityRaw);
+      const unitPrice = Number(unitPriceRaw);
+      return {
+        description,
+        quantity,
+        unitPrice,
+        total: quantity * unitPrice,
+      };
+    })
+    .filter((item) => item.description && item.quantity > 0);
+}
 
 export default function AdminLabInvoicesPage() {
-  const [deliveries] = useState<Parameters<typeof DeliveryInvoicing>[0]["deliveries"]>([]);
-  const [invoices] = useState<Parameters<typeof DeliveryInvoicing>[0]["invoices"]>([]);
+  const { addToast } = useToast();
+  const [deliveries, setDeliveries] = useState<
+    Parameters<typeof DeliveryInvoicing>[0]["deliveries"]
+  >([]);
+  const [invoices, setInvoices] = useState<Parameters<typeof DeliveryInvoicing>[0]["invoices"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchLabDeliveriesAndInvoices(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setDeliveries(data.deliveries);
+      setInvoices(data.invoices);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  async function reloadData() {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) return;
+    const data = await fetchLabDeliveriesAndInvoices(user.clinic_id);
+    setDeliveries(data.deliveries);
+    setInvoices(data.invoices);
+  }
+
+  async function handleAddInvoice(invoice: {
+    invoiceNumber: string;
+    dentistName: string;
+    items: string;
+    dueDate: string;
+    notes: string;
+  }) {
+    const items = parseInvoiceItems(invoice.items);
+    if (items.length === 0) {
+      addToast("Enter at least one valid invoice line", "error");
+      return;
+    }
+    try {
+      await createClinicLabInvoice({
+        invoiceNumber: invoice.invoiceNumber,
+        dentistName: invoice.dentistName,
+        dueDate: invoice.dueDate,
+        notes: invoice.notes,
+        items,
+      });
+      await reloadData();
+      addToast("Invoice created", "success");
+    } catch (err) {
+      logger.warn("Failed to create lab invoice", { context: "admin/lab-invoices", error: err });
+      addToast("Failed to create invoice", "error");
+    }
+  }
+
+  async function handleUpdateInvoiceStatus(invoiceId: string, status: LabInvoiceStatus) {
+    const previous = invoices;
+    setInvoices((current) =>
+      current.map((invoice) =>
+        invoice.id === invoiceId
+          ? {
+              ...invoice,
+              status,
+              paidDate:
+                status === "paid" ? new Date().toISOString().split("T")[0] : invoice.paidDate,
+            }
+          : invoice,
+      ),
+    );
+    try {
+      await updateClinicLabInvoiceStatus(invoiceId, status);
+      addToast("Invoice status updated", "success");
+    } catch (err) {
+      logger.warn("Failed to update lab invoice status", {
+        context: "admin/lab-invoices",
+        error: err,
+      });
+      setInvoices(previous);
+      addToast("Failed to update invoice", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading lab invoices..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load lab invoicing data.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -14,7 +144,13 @@ export default function AdminLabInvoicesPage() {
         items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Lab Invoices" }]}
       />
       <h1 className="text-2xl font-bold">Delivery & Invoicing</h1>
-      <DeliveryInvoicing deliveries={deliveries} invoices={invoices} editable />
+      <DeliveryInvoicing
+        deliveries={deliveries}
+        invoices={invoices}
+        editable
+        onAddInvoice={handleAddInvoice}
+        onUpdateInvoiceStatus={handleUpdateInvoiceStatus}
+      />
     </div>
   );
 }

--- a/src/app/(admin)/admin/lab-materials/page.tsx
+++ b/src/app/(admin)/admin/lab-materials/page.tsx
@@ -1,11 +1,98 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { MaterialsInventory } from "@/components/dental-lab/materials-inventory";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { useToast } from "@/components/ui/toast";
+import { createClinicLabMaterial, restockClinicLabMaterial } from "@/lib/admin-actions";
+import { fetchLabMaterials, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function AdminLabMaterialsPage() {
-  const [materials] = useState<Parameters<typeof MaterialsInventory>[0]["materials"]>([]);
+  const { addToast } = useToast();
+  const [materials, setMaterials] = useState<Parameters<typeof MaterialsInventory>[0]["materials"]>(
+    [],
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchLabMaterials(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setMaterials(data);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  async function reloadMaterials() {
+    const user = await getCurrentUser();
+    if (!user?.clinic_id) return;
+    setMaterials(await fetchLabMaterials(user.clinic_id));
+  }
+
+  async function handleAdd(material: {
+    name: string;
+    category: string;
+    quantity: number;
+    unit: string;
+    minThreshold: number;
+    unitCost: number;
+    supplier: string;
+  }) {
+    try {
+      await createClinicLabMaterial(material);
+      await reloadMaterials();
+      addToast("Material added", "success");
+    } catch (err) {
+      logger.warn("Failed to add lab material", { context: "admin/lab-materials", error: err });
+      addToast("Failed to add material", "error");
+    }
+  }
+
+  async function handleRestock(materialId: string, quantity: number) {
+    if (quantity <= 0) {
+      addToast("Enter a valid restock quantity", "error");
+      return;
+    }
+    try {
+      await restockClinicLabMaterial(materialId, quantity);
+      await reloadMaterials();
+      addToast("Inventory updated", "success");
+    } catch (err) {
+      logger.warn("Failed to restock lab material", {
+        context: "admin/lab-materials",
+        error: err,
+      });
+      addToast("Failed to restock material", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading lab materials..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load lab materials.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -13,7 +100,12 @@ export default function AdminLabMaterialsPage() {
         items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Lab Materials" }]}
       />
       <h1 className="text-2xl font-bold">Lab Materials Inventory</h1>
-      <MaterialsInventory materials={materials} editable />
+      <MaterialsInventory
+        materials={materials}
+        editable
+        onAdd={handleAdd}
+        onRestock={handleRestock}
+      />
     </div>
   );
 }

--- a/src/app/(admin)/admin/machines/page.tsx
+++ b/src/app/(admin)/admin/machines/page.tsx
@@ -1,17 +1,102 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { MachineManagement } from "@/components/dialysis/machine-management";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { useToast } from "@/components/ui/toast";
+import {
+  createClinicDialysisMachine,
+  updateClinicDialysisMachineStatus,
+} from "@/lib/admin-actions";
+import { fetchDialysisMachines, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
+import type { DialysisMachineStatus } from "@/lib/types/database";
 
 export default function AdminMachinesPage() {
-  const [machines] = useState<Parameters<typeof MachineManagement>[0]["machines"]>([]);
+  const { addToast } = useToast();
+  const [machines, setMachines] = useState<Parameters<typeof MachineManagement>[0]["machines"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchDialysisMachines(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setMachines(data);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  async function handleAdd(machine: {
+    machineName: string;
+    machineModel: string;
+    serialNumber: string;
+  }) {
+    try {
+      await createClinicDialysisMachine(machine);
+      const user = await getCurrentUser();
+      if (user?.clinic_id) setMachines(await fetchDialysisMachines(user.clinic_id));
+      addToast("Machine added", "success");
+    } catch (err) {
+      logger.warn("Failed to add dialysis machine", { context: "admin/machines", error: err });
+      addToast("Failed to add machine", "error");
+    }
+  }
+
+  async function handleUpdateStatus(machineId: string, status: DialysisMachineStatus) {
+    const previous = machines;
+    setMachines((current) =>
+      current.map((machine) => (machine.id === machineId ? { ...machine, status } : machine)),
+    );
+    try {
+      await updateClinicDialysisMachineStatus(machineId, status);
+      addToast("Machine status updated", "success");
+    } catch (err) {
+      logger.warn("Failed to update machine status", {
+        context: "admin/machines",
+        error: err,
+      });
+      setMachines(previous);
+      addToast("Failed to update machine status", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading machines..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load dialysis machines.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
       <Breadcrumb items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Machines" }]} />
       <h1 className="text-2xl font-bold">Dialysis Machines</h1>
-      <MachineManagement machines={machines} editable />
+      <MachineManagement
+        machines={machines}
+        editable
+        onAdd={handleAdd}
+        onUpdateStatus={handleUpdateStatus}
+      />
     </div>
   );
 }

--- a/src/app/(doctor)/doctor/departments/page.tsx
+++ b/src/app/(doctor)/doctor/departments/page.tsx
@@ -1,14 +1,57 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { DepartmentDashboard } from "@/components/polyclinic/department-dashboard";
 import { DepartmentManagement } from "@/components/polyclinic/department-management";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { fetchDepartmentOverview, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function DoctorDepartmentsPage() {
-  const [departments] = useState<Parameters<typeof DepartmentManagement>[0]["departments"]>([]);
-  const [stats] = useState<Parameters<typeof DepartmentDashboard>[0]["stats"]>([]);
+  const [departments, setDepartments] = useState<
+    Parameters<typeof DepartmentManagement>[0]["departments"]
+  >([]);
+  const [stats, setStats] = useState<Parameters<typeof DepartmentDashboard>[0]["stats"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchDepartmentOverview(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setDepartments(data.departments);
+      setStats(data.stats);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        logger.warn("Failed to load departments", { context: "doctor/departments", error: err });
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  if (loading) return <PageLoader message="Loading departments..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load department data.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -25,6 +68,7 @@ export default function DoctorDepartmentsPage() {
           <DepartmentDashboard stats={stats} />
         </TabsContent>
         <TabsContent value="departments" className="mt-4">
+          {/* Read-only for doctors — management is handled by clinic admin */}
           <DepartmentManagement departments={departments} />
         </TabsContent>
       </Tabs>

--- a/src/app/(doctor)/doctor/dialysis-machines/page.tsx
+++ b/src/app/(doctor)/doctor/dialysis-machines/page.tsx
@@ -1,11 +1,54 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { MachineManagement } from "@/components/dialysis/machine-management";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { fetchDialysisMachines, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function DoctorDialysisMachinesPage() {
-  const [machines] = useState<Parameters<typeof MachineManagement>[0]["machines"]>([]);
+  const [machines, setMachines] = useState<Parameters<typeof MachineManagement>[0]["machines"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchDialysisMachines(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setMachines(data);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        logger.warn("Failed to load dialysis machines", {
+          context: "doctor/dialysis-machines",
+          error: err,
+        });
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  if (loading) return <PageLoader message="Loading dialysis machines..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load dialysis machines.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -13,7 +56,8 @@ export default function DoctorDialysisMachinesPage() {
         items={[{ label: "Doctor", href: "/doctor/dashboard" }, { label: "Dialysis Machines" }]}
       />
       <h1 className="text-2xl font-bold">Dialysis Machines</h1>
-      <MachineManagement machines={machines} editable />
+      {/* Read-only view for doctors — status management is handled by clinic admin */}
+      <MachineManagement machines={machines} />
     </div>
   );
 }

--- a/src/app/(doctor)/doctor/lab-invoices/page.tsx
+++ b/src/app/(doctor)/doctor/lab-invoices/page.tsx
@@ -1,12 +1,55 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { DeliveryInvoicing } from "@/components/dental-lab/delivery-invoicing";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { fetchLabDeliveriesAndInvoices, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function DoctorLabInvoicesPage() {
-  const [deliveries] = useState<Parameters<typeof DeliveryInvoicing>[0]["deliveries"]>([]);
-  const [invoices] = useState<Parameters<typeof DeliveryInvoicing>[0]["invoices"]>([]);
+  const [deliveries, setDeliveries] = useState<
+    Parameters<typeof DeliveryInvoicing>[0]["deliveries"]
+  >([]);
+  const [invoices, setInvoices] = useState<Parameters<typeof DeliveryInvoicing>[0]["invoices"]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchLabDeliveriesAndInvoices(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setDeliveries(data.deliveries);
+      setInvoices(data.invoices);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        logger.warn("Failed to load lab invoices", { context: "doctor/lab-invoices", error: err });
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  if (loading) return <PageLoader message="Loading lab invoices..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load lab invoicing data.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -14,7 +57,8 @@ export default function DoctorLabInvoicesPage() {
         items={[{ label: "Doctor", href: "/doctor/dashboard" }, { label: "Lab Invoices" }]}
       />
       <h1 className="text-2xl font-bold">Deliveries & Invoices</h1>
-      <DeliveryInvoicing deliveries={deliveries} invoices={invoices} editable />
+      {/* Read-only view for doctors — invoice management is handled by clinic admin */}
+      <DeliveryInvoicing deliveries={deliveries} invoices={invoices} />
     </div>
   );
 }

--- a/src/app/(doctor)/doctor/lab-materials/page.tsx
+++ b/src/app/(doctor)/doctor/lab-materials/page.tsx
@@ -1,11 +1,56 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { MaterialsInventory } from "@/components/dental-lab/materials-inventory";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { PageLoader } from "@/components/ui/page-loader";
+import { fetchLabMaterials, getCurrentUser } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 
 export default function DoctorLabMaterialsPage() {
-  const [materials] = useState<Parameters<typeof MaterialsInventory>[0]["materials"]>([]);
+  const [materials, setMaterials] = useState<Parameters<typeof MaterialsInventory>[0]["materials"]>(
+    [],
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      const user = await getCurrentUser();
+      if (controller.signal.aborted) return;
+      if (!user?.clinic_id) {
+        setLoading(false);
+        return;
+      }
+      const data = await fetchLabMaterials(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setMaterials(data);
+      setLoading(false);
+    }
+    load().catch((err) => {
+      if (!controller.signal.aborted) {
+        logger.warn("Failed to load lab materials", {
+          context: "doctor/lab-materials",
+          error: err,
+        });
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setLoading(false);
+      }
+    });
+    return () => controller.abort();
+  }, []);
+
+  if (loading) return <PageLoader message="Loading lab materials..." />;
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-red-600 font-medium">Failed to load lab materials.</p>
+        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -13,7 +58,8 @@ export default function DoctorLabMaterialsPage() {
         items={[{ label: "Doctor", href: "/doctor/dashboard" }, { label: "Lab Materials" }]}
       />
       <h1 className="text-2xl font-bold">Lab Materials</h1>
-      <MaterialsInventory materials={materials} editable />
+      {/* Read-only view for doctors — inventory management is handled by clinic admin */}
+      <MaterialsInventory materials={materials} />
     </div>
   );
 }

--- a/src/app/(specialist)/nutritionist/meal-plans/page.tsx
+++ b/src/app/(specialist)/nutritionist/meal-plans/page.tsx
@@ -4,11 +4,22 @@ import { Apple } from "lucide-react";
 import { useState, useEffect } from "react";
 import { MealPlanBuilder } from "@/components/para-medical/meal-plan-builder";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
-import type { MealPlan } from "@/lib/types/para-medical";
+import { useToast } from "@/components/ui/toast";
+import {
+  getCurrentUser,
+  fetchMealPlans,
+  addMealPlanItem,
+  removeMealPlanItem,
+} from "@/lib/data/client";
+import { logger } from "@/lib/logger";
+import type { MealItem, MealPlan } from "@/lib/types/para-medical";
+
+type MealSlot = "breakfast" | "morning_snack" | "lunch" | "afternoon_snack" | "dinner";
 
 export default function MealPlansPage() {
+  const { addToast } = useToast();
   const [plans, setPlans] = useState<MealPlan[]>([]);
+  const [clinicId, setClinicId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -21,30 +32,72 @@ export default function MealPlansPage() {
         setLoading(false);
         return;
       }
-      setPlans([]);
+      setClinicId(user.clinic_id);
+      const data = await fetchMealPlans(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setPlans(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load meal plans", {
+          context: "nutritionist/meal-plans",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading meal plans..." />;
+  async function handleAddMealItem(planId: string, dayIndex: number, slot: string, item: MealItem) {
+    if (!clinicId) return;
+    try {
+      const updatedDays = await addMealPlanItem(clinicId, planId, dayIndex, slot as MealSlot, item);
+      setPlans((current: MealPlan[]) =>
+        current.map((plan: MealPlan) =>
+          plan.id === planId ? { ...plan, daily_plans: updatedDays } : plan,
+        ),
+      );
+    } catch (err) {
+      logger.warn("Failed to add meal item", { context: "nutritionist/meal-plans", error: err });
+      addToast("Failed to add item", "error");
+    }
   }
+
+  async function handleRemoveMealItem(
+    planId: string,
+    dayIndex: number,
+    slot: string,
+    itemIndex: number,
+  ) {
+    if (!clinicId) return;
+    try {
+      const updatedDays = await removeMealPlanItem(
+        clinicId,
+        planId,
+        dayIndex,
+        slot as MealSlot,
+        itemIndex,
+      );
+      setPlans((current: MealPlan[]) =>
+        current.map((plan: MealPlan) =>
+          plan.id === planId ? { ...plan, daily_plans: updatedDays } : plan,
+        ),
+      );
+    } catch (err) {
+      logger.warn("Failed to remove meal item", { context: "nutritionist/meal-plans", error: err });
+      addToast("Failed to remove item", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading meal plans..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load meal plans.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );
@@ -56,7 +109,12 @@ export default function MealPlansPage() {
         <Apple className="h-6 w-6 text-green-600" />
         <h1 className="text-2xl font-bold">Meal Plans</h1>
       </div>
-      <MealPlanBuilder plans={plans} editable />
+      <MealPlanBuilder
+        plans={plans}
+        editable
+        onAddMealItem={handleAddMealItem}
+        onRemoveMealItem={handleRemoveMealItem}
+      />
     </div>
   );
 }

--- a/src/app/(specialist)/nutritionist/measurements/page.tsx
+++ b/src/app/(specialist)/nutritionist/measurements/page.tsx
@@ -4,7 +4,7 @@ import { Scale } from "lucide-react";
 import dynamic from "next/dynamic";
 import { useState, useEffect } from "react";
 // eslint-disable-next-line import/order
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchBodyMeasurements } from "@/lib/data/client";
 
 const BodyMeasurementTracker = dynamic(
   () =>
@@ -14,6 +14,8 @@ const BodyMeasurementTracker = dynamic(
   { ssr: false, loading: () => <div className="h-[400px] animate-pulse bg-muted rounded-lg" /> },
 );
 import type { BodyMeasurement } from "@/lib/types/para-medical";
+// eslint-disable-next-line import/order
+import { logger } from "@/lib/logger";
 // eslint-disable-next-line import/order
 import { PageLoader } from "@/components/ui/page-loader";
 
@@ -31,30 +33,30 @@ export default function MeasurementsPage() {
         setLoading(false);
         return;
       }
-      setMeasurements([]);
+      const data = await fetchBodyMeasurements(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setMeasurements(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load body measurements", {
+          context: "nutritionist/measurements",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading measurements..." />;
-  }
+  if (loading) return <PageLoader message="Loading measurements..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load measurements.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/optician/frame-catalog/page.tsx
+++ b/src/app/(specialist)/optician/frame-catalog/page.tsx
@@ -4,7 +4,8 @@ import { Glasses } from "lucide-react";
 import { useState, useEffect } from "react";
 import { FrameCatalog } from "@/components/para-medical/frame-catalog";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchFrameCatalog } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { FrameCatalogItem } from "@/lib/types/para-medical";
 
 export default function FrameCatalogPage() {
@@ -21,30 +22,30 @@ export default function FrameCatalogPage() {
         setLoading(false);
         return;
       }
-      setFrames([]);
+      const data = await fetchFrameCatalog(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setFrames(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load frame catalog", {
+          context: "optician/frame-catalog",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading frame catalog..." />;
-  }
+  if (loading) return <PageLoader message="Loading frame catalog..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load frame catalog.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/optician/lens-inventory/page.tsx
+++ b/src/app/(specialist)/optician/lens-inventory/page.tsx
@@ -4,7 +4,8 @@ import { Package } from "lucide-react";
 import { useState, useEffect } from "react";
 import { LensInventoryManager } from "@/components/para-medical/lens-inventory-manager";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchLensInventory } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { LensInventoryItem } from "@/lib/types/para-medical";
 
 export default function LensInventoryPage() {
@@ -21,30 +22,30 @@ export default function LensInventoryPage() {
         setLoading(false);
         return;
       }
-      setItems([]);
+      const data = await fetchLensInventory(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setItems(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load lens inventory", {
+          context: "optician/lens-inventory",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading lens inventory..." />;
-  }
+  if (loading) return <PageLoader message="Loading lens inventory..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load lens inventory.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/optician/prescriptions/page.tsx
+++ b/src/app/(specialist)/optician/prescriptions/page.tsx
@@ -4,11 +4,19 @@ import { FileText } from "lucide-react";
 import { useState, useEffect } from "react";
 import { OpticalPrescriptionTracker } from "@/components/para-medical/optical-prescription-tracker";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { useToast } from "@/components/ui/toast";
+import {
+  getCurrentUser,
+  fetchOpticalPrescriptions,
+  updateOpticalPrescriptionStatus,
+} from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { OpticalPrescription } from "@/lib/types/para-medical";
 
 export default function OpticalPrescriptionsPage() {
+  const { addToast } = useToast();
   const [prescriptions, setPrescriptions] = useState<OpticalPrescription[]>([]);
+  const [clinicId, setClinicId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -21,30 +29,50 @@ export default function OpticalPrescriptionsPage() {
         setLoading(false);
         return;
       }
-      setPrescriptions([]);
+      setClinicId(user.clinic_id);
+      const data = await fetchOpticalPrescriptions(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setPrescriptions(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load optical prescriptions", {
+          context: "optician/prescriptions",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading prescriptions..." />;
+  async function handleUpdateStatus(id: string, status: OpticalPrescription["status"]) {
+    if (!clinicId) return;
+    const previous = prescriptions;
+    setPrescriptions((current: OpticalPrescription[]) =>
+      current.map((rx: OpticalPrescription) => (rx.id === id ? { ...rx, status } : rx)),
+    );
+    try {
+      await updateOpticalPrescriptionStatus(clinicId, id, status);
+      addToast("Prescription status updated", "success");
+    } catch (err) {
+      logger.warn("Failed to update prescription status", {
+        context: "optician/prescriptions",
+        error: err,
+      });
+      setPrescriptions(previous);
+      addToast("Failed to update status", "error");
+    }
   }
+
+  if (loading) return <PageLoader message="Loading prescriptions..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load prescriptions.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );
@@ -56,7 +84,11 @@ export default function OpticalPrescriptionsPage() {
         <FileText className="h-6 w-6 text-blue-600" />
         <h1 className="text-2xl font-bold">Optical Prescriptions</h1>
       </div>
-      <OpticalPrescriptionTracker prescriptions={prescriptions} editable />
+      <OpticalPrescriptionTracker
+        prescriptions={prescriptions}
+        editable
+        onUpdateStatus={handleUpdateStatus}
+      />
     </div>
   );
 }

--- a/src/app/(specialist)/physiotherapist/exercise-programs/page.tsx
+++ b/src/app/(specialist)/physiotherapist/exercise-programs/page.tsx
@@ -4,11 +4,21 @@ import { Dumbbell } from "lucide-react";
 import { useState, useEffect } from "react";
 import { ExerciseProgramBuilder } from "@/components/para-medical/exercise-program-builder";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
-import type { ExerciseProgram } from "@/lib/types/para-medical";
+import { useToast } from "@/components/ui/toast";
+import {
+  getCurrentUser,
+  fetchExercisePrograms,
+  addExerciseToProgram,
+  removeExerciseFromProgram,
+  updateExerciseProgramStatus,
+} from "@/lib/data/client";
+import { logger } from "@/lib/logger";
+import type { Exercise, ExerciseProgram } from "@/lib/types/para-medical";
 
 export default function ExerciseProgramsPage() {
+  const { addToast } = useToast();
   const [programs, setPrograms] = useState<ExerciseProgram[]>([]);
+  const [clinicId, setClinicId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -21,31 +31,87 @@ export default function ExerciseProgramsPage() {
         setLoading(false);
         return;
       }
-      // Data will come from Supabase once wired
-      setPrograms([]);
+      setClinicId(user.clinic_id);
+      const data = await fetchExercisePrograms(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setPrograms(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load exercise programs", {
+          context: "physiotherapist/exercise-programs",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading exercise programs..." />;
+  async function handleAddExercise(programId: string, exercise: Omit<Exercise, "id">) {
+    if (!clinicId) return;
+    try {
+      const updatedExercises = await addExerciseToProgram(clinicId, programId, exercise);
+      setPrograms((current: ExerciseProgram[]) =>
+        current.map((program: ExerciseProgram) =>
+          program.id === programId ? { ...program, exercises: updatedExercises } : program,
+        ),
+      );
+    } catch (err) {
+      logger.warn("Failed to add exercise", {
+        context: "physiotherapist/exercise-programs",
+        error: err,
+      });
+      addToast("Failed to add exercise", "error");
+    }
   }
+
+  async function handleRemoveExercise(programId: string, exerciseIndex: number) {
+    if (!clinicId) return;
+    try {
+      const updatedExercises = await removeExerciseFromProgram(clinicId, programId, exerciseIndex);
+      setPrograms((current: ExerciseProgram[]) =>
+        current.map((program: ExerciseProgram) =>
+          program.id === programId ? { ...program, exercises: updatedExercises } : program,
+        ),
+      );
+    } catch (err) {
+      logger.warn("Failed to remove exercise", {
+        context: "physiotherapist/exercise-programs",
+        error: err,
+      });
+      addToast("Failed to remove exercise", "error");
+    }
+  }
+
+  async function handleUpdateStatus(programId: string, status: ExerciseProgram["status"]) {
+    if (!clinicId) return;
+    const previous = programs;
+    setPrograms((current: ExerciseProgram[]) =>
+      current.map((program: ExerciseProgram) =>
+        program.id === programId ? { ...program, status } : program,
+      ),
+    );
+    try {
+      await updateExerciseProgramStatus(clinicId, programId, status);
+    } catch (err) {
+      logger.warn("Failed to update program status", {
+        context: "physiotherapist/exercise-programs",
+        error: err,
+      });
+      setPrograms(previous);
+      addToast("Failed to update program status", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading exercise programs..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load exercise programs.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );
@@ -59,7 +125,13 @@ export default function ExerciseProgramsPage() {
           <h1 className="text-2xl font-bold">Exercise Programs</h1>
         </div>
       </div>
-      <ExerciseProgramBuilder programs={programs} editable />
+      <ExerciseProgramBuilder
+        programs={programs}
+        editable
+        onAddExercise={handleAddExercise}
+        onRemoveExercise={handleRemoveExercise}
+        onUpdateStatus={handleUpdateStatus}
+      />
     </div>
   );
 }

--- a/src/app/(specialist)/physiotherapist/progress-photos/page.tsx
+++ b/src/app/(specialist)/physiotherapist/progress-photos/page.tsx
@@ -4,7 +4,8 @@ import { Camera } from "lucide-react";
 import { useState, useEffect } from "react";
 import { ProgressPhotoGallery } from "@/components/para-medical/progress-photo-gallery";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchProgressPhotos } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { ProgressPhoto } from "@/lib/types/para-medical";
 
 export default function ProgressPhotosPage() {
@@ -21,30 +22,30 @@ export default function ProgressPhotosPage() {
         setLoading(false);
         return;
       }
-      setPhotos([]);
+      const data = await fetchProgressPhotos(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setPhotos(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load progress photos", {
+          context: "physiotherapist/progress-photos",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading photos..." />;
-  }
+  if (loading) return <PageLoader message="Loading photos..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load progress photos.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/physiotherapist/sessions/page.tsx
+++ b/src/app/(specialist)/physiotherapist/sessions/page.tsx
@@ -4,7 +4,8 @@ import { ClipboardList } from "lucide-react";
 import { useState, useEffect } from "react";
 import { PhysioSessionTracker } from "@/components/para-medical/physio-session-tracker";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchPhysioSessions } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { PhysioSession } from "@/lib/types/para-medical";
 
 export default function PhysioSessionsPage() {
@@ -21,30 +22,30 @@ export default function PhysioSessionsPage() {
         setLoading(false);
         return;
       }
-      setSessions([]);
+      const data = await fetchPhysioSessions(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setSessions(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load physio sessions", {
+          context: "physiotherapist/sessions",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading sessions..." />;
-  }
+  if (loading) return <PageLoader message="Loading sessions..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load sessions.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/psychologist/progress/page.tsx
+++ b/src/app/(specialist)/psychologist/progress/page.tsx
@@ -5,7 +5,8 @@ import dynamic from "next/dynamic";
 import { useState, useEffect } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchTherapySessionNotes } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { TherapySessionNote } from "@/lib/types/para-medical";
 
 const MoodChart = dynamic(() => import("./mood-chart").then((m) => m.MoodChart), {
@@ -27,30 +28,30 @@ export default function ProgressTrackingPage() {
         setLoading(false);
         return;
       }
-      setSessions([]);
+      const data = await fetchTherapySessionNotes(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setSessions(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load therapy sessions for progress", {
+          context: "psychologist/progress",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading progress data..." />;
-  }
+  if (loading) return <PageLoader message="Loading progress data..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load progress data.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/psychologist/session-notes/page.tsx
+++ b/src/app/(specialist)/psychologist/session-notes/page.tsx
@@ -4,7 +4,8 @@ import { Brain } from "lucide-react";
 import { useState, useEffect } from "react";
 import { TherapySessionNotes } from "@/components/para-medical/therapy-session-notes";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchTherapySessionNotes } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { TherapySessionNote } from "@/lib/types/para-medical";
 
 export default function SessionNotesPage() {
@@ -21,30 +22,30 @@ export default function SessionNotesPage() {
         setLoading(false);
         return;
       }
-      setSessions([]);
+      const data = await fetchTherapySessionNotes(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setSessions(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load session notes", {
+          context: "psychologist/session-notes",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading session notes..." />;
-  }
+  if (loading) return <PageLoader message="Loading session notes..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load session notes.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/psychologist/therapy-plans/page.tsx
+++ b/src/app/(specialist)/psychologist/therapy-plans/page.tsx
@@ -4,11 +4,20 @@ import { Target } from "lucide-react";
 import { useState, useEffect } from "react";
 import { TherapyPlanView } from "@/components/para-medical/therapy-plan-view";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
-import type { TherapyPlan } from "@/lib/types/para-medical";
+import { useToast } from "@/components/ui/toast";
+import {
+  getCurrentUser,
+  fetchTherapyPlans,
+  updateTherapyPlanGoalStatus,
+  toggleTherapyPlanMilestone,
+} from "@/lib/data/client";
+import { logger } from "@/lib/logger";
+import type { TherapyGoal, TherapyPlan } from "@/lib/types/para-medical";
 
 export default function TherapyPlansPage() {
+  const { addToast } = useToast();
   const [plans, setPlans] = useState<TherapyPlan[]>([]);
+  const [clinicId, setClinicId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -21,30 +30,76 @@ export default function TherapyPlansPage() {
         setLoading(false);
         return;
       }
-      setPlans([]);
+      setClinicId(user.clinic_id);
+      const data = await fetchTherapyPlans(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setPlans(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load therapy plans", {
+          context: "psychologist/therapy-plans",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading therapy plans..." />;
+  async function handleUpdateGoalStatus(
+    planId: string,
+    goalId: string,
+    status: TherapyGoal["status"],
+  ) {
+    if (!clinicId) return;
+    try {
+      const updatedGoals = await updateTherapyPlanGoalStatus(clinicId, planId, goalId, status);
+      setPlans((current: TherapyPlan[]) =>
+        current.map((plan: TherapyPlan) =>
+          plan.id === planId ? { ...plan, goals: updatedGoals } : plan,
+        ),
+      );
+    } catch (err) {
+      logger.warn("Failed to update goal status", {
+        context: "psychologist/therapy-plans",
+        error: err,
+      });
+      addToast("Failed to update goal", "error");
+    }
   }
+
+  async function handleToggleMilestone(planId: string, goalId: string, milestoneIndex: number) {
+    if (!clinicId) return;
+    try {
+      const updatedGoals = await toggleTherapyPlanMilestone(
+        clinicId,
+        planId,
+        goalId,
+        milestoneIndex,
+      );
+      setPlans((current: TherapyPlan[]) =>
+        current.map((plan: TherapyPlan) =>
+          plan.id === planId ? { ...plan, goals: updatedGoals } : plan,
+        ),
+      );
+    } catch (err) {
+      logger.warn("Failed to toggle milestone", {
+        context: "psychologist/therapy-plans",
+        error: err,
+      });
+      addToast("Failed to update milestone", "error");
+    }
+  }
+
+  if (loading) return <PageLoader message="Loading therapy plans..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load therapy plans.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );
@@ -56,7 +111,12 @@ export default function TherapyPlansPage() {
         <Target className="h-6 w-6 text-purple-600" />
         <h1 className="text-2xl font-bold">Therapy Plans</h1>
       </div>
-      <TherapyPlanView plans={plans} editable />
+      <TherapyPlanView
+        plans={plans}
+        editable
+        onUpdateGoalStatus={handleUpdateGoalStatus}
+        onToggleMilestone={handleToggleMilestone}
+      />
     </div>
   );
 }

--- a/src/app/(specialist)/speech-therapist/exercise-library/page.tsx
+++ b/src/app/(specialist)/speech-therapist/exercise-library/page.tsx
@@ -4,7 +4,8 @@ import { BookOpen } from "lucide-react";
 import { useState, useEffect } from "react";
 import { SpeechExerciseLibrary } from "@/components/para-medical/speech-exercise-library";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchSpeechExercises } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { SpeechExercise } from "@/lib/types/para-medical";
 
 export default function ExerciseLibraryPage() {
@@ -21,30 +22,30 @@ export default function ExerciseLibraryPage() {
         setLoading(false);
         return;
       }
-      setExercises([]);
+      const data = await fetchSpeechExercises(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setExercises(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load speech exercises", {
+          context: "speech-therapist/exercise-library",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading exercise library..." />;
-  }
+  if (loading) return <PageLoader message="Loading exercise library..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load exercise library.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/speech-therapist/reports/page.tsx
+++ b/src/app/(specialist)/speech-therapist/reports/page.tsx
@@ -4,7 +4,8 @@ import { FileText } from "lucide-react";
 import { useState, useEffect } from "react";
 import { SpeechProgressReports } from "@/components/para-medical/speech-progress-reports";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchSpeechProgressReports } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { SpeechProgressReport } from "@/lib/types/para-medical";
 
 export default function SpeechReportsPage() {
@@ -21,30 +22,30 @@ export default function SpeechReportsPage() {
         setLoading(false);
         return;
       }
-      setReports([]);
+      const data = await fetchSpeechProgressReports(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setReports(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load speech reports", {
+          context: "speech-therapist/reports",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading reports..." />;
-  }
+  if (loading) return <PageLoader message="Loading reports..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load progress reports.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/app/(specialist)/speech-therapist/sessions/page.tsx
+++ b/src/app/(specialist)/speech-therapist/sessions/page.tsx
@@ -4,7 +4,8 @@ import { ClipboardList } from "lucide-react";
 import { useState, useEffect } from "react";
 import { SpeechSessionTracker } from "@/components/para-medical/speech-session-tracker";
 import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser } from "@/lib/data/client";
+import { getCurrentUser, fetchSpeechSessions } from "@/lib/data/client";
+import { logger } from "@/lib/logger";
 import type { SpeechSession } from "@/lib/types/para-medical";
 
 export default function SpeechSessionsPage() {
@@ -21,30 +22,30 @@ export default function SpeechSessionsPage() {
         setLoading(false);
         return;
       }
-      setSessions([]);
+      const data = await fetchSpeechSessions(user.clinic_id);
+      if (controller.signal.aborted) return;
+      setSessions(data);
       setLoading(false);
     }
     load().catch((err) => {
       if (!controller.signal.aborted) {
+        logger.warn("Failed to load speech sessions", {
+          context: "speech-therapist/sessions",
+          error: err,
+        });
         setError(err instanceof Error ? err : new Error(String(err)));
         setLoading(false);
       }
     });
-    return () => {
-      controller.abort();
-    };
+    return () => controller.abort();
   }, []);
 
-  if (loading) {
-    return <PageLoader message="Loading sessions..." />;
-  }
+  if (loading) return <PageLoader message="Loading sessions..." />;
 
   if (error) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
+        <p className="text-red-600 font-medium">Failed to load sessions.</p>
         {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
       </div>
     );

--- a/src/components/dental-lab/delivery-invoicing.tsx
+++ b/src/components/dental-lab/delivery-invoicing.tsx
@@ -146,7 +146,7 @@ export function DeliveryInvoicing({
         >
           <Truck className="h-4 w-4 mr-1" /> Deliveries
         </Button>
-        {editable && activeTab === "invoices" && (
+        {editable && onAddInvoice && activeTab === "invoices" && (
           <Button
             size="sm"
             variant="outline"
@@ -281,7 +281,7 @@ export function DeliveryInvoicing({
                             </p>
                           )}
                         </div>
-                        {editable && invoice.status === "draft" && (
+                        {editable && onUpdateInvoiceStatus && invoice.status === "draft" && (
                           <Button
                             size="sm"
                             variant="outline"
@@ -291,7 +291,7 @@ export function DeliveryInvoicing({
                             Send
                           </Button>
                         )}
-                        {editable && invoice.status === "sent" && (
+                        {editable && onUpdateInvoiceStatus && invoice.status === "sent" && (
                           <Button
                             size="sm"
                             variant="outline"

--- a/src/components/dental-lab/materials-inventory.tsx
+++ b/src/components/dental-lab/materials-inventory.tsx
@@ -105,7 +105,7 @@ export function MaterialsInventory({
             </Badge>
           )}
         </h2>
-        {editable && (
+        {editable && onAdd && (
           <Button size="sm" onClick={() => setShowForm(!showForm)}>
             <Plus className="h-4 w-4 mr-1" />
             Add Material
@@ -291,7 +291,7 @@ export function MaterialsInventory({
                             "—"
                           )}
                         </td>
-                        {editable && (
+                        {editable && onRestock && (
                           <td className="p-2">
                             {restockId === m.id ? (
                               <div className="flex items-center gap-1">

--- a/src/components/dialysis/machine-management.tsx
+++ b/src/components/dialysis/machine-management.tsx
@@ -100,7 +100,7 @@ export function MachineManagement({
             {machines.length}
           </Badge>
         </h2>
-        {editable && (
+        {editable && onAdd && (
           <Button size="sm" onClick={() => setShowForm(!showForm)}>
             <Plus className="h-4 w-4 mr-1" />
             Add Machine
@@ -225,7 +225,7 @@ export function MachineManagement({
                       </span>
                     </div>
                   )}
-                  {editable && (
+                  {editable && onUpdateStatus && (
                     <div className="mt-2 flex gap-1 justify-center">
                       {machine.status === "available" && (
                         <Button

--- a/src/components/para-medical/exercise-program-builder.tsx
+++ b/src/components/para-medical/exercise-program-builder.tsx
@@ -104,7 +104,7 @@ export function ExerciseProgramBuilder({
                   <Badge variant={STATUS_VARIANT[program.status]} className="text-xs">
                     {program.status}
                   </Badge>
-                  {editable && program.status === "active" && (
+                  {editable && onUpdateStatus && program.status === "active" && (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -117,7 +117,7 @@ export function ExerciseProgramBuilder({
                       <Pause className="h-3.5 w-3.5" />
                     </Button>
                   )}
-                  {editable && program.status === "paused" && (
+                  {editable && onUpdateStatus && program.status === "paused" && (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -130,7 +130,7 @@ export function ExerciseProgramBuilder({
                       <Play className="h-3.5 w-3.5" />
                     </Button>
                   )}
-                  {editable && program.status !== "completed" && (
+                  {editable && onUpdateStatus && program.status !== "completed" && (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -187,12 +187,12 @@ export function ExerciseProgramBuilder({
                           <span>Rest: {ex.rest_seconds}s</span>
                         </div>
                       </div>
-                      {editable && (
+                      {editable && onRemoveExercise && (
                         <Button
                           variant="ghost"
                           size="sm"
                           aria-label="Remove exercise"
-                          onClick={() => onRemoveExercise?.(program.id, idx)}
+                          onClick={() => onRemoveExercise(program.id, idx)}
                         >
                           <Trash2 className="h-3.5 w-3.5 text-red-500" />
                         </Button>
@@ -201,7 +201,7 @@ export function ExerciseProgramBuilder({
                   ))}
                 </div>
 
-                {editable && (
+                {editable && onAddExercise && (
                   <div className="mt-3">
                     {adding === program.id ? (
                       <div className="space-y-3 p-3 border rounded-lg">

--- a/src/components/para-medical/meal-plan-builder.tsx
+++ b/src/components/para-medical/meal-plan-builder.tsx
@@ -165,12 +165,12 @@ export function MealPlanBuilder({
                                   <span className="flex-1">{item.name}</span>
                                   <span className="text-muted-foreground">{item.quantity}</span>
                                   <span className="w-14 text-right">{item.calories} kcal</span>
-                                  {editable && (
+                                  {editable && onRemoveMealItem && (
                                     <button
                                       type="button"
                                       aria-label="Remove item"
                                       onClick={() =>
-                                        onRemoveMealItem?.(plan.id, expandedDay, slot, idx)
+                                        onRemoveMealItem(plan.id, expandedDay, slot, idx)
                                       }
                                     >
                                       <Trash2 className="h-3 w-3 text-red-500" />
@@ -180,7 +180,7 @@ export function MealPlanBuilder({
                               ))}
                             </div>
                           )}
-                          {editable && (
+                          {editable && onAddMealItem && (
                             <>
                               {addingSlot === `${plan.id}-${expandedDay}-${slot}` ? (
                                 <div className="mt-2 space-y-2 p-2 border rounded bg-muted/30">

--- a/src/components/para-medical/optical-prescription-tracker.tsx
+++ b/src/components/para-medical/optical-prescription-tracker.tsx
@@ -216,7 +216,7 @@ export function OpticalPrescriptionTracker({
                 )}
 
                 {/* Status actions */}
-                {editable && rx.status !== "delivered" && (
+                {editable && onUpdateStatus && rx.status !== "delivered" && (
                   <div className="flex gap-2 pt-2 border-t">
                     {rx.status === "pending" && (
                       <button

--- a/src/components/para-medical/therapy-plan-view.tsx
+++ b/src/components/para-medical/therapy-plan-view.tsx
@@ -158,7 +158,7 @@ export function TherapyPlanView({
                                 {goal.milestones.map((ms, mIdx) => (
                                   <div key={mIdx} className="flex items-center gap-2 text-xs">
                                     <button
-                                      disabled={!editable}
+                                      disabled={!editable || !onToggleMilestone}
                                       onClick={() => onToggleMilestone?.(plan.id, goal.id, mIdx)}
                                       className="shrink-0"
                                     >
@@ -186,7 +186,7 @@ export function TherapyPlanView({
                             )}
 
                             {/* Goal status actions */}
-                            {editable && goal.status !== "achieved" && (
+                            {editable && onUpdateGoalStatus && goal.status !== "achieved" && (
                               <div className="flex gap-1 mt-2">
                                 {goal.status === "not_started" && (
                                   <Button

--- a/src/components/polyclinic/bed-management.tsx
+++ b/src/components/polyclinic/bed-management.tsx
@@ -89,7 +89,7 @@ export function BedManagement({
           <BedDouble className="h-5 w-5" />
           Bed Management
         </h2>
-        {editable && (
+        {editable && onAddRoom && (
           <Button size="sm" onClick={() => setShowForm(!showForm)}>
             <Plus className="h-4 w-4 mr-1" />
             Add Room
@@ -231,7 +231,7 @@ export function BedManagement({
                         {bed.patientName && (
                           <p className="text-[10px] mt-1 truncate">{bed.patientName}</p>
                         )}
-                        {editable && bed.status === "available" && (
+                        {editable && onAdmit && bed.status === "available" && (
                           <Button
                             size="sm"
                             variant="outline"
@@ -241,7 +241,7 @@ export function BedManagement({
                             Admit
                           </Button>
                         )}
-                        {editable && bed.status === "occupied" && (
+                        {editable && onDischarge && bed.status === "occupied" && (
                           <Button
                             size="sm"
                             variant="outline"

--- a/src/components/polyclinic/department-management.tsx
+++ b/src/components/polyclinic/department-management.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Building2, Plus, Users, Edit2, ChevronDown, ChevronUp } from "lucide-react";
+import { Building2, Plus, Users, ChevronDown, ChevronUp } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -56,7 +56,7 @@ export function DepartmentManagement({
             {departments.length}
           </Badge>
         </h2>
-        {editable && (
+        {editable && onAdd && (
           <Button size="sm" onClick={() => setShowForm(!showForm)}>
             <Plus className="h-4 w-4 mr-1" />
             Add Department
@@ -180,16 +180,13 @@ export function DepartmentManagement({
                     {dept.description && (
                       <p className="text-xs text-muted-foreground">{dept.description}</p>
                     )}
-                    {editable && (
+                    {editable && onToggleActive && (
                       <div className="flex gap-2">
-                        <Button size="sm" variant="outline" className="text-xs h-7">
-                          <Edit2 className="h-3 w-3 mr-1" /> Edit
-                        </Button>
                         <Button
                           size="sm"
                           variant="outline"
                           className="text-xs h-7"
-                          onClick={() => onToggleActive?.(dept.id, !dept.isActive)}
+                          onClick={() => onToggleActive(dept.id, !dept.isActive)}
                         >
                           {dept.isActive ? "Deactivate" : "Activate"}
                         </Button>

--- a/src/lib/admin-actions.ts
+++ b/src/lib/admin-actions.ts
@@ -29,7 +29,13 @@ import { staffWelcomeEmail } from "@/lib/email-templates";
 import { getSiteUrl, getSupabaseServiceRoleKey } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { createClient, createScopedAdminClient } from "@/lib/supabase-server";
-import type { Json, TablesInsert, TablesUpdate } from "@/lib/types/database";
+import type {
+  DialysisMachineStatus,
+  Json,
+  LabInvoiceStatus,
+  TablesInsert,
+  TablesUpdate,
+} from "@/lib/types/database";
 
 // ─────────────────────────────────────────────
 // Shared context + row shapes
@@ -128,7 +134,9 @@ export async function createClinicUser(input: CreateClinicUserInput): Promise<Cl
       if (authError) {
         if (authError.message?.includes("already been registered")) {
           const { data: listData } = await admin.auth.admin.listUsers();
-          const existing = listData?.users?.find((u) => u.email === email);
+          const existing = listData?.users?.find(
+            (u: { email?: string | null; id: string }) => u.email === email,
+          );
           if (existing) authId = existing.id;
         } else {
           logger.warn("Failed to create auth account for staff — creating without login", {
@@ -376,4 +384,246 @@ export async function deleteClinicService(serviceId: string): Promise<void> {
     .eq("id", serviceId)
     .eq("clinic_id", clinicId);
   if (error) throw new Error(`Failed to delete service: ${error.message}`);
+}
+
+// ─────────────────────────────────────────────
+// Clinic center / specialist admin CRUD
+// ─────────────────────────────────────────────
+
+export interface CreateClinicDepartmentInput {
+  name: string;
+  nameAr?: string;
+  floor?: string;
+  description?: string;
+}
+
+export async function createClinicDepartment(input: CreateClinicDepartmentInput) {
+  const { clinicId, supabase } = await adminContext();
+  const { data, error } = await supabase
+    .from("departments")
+    .insert({
+      clinic_id: clinicId,
+      name: input.name.trim(),
+      name_ar: input.nameAr?.trim() || null,
+      floor: input.floor?.trim() || null,
+      description: input.description?.trim() || null,
+      is_active: true,
+    } as TablesInsert<"departments">)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create department: ${error.message}`);
+  return data;
+}
+
+export async function setClinicDepartmentActive(
+  departmentId: string,
+  isActive: boolean,
+): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { error } = await supabase
+    .from("departments")
+    .update({
+      is_active: isActive,
+      updated_at: new Date().toISOString(),
+    } as TablesUpdate<"departments">)
+    .eq("id", departmentId)
+    .eq("clinic_id", clinicId);
+
+  if (error) throw new Error(`Failed to update department status: ${error.message}`);
+}
+
+export interface CreateClinicRoomInput {
+  roomNumber: string;
+  roomType: string;
+  floor?: string;
+  totalBeds: number;
+}
+
+export async function createClinicRoom(input: CreateClinicRoomInput) {
+  const { clinicId, supabase } = await adminContext();
+  const totalBeds = Math.max(1, Math.floor(input.totalBeds || 1));
+
+  const { data: room, error: roomError } = await supabase
+    .from("rooms")
+    .insert({
+      clinic_id: clinicId,
+      room_number: input.roomNumber.trim(),
+      room_type: input.roomType,
+      floor: input.floor?.trim() || null,
+      total_beds: totalBeds,
+      is_active: true,
+    } as TablesInsert<"rooms">)
+    .select()
+    .single();
+
+  if (roomError) throw new Error(`Failed to create room: ${roomError.message}`);
+
+  const bedRows = Array.from({ length: totalBeds }, (_, index) => ({
+    clinic_id: clinicId,
+    room_id: room.id,
+    department_id: room.department_id ?? null,
+    bed_number: String(index + 1),
+    status: "available",
+  })) as TablesInsert<"beds">[];
+
+  const { error: bedError } = await supabase.from("beds").insert(bedRows);
+  if (bedError) throw new Error(`Failed to create room beds: ${bedError.message}`);
+
+  return room;
+}
+
+export interface CreateClinicDialysisMachineInput {
+  machineName: string;
+  machineModel?: string;
+  serialNumber?: string;
+}
+
+export async function createClinicDialysisMachine(input: CreateClinicDialysisMachineInput) {
+  const { clinicId, supabase } = await adminContext();
+  const { data, error } = await supabase
+    .from("dialysis_machines")
+    .insert({
+      clinic_id: clinicId,
+      machine_name: input.machineName.trim(),
+      machine_model: input.machineModel?.trim() || null,
+      serial_number: input.serialNumber?.trim() || null,
+      status: "available",
+    } as TablesInsert<"dialysis_machines">)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create dialysis machine: ${error.message}`);
+  return data;
+}
+
+export async function updateClinicDialysisMachineStatus(
+  machineId: string,
+  status: DialysisMachineStatus,
+): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const patch: TablesUpdate<"dialysis_machines"> = {
+    status,
+    updated_at: new Date().toISOString(),
+  };
+  if (status === "available") patch.last_maintenance = new Date().toISOString();
+
+  const { error } = await supabase
+    .from("dialysis_machines")
+    .update(patch)
+    .eq("id", machineId)
+    .eq("clinic_id", clinicId);
+
+  if (error) throw new Error(`Failed to update machine status: ${error.message}`);
+}
+
+export interface CreateClinicLabMaterialInput {
+  name: string;
+  category: string;
+  quantity: number;
+  unit: string;
+  minThreshold: number;
+  unitCost?: number;
+  supplier?: string;
+}
+
+export async function createClinicLabMaterial(input: CreateClinicLabMaterialInput) {
+  const { clinicId, supabase } = await adminContext();
+  const { data, error } = await supabase
+    .from("lab_materials")
+    .insert({
+      clinic_id: clinicId,
+      name: input.name.trim(),
+      category: input.category.trim(),
+      quantity: input.quantity,
+      unit: input.unit.trim() || "pcs",
+      min_threshold: input.minThreshold,
+      unit_cost: input.unitCost ?? null,
+      supplier: input.supplier?.trim() || null,
+      last_restocked: new Date().toISOString(),
+    } as TablesInsert<"lab_materials">)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create lab material: ${error.message}`);
+  return data;
+}
+
+export async function restockClinicLabMaterial(
+  materialId: string,
+  quantity: number,
+): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { data: current, error: fetchError } = await supabase
+    .from("lab_materials")
+    .select("quantity")
+    .eq("id", materialId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (fetchError) throw new Error(`Failed to load lab material: ${fetchError.message}`);
+
+  const { error } = await supabase
+    .from("lab_materials")
+    .update({
+      quantity: (current?.quantity ?? 0) + quantity,
+      last_restocked: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as TablesUpdate<"lab_materials">)
+    .eq("id", materialId)
+    .eq("clinic_id", clinicId);
+
+  if (error) throw new Error(`Failed to restock lab material: ${error.message}`);
+}
+
+export interface CreateClinicLabInvoiceInput {
+  invoiceNumber: string;
+  dentistName?: string;
+  dueDate?: string;
+  notes?: string;
+  items: Array<{ description: string; quantity: number; unitPrice: number; total: number }>;
+}
+
+export async function createClinicLabInvoice(input: CreateClinicLabInvoiceInput) {
+  const { clinicId, supabase } = await adminContext();
+  const subtotal = input.items.reduce((sum, item) => sum + item.total, 0);
+  const { data, error } = await supabase
+    .from("lab_invoices")
+    .insert({
+      clinic_id: clinicId,
+      invoice_number: input.invoiceNumber.trim(),
+      dentist_name: input.dentistName?.trim() || null,
+      due_date: input.dueDate || null,
+      notes: input.notes?.trim() || null,
+      items: input.items as Json,
+      subtotal,
+      tax_amount: 0,
+      total: subtotal,
+      currency: "MAD",
+      status: "draft",
+      issued_date: new Date().toISOString().split("T")[0],
+    } as TablesInsert<"lab_invoices">)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create lab invoice: ${error.message}`);
+  return data;
+}
+
+export async function updateClinicLabInvoiceStatus(
+  invoiceId: string,
+  status: LabInvoiceStatus,
+): Promise<void> {
+  const { clinicId, supabase } = await adminContext();
+  const { error } = await supabase
+    .from("lab_invoices")
+    .update({
+      status,
+      paid_date: status === "paid" ? new Date().toISOString().split("T")[0] : null,
+      updated_at: new Date().toISOString(),
+    } as TablesUpdate<"lab_invoices">)
+    .eq("id", invoiceId)
+    .eq("clinic_id", clinicId);
+
+  if (error) throw new Error(`Failed to update lab invoice status: ${error.message}`);
 }

--- a/src/lib/data/client/clinic-centers.ts
+++ b/src/lib/data/client/clinic-centers.ts
@@ -1,0 +1,544 @@
+"use client";
+
+import { createClient } from "@/lib/supabase-client";
+import type {
+  Database,
+  DialysisMachineStatus,
+  DeliveryCondition,
+  LabInvoiceStatus,
+} from "@/lib/types/database";
+import { getLocalDateStr } from "@/lib/utils";
+import { fetchTodayAppointments } from "./appointments";
+import { ensureLookups, fetchRows, _activeUserMap } from "./_core";
+
+export interface DepartmentManagementView {
+  id: string;
+  name: string;
+  nameAr: string | null;
+  headDoctorName: string | null;
+  floor: string | null;
+  description: string | null;
+  doctorCount: number;
+  patientCount: number;
+  isActive: boolean;
+}
+
+export interface DepartmentDashboardStatView {
+  id: string;
+  name: string;
+  doctorCount: number;
+  patientCount: number;
+  totalBeds: number;
+  occupiedBeds: number;
+  todayAppointments: number;
+  admissionsThisMonth: number;
+  dischargesThisMonth: number;
+}
+
+export interface DepartmentOverviewView {
+  departments: DepartmentManagementView[];
+  stats: DepartmentDashboardStatView[];
+}
+
+export interface BedManagementBedView {
+  id: string;
+  bedNumber: string;
+  status: "available" | "occupied" | "maintenance" | "reserved";
+  patientName: string | null;
+  admissionDate: string | null;
+}
+
+export interface BedManagementRoomView {
+  id: string;
+  roomNumber: string;
+  roomType: string;
+  floor: string | null;
+  departmentName: string | null;
+  totalBeds: number;
+  beds: BedManagementBedView[];
+}
+
+export interface DialysisMachineView {
+  id: string;
+  machineName: string;
+  machineModel: string | null;
+  serialNumber: string | null;
+  status: DialysisMachineStatus;
+  lastMaintenance: string | null;
+  nextMaintenance: string | null;
+  currentPatientName: string | null;
+  notes: string | null;
+}
+
+export interface LabMaterialView {
+  id: string;
+  name: string;
+  category: string;
+  quantity: number;
+  unit: string;
+  minThreshold: number;
+  unitCost: number | null;
+  supplier: string | null;
+  expiryDate: string | null;
+  lastRestocked: string | null;
+}
+
+export interface LabDeliveryView {
+  id: string;
+  orderType: string;
+  deliveryDate: string;
+  deliveredBy: string | null;
+  receivedBy: string | null;
+  condition: DeliveryCondition;
+  dentistName: string | null;
+  notes: string | null;
+}
+
+export interface LabInvoiceView {
+  id: string;
+  invoiceNumber: string;
+  dentistName: string | null;
+  items: { description: string; quantity: number; unitPrice: number; total: number }[];
+  subtotal: number;
+  taxAmount: number;
+  total: number;
+  currency: string;
+  status: LabInvoiceStatus;
+  issuedDate: string;
+  dueDate: string | null;
+  paidDate: string | null;
+}
+
+interface DepartmentRow {
+  id: string;
+  clinic_id: string;
+  name: string;
+  name_ar: string | null;
+  head_doctor_id: string | null;
+  description: string | null;
+  floor: string | null;
+  is_active: boolean;
+}
+
+interface DoctorDepartmentRow {
+  id: string;
+  clinic_id: string;
+  department_id: string;
+  doctor_id: string;
+  is_primary: boolean;
+}
+
+interface BedRow {
+  id: string;
+  clinic_id: string;
+  room_id: string;
+  department_id: string | null;
+  bed_number: string;
+  status: string;
+  current_patient_id: string | null;
+  patient_id: string | null;
+  notes: string | null;
+  updated_at: string | null;
+}
+
+interface RoomRow {
+  id: string;
+  clinic_id: string;
+  department_id: string | null;
+  room_number: string;
+  room_type: string;
+  floor: string | null;
+  total_beds: number;
+  is_active: boolean;
+}
+
+interface AdmissionRow {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  bed_id: string;
+  department_id: string | null;
+  admission_date: string;
+  discharge_date: string | null;
+  status: string;
+}
+
+interface DialysisMachineRow {
+  id: string;
+  clinic_id: string;
+  machine_name: string;
+  machine_model: string | null;
+  serial_number: string | null;
+  status: string;
+  last_maintenance: string | null;
+  next_maintenance: string | null;
+  notes: string | null;
+}
+
+interface DialysisSessionRow {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  machine_id: string | null;
+  session_date: string;
+  status: string;
+}
+
+interface LabMaterialRow {
+  id: string;
+  clinic_id: string;
+  name: string;
+  category: string;
+  quantity: number;
+  unit: string;
+  min_threshold: number;
+  unit_cost: number | null;
+  supplier: string | null;
+  expiry_date: string | null;
+  last_restocked: string | null;
+}
+
+interface LabDeliveryRow {
+  id: string;
+  clinic_id: string;
+  order_id: string;
+  delivery_date: string;
+  delivered_by: string | null;
+  received_by: string | null;
+  condition: string | null;
+  notes: string | null;
+}
+
+interface LabInvoiceRow {
+  id: string;
+  clinic_id: string;
+  invoice_number: string;
+  dentist_id: string | null;
+  dentist_name: string | null;
+  items: Database["public"]["Tables"]["lab_invoices"]["Row"]["items"];
+  subtotal: number;
+  tax_amount: number | null;
+  total: number;
+  currency: string;
+  status: string;
+  issued_date: string;
+  due_date: string | null;
+  paid_date: string | null;
+}
+
+interface ProstheticOrderRow {
+  id: string;
+  clinic_id: string;
+  order_type: string;
+  dentist_id: string | null;
+  dentist_name: string | null;
+}
+
+function byNumericOrText(a: string, b: string): number {
+  const aNum = Number(a);
+  const bNum = Number(b);
+  if (Number.isFinite(aNum) && Number.isFinite(bNum)) return aNum - bNum;
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+}
+
+function parseInvoiceItems(
+  value: Database["public"]["Tables"]["lab_invoices"]["Row"]["items"],
+): LabInvoiceView["items"] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      const row = item as Record<string, unknown>;
+      const quantity = Number(row.quantity ?? 0);
+      const unitPrice = Number(row.unitPrice ?? row.unit_price ?? 0);
+      return {
+        description: typeof row.description === "string" ? row.description : "Item",
+        quantity,
+        unitPrice,
+        total: Number(row.total ?? quantity * unitPrice),
+      };
+    })
+    .filter((item) => item.description);
+}
+
+export async function fetchDepartmentOverview(clinicId: string): Promise<DepartmentOverviewView> {
+  await ensureLookups(clinicId);
+
+  const monthPrefix = getLocalDateStr().slice(0, 7);
+  const [departments, doctorDepartments, beds, admissions, todayAppointments] = await Promise.all([
+    fetchRows<DepartmentRow>("departments", {
+      eq: [["clinic_id", clinicId]],
+      order: ["name", { ascending: true }],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<DoctorDepartmentRow>("doctor_departments", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<BedRow>("beds", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<AdmissionRow>("admissions", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchTodayAppointments(clinicId),
+  ]);
+
+  const departmentsView = departments.map((dept) => {
+    const assignedDoctorIds = new Set(
+      doctorDepartments.filter((row) => row.department_id === dept.id).map((row) => row.doctor_id),
+    );
+    if (dept.head_doctor_id) assignedDoctorIds.add(dept.head_doctor_id);
+
+    const patientIds = new Set<string>();
+    for (const admission of admissions) {
+      if (admission.department_id === dept.id) patientIds.add(admission.patient_id);
+    }
+    for (const appointment of todayAppointments) {
+      if (assignedDoctorIds.has(appointment.doctorId)) patientIds.add(appointment.patientId);
+    }
+
+    return {
+      id: dept.id,
+      name: dept.name,
+      nameAr: dept.name_ar,
+      headDoctorName: dept.head_doctor_id
+        ? (_activeUserMap?.get(dept.head_doctor_id)?.name ?? null)
+        : null,
+      floor: dept.floor,
+      description: dept.description,
+      doctorCount: assignedDoctorIds.size,
+      patientCount: patientIds.size,
+      isActive: dept.is_active,
+    } satisfies DepartmentManagementView;
+  });
+
+  const stats = departmentsView.map((dept) => {
+    const deptDoctorIds = new Set(
+      doctorDepartments
+        .filter((row) => row.department_id === dept.id)
+        .map((row) => row.doctor_id),
+    );
+    const deptBeds = beds.filter((bed) => bed.department_id === dept.id);
+    const deptAdmissions = admissions.filter((admission) => admission.department_id === dept.id);
+    const patientIds = new Set<string>(deptAdmissions.map((admission) => admission.patient_id));
+    const todayAppointmentsCount = todayAppointments.filter((appointment) => {
+      if (!deptDoctorIds.has(appointment.doctorId)) return false;
+      patientIds.add(appointment.patientId);
+      return true;
+    }).length;
+
+    return {
+      id: dept.id,
+      name: dept.name,
+      doctorCount: dept.doctorCount,
+      patientCount: patientIds.size,
+      totalBeds: deptBeds.length,
+      occupiedBeds: deptBeds.filter((bed) => bed.status === "occupied").length,
+      todayAppointments: todayAppointmentsCount,
+      admissionsThisMonth: deptAdmissions.filter((admission) =>
+        admission.admission_date.startsWith(monthPrefix),
+      ).length,
+      dischargesThisMonth: deptAdmissions.filter(
+        (admission) => admission.discharge_date?.startsWith(monthPrefix) ?? false,
+      ).length,
+    } satisfies DepartmentDashboardStatView;
+  });
+
+  return { departments: departmentsView, stats };
+}
+
+export async function fetchBedManagementRooms(clinicId: string): Promise<BedManagementRoomView[]> {
+  await ensureLookups(clinicId);
+  const [rooms, beds, departments, admissions] = await Promise.all([
+    fetchRows<RoomRow>("rooms", {
+      eq: [
+        ["clinic_id", clinicId],
+        ["is_active", true],
+      ],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<BedRow>("beds", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<DepartmentRow>("departments", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<AdmissionRow>("admissions", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+  ]);
+
+  const departmentMap = new Map(departments.map((department) => [department.id, department.name]));
+  const activeAdmissionByBed = new Map<string, AdmissionRow>();
+  for (const admission of [...admissions].sort((a, b) => b.admission_date.localeCompare(a.admission_date))) {
+    if (activeAdmissionByBed.has(admission.bed_id)) continue;
+    if (admission.status === "discharged") continue;
+    activeAdmissionByBed.set(admission.bed_id, admission);
+  }
+
+  return [...rooms]
+    .sort((a, b) => byNumericOrText(a.room_number, b.room_number))
+    .map((room) => {
+      const roomBeds = beds
+        .filter((bed) => bed.room_id === room.id)
+        .sort((a, b) => byNumericOrText(a.bed_number, b.bed_number))
+        .map((bed) => {
+          const activeAdmission = activeAdmissionByBed.get(bed.id);
+          const patientId = bed.current_patient_id ?? bed.patient_id ?? activeAdmission?.patient_id ?? null;
+          return {
+            id: bed.id,
+            bedNumber: bed.bed_number,
+            status: (bed.status ?? "available") as BedManagementBedView["status"],
+            patientName: patientId ? (_activeUserMap?.get(patientId)?.name ?? null) : null,
+            admissionDate: activeAdmission?.admission_date?.split("T")[0] ?? null,
+          } satisfies BedManagementBedView;
+        });
+
+      return {
+        id: room.id,
+        roomNumber: room.room_number,
+        roomType: room.room_type,
+        floor: room.floor,
+        departmentName: room.department_id ? (departmentMap.get(room.department_id) ?? null) : null,
+        totalBeds: room.total_beds,
+        beds: roomBeds,
+      } satisfies BedManagementRoomView;
+    });
+}
+
+export async function fetchDialysisMachines(clinicId: string): Promise<DialysisMachineView[]> {
+  await ensureLookups(clinicId);
+  const today = getLocalDateStr();
+  const [machines, sessions] = await Promise.all([
+    fetchRows<DialysisMachineRow>("dialysis_machines", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<DialysisSessionRow>("dialysis_sessions", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+  ]);
+
+  const relevantSessionByMachine = new Map<string, DialysisSessionRow>();
+  for (const session of [...sessions].sort((a, b) => b.session_date.localeCompare(a.session_date))) {
+    if (!session.machine_id || relevantSessionByMachine.has(session.machine_id)) continue;
+    const isCurrent = session.session_date === today && ["scheduled", "in_progress"].includes(session.status);
+    const isRecent = session.status === "in_progress";
+    if (isCurrent || isRecent) relevantSessionByMachine.set(session.machine_id, session);
+  }
+
+  return [...machines]
+    .sort((a, b) => a.machine_name.localeCompare(b.machine_name, undefined, { numeric: true }))
+    .map((machine) => ({
+      id: machine.id,
+      machineName: machine.machine_name,
+      machineModel: machine.machine_model,
+      serialNumber: machine.serial_number,
+      status: machine.status as DialysisMachineStatus,
+      lastMaintenance: machine.last_maintenance,
+      nextMaintenance: machine.next_maintenance,
+      currentPatientName: relevantSessionByMachine.get(machine.id)?.patient_id
+        ? (_activeUserMap?.get(relevantSessionByMachine.get(machine.id)!.patient_id)?.name ?? null)
+        : null,
+      notes: machine.notes,
+    }));
+}
+
+export async function fetchLabMaterials(clinicId: string): Promise<LabMaterialView[]> {
+  const rows = await fetchRows<LabMaterialRow>("lab_materials", {
+    eq: [["clinic_id", clinicId]],
+    order: ["name", { ascending: true }],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    quantity: row.quantity,
+    unit: row.unit,
+    minThreshold: row.min_threshold,
+    unitCost: row.unit_cost,
+    supplier: row.supplier,
+    expiryDate: row.expiry_date,
+    lastRestocked: row.last_restocked,
+  }));
+}
+
+export async function fetchLabDeliveriesAndInvoices(clinicId: string): Promise<{
+  deliveries: LabDeliveryView[];
+  invoices: LabInvoiceView[];
+}> {
+  await ensureLookups(clinicId);
+  const [deliveries, invoices, orders] = await Promise.all([
+    fetchRows<LabDeliveryRow>("lab_deliveries", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<LabInvoiceRow>("lab_invoices", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+    fetchRows<ProstheticOrderRow>("prosthetic_orders", {
+      eq: [["clinic_id", clinicId]],
+      tenantClinicId: clinicId,
+    }),
+  ]);
+
+  const orderMap = new Map(orders.map((order) => [order.id, order]));
+
+  return {
+    deliveries: [...deliveries]
+      .sort((a, b) => b.delivery_date.localeCompare(a.delivery_date))
+      .map((delivery) => {
+        const order = orderMap.get(delivery.order_id);
+        return {
+          id: delivery.id,
+          orderType: order?.order_type ?? "prosthetic",
+          deliveryDate: delivery.delivery_date,
+          deliveredBy: delivery.delivered_by,
+          receivedBy: delivery.received_by,
+          condition: (delivery.condition ?? "good") as DeliveryCondition,
+          dentistName:
+            order?.dentist_name ??
+            (order?.dentist_id ? (_activeUserMap?.get(order.dentist_id)?.name ?? null) : null),
+          notes: delivery.notes,
+        } satisfies LabDeliveryView;
+      }),
+    invoices: [...invoices]
+      .sort((a, b) => b.issued_date.localeCompare(a.issued_date))
+      .map((invoice) => ({
+        id: invoice.id,
+        invoiceNumber: invoice.invoice_number,
+        dentistName:
+          invoice.dentist_name ??
+          (invoice.dentist_id ? (_activeUserMap?.get(invoice.dentist_id)?.name ?? null) : null),
+        items: parseInvoiceItems(invoice.items),
+        subtotal: invoice.subtotal,
+        taxAmount: invoice.tax_amount ?? 0,
+        total: invoice.total,
+        currency: invoice.currency,
+        status: invoice.status as LabInvoiceStatus,
+        issuedDate: invoice.issued_date,
+        dueDate: invoice.due_date,
+        paidDate: invoice.paid_date,
+      })),
+  };
+}
+
+export async function fetchClinicSales(clinicId: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("sales")
+    .select("id, clinic_id, patient_id, patient_name, items, total, currency, payment_method, has_prescription, loyalty_points_earned, date, time, created_at")
+    .eq("clinic_id", clinicId)
+    .order("date", { ascending: false });
+
+  if (error) return [];
+  return data ?? [];
+}

--- a/src/lib/data/client/clinic-centers.ts
+++ b/src/lib/data/client/clinic-centers.ts
@@ -8,8 +8,8 @@ import type {
   LabInvoiceStatus,
 } from "@/lib/types/database";
 import { getLocalDateStr } from "@/lib/utils";
-import { fetchTodayAppointments } from "./appointments";
 import { ensureLookups, fetchRows, _activeUserMap } from "./_core";
+import { fetchTodayAppointments } from "./appointments";
 
 export interface DepartmentManagementView {
   id: string;
@@ -316,9 +316,7 @@ export async function fetchDepartmentOverview(clinicId: string): Promise<Departm
 
   const stats = departmentsView.map((dept) => {
     const deptDoctorIds = new Set(
-      doctorDepartments
-        .filter((row) => row.department_id === dept.id)
-        .map((row) => row.doctor_id),
+      doctorDepartments.filter((row) => row.department_id === dept.id).map((row) => row.doctor_id),
     );
     const deptBeds = beds.filter((bed) => bed.department_id === dept.id);
     const deptAdmissions = admissions.filter((admission) => admission.department_id === dept.id);
@@ -375,7 +373,9 @@ export async function fetchBedManagementRooms(clinicId: string): Promise<BedMana
 
   const departmentMap = new Map(departments.map((department) => [department.id, department.name]));
   const activeAdmissionByBed = new Map<string, AdmissionRow>();
-  for (const admission of [...admissions].sort((a, b) => b.admission_date.localeCompare(a.admission_date))) {
+  for (const admission of [...admissions].sort((a, b) =>
+    b.admission_date.localeCompare(a.admission_date),
+  )) {
     if (activeAdmissionByBed.has(admission.bed_id)) continue;
     if (admission.status === "discharged") continue;
     activeAdmissionByBed.set(admission.bed_id, admission);
@@ -389,7 +389,8 @@ export async function fetchBedManagementRooms(clinicId: string): Promise<BedMana
         .sort((a, b) => byNumericOrText(a.bed_number, b.bed_number))
         .map((bed) => {
           const activeAdmission = activeAdmissionByBed.get(bed.id);
-          const patientId = bed.current_patient_id ?? bed.patient_id ?? activeAdmission?.patient_id ?? null;
+          const patientId =
+            bed.current_patient_id ?? bed.patient_id ?? activeAdmission?.patient_id ?? null;
           return {
             id: bed.id,
             bedNumber: bed.bed_number,
@@ -426,9 +427,12 @@ export async function fetchDialysisMachines(clinicId: string): Promise<DialysisM
   ]);
 
   const relevantSessionByMachine = new Map<string, DialysisSessionRow>();
-  for (const session of [...sessions].sort((a, b) => b.session_date.localeCompare(a.session_date))) {
+  for (const session of [...sessions].sort((a, b) =>
+    b.session_date.localeCompare(a.session_date),
+  )) {
     if (!session.machine_id || relevantSessionByMachine.has(session.machine_id)) continue;
-    const isCurrent = session.session_date === today && ["scheduled", "in_progress"].includes(session.status);
+    const isCurrent =
+      session.session_date === today && ["scheduled", "in_progress"].includes(session.status);
     const isRecent = session.status === "in_progress";
     if (isCurrent || isRecent) relevantSessionByMachine.set(session.machine_id, session);
   }
@@ -535,7 +539,9 @@ export async function fetchClinicSales(clinicId: string) {
   const supabase = createClient();
   const { data, error } = await supabase
     .from("sales")
-    .select("id, clinic_id, patient_id, patient_name, items, total, currency, payment_method, has_prescription, loyalty_points_earned, date, time, created_at")
+    .select(
+      "id, clinic_id, patient_id, patient_name, items, total, currency, payment_method, has_prescription, loyalty_points_earned, date, time, created_at",
+    )
     .eq("clinic_id", clinicId)
     .order("date", { ascending: false });
 

--- a/src/lib/data/client/index.ts
+++ b/src/lib/data/client/index.ts
@@ -32,5 +32,7 @@ export * from "./pediatrician";
 export * from "./gynecologist";
 export * from "./ophthalmologist";
 export * from "./kpis";
+export * from "./clinic-centers";
+export * from "./para-medical";
 export * from "./onboarding";
 export * from "./timeline";

--- a/src/lib/data/client/para-medical.ts
+++ b/src/lib/data/client/para-medical.ts
@@ -2,7 +2,7 @@
 
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase-client";
-import { getLocalDateStr } from "@/lib/utils";
+import type { Json } from "@/lib/types/database";
 import type {
   BodyMeasurement,
   Exercise,
@@ -21,6 +21,7 @@ import type {
   TherapyPlan,
   TherapySessionNote,
 } from "@/lib/types/para-medical";
+import { getLocalDateStr } from "@/lib/utils";
 import { ensureLookups, fetchRows, _activeUserMap } from "./_core";
 
 type MealSlot = "breakfast" | "morning_snack" | "lunch" | "afternoon_snack" | "dinner";
@@ -287,13 +288,19 @@ function recalculateMealDay(day: MealDay): MealDay {
 function updateGoalProgress(goal: TherapyGoal): TherapyGoal {
   const completedMilestones = goal.milestones.filter((milestone) => milestone.completed).length;
   const milestoneProgress =
-    goal.milestones.length > 0 ? Math.round((completedMilestones / goal.milestones.length) * 100) : 0;
+    goal.milestones.length > 0
+      ? Math.round((completedMilestones / goal.milestones.length) * 100)
+      : 0;
   const progress_pct =
     goal.status === "achieved"
       ? 100
       : goal.status === "not_started"
         ? 0
-        : Math.max(goal.progress_pct ?? 0, milestoneProgress, goal.status === "in_progress" ? 25 : 0);
+        : Math.max(
+            goal.progress_pct ?? 0,
+            milestoneProgress,
+            goal.status === "in_progress" ? 25 : 0,
+          );
 
   return { ...goal, progress_pct };
 }
@@ -512,7 +519,9 @@ export async function fetchSpeechSessions(clinicId: string): Promise<SpeechSessi
   }));
 }
 
-export async function fetchSpeechProgressReports(clinicId: string): Promise<SpeechProgressReport[]> {
+export async function fetchSpeechProgressReports(
+  clinicId: string,
+): Promise<SpeechProgressReport[]> {
   await ensureLookups(clinicId);
   const rows = await fetchRows<SpeechProgressReportRaw>("speech_progress_reports", {
     eq: [["clinic_id", clinicId]],
@@ -659,7 +668,7 @@ export async function addMealPlanItem(
 
   const { error: updateError } = await supabase
     .from("meal_plans")
-    .update({ daily_plans: next, updated_at: new Date().toISOString() })
+    .update({ daily_plans: next as unknown as Json, updated_at: new Date().toISOString() })
     .eq("id", planId)
     .eq("clinic_id", clinicId);
 
@@ -695,7 +704,7 @@ export async function removeMealPlanItem(
 
   const { error: updateError } = await supabase
     .from("meal_plans")
-    .update({ daily_plans: next, updated_at: new Date().toISOString() })
+    .update({ daily_plans: next as unknown as Json, updated_at: new Date().toISOString() })
     .eq("id", planId)
     .eq("clinic_id", clinicId);
 
@@ -725,7 +734,7 @@ export async function addExerciseToProgram(
 
   const { error: updateError } = await supabase
     .from("exercise_programs")
-    .update({ exercises: next, updated_at: new Date().toISOString() })
+    .update({ exercises: next as unknown as Json, updated_at: new Date().toISOString() })
     .eq("id", programId)
     .eq("clinic_id", clinicId);
 
@@ -754,7 +763,7 @@ export async function removeExerciseFromProgram(
 
   const { error: updateError } = await supabase
     .from("exercise_programs")
-    .update({ exercises: next, updated_at: new Date().toISOString() })
+    .update({ exercises: next as unknown as Json, updated_at: new Date().toISOString() })
     .eq("id", programId)
     .eq("clinic_id", clinicId);
 
@@ -809,7 +818,7 @@ export async function updateTherapyPlanGoalStatus(
 
   const { error: updateError } = await supabase
     .from("therapy_plans")
-    .update({ goals: next, updated_at: new Date().toISOString() })
+    .update({ goals: next as unknown as Json, updated_at: new Date().toISOString() })
     .eq("id", planId)
     .eq("clinic_id", clinicId);
 
@@ -860,13 +869,15 @@ export async function toggleTherapyPlanMilestone(
       milestones,
       status,
       progress_pct:
-        milestones.length > 0 ? Math.round((completedCount / milestones.length) * 100) : goal.progress_pct,
+        milestones.length > 0
+          ? Math.round((completedCount / milestones.length) * 100)
+          : goal.progress_pct,
     });
   });
 
   const { error: updateError } = await supabase
     .from("therapy_plans")
-    .update({ goals: next, updated_at: new Date().toISOString() })
+    .update({ goals: next as unknown as Json, updated_at: new Date().toISOString() })
     .eq("id", planId)
     .eq("clinic_id", clinicId);
 

--- a/src/lib/data/client/para-medical.ts
+++ b/src/lib/data/client/para-medical.ts
@@ -1,0 +1,875 @@
+"use client";
+
+import { logger } from "@/lib/logger";
+import { createClient } from "@/lib/supabase-client";
+import { getLocalDateStr } from "@/lib/utils";
+import type {
+  BodyMeasurement,
+  Exercise,
+  ExerciseProgram,
+  FrameCatalogItem,
+  LensInventoryItem,
+  MealItem,
+  MealPlan,
+  OpticalPrescription,
+  ProgressPhoto,
+  PhysioSession,
+  SpeechExercise,
+  SpeechProgressReport,
+  SpeechSession,
+  TherapyGoal,
+  TherapyPlan,
+  TherapySessionNote,
+} from "@/lib/types/para-medical";
+import { ensureLookups, fetchRows, _activeUserMap } from "./_core";
+
+type MealSlot = "breakfast" | "morning_snack" | "lunch" | "afternoon_snack" | "dinner";
+
+type MealDay = {
+  day: string;
+  breakfast: MealItem[];
+  morning_snack: MealItem[];
+  lunch: MealItem[];
+  afternoon_snack: MealItem[];
+  dinner: MealItem[];
+  total_calories: number;
+  total_protein: number;
+  total_carbs: number;
+  total_fat: number;
+};
+
+interface ExerciseProgramRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  therapist_id: string;
+  title: string;
+  exercises: Exercise[] | null;
+  frequency: string;
+  start_date: string;
+  end_date: string | null;
+  status: string;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface PhysioSessionRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  therapist_id: string;
+  program_id: string | null;
+  session_date: string;
+  duration_minutes: number;
+  attended: boolean;
+  progress_notes: string | null;
+  pain_level_before: number | null;
+  pain_level_after: number | null;
+  exercises_completed: string[] | null;
+  created_at: string;
+}
+
+interface ProgressPhotoRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  photo_url: string;
+  photo_date: string;
+  category: string | null;
+  notes: string | null;
+  created_at: string;
+}
+
+interface MealPlanRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  nutritionist_id: string;
+  title: string;
+  type: string;
+  daily_plans: MealDay[] | null;
+  target_calories: number | null;
+  notes: string | null;
+  start_date: string;
+  end_date: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BodyMeasurementRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  measurement_date: string;
+  weight_kg: number | null;
+  height_cm: number | null;
+  bmi: number | null;
+  body_fat_pct: number | null;
+  waist_cm: number | null;
+  hip_cm: number | null;
+  chest_cm: number | null;
+  arm_cm: number | null;
+  thigh_cm: number | null;
+  notes: string | null;
+  created_at: string;
+}
+
+interface TherapySessionNoteRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  therapist_id: string;
+  session_date: string;
+  session_number: number;
+  duration_minutes: number;
+  session_type: string;
+  mood_rating: number | null;
+  presenting_issues: string | null;
+  interventions: string | null;
+  observations: string | null;
+  homework: string | null;
+  is_confidential: boolean;
+  risk_assessment: string | null;
+  next_session_date: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TherapyPlanRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  therapist_id: string;
+  diagnosis: string | null;
+  treatment_approach: string;
+  goals: TherapyGoal[] | null;
+  start_date: string;
+  review_date: string | null;
+  status: string;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SpeechExerciseRaw {
+  id: string;
+  clinic_id: string;
+  name: string;
+  category: string;
+  description: string;
+  difficulty: string;
+  target_sounds: string[] | null;
+  instructions: string;
+  materials_needed: string | null;
+  duration_minutes: number;
+}
+
+interface SpeechSessionRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  therapist_id: string;
+  session_date: string;
+  duration_minutes: number;
+  attended: boolean;
+  exercises_assigned: string[] | null;
+  exercises_completed: string[] | null;
+  accuracy_pct: number | null;
+  notes: string | null;
+  home_practice: string | null;
+  created_at: string;
+}
+
+interface SpeechProgressReportRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  therapist_id: string;
+  report_date: string;
+  period_start: string;
+  period_end: string;
+  goals_summary: string;
+  progress_summary: string;
+  areas_of_improvement: string[] | null;
+  areas_of_concern: string[] | null;
+  recommendations: string;
+  next_steps: string;
+  overall_progress: string;
+  created_at: string;
+}
+
+interface LensInventoryRaw {
+  id: string;
+  clinic_id: string;
+  type: string;
+  material: string;
+  coating: string | null;
+  power_range: string;
+  stock_quantity: number;
+  min_threshold: number;
+  unit_cost: number;
+  selling_price: number;
+  supplier: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FrameCatalogRaw {
+  id: string;
+  clinic_id: string;
+  brand: string;
+  model: string;
+  color: string;
+  size: string;
+  material: string;
+  frame_type: string;
+  gender: string;
+  price: number;
+  cost_price: number;
+  stock_quantity: number;
+  photo_url: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface OpticalPrescriptionRaw {
+  id: string;
+  clinic_id: string;
+  patient_id: string;
+  ophthalmologist_name: string | null;
+  prescription_date: string;
+  expiry_date: string | null;
+  right_eye: OpticalPrescription["right_eye"];
+  left_eye: OpticalPrescription["left_eye"];
+  notes: string | null;
+  frame_id: string | null;
+  lens_type: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function patientName(patientId: string, fallback = "Patient") {
+  return _activeUserMap?.get(patientId)?.name ?? fallback;
+}
+
+function therapistName(therapistId: string, fallback = "Staff") {
+  return _activeUserMap?.get(therapistId)?.name ?? fallback;
+}
+
+function recalculateMealDay(day: MealDay): MealDay {
+  const slots: MealSlot[] = ["breakfast", "morning_snack", "lunch", "afternoon_snack", "dinner"];
+  const totals = slots.reduce(
+    (acc, slot) => {
+      for (const item of day[slot] ?? []) {
+        acc.calories += item.calories ?? 0;
+        acc.protein += item.protein_g ?? 0;
+        acc.carbs += item.carbs_g ?? 0;
+        acc.fat += item.fat_g ?? 0;
+      }
+      return acc;
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0 },
+  );
+
+  return {
+    ...day,
+    total_calories: totals.calories,
+    total_protein: totals.protein,
+    total_carbs: totals.carbs,
+    total_fat: totals.fat,
+  };
+}
+
+function updateGoalProgress(goal: TherapyGoal): TherapyGoal {
+  const completedMilestones = goal.milestones.filter((milestone) => milestone.completed).length;
+  const milestoneProgress =
+    goal.milestones.length > 0 ? Math.round((completedMilestones / goal.milestones.length) * 100) : 0;
+  const progress_pct =
+    goal.status === "achieved"
+      ? 100
+      : goal.status === "not_started"
+        ? 0
+        : Math.max(goal.progress_pct ?? 0, milestoneProgress, goal.status === "in_progress" ? 25 : 0);
+
+  return { ...goal, progress_pct };
+}
+
+export async function fetchExercisePrograms(clinicId: string): Promise<ExerciseProgram[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<ExerciseProgramRaw>("exercise_programs", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    therapist_id: row.therapist_id,
+    therapist_name: therapistName(row.therapist_id),
+    title: row.title,
+    exercises: row.exercises ?? [],
+    frequency: row.frequency,
+    start_date: row.start_date,
+    end_date: row.end_date,
+    status: row.status as ExerciseProgram["status"],
+    notes: row.notes,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function fetchPhysioSessions(clinicId: string): Promise<PhysioSession[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<PhysioSessionRaw>("physio_sessions", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    therapist_id: row.therapist_id,
+    program_id: row.program_id,
+    session_date: row.session_date,
+    duration_minutes: row.duration_minutes,
+    attended: row.attended,
+    progress_notes: row.progress_notes,
+    pain_level_before: row.pain_level_before,
+    pain_level_after: row.pain_level_after,
+    exercises_completed: row.exercises_completed ?? [],
+    created_at: row.created_at,
+  }));
+}
+
+export async function fetchProgressPhotos(clinicId: string): Promise<ProgressPhoto[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<ProgressPhotoRaw>("progress_photos", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    photo_url: row.photo_url,
+    photo_date: row.photo_date,
+    category: row.category ?? "general",
+    notes: row.notes,
+    created_at: row.created_at,
+  }));
+}
+
+export async function fetchMealPlans(clinicId: string): Promise<MealPlan[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<MealPlanRaw>("meal_plans", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    nutritionist_id: row.nutritionist_id,
+    nutritionist_name: therapistName(row.nutritionist_id, "Nutritionist"),
+    title: row.title,
+    type: row.type as MealPlan["type"],
+    daily_plans: row.daily_plans ?? [],
+    target_calories: row.target_calories ?? 0,
+    notes: row.notes,
+    start_date: row.start_date,
+    end_date: row.end_date,
+    status: row.status as MealPlan["status"],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function fetchBodyMeasurements(clinicId: string): Promise<BodyMeasurement[]> {
+  const rows = await fetchRows<BodyMeasurementRaw>("body_measurements", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    measurement_date: row.measurement_date,
+    weight_kg: row.weight_kg,
+    height_cm: row.height_cm,
+    bmi: row.bmi,
+    body_fat_pct: row.body_fat_pct,
+    waist_cm: row.waist_cm,
+    hip_cm: row.hip_cm,
+    chest_cm: row.chest_cm,
+    arm_cm: row.arm_cm,
+    thigh_cm: row.thigh_cm,
+    notes: row.notes,
+    created_at: row.created_at,
+  }));
+}
+
+export async function fetchTherapySessionNotes(clinicId: string): Promise<TherapySessionNote[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<TherapySessionNoteRaw>("therapy_session_notes", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    therapist_id: row.therapist_id,
+    session_date: row.session_date,
+    session_number: row.session_number,
+    duration_minutes: row.duration_minutes,
+    session_type: row.session_type as TherapySessionNote["session_type"],
+    mood_rating: row.mood_rating,
+    presenting_issues: row.presenting_issues,
+    interventions: row.interventions,
+    observations: row.observations,
+    homework: row.homework,
+    is_confidential: row.is_confidential,
+    risk_assessment: row.risk_assessment as TherapySessionNote["risk_assessment"],
+    next_session_date: row.next_session_date,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function fetchTherapyPlans(clinicId: string): Promise<TherapyPlan[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<TherapyPlanRaw>("therapy_plans", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    therapist_id: row.therapist_id,
+    therapist_name: therapistName(row.therapist_id, "Therapist"),
+    diagnosis: row.diagnosis,
+    treatment_approach: row.treatment_approach,
+    goals: (row.goals ?? []).map(updateGoalProgress),
+    start_date: row.start_date,
+    review_date: row.review_date,
+    status: row.status as TherapyPlan["status"],
+    notes: row.notes,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function fetchSpeechExercises(clinicId: string): Promise<SpeechExercise[]> {
+  const rows = await fetchRows<SpeechExerciseRaw>("speech_exercises", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    category: row.category as SpeechExercise["category"],
+    description: row.description,
+    difficulty: row.difficulty as SpeechExercise["difficulty"],
+    target_sounds: row.target_sounds ?? [],
+    instructions: row.instructions,
+    materials_needed: row.materials_needed,
+    duration_minutes: row.duration_minutes,
+  }));
+}
+
+export async function fetchSpeechSessions(clinicId: string): Promise<SpeechSession[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<SpeechSessionRaw>("speech_sessions", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    therapist_id: row.therapist_id,
+    session_date: row.session_date,
+    duration_minutes: row.duration_minutes,
+    attended: row.attended,
+    exercises_assigned: row.exercises_assigned ?? [],
+    exercises_completed: row.exercises_completed ?? [],
+    accuracy_pct: row.accuracy_pct,
+    notes: row.notes,
+    home_practice: row.home_practice,
+    created_at: row.created_at,
+  }));
+}
+
+export async function fetchSpeechProgressReports(clinicId: string): Promise<SpeechProgressReport[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<SpeechProgressReportRaw>("speech_progress_reports", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    therapist_id: row.therapist_id,
+    therapist_name: therapistName(row.therapist_id, "Therapist"),
+    report_date: row.report_date,
+    period_start: row.period_start,
+    period_end: row.period_end,
+    goals_summary: row.goals_summary,
+    progress_summary: row.progress_summary,
+    areas_of_improvement: row.areas_of_improvement ?? [],
+    areas_of_concern: row.areas_of_concern ?? [],
+    recommendations: row.recommendations,
+    next_steps: row.next_steps,
+    overall_progress: row.overall_progress as SpeechProgressReport["overall_progress"],
+    created_at: row.created_at,
+  }));
+}
+
+export async function fetchLensInventory(clinicId: string): Promise<LensInventoryItem[]> {
+  const rows = await fetchRows<LensInventoryRaw>("lens_inventory", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    type: row.type as LensInventoryItem["type"],
+    material: row.material,
+    coating: row.coating,
+    power_range: row.power_range,
+    stock_quantity: row.stock_quantity,
+    min_threshold: row.min_threshold,
+    unit_cost: row.unit_cost,
+    selling_price: row.selling_price,
+    supplier: row.supplier,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function fetchFrameCatalog(clinicId: string): Promise<FrameCatalogItem[]> {
+  const rows = await fetchRows<FrameCatalogRaw>("frame_catalog", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    brand: row.brand,
+    model: row.model,
+    color: row.color,
+    size: row.size,
+    material: row.material,
+    frame_type: row.frame_type as FrameCatalogItem["frame_type"],
+    gender: row.gender as FrameCatalogItem["gender"],
+    price: row.price,
+    cost_price: row.cost_price,
+    stock_quantity: row.stock_quantity,
+    photo_url: row.photo_url,
+    is_active: row.is_active,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function fetchOpticalPrescriptions(clinicId: string): Promise<OpticalPrescription[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<OpticalPrescriptionRaw>("optical_prescriptions", {
+    eq: [["clinic_id", clinicId]],
+    tenantClinicId: clinicId,
+  });
+  return rows.map((row) => ({
+    id: row.id,
+    clinic_id: row.clinic_id,
+    patient_id: row.patient_id,
+    patient_name: patientName(row.patient_id),
+    ophthalmologist_name: row.ophthalmologist_name,
+    prescription_date: row.prescription_date,
+    expiry_date: row.expiry_date,
+    right_eye: row.right_eye,
+    left_eye: row.left_eye,
+    notes: row.notes,
+    frame_id: row.frame_id,
+    lens_type: row.lens_type,
+    status: row.status as OpticalPrescription["status"],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+export async function updateOpticalPrescriptionStatus(
+  clinicId: string,
+  prescriptionId: string,
+  status: OpticalPrescription["status"],
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("optical_prescriptions")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", prescriptionId)
+    .eq("clinic_id", clinicId);
+  if (error) {
+    logger.warn("Failed to update optical prescription", {
+      context: "data/client/para-medical",
+      error,
+    });
+    throw new Error(error.message);
+  }
+}
+
+export async function addMealPlanItem(
+  clinicId: string,
+  planId: string,
+  dayIndex: number,
+  slot: MealSlot,
+  item: MealItem,
+): Promise<MealDay[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("meal_plans")
+    .select("daily_plans")
+    .eq("id", planId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const next = [...(((data?.daily_plans as MealDay[] | null) ?? []) as MealDay[])];
+  if (!next[dayIndex]) throw new Error("Invalid meal plan day");
+
+  next[dayIndex] = {
+    ...next[dayIndex],
+    [slot]: [...(next[dayIndex][slot] ?? []), item],
+  };
+  next[dayIndex] = recalculateMealDay(next[dayIndex]);
+
+  const { error: updateError } = await supabase
+    .from("meal_plans")
+    .update({ daily_plans: next, updated_at: new Date().toISOString() })
+    .eq("id", planId)
+    .eq("clinic_id", clinicId);
+
+  if (updateError) throw new Error(updateError.message);
+  return next;
+}
+
+export async function removeMealPlanItem(
+  clinicId: string,
+  planId: string,
+  dayIndex: number,
+  slot: MealSlot,
+  itemIndex: number,
+): Promise<MealDay[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("meal_plans")
+    .select("daily_plans")
+    .eq("id", planId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const next = [...(((data?.daily_plans as MealDay[] | null) ?? []) as MealDay[])];
+  if (!next[dayIndex]) throw new Error("Invalid meal plan day");
+
+  next[dayIndex] = {
+    ...next[dayIndex],
+    [slot]: [...(next[dayIndex][slot] ?? [])].filter((_, index) => index !== itemIndex),
+  };
+  next[dayIndex] = recalculateMealDay(next[dayIndex]);
+
+  const { error: updateError } = await supabase
+    .from("meal_plans")
+    .update({ daily_plans: next, updated_at: new Date().toISOString() })
+    .eq("id", planId)
+    .eq("clinic_id", clinicId);
+
+  if (updateError) throw new Error(updateError.message);
+  return next;
+}
+
+export async function addExerciseToProgram(
+  clinicId: string,
+  programId: string,
+  exercise: Omit<Exercise, "id">,
+): Promise<Exercise[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("exercise_programs")
+    .select("exercises")
+    .eq("id", programId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const next = [
+    ...(((data?.exercises as Exercise[] | null) ?? []) as Exercise[]),
+    { ...exercise, id: crypto.randomUUID() },
+  ];
+
+  const { error: updateError } = await supabase
+    .from("exercise_programs")
+    .update({ exercises: next, updated_at: new Date().toISOString() })
+    .eq("id", programId)
+    .eq("clinic_id", clinicId);
+
+  if (updateError) throw new Error(updateError.message);
+  return next;
+}
+
+export async function removeExerciseFromProgram(
+  clinicId: string,
+  programId: string,
+  exerciseIndex: number,
+): Promise<Exercise[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("exercise_programs")
+    .select("exercises")
+    .eq("id", programId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const next = (((data?.exercises as Exercise[] | null) ?? []) as Exercise[]).filter(
+    (_, index) => index !== exerciseIndex,
+  );
+
+  const { error: updateError } = await supabase
+    .from("exercise_programs")
+    .update({ exercises: next, updated_at: new Date().toISOString() })
+    .eq("id", programId)
+    .eq("clinic_id", clinicId);
+
+  if (updateError) throw new Error(updateError.message);
+  return next;
+}
+
+export async function updateExerciseProgramStatus(
+  clinicId: string,
+  programId: string,
+  status: ExerciseProgram["status"],
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("exercise_programs")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", programId)
+    .eq("clinic_id", clinicId);
+  if (error) throw new Error(error.message);
+}
+
+export async function updateTherapyPlanGoalStatus(
+  clinicId: string,
+  planId: string,
+  goalId: string,
+  status: TherapyGoal["status"],
+): Promise<TherapyGoal[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("therapy_plans")
+    .select("goals")
+    .eq("id", planId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const next = (((data?.goals as TherapyGoal[] | null) ?? []) as TherapyGoal[]).map((goal) => {
+    if (goal.id !== goalId) return updateGoalProgress(goal);
+    const updatedGoal: TherapyGoal = {
+      ...goal,
+      status,
+      progress_pct:
+        status === "achieved"
+          ? 100
+          : status === "not_started"
+            ? 0
+            : Math.max(goal.progress_pct ?? 0, 25),
+    };
+    return updateGoalProgress(updatedGoal);
+  });
+
+  const { error: updateError } = await supabase
+    .from("therapy_plans")
+    .update({ goals: next, updated_at: new Date().toISOString() })
+    .eq("id", planId)
+    .eq("clinic_id", clinicId);
+
+  if (updateError) throw new Error(updateError.message);
+  return next;
+}
+
+export async function toggleTherapyPlanMilestone(
+  clinicId: string,
+  planId: string,
+  goalId: string,
+  milestoneIndex: number,
+): Promise<TherapyGoal[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("therapy_plans")
+    .select("goals")
+    .eq("id", planId)
+    .eq("clinic_id", clinicId)
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  const today = getLocalDateStr();
+  const next = (((data?.goals as TherapyGoal[] | null) ?? []) as TherapyGoal[]).map((goal) => {
+    if (goal.id !== goalId) return updateGoalProgress(goal);
+
+    const milestones = goal.milestones.map((milestone, index) => {
+      if (index !== milestoneIndex) return milestone;
+      const completed = !milestone.completed;
+      return {
+        ...milestone,
+        completed,
+        completed_date: completed ? today : null,
+      };
+    });
+
+    const completedCount = milestones.filter((milestone) => milestone.completed).length;
+    const status: TherapyGoal["status"] =
+      completedCount === milestones.length && milestones.length > 0
+        ? "achieved"
+        : completedCount > 0
+          ? "in_progress"
+          : "not_started";
+
+    return updateGoalProgress({
+      ...goal,
+      milestones,
+      status,
+      progress_pct:
+        milestones.length > 0 ? Math.round((completedCount / milestones.length) * 100) : goal.progress_pct,
+    });
+  });
+
+  const { error: updateError } = await supabase
+    .from("therapy_plans")
+    .update({ goals: next, updated_at: new Date().toISOString() })
+    .eq("id", planId)
+    .eq("clinic_id", clinicId);
+
+  if (updateError) throw new Error(updateError.message);
+  return next;
+}

--- a/src/lib/data/client/pharmacy-transactions.ts
+++ b/src/lib/data/client/pharmacy-transactions.ts
@@ -1,9 +1,15 @@
 "use client";
 
-import { ensureLookups, fetchRows, _activeUserMap, type TableName } from "./_core";
+import { ensureLookups, fetchRows, _activeUserMap } from "./_core";
 
 // ─────────────────────────────────────────────
-// Pharmacy: Daily Sales
+// Pharmacy / Parapharmacy: Daily Sales
+//
+// Both modules write to the canonical `sales` table (with the
+// `is_parapharmacy` flag set to true for parapharmacy transactions).
+// Previously this function was reading from `pharmacy_sales` (a
+// non-existent table name used as a TypeScript cast), which meant
+// reads always returned an empty array while writes persisted fine.
 // ─────────────────────────────────────────────
 
 interface DailySaleItemView {
@@ -25,41 +31,47 @@ export interface DailySaleView {
   loyaltyPointsEarned: number;
 }
 
-interface PharmacySaleRaw {
+interface SaleRaw {
   id: string;
   clinic_id: string;
   patient_id: string | null;
+  patient_name: string | null;
   items: DailySaleItemView[] | null;
   total: number | null;
-  payment_method: string | null;
-  has_prescription?: boolean;
-  loyalty_points_earned?: number | null;
-  created_at: string;
+  currency: string;
+  payment_method: string;
+  has_prescription: boolean | null;
+  loyalty_points_earned: number | null;
+  date: string;
+  time: string;
 }
 
-export async function fetchDailySales(clinicId: string): Promise<DailySaleView[]> {
+export async function fetchDailySales(
+  clinicId: string,
+  options?: { parapharmacyOnly?: boolean },
+): Promise<DailySaleView[]> {
   await ensureLookups(clinicId);
-  const rows = await fetchRows<PharmacySaleRaw>("pharmacy_sales" as TableName, {
-    eq: [["clinic_id", clinicId]],
-    order: ["created_at", { ascending: false }],
+  const eq: [string, unknown][] = [["clinic_id", clinicId]];
+  if (options?.parapharmacyOnly) eq.push(["is_parapharmacy", true]);
+  const rows = await fetchRows<SaleRaw>("sales", {
+    eq,
+    order: ["date", { ascending: false }],
+    tenantClinicId: clinicId,
   });
-  return rows.map((r) => {
-    const dt = r.created_at ?? "";
-    return {
-      id: r.id,
-      date: dt.split("T")[0] ?? "",
-      time: dt.split("T")[1]?.slice(0, 5) ?? "",
-      patientName: r.patient_id
-        ? (_activeUserMap?.get(r.patient_id)?.name ?? "Patient")
-        : "Walk-in",
-      items: r.items ?? [],
-      total: r.total ?? 0,
-      currency: "MAD",
-      paymentMethod: (r.payment_method as "cash" | "card" | "insurance") ?? "cash",
-      hasPrescription: r.has_prescription ?? false,
-      loyaltyPointsEarned: r.loyalty_points_earned ?? 0,
-    };
-  });
+  return rows.map((r) => ({
+    id: r.id,
+    date: r.date ?? "",
+    time: typeof r.time === "string" ? r.time.slice(0, 5) : "",
+    patientName:
+      r.patient_name ??
+      (r.patient_id ? (_activeUserMap?.get(r.patient_id)?.name ?? "Patient") : "Walk-in"),
+    items: r.items ?? [],
+    total: r.total ?? 0,
+    currency: r.currency ?? "MAD",
+    paymentMethod: (r.payment_method as "cash" | "card" | "insurance") ?? "cash",
+    hasPrescription: r.has_prescription ?? false,
+    loyaltyPointsEarned: r.loyalty_points_earned ?? 0,
+  }));
 }
 
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the "static text instead of real controls" problem identified in the dashboard audit. Every page that had hardcoded data or local-only state is now wired to real Supabase read/write operations.

---

### Data layer (new files)

- **`src/lib/data/client/clinic-centers.ts`** — fetch helpers for departments (with live dashboard stats), rooms/beds, dialysis machines, lab materials, lab deliveries & invoices
- **`src/lib/data/client/para-medical.ts`** — fetch + mutation helpers for all 13 para-medical entities: exercise programs, physio/speech/therapy sessions, meal plans, body measurements, optical prescriptions, frame catalog, lens inventory
- **Bug fix** `pharmacy-transactions.ts` — `fetchDailySales` was reading from the non-existent `pharmacy_sales` table cast; now reads from the canonical `sales` table that `createParapharmacySale` actually writes to

### Server actions (`admin-actions.ts`)

Added 9 new clinic-admin server actions (all gated with `requireRole` + explicit `clinic_id` scoping):
`createClinicDepartment`, `setClinicDepartmentActive`, `createClinicRoom`, `createClinicDialysisMachine`, `updateClinicDialysisMachineStatus`, `createClinicLabMaterial`, `restockClinicLabMaterial`, `createClinicLabInvoice`, `updateClinicLabInvoiceStatus`

### Admin pages (5 empty shells → full CRUD)

`admin/beds`, `admin/machines`, `admin/lab-materials`, `admin/lab-invoices`, `admin/departments` — each loads live data on mount, persists all creates/updates, and rolls back optimistically on error.

### Doctor mirror pages (4 empty shells → read-only live views)

`doctor/departments`, `doctor/dialysis-machines`, `doctor/lab-materials`, `doctor/lab-invoices`

### Specialist pages (14 `setX([])` stubs → live fetches + mutations)

| Role | Pages |
|---|---|
| Optician | frame-catalog (read), lens-inventory (read), prescriptions (status update persisted) |
| Nutritionist | meal-plans (add/remove items persisted), measurements (read) |
| Physiotherapist | exercise-programs (add/remove/status persisted), progress-photos (read), sessions (read) |
| Psychologist | progress (real mood chart from DB), session-notes (read), therapy-plans (goal status + milestone toggle persisted) |
| Speech Therapist | exercise-library (read), reports (read), sessions (read) |

### Shared component hardening (fake-control fix)

9 shared components updated to gate action buttons behind their callback props — buttons no longer render at all when no backing handler is provided:
`BedManagement`, `MachineManagement`, `MaterialsInventory`, `DeliveryInvoicing`, `DepartmentManagement`, `ExerciseProgramBuilder`, `MealPlanBuilder`, `TherapyPlanView`, `OpticalPrescriptionTracker`

---

**37 files changed, 2806 insertions, 247 deletions**