### PR TITLE
fix(super-admin): unify Operations monitoring + fix dashboard QA findings

### DIFF
--- a/docs/ops-dashboard-qa-2026-06-18.md
+++ b/docs/ops-dashboard-qa-2026-06-18.md
@@ -1,0 +1,63 @@
+# Operations Dashboard — QA Remediation (2026-06-18)
+
+Addresses the Super Admin → Operations QA report (System Status · Health
+Metrics · Uptime SLA · Compliance · Support). This change set fixes the
+**dashboard/code** issues. Items that are genuine infrastructure, data-pipeline,
+or legal actions (and therefore cannot be fixed by front-end code) are listed at
+the bottom so they are not lost.
+
+## Root cause of the headline contradiction
+
+System Status and Uptime SLA both read `GET /api/admin/health`, but they
+interpreted failures differently. The health route returns **503** when the
+database is unreachable. System Status correctly treated that as DB **Down**;
+the Uptime SLA page only updated the database status on the **success** path and
+left it at its initial `"operational"` value on the error path — so the same
+503 showed the DB as **Operational** on one page and **Down** on the other.
+
+Both pages now derive Web App / Database / Auth status through a single shared
+probe so they can no longer drift apart.
+
+## What changed (code)
+
+New shared module:
+
+- `src/lib/monitoring/services.ts` — pure status logic: `deriveHealthStatus`,
+  `computeOverallStatus`, `MONITORED_SERVICES`, shared types.
+- `src/lib/monitoring/health-client.ts` — `fetchCoreHealth()`, the single
+  client-side probe used by both Operations pages.
+- `src/lib/monitoring/__tests__/health-status.test.ts` — unit tests, including a
+  regression test asserting a 503 maps the DB to **down**.
+
+| # | Report finding | Fix |
+|---|----------------|-----|
+| 1 | System Status DB "Down" vs Uptime SLA DB "Operational" | Shared probe; DB is marked **down** on any health error (503/parse/network). |
+| 2 | Severity label mismatch ("Down" vs "Degraded") | Status now computed in one place via `deriveHealthStatus`. |
+| 3 | Three panels stuck on "Loading…" forever (Environment, Backups, Background Jobs) | Added a settled flag; panels show an "unavailable" message instead of spinning when an endpoint fails. |
+| 4 | "Recent Incidents" hardcoded to "No recent incidents" during outages | Now derived from live service health; lists every non-operational service. |
+| 5 | "Last Deployment" = N/A | `NEXT_PUBLIC_DEPLOY_TIME` now defaults to the build timestamp in `next.config.ts`; rendered via a date formatter. |
+| 6 | "Node.js Version" blank | `/api/admin/health` now returns `nodeVersion`; the page reads it from the server instead of the (always-empty) client `process.version`. |
+| 7 | "API Latency" hardcoded "avg 120ms" | Shows the real measured health round-trip time. |
+| 8 | Health Metrics "Services Tracked: 0" | Counts distinct monitors, falling back to the canonical `MONITORED_SERVICES` count so it never reads a misleading 0. |
+| 9 | Health Metrics / SLA tables blank with no explanation | Added explicit empty-state rows/messages. |
+| 10 | Compliance "Open DSARs" showed a warning badge on a 0 value | Badge is now success when there are no open/overdue DSARs, warning only when there are open ones, destructive when overdue. |
+| 11 | Support "Avg Response" showed "--" | Now shows "N/A". |
+
+## Not fixable in dashboard code (infra / data / legal follow-ups)
+
+These were reported as issues but are not front-end bugs. The dashboard now
+reports them honestly; resolving them requires action outside this repo:
+
+- **Database (Supabase) production outage** — operational; fix the database /
+  connection, not the UI.
+- **CNDP registration not filed** — legal/compliance action (Moroccan CNDP
+  filing). The dashboard correctly shows "Not filed / pending".
+- **6 overdue retention purge runs** — the data-retention purge job is not
+  advancing `next_purge_at`. Backend cron/worker fix.
+- **Consent ledger = 0** — needs consent-evidence logging wired into the consent
+  flows (data pipeline), not a display change.
+- **Health Metrics / SLA history empty** — the monitoring pipeline that writes
+  `uptime_sla_monthly` / `uptime_events` needs to run; the pages now show
+  empty-state messaging until it does.
+- **Last Deployment in production** — set `NEXT_PUBLIC_DEPLOY_TIME` in CI (e.g.
+  to the deploy time or release SHA) to override the build-time default.

--- a/docs/ops-dashboard-qa-2026-06-18.md
+++ b/docs/ops-dashboard-qa-2026-06-18.md
@@ -29,19 +29,19 @@ New shared module:
 - `src/lib/monitoring/__tests__/health-status.test.ts` — unit tests, including a
   regression test asserting a 503 maps the DB to **down**.
 
-| # | Report finding | Fix |
-|---|----------------|-----|
-| 1 | System Status DB "Down" vs Uptime SLA DB "Operational" | Shared probe; DB is marked **down** on any health error (503/parse/network). |
-| 2 | Severity label mismatch ("Down" vs "Degraded") | Status now computed in one place via `deriveHealthStatus`. |
-| 3 | Three panels stuck on "Loading…" forever (Environment, Backups, Background Jobs) | Added a settled flag; panels show an "unavailable" message instead of spinning when an endpoint fails. |
-| 4 | "Recent Incidents" hardcoded to "No recent incidents" during outages | Now derived from live service health; lists every non-operational service. |
-| 5 | "Last Deployment" = N/A | `NEXT_PUBLIC_DEPLOY_TIME` now defaults to the build timestamp in `next.config.ts`; rendered via a date formatter. |
-| 6 | "Node.js Version" blank | `/api/admin/health` now returns `nodeVersion`; the page reads it from the server instead of the (always-empty) client `process.version`. |
-| 7 | "API Latency" hardcoded "avg 120ms" | Shows the real measured health round-trip time. |
-| 8 | Health Metrics "Services Tracked: 0" | Counts distinct monitors, falling back to the canonical `MONITORED_SERVICES` count so it never reads a misleading 0. |
-| 9 | Health Metrics / SLA tables blank with no explanation | Added explicit empty-state rows/messages. |
-| 10 | Compliance "Open DSARs" showed a warning badge on a 0 value | Badge is now success when there are no open/overdue DSARs, warning only when there are open ones, destructive when overdue. |
-| 11 | Support "Avg Response" showed "--" | Now shows "N/A". |
+| #   | Report finding                                                                   | Fix                                                                                                                                      |
+| --- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | System Status DB "Down" vs Uptime SLA DB "Operational"                           | Shared probe; DB is marked **down** on any health error (503/parse/network).                                                             |
+| 2   | Severity label mismatch ("Down" vs "Degraded")                                   | Status now computed in one place via `deriveHealthStatus`.                                                                               |
+| 3   | Three panels stuck on "Loading…" forever (Environment, Backups, Background Jobs) | Added a settled flag; panels show an "unavailable" message instead of spinning when an endpoint fails.                                   |
+| 4   | "Recent Incidents" hardcoded to "No recent incidents" during outages             | Now derived from live service health; lists every non-operational service.                                                               |
+| 5   | "Last Deployment" = N/A                                                          | `NEXT_PUBLIC_DEPLOY_TIME` now defaults to the build timestamp in `next.config.ts`; rendered via a date formatter.                        |
+| 6   | "Node.js Version" blank                                                          | `/api/admin/health` now returns `nodeVersion`; the page reads it from the server instead of the (always-empty) client `process.version`. |
+| 7   | "API Latency" hardcoded "avg 120ms"                                              | Shows the real measured health round-trip time.                                                                                          |
+| 8   | Health Metrics "Services Tracked: 0"                                             | Counts distinct monitors, falling back to the canonical `MONITORED_SERVICES` count so it never reads a misleading 0.                     |
+| 9   | Health Metrics / SLA tables blank with no explanation                            | Added explicit empty-state rows/messages.                                                                                                |
+| 10  | Compliance "Open DSARs" showed a warning badge on a 0 value                      | Badge is now success when there are no open/overdue DSARs, warning only when there are open ones, destructive when overdue.              |
+| 11  | Support "Avg Response" showed "--"                                               | Now shows "N/A".                                                                                                                         |
 
 ## Not fixable in dashboard code (infra / data / legal follow-ups)
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -74,6 +74,10 @@ const nextConfig: NextConfig = {
   // the env var still ship a safe default.
   env: {
     NEXT_PUBLIC_DATA_MASKING: process.env.NEXT_PUBLIC_DATA_MASKING || "partial",
+    // Ops dashboard "Last Deployment": inline a build timestamp so the metric
+    // is populated even when CI does not set NEXT_PUBLIC_DEPLOY_TIME. CI may
+    // still override it (e.g. with the deploy time or release SHA).
+    NEXT_PUBLIC_DEPLOY_TIME: process.env.NEXT_PUBLIC_DEPLOY_TIME || new Date().toISOString(),
   },
 
   // E2E suite (login-flow / registration-flow / pricing / mobile-flows specs)

--- a/src/app/(super-admin)/super-admin/compliance/page.tsx
+++ b/src/app/(super-admin)/super-admin/compliance/page.tsx
@@ -129,7 +129,13 @@ export default async function ComplianceCenterPage() {
           title="Open DSARs"
           value={String(openDsarsResult.count ?? 0)}
           hint={`${overdueDsarsResult.count ?? 0} overdue`}
-          variant={(overdueDsarsResult.count ?? 0) > 0 ? "destructive" : "warning"}
+          variant={
+            (overdueDsarsResult.count ?? 0) > 0
+              ? "destructive"
+              : (openDsarsResult.count ?? 0) > 0
+                ? "warning"
+                : "success"
+          }
         />
         <OverviewCard
           title="Active breaches"

--- a/src/app/(super-admin)/super-admin/support/page.tsx
+++ b/src/app/(super-admin)/super-admin/support/page.tsx
@@ -345,7 +345,7 @@ export default function SupportPage() {
               <MessageSquare className="h-4 w-4 text-muted-foreground" />
               <p className="text-xs text-muted-foreground">Avg Response</p>
             </div>
-            <p className="text-2xl font-bold">--</p>
+            <p className="text-2xl font-bold">N/A</p>
           </CardContent>
         </Card>
         <Card>

--- a/src/app/(super-admin)/super-admin/system/health/page.tsx
+++ b/src/app/(super-admin)/super-admin/system/health/page.tsx
@@ -2,6 +2,7 @@
 import { AlertTriangle, Database, ShieldAlert } from "lucide-react";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MONITORED_SERVICES } from "@/lib/monitoring/services";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
 
 // uptime_sla_monthly (view) and uptime_events are introduced by migration
@@ -44,6 +45,11 @@ export default async function SystemHealthPage() {
   const metrics = await getMetrics();
   const latestMonth = metrics.uptime[0]?.month;
   const latestMonthRows = metrics.uptime.filter((row) => row.month === latestMonth);
+  const distinctMonitors = new Set(metrics.uptime.map((row) => row.monitor_name)).size;
+  // Fall back to the canonical monitored-services count so "Services suivis"
+  // never reads a misleading 0 before the historical uptime_sla_monthly table
+  // has been populated by the monitoring pipeline.
+  const servicesTracked = distinctMonitors > 0 ? distinctMonitors : MONITORED_SERVICES.length;
 
   return (
     <div className="space-y-6">
@@ -71,7 +77,7 @@ export default async function SystemHealthPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{latestMonthRows.length}</div>
+            <div className="text-2xl font-bold">{servicesTracked}</div>
           </CardContent>
         </Card>
         <Card>
@@ -116,19 +122,27 @@ export default async function SystemHealthPage() {
                 </tr>
               </thead>
               <tbody>
-                {metrics.uptime.map((row) => (
-                  <tr key={`${row.monitor_name}-${row.month}`} className="border-b">
-                    <td className="p-3">{row.monitor_name}</td>
-                    <td className="p-3">
-                      {new Date(row.month).toLocaleDateString("fr-MA", {
-                        year: "numeric",
-                        month: "long",
-                      })}
+                {metrics.uptime.length === 0 ? (
+                  <tr>
+                    <td className="p-3 text-muted-foreground" colSpan={4}>
+                      Aucune donnée de disponibilité enregistrée pour le moment.
                     </td>
-                    <td className="p-3">{row.uptime_pct}%</td>
-                    <td className="p-3">{row.downtime_events}</td>
                   </tr>
-                ))}
+                ) : (
+                  metrics.uptime.map((row) => (
+                    <tr key={`${row.monitor_name}-${row.month}`} className="border-b">
+                      <td className="p-3">{row.monitor_name}</td>
+                      <td className="p-3">
+                        {new Date(row.month).toLocaleDateString("fr-MA", {
+                          year: "numeric",
+                          month: "long",
+                        })}
+                      </td>
+                      <td className="p-3">{row.uptime_pct}%</td>
+                      <td className="p-3">{row.downtime_events}</td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </div>
@@ -141,22 +155,26 @@ export default async function SystemHealthPage() {
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {metrics.events.map((event) => (
-              <div key={event.id} className="rounded-lg border p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <div className="font-medium">{event.monitor_name}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {new Date(event.occurred_at).toLocaleString("fr-MA")}
+            {metrics.events.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Aucun événement récent enregistré.</p>
+            ) : (
+              metrics.events.map((event) => (
+                <div key={event.id} className="rounded-lg border p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <div className="font-medium">{event.monitor_name}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {new Date(event.occurred_at).toLocaleString("fr-MA")}
+                      </div>
                     </div>
+                    <div className="text-sm capitalize">{event.event_type}</div>
                   </div>
-                  <div className="text-sm capitalize">{event.event_type}</div>
+                  {event.message ? (
+                    <p className="mt-2 text-sm text-muted-foreground">{event.message}</p>
+                  ) : null}
                 </div>
-                {event.message ? (
-                  <p className="mt-2 text-sm text-muted-foreground">{event.message}</p>
-                ) : null}
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/app/(super-admin)/super-admin/system/page.tsx
+++ b/src/app/(super-admin)/super-admin/system/page.tsx
@@ -25,6 +25,8 @@ import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CardSkeleton } from "@/components/ui/loading-skeleton";
 import { logger } from "@/lib/logger";
+import { fetchCoreHealth } from "@/lib/monitoring/health-client";
+import { computeOverallStatus } from "@/lib/monitoring/services";
 import { createClient } from "@/lib/supabase-client";
 
 type ServiceStatus = "operational" | "degraded" | "down";
@@ -68,13 +70,6 @@ interface JobsData {
   notifications: { pending: number; failed: number; deadLettered: number };
 }
 
-interface HealthApiResponse {
-  status: string;
-  database: string;
-  version: string;
-  timestamp: string;
-}
-
 const STATUS_CONFIG: Record<
   ServiceStatus,
   { label: string; color: string; bg: string; icon: React.ComponentType<{ className?: string }> }
@@ -112,6 +107,12 @@ function StatusBadge({ status }: { status: ServiceStatus }) {
   );
 }
 
+function formatDeployTime(raw: string | undefined): string {
+  if (!raw) return "N/A";
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? raw : date.toLocaleString();
+}
+
 export default function SystemStatusPage() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -119,38 +120,28 @@ export default function SystemStatusPage() {
   const [overallStatus, setOverallStatus] = useState<ServiceStatus>("operational");
   const [activeUsers, setActiveUsers] = useState(0);
   const [appVersion, setAppVersion] = useState("0.1.0");
+  const [nodeVersion, setNodeVersion] = useState<string | null>(null);
+  const [apiLatencyMs, setApiLatencyMs] = useState<number | null>(null);
   const [lastChecked, setLastChecked] = useState<Date>(new Date());
   const [readiness, setReadiness] = useState<ReadinessData | null>(null);
   const [backups, setBackups] = useState<BackupsData | null>(null);
   const [jobs, setJobs] = useState<JobsData | null>(null);
+  // Tracks whether the readiness/backups/jobs fetches have settled, so their
+  // panels can show an "unavailable" state instead of spinning on "Loading..."
+  // forever when an endpoint fails to return usable data.
+  const [opsLoaded, setOpsLoaded] = useState(false);
 
   const loadHealth = useCallback(async () => {
     try {
-      const now = new Date();
+      // Single shared probe — identical source/logic to the Uptime SLA page,
+      // so the two pages can no longer disagree about service status.
+      const core = await fetchCoreHealth();
+      const now = core.checkedAt;
       const serviceResults: ServiceHealth[] = [];
 
-      let webAppStatus: ServiceStatus = "operational";
-      let dbStatus: ServiceStatus = "operational";
-      let dbConnected = false;
-      let version = "0.1.0";
-
-      try {
-        const res = await fetch("/api/admin/health");
-        if (res.ok) {
-          const json = (await res.json()) as { ok: boolean; data: HealthApiResponse };
-          if (json.ok && json.data) {
-            dbConnected = json.data.database === "connected";
-            version = json.data.version;
-          }
-        } else {
-          webAppStatus = "degraded";
-        }
-      } catch {
-        webAppStatus = "degraded";
-      }
-
-      dbStatus = dbConnected ? "operational" : "down";
-      setAppVersion(version);
+      setAppVersion(core.version);
+      setNodeVersion(core.nodeVersion);
+      setApiLatencyMs(core.responseTimeMs);
 
       let userCount = 0;
       try {
@@ -167,34 +158,25 @@ export default function SystemStatusPage() {
       }
       setActiveUsers(userCount);
 
-      let authStatus: ServiceStatus = "operational";
-      try {
-        const supabase = createClient();
-        const { error } = await supabase.auth.getUser();
-        if (error) authStatus = "degraded";
-      } catch {
-        authStatus = "down";
-      }
-
       serviceResults.push(
         {
           name: "Web App (Next.js)",
           description: "Main application server",
-          status: webAppStatus,
+          status: core.webApp,
           icon: Globe,
           lastChecked: now,
         },
         {
           name: "Database (Supabase)",
           description: "PostgreSQL database with RLS",
-          status: dbStatus,
+          status: core.database,
           icon: Database,
           lastChecked: now,
         },
         {
           name: "Auth (Supabase Auth)",
           description: "Authentication service",
-          status: authStatus,
+          status: core.auth,
           icon: Shield,
           lastChecked: now,
         },
@@ -243,13 +225,14 @@ export default function SystemStatusPage() {
         }
       } catch (e) {
         logger.warn("Failed to fetch readiness APIs", { error: e });
+      } finally {
+        // Mark the ops panels as settled so they stop showing "Loading..."
+        // even when an endpoint failed to return usable data.
+        setOpsLoaded(true);
       }
 
       setServices(serviceResults);
-
-      const hasDown = serviceResults.some((s) => s.status === "down");
-      const hasDegraded = serviceResults.some((s) => s.status === "degraded");
-      setOverallStatus(hasDown ? "down" : hasDegraded ? "degraded" : "operational");
+      setOverallStatus(computeOverallStatus(serviceResults.map((s) => s.status)));
       setLastChecked(now);
     } finally {
       setLoading(false);
@@ -278,6 +261,10 @@ export default function SystemStatusPage() {
   const overallConfig = STATUS_CONFIG[overallStatus];
   const OverallIcon = overallConfig.icon;
 
+  // Derive incidents from live service health so this panel can never claim
+  // "No recent incidents" while a service is actually down or degraded.
+  const activeIncidents = services.filter((s) => s.status !== "operational");
+
   const kpiCards = [
     {
       label: "System Status",
@@ -300,7 +287,7 @@ export default function SystemStatusPage() {
     },
     {
       label: "API Latency",
-      value: "avg 120ms",
+      value: apiLatencyMs !== null ? `${apiLatencyMs}ms` : "N/A",
       icon: Clock,
       color: "text-purple-600",
       bg: "bg-purple-50",
@@ -436,11 +423,14 @@ export default function SystemStatusPage() {
                 { label: "App Version", value: appVersion },
                 {
                   label: "Node.js Version",
-                  value: typeof process !== "undefined" ? (process.version ?? "N/A") : "N/A",
+                  value: nodeVersion ?? "N/A",
                 },
                 { label: "Next.js Version", value: "16" },
                 // nosemgrep: semgrep.env-access — NEXT_PUBLIC_* is a client-side public env var for display only
-                { label: "Last Deployment", value: process.env.NEXT_PUBLIC_DEPLOY_TIME ?? "N/A" },
+                {
+                  label: "Last Deployment",
+                  value: formatDeployTime(process.env.NEXT_PUBLIC_DEPLOY_TIME),
+                },
                 {
                   label: "Environment",
                   // nosemgrep: semgrep.env-access — NODE_ENV is always available at build time
@@ -471,13 +461,48 @@ export default function SystemStatusPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-col items-center justify-center py-8 text-center">
-            <CheckCircle className="h-10 w-10 text-green-500 mb-3" />
-            <p className="text-sm font-medium">No recent incidents</p>
-            <p className="text-xs text-muted-foreground mt-1">
-              All systems have been running smoothly
-            </p>
-          </div>
+          {activeIncidents.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <CheckCircle className="h-10 w-10 text-green-500 mb-3" />
+              <p className="text-sm font-medium">No recent incidents</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                All systems have been running smoothly
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {activeIncidents.map((incident) => (
+                <div
+                  key={incident.name}
+                  className="flex items-start justify-between gap-3 rounded-lg border p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <span
+                      className={`mt-0.5 rounded-lg p-2 ${
+                        incident.status === "down" ? "bg-red-50" : "bg-amber-50"
+                      }`}
+                    >
+                      {incident.status === "down" ? (
+                        <XCircle className="h-4 w-4 text-red-600" />
+                      ) : (
+                        <AlertTriangle className="h-4 w-4 text-amber-600" />
+                      )}
+                    </span>
+                    <div>
+                      <p className="text-sm font-medium">{incident.name}</p>
+                      <p className="text-xs text-muted-foreground">{incident.description}</p>
+                    </div>
+                  </div>
+                  <div className="flex flex-col items-end gap-1">
+                    <StatusBadge status={incident.status} />
+                    <span className="text-[10px] text-muted-foreground">
+                      since {incident.lastChecked.toLocaleTimeString()}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -514,6 +539,10 @@ export default function SystemStatusPage() {
                   </div>
                 ))}
               </div>
+            ) : opsLoaded ? (
+              <p className="text-sm text-muted-foreground">
+                Environment details unavailable. The readiness check did not return data.
+              </p>
             ) : (
               <p className="text-sm text-muted-foreground">Loading environment details...</p>
             )}
@@ -547,6 +576,10 @@ export default function SystemStatusPage() {
                     <span className="font-medium text-xs">{backups.lastRestoreDrill}</span>
                   </div>
                 </div>
+              ) : opsLoaded ? (
+                <p className="text-sm text-muted-foreground">
+                  Backups data unavailable. The readiness check did not return data.
+                </p>
               ) : (
                 <p className="text-sm text-muted-foreground">Loading backups data...</p>
               )}
@@ -582,6 +615,10 @@ export default function SystemStatusPage() {
                     </div>
                   </div>
                 </div>
+              ) : opsLoaded ? (
+                <p className="text-sm text-muted-foreground">
+                  Background jobs data unavailable. The readiness check did not return data.
+                </p>
               ) : (
                 <p className="text-sm text-muted-foreground">Loading jobs data...</p>
               )}

--- a/src/app/(super-admin)/super-admin/system/sla/page.tsx
+++ b/src/app/(super-admin)/super-admin/system/sla/page.tsx
@@ -90,19 +90,30 @@ export default async function SLAPage() {
                 </tr>
               </thead>
               <tbody>
-                {(slaRows.data ?? []).map((row: Record<string, unknown>) => (
-                  <tr key={`${String(row.monitor_name)}-${String(row.month)}`} className="border-b">
-                    <td className="p-3">{String(row.monitor_name ?? "unknown")}</td>
-                    <td className="p-3">
-                      {new Date(String(row.month)).toLocaleDateString("fr-MA", {
-                        month: "long",
-                        year: "numeric",
-                      })}
+                {(slaRows.data ?? []).length === 0 ? (
+                  <tr>
+                    <td className="p-3 text-muted-foreground" colSpan={4}>
+                      Aucune donnée SLA enregistrée pour le moment.
                     </td>
-                    <td className="p-3">{String(row.uptime_pct ?? "—")}%</td>
-                    <td className="p-3">{String(row.downtime_events ?? 0)}</td>
                   </tr>
-                ))}
+                ) : (
+                  (slaRows.data ?? []).map((row: Record<string, unknown>) => (
+                    <tr
+                      key={`${String(row.monitor_name)}-${String(row.month)}`}
+                      className="border-b"
+                    >
+                      <td className="p-3">{String(row.monitor_name ?? "unknown")}</td>
+                      <td className="p-3">
+                        {new Date(String(row.month)).toLocaleDateString("fr-MA", {
+                          month: "long",
+                          year: "numeric",
+                        })}
+                      </td>
+                      <td className="p-3">{String(row.uptime_pct ?? "—")}%</td>
+                      <td className="p-3">{String(row.downtime_events ?? 0)}</td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </div>
@@ -115,17 +126,21 @@ export default async function SLAPage() {
         </CardHeader>
         <CardContent>
           <div className="space-y-3">
-            {(recentEvents.data ?? []).map((event: Record<string, unknown>) => (
-              <div key={String(event.id)} className="rounded-lg border p-3">
-                <div className="font-medium">{String(event.monitor_name ?? "unknown")}</div>
-                <div className="text-xs text-muted-foreground">
-                  {new Date(String(event.occurred_at)).toLocaleString("fr-MA")}
+            {(recentEvents.data ?? []).length === 0 ? (
+              <p className="text-sm text-muted-foreground">Aucune panne enregistrée.</p>
+            ) : (
+              (recentEvents.data ?? []).map((event: Record<string, unknown>) => (
+                <div key={String(event.id)} className="rounded-lg border p-3">
+                  <div className="font-medium">{String(event.monitor_name ?? "unknown")}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {new Date(String(event.occurred_at)).toLocaleString("fr-MA")}
+                  </div>
+                  {typeof event.message === "string" ? (
+                    <p className="mt-2 text-sm text-muted-foreground">{event.message}</p>
+                  ) : null}
                 </div>
-                {typeof event.message === "string" ? (
-                  <p className="mt-2 text-sm text-muted-foreground">{event.message}</p>
-                ) : null}
-              </div>
-            ))}
+              ))
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/app/(super-admin)/super-admin/uptime/page.tsx
+++ b/src/app/(super-admin)/super-admin/uptime/page.tsx
@@ -19,15 +19,9 @@ import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fetchCoreHealth } from "@/lib/monitoring/health-client";
 
 type ServiceStatus = "operational" | "degraded" | "down";
-
-interface HealthData {
-  status: string;
-  database: string;
-  version: string;
-  timestamp: string;
-}
 
 const statusConfig: Record<
   ServiceStatus,
@@ -56,40 +50,17 @@ export default function UptimeSLAPage() {
   const [lastChecked, setLastChecked] = useState<Date>(new Date());
 
   const checkHealth = useCallback(async () => {
-    const start = performance.now();
-    try {
-      const res = await fetch("/api/admin/health");
-      const elapsed = Math.round(performance.now() - start);
-      setResponseTime(elapsed);
-
-      if (res.ok) {
-        const json = (await res.json()) as { ok: boolean; data: HealthData };
-        if (json.ok && json.data) {
-          setWebAppStatus("operational");
-          setDbStatus(json.data.database === "connected" ? "operational" : "down");
-          setAppVersion(json.data.version);
-        } else {
-          setWebAppStatus("degraded");
-        }
-      } else {
-        setWebAppStatus("degraded");
-      }
-    } catch {
-      setWebAppStatus("down");
-      setResponseTime(null);
-    }
-
-    // Check auth
-    try {
-      const { createClient } = await import("@/lib/supabase-client");
-      const supabase = createClient();
-      const { error } = await supabase.auth.getUser();
-      setAuthStatus(error ? "degraded" : "operational");
-    } catch {
-      setAuthStatus("down");
-    }
-
-    setLastChecked(new Date());
+    // Use the shared probe so this page derives Web App / Database / Auth
+    // status identically to System Status. Previously this page left the
+    // database at its initial "operational" value when /api/admin/health
+    // returned an error, which contradicted System Status (DB "Down").
+    const snapshot = await fetchCoreHealth();
+    setWebAppStatus(snapshot.webApp);
+    setDbStatus(snapshot.database);
+    setAuthStatus(snapshot.auth);
+    setAppVersion(snapshot.version);
+    setResponseTime(snapshot.responseTimeMs);
+    setLastChecked(snapshot.checkedAt);
     setLoading(false);
   }, []);
 

--- a/src/app/api/admin/health/route.ts
+++ b/src/app/api/admin/health/route.ts
@@ -56,6 +56,10 @@ async function handler(_request: NextRequest, auth: AuthContext) {
     status: "ok",
     database: databaseStatus,
     version,
+    // Surface the server runtime version so the System Status "Platform Info"
+    // panel can populate "Node.js Version" — a client component cannot read
+    // process.version reliably. Null on runtimes that do not expose it.
+    nodeVersion: typeof process !== "undefined" ? (process.version ?? null) : null,
     timestamp,
   });
 }

--- a/src/lib/monitoring/__tests__/health-status.test.ts
+++ b/src/lib/monitoring/__tests__/health-status.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeOverallStatus,
+  deriveHealthStatus,
+  MONITORED_SERVICES,
+  type HealthApiData,
+} from "@/lib/monitoring/services";
+
+const healthData = (overrides: Partial<HealthApiData> = {}): HealthApiData => ({
+  status: "ok",
+  database: "connected",
+  version: "0.1.0",
+  nodeVersion: "v22.13.0",
+  timestamp: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("deriveHealthStatus", () => {
+  it("reports everything operational on a healthy response", () => {
+    const result = deriveHealthStatus({ kind: "ok", data: healthData() });
+    expect(result.webApp).toBe("operational");
+    expect(result.database).toBe("operational");
+    expect(result.version).toBe("0.1.0");
+    expect(result.nodeVersion).toBe("v22.13.0");
+  });
+
+  it("marks the database down when the health body says disconnected", () => {
+    const result = deriveHealthStatus({
+      kind: "ok",
+      data: healthData({ database: "disconnected" }),
+    });
+    expect(result.webApp).toBe("operational");
+    expect(result.database).toBe("down");
+  });
+
+  // Regression test for the System Status vs Uptime SLA contradiction: a 503
+  // (database unreachable) must surface the DB as "down", never "operational".
+  it("marks the database down on an HTTP error (e.g. 503 DB_UNREACHABLE)", () => {
+    const result = deriveHealthStatus({ kind: "http-error" });
+    expect(result.webApp).toBe("degraded");
+    expect(result.database).toBe("down");
+  });
+
+  it("marks the database down on a malformed body", () => {
+    const result = deriveHealthStatus({ kind: "bad-json" });
+    expect(result.database).toBe("down");
+  });
+
+  it("marks both web app and database down when the server is unreachable", () => {
+    const result = deriveHealthStatus({ kind: "network-error" });
+    expect(result.webApp).toBe("down");
+    expect(result.database).toBe("down");
+    expect(result.nodeVersion).toBeNull();
+  });
+
+  it("falls back to the default version when the response omits it", () => {
+    const result = deriveHealthStatus({
+      kind: "ok",
+      data: healthData({ version: "" }),
+    });
+    expect(result.version).toBe("0.1.0");
+  });
+});
+
+describe("computeOverallStatus", () => {
+  it("returns operational when all services are operational", () => {
+    expect(computeOverallStatus(["operational", "operational", "operational"])).toBe("operational");
+  });
+
+  it("returns degraded when any service is degraded but none are down", () => {
+    expect(computeOverallStatus(["operational", "degraded", "operational"])).toBe("degraded");
+  });
+
+  it("returns down when any service is down (worst-wins over degraded)", () => {
+    expect(computeOverallStatus(["degraded", "down", "operational"])).toBe("down");
+  });
+
+  it("treats an empty set as operational", () => {
+    expect(computeOverallStatus([])).toBe("operational");
+  });
+});
+
+describe("MONITORED_SERVICES", () => {
+  it("tracks the three always-on core services", () => {
+    expect(MONITORED_SERVICES.map((s) => s.key)).toEqual(["web", "database", "auth"]);
+  });
+});

--- a/src/lib/monitoring/health-client.ts
+++ b/src/lib/monitoring/health-client.ts
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Client-side health probe shared by the super-admin System Status and
+ * Uptime SLA pages. Both pages call {@link fetchCoreHealth} so they always
+ * compute Web App / Database / Auth status from the exact same source and
+ * the same rules (see {@link deriveHealthStatus}).
+ */
+
+import {
+  deriveHealthStatus,
+  type HealthApiData,
+  type HealthFetchOutcome,
+  type ServiceStatus,
+} from "@/lib/monitoring/services";
+import { createClient } from "@/lib/supabase-client";
+
+export interface CoreHealthSnapshot {
+  webApp: ServiceStatus;
+  database: ServiceStatus;
+  auth: ServiceStatus;
+  version: string;
+  nodeVersion: string | null;
+  /** Round-trip time of the /api/admin/health call, in ms (null on failure). */
+  responseTimeMs: number | null;
+  checkedAt: Date;
+}
+
+/**
+ * Probe platform health once and return a normalised snapshot.
+ *
+ * Never throws: any failure is mapped onto a {@link ServiceStatus}.
+ */
+export async function fetchCoreHealth(): Promise<CoreHealthSnapshot> {
+  const checkedAt = new Date();
+  const start = performance.now();
+
+  let outcome: HealthFetchOutcome = { kind: "network-error" };
+  let responseTimeMs: number | null = null;
+
+  try {
+    const res = await fetch("/api/admin/health");
+    responseTimeMs = Math.round(performance.now() - start);
+    if (res.ok) {
+      const json = (await res.json()) as { ok?: boolean; data?: HealthApiData };
+      outcome = json?.ok && json.data ? { kind: "ok", data: json.data } : { kind: "bad-json" };
+    } else {
+      outcome = { kind: "http-error" };
+    }
+  } catch {
+    outcome = { kind: "network-error" };
+    responseTimeMs = null;
+  }
+
+  const derived = deriveHealthStatus(outcome);
+
+  // Auth is probed independently of the database/web-app health check so an
+  // auth outage is reported even when the rest of the platform is healthy.
+  let auth: ServiceStatus = "operational";
+  try {
+    const supabase = createClient();
+    const { error } = await supabase.auth.getUser();
+    auth = error ? "degraded" : "operational";
+  } catch {
+    auth = "down";
+  }
+
+  return {
+    webApp: derived.webApp,
+    database: derived.database,
+    auth,
+    version: derived.version,
+    nodeVersion: derived.nodeVersion,
+    responseTimeMs,
+    checkedAt,
+  };
+}

--- a/src/lib/monitoring/services.ts
+++ b/src/lib/monitoring/services.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared, framework-agnostic monitoring primitives.
+ *
+ * This module is the single source of truth for how the super-admin
+ * Operations pages (System Status, Uptime SLA, Health Metrics) interpret
+ * service health. It exists to fix the QA finding that the System Status
+ * and Uptime SLA pages "don't share the same health source" — both pages
+ * now derive status through the pure helpers below, so they can no longer
+ * drift apart (e.g. one page showing the database "Down" while another
+ * shows it "Operational").
+ *
+ * Keep this file free of client-only APIs (fetch, performance, supabase)
+ * so it is safe to import from both server and client components and is
+ * trivially unit-testable.
+ */
+
+export type ServiceStatus = "operational" | "degraded" | "down";
+
+/**
+ * Canonical always-on services that the platform monitors in real time.
+ *
+ * Used so "Services Tracked" reflects what is actually being monitored even
+ * when the historical `uptime_sla_monthly` aggregation table has not been
+ * populated yet (the QA report observed "Services Tracked: 0" despite three
+ * live services being monitored).
+ */
+export const MONITORED_SERVICES = [
+  { key: "web", name: "Web App (Next.js)" },
+  { key: "database", name: "Database (Supabase)" },
+  { key: "auth", name: "Auth (Supabase Auth)" },
+] as const;
+
+/** Shape returned by `GET /api/admin/health` inside the `data` envelope. */
+export interface HealthApiData {
+  status: string;
+  database: string;
+  version: string;
+  /** Server runtime version (e.g. "v22.13.0"); null when unavailable. */
+  nodeVersion?: string | null;
+  timestamp: string;
+}
+
+/**
+ * Normalised outcome of a call to `GET /api/admin/health`.
+ *
+ * - `ok`            — HTTP 200 with a well-formed `{ ok: true, data }` body.
+ * - `bad-json`      — HTTP 200 but the body was not the expected envelope.
+ * - `http-error`    — the server responded but with a non-2xx status. The
+ *                     health route returns 503 when the database is
+ *                     unreachable, so this path must mark the DB as "down".
+ * - `network-error` — the request threw (server unreachable).
+ */
+export type HealthFetchOutcome =
+  | { kind: "ok"; data: HealthApiData }
+  | { kind: "bad-json" }
+  | { kind: "http-error" }
+  | { kind: "network-error" };
+
+export interface DerivedHealth {
+  webApp: ServiceStatus;
+  database: ServiceStatus;
+  version: string;
+  nodeVersion: string | null;
+}
+
+const DEFAULT_VERSION = "0.1.0";
+
+/**
+ * Derive Web App + Database status from a health-check outcome.
+ *
+ * This is the heart of the "unify monitoring data" fix. Previously the
+ * Uptime SLA page only updated the database status on the success path and
+ * left it at its initial "operational" value when the health endpoint
+ * returned an error — so a 503 (database unreachable) showed the DB as
+ * "Operational" on Uptime SLA while System Status correctly showed "Down".
+ * Centralising the logic here guarantees both pages agree.
+ */
+export function deriveHealthStatus(outcome: HealthFetchOutcome): DerivedHealth {
+  switch (outcome.kind) {
+    case "ok":
+      return {
+        webApp: "operational",
+        database: outcome.data.database === "connected" ? "operational" : "down",
+        version: outcome.data.version || DEFAULT_VERSION,
+        nodeVersion: outcome.data.nodeVersion ?? null,
+      };
+    case "bad-json":
+    case "http-error":
+      // The app server responded but the health probe failed. The most
+      // common cause is the database being unreachable (the route returns
+      // 503 / DB_UNREACHABLE), so the web app is degraded and the DB is down.
+      return { webApp: "degraded", database: "down", version: DEFAULT_VERSION, nodeVersion: null };
+    case "network-error":
+    default:
+      // Could not reach the app at all.
+      return { webApp: "down", database: "down", version: DEFAULT_VERSION, nodeVersion: null };
+  }
+}
+
+/**
+ * Roll a set of individual service statuses up into a single overall status,
+ * using worst-wins precedence: any "down" => down, else any "degraded" =>
+ * degraded, else operational.
+ */
+export function computeOverallStatus(statuses: ServiceStatus[]): ServiceStatus {
+  if (statuses.some((s) => s === "down")) return "down";
+  if (statuses.some((s) => s === "degraded")) return "degraded";
+  return "operational";
+}


### PR DESCRIPTION
## What & why

Fixes the Operations QA report dated 2026-06-18 (`dashboard fix 1.txt`). This PR addresses the **code-level** dashboard bugs.

### Root cause of the System Status vs Uptime SLA contradiction
Both pages read `GET /api/admin/health`, which returns **503** when the database is unreachable. System Status treated that as DB **Down**, but the Uptime SLA page only updated DB status on the *success* path, leaving it at the initial `"operational"` on errors. Both pages now derive status through a single shared probe (`src/lib/monitoring`), so they can no longer disagree.

### Fixes
| Report finding | Fix |
|---|---|
| DB "Down" vs "Operational" across pages | Shared probe; DB marked **down** on any health error (503/parse/network) |
| Severity label mismatch | Status computed in one place |
| 3 panels stuck on "Loading…" forever | Settled flag → "unavailable" message on failure |
| "Recent Incidents" hardcoded to none during outages | Derived from live service health |
| "Last Deployment" = N/A | Build-time `NEXT_PUBLIC_DEPLOY_TIME` default + formatter |
| "Node.js Version" blank | `/api/admin/health` now returns `nodeVersion` |
| "API Latency" hardcoded 120ms | Real measured round-trip time |
| Health Metrics "Services Tracked: 0" | Distinct monitors, fallback to canonical count |
| Empty tables with no explanation | Explicit empty states (Health Metrics + SLA) |
| Open DSARs warning badge on a 0 value | success/warning/destructive by actual counts |
| Support "Avg Response" = "--" | Now "N/A" |

Adds `src/lib/monitoring/*` + unit tests (incl. a regression test that a 503 maps the DB to **down**).

### Out of scope (infra / data / legal — not front-end bugs)
DB production outage, CNDP filing, overdue retention purge cron, consent-evidence logging, populating the historical uptime tables, and setting `NEXT_PUBLIC_DEPLOY_TIME` in CI. See `docs/ops-dashboard-qa-2026-06-18.md`.

---
🤖 Generated against the QA report; please review before merging.
