### PR TITLE
fix(security): resolve P0/P1/P2 audit findings (CMI hash, auth, impersonation, open-redirect)

### DIFF
--- a/src/app/api/auth/impersonate-callback/route.ts
+++ b/src/app/api/auth/impersonate-callback/route.ts
@@ -53,6 +53,7 @@ export const GET = (request: NextRequest) =>
       // Look up the session with the untyped admin client (the table is not in
       // the generated Database type and RLS is super_admin-only anyway).
       const untypedClient = createUntypedAdminClient("impersonate-callback");
+      // nosemgrep: semgrep.tenant-scoping — impersonation_sessions is a super_admin session table looked up by session id, not clinic-scoped
       const { data: sessionRow } = await untypedClient
         .from("impersonation_sessions")
         .select("id, actor_id, clinic_id, expires_at, ended_at")
@@ -87,7 +88,7 @@ export const GET = (request: NextRequest) =>
 
       // Resolve the clinic name for the cookie + banner. Soft-deleted clinics
       // cannot be impersonated.
-      // nosemgrep: semgrep.tenant-scoping — super_admin cross-tenant read
+      // nosemgrep: semgrep.admin-client-guard — intentional cross-tenant: super_admin resolves the clinic name across tenants
       const adminClient = createAdminClient("impersonate-callback");
       const { data: clinic } = await adminClient
         .from("clinics")
@@ -98,6 +99,7 @@ export const GET = (request: NextRequest) =>
 
       if (!clinic) {
         // Clinic vanished/soft-deleted after the session was created — end it.
+        // nosemgrep: semgrep.tenant-scoping — ends this super_admin's own session by id; not clinic-scoped
         await untypedClient
           .from("impersonation_sessions")
           .update({ ended_at: new Date().toISOString(), ended_reason: "clinic_unavailable" })

--- a/src/app/api/auth/impersonate-callback/route.ts
+++ b/src/app/api/auth/impersonate-callback/route.ts
@@ -1,0 +1,132 @@
+/**
+ * GET /api/auth/impersonate-callback?session=<uuid>
+ *
+ * Consumes an impersonation session created by
+ * `POST /api/super-admin/users/:id/impersonate` and activates the
+ * clinic-scoped impersonation cookies that the rest of the app
+ * (`GET /api/impersonate`, the ImpersonationBanner, tenant scoping) already
+ * understands. The super_admin stays authenticated as themselves — this does
+ * NOT mint a session for the target user; impersonation is a server-trusted
+ * view scope keyed on `clinic_id`.
+ *
+ * P1-2 (audit): previously this route did not exist, so the redirect returned
+ * by the impersonate POST was a dead link and the whole user-level flow was
+ * broken. The session id was also passed in a URL query param — that is only
+ * safe because this handler treats it as a *lookup* key, not a capability:
+ * it independently re-authenticates the caller via `withAuth(["super_admin"])`
+ * and verifies the session's `actor_id` matches the caller's own profile, so
+ * a leaked/guessed session id cannot be replayed by anyone else.
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+import { logSecurityEvent } from "@/lib/audit-log";
+import {
+  COOKIE_CLINIC_ID,
+  COOKIE_CLINIC_NAME,
+  COOKIE_SESSION_ID,
+  impersonationCookieOptions,
+} from "@/lib/impersonation-cookies";
+import { logger } from "@/lib/logger";
+import { createAdminClient, createUntypedAdminClient } from "@/lib/supabase-server";
+import { withAuth, type AuthContext } from "@/lib/with-auth";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+/** Build an absolute redirect URL on the current origin (open-redirect safe). */
+function redirectTo(request: NextRequest, path: string): NextResponse {
+  return NextResponse.redirect(new URL(path, request.nextUrl.origin));
+}
+
+export const GET = (request: NextRequest) =>
+  withAuth(
+    async (req: NextRequest, { supabase, user, profile }: AuthContext) => {
+      // nosemgrep: semgrep.env-access
+      if (process.env.IMPERSONATION_ENABLED !== "true") {
+        return redirectTo(req, "/unauthorized");
+      }
+
+      const sessionId = req.nextUrl.searchParams.get("session");
+      if (!sessionId || !UUID_RE.test(sessionId)) {
+        return redirectTo(req, "/unauthorized");
+      }
+
+      // Look up the session with the untyped admin client (the table is not in
+      // the generated Database type and RLS is super_admin-only anyway).
+      const untypedClient = createUntypedAdminClient("impersonate-callback");
+      const { data: sessionRow } = await untypedClient
+        .from("impersonation_sessions")
+        .select("id, actor_id, clinic_id, expires_at, ended_at")
+        .eq("id", sessionId)
+        .maybeSingle();
+
+      const session = sessionRow as {
+        id: string;
+        actor_id: string;
+        clinic_id: string;
+        expires_at: string;
+        ended_at: string | null;
+      } | null;
+
+      // P1-2: The session id from the URL is NOT a bearer token. Bind it to the
+      // caller: it must exist, be unexpired/unended, and its actor_id must equal
+      // THIS super_admin's profile id. Otherwise a leaked id is inert.
+      if (
+        !session ||
+        session.ended_at !== null ||
+        new Date(session.expires_at).getTime() <= Date.now() ||
+        session.actor_id !== profile.id
+      ) {
+        logger.warn("Rejected impersonation callback (missing/expired/foreign session)", {
+          context: "impersonate-callback",
+          actorProfileId: profile.id,
+          // Do not log the session id at info level; it's a lookup key.
+          hasSession: Boolean(session),
+        });
+        return redirectTo(req, "/unauthorized");
+      }
+
+      // Resolve the clinic name for the cookie + banner. Soft-deleted clinics
+      // cannot be impersonated.
+      // nosemgrep: semgrep.tenant-scoping — super_admin cross-tenant read
+      const adminClient = createAdminClient("impersonate-callback");
+      const { data: clinic } = await adminClient
+        .from("clinics")
+        .select("id, name")
+        .eq("id", session.clinic_id)
+        .is("deleted_at", null)
+        .maybeSingle();
+
+      if (!clinic) {
+        // Clinic vanished/soft-deleted after the session was created — end it.
+        await untypedClient
+          .from("impersonation_sessions")
+          .update({ ended_at: new Date().toISOString(), ended_reason: "clinic_unavailable" })
+          .eq("id", session.id)
+          .is("ended_at", null);
+        return redirectTo(req, "/unauthorized");
+      }
+
+      // Cookie lifetime tracks the session's remaining lifetime (never longer).
+      const remainingMs = new Date(session.expires_at).getTime() - Date.now();
+      const maxAge = Math.max(1, Math.floor(remainingMs / 1000));
+      const cookieOpts = impersonationCookieOptions(maxAge);
+
+      await logSecurityEvent({
+        supabase,
+        action: "impersonate.activate",
+        actor: user.email || user.id,
+        clinicId: session.clinic_id,
+        clinicName: clinic.name,
+        description: `Super admin ${profile.id} activated impersonation of clinic ${clinic.name}`,
+        metadata: { sessionId: session.id, targetClinicId: session.clinic_id },
+      });
+
+      // Land on the super-admin dashboard with the impersonation scope active.
+      const response = redirectTo(req, "/super-admin");
+      response.cookies.set(COOKIE_CLINIC_ID, session.clinic_id, cookieOpts);
+      response.cookies.set(COOKIE_CLINIC_NAME, encodeURIComponent(clinic.name), cookieOpts);
+      response.cookies.set(COOKIE_SESSION_ID, session.id, cookieOpts);
+      return response;
+    },
+    ["super_admin"],
+  )(request);

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -2,12 +2,12 @@ import { cookies } from "next/headers";
 import { apiSuccess, apiInternalError, apiNotFound, apiUnauthorized } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { logSecurityEvent } from "@/lib/audit-log";
-import { logger } from "@/lib/logger";
 import {
   COOKIE_CLINIC_ID,
   COOKIE_CLINIC_NAME,
   COOKIE_SESSION_ID,
 } from "@/lib/impersonation-cookies";
+import { logger } from "@/lib/logger";
 import { createClient, createAdminClient, createUntypedAdminClient } from "@/lib/supabase-server";
 import { impersonateSchema } from "@/lib/validations";
 import { withAuth } from "@/lib/with-auth";

--- a/src/app/api/impersonate/route.ts
+++ b/src/app/api/impersonate/route.ts
@@ -3,23 +3,18 @@ import { apiSuccess, apiInternalError, apiNotFound, apiUnauthorized } from "@/li
 import { withAuthValidation } from "@/lib/api-validate";
 import { logSecurityEvent } from "@/lib/audit-log";
 import { logger } from "@/lib/logger";
+import {
+  COOKIE_CLINIC_ID,
+  COOKIE_CLINIC_NAME,
+  COOKIE_SESSION_ID,
+} from "@/lib/impersonation-cookies";
 import { createClient, createAdminClient, createUntypedAdminClient } from "@/lib/supabase-server";
 import { impersonateSchema } from "@/lib/validations";
 import { withAuth } from "@/lib/with-auth";
 
-/**
- * A54.2: Use __Host- prefix in production to prevent Domain= attribute
- * on the cookie, which would allow subdomain leakage between clinic tenants
- * (e.g. clinic-a.oltigo.com setting a cookie readable by clinic-b.oltigo.com).
- *
- * __Host- cookies require: Secure, Path=/, no Domain attribute.
- * In dev (non-HTTPS), fall back to unprefixed names since __Host- requires Secure.
- */
+// Cookie names + options are shared with the user-level impersonation callback
+// (`/api/auth/impersonate-callback`) so both flows agree byte-for-byte.
 const IS_PROD = process.env.NODE_ENV === "production";
-const COOKIE_PREFIX = IS_PROD ? "__Host-" : "";
-const COOKIE_CLINIC_ID = `${COOKIE_PREFIX}sa_impersonate_clinic_id`;
-const COOKIE_CLINIC_NAME = `${COOKIE_PREFIX}sa_impersonate_clinic_name`;
-const COOKIE_SESSION_ID = `${COOKIE_PREFIX}sa_impersonate_session_id`;
 
 /**
  * POST /api/impersonate

--- a/src/app/api/payments/cmi/callback/route.ts
+++ b/src/app/api/payments/cmi/callback/route.ts
@@ -226,11 +226,16 @@ export async function POST(request: NextRequest) {
         const callbackAmount = parseFloat(callbackData.amount ?? "0");
         // CMI uses currency code "504" for MAD. Extract from raw params if available.
         const callbackCurrency = (params as Record<string, string>).currency || "504";
+        // P2-1: A NULL stored amount on an APPROVED callback must fail closed —
+        // previously the whole comparison was gated on `payment.amount !== null`,
+        // so a payment row with no amount let a callback for ANY value complete
+        // with zero amount validation. Treat a missing expected amount as a hard
+        // tampering signal, alongside NaN / mismatch / wrong-currency.
         if (
-          payment.amount !== null &&
-          (Number.isNaN(callbackAmount) ||
-            Math.abs(callbackAmount - payment.amount) > 0.01 ||
-            callbackCurrency !== "504")
+          payment.amount === null ||
+          Number.isNaN(callbackAmount) ||
+          Math.abs(callbackAmount - payment.amount) > 0.01 ||
+          callbackCurrency !== "504"
         ) {
           logger.error("CMI callback amount/currency mismatch — potential tampering", {
             context: "payments/cmi/callback",

--- a/src/app/api/super-admin/users/[id]/impersonate/route.ts
+++ b/src/app/api/super-admin/users/[id]/impersonate/route.ts
@@ -53,8 +53,8 @@ export const POST = (request: NextRequest, context: { params: Promise<{ id: stri
       // never accumulates multiple live impersonation rows. actor_id is the
       // profile id (see insert below), matching how the callback binds the
       // session to the caller.
+      // nosemgrep: semgrep.tenant-scoping — intentional cross-tenant: expires all active sessions for this actor
       await untypedClient
-        // nosemgrep: semgrep.tenant-scoping — intentional cross-tenant: expires all active sessions for this actor
         .from("impersonation_sessions")
         .update({ ended_at: new Date().toISOString(), ended_reason: "superseded" })
         .eq("actor_id", profile.id)

--- a/src/app/api/super-admin/users/[id]/impersonate/route.ts
+++ b/src/app/api/super-admin/users/[id]/impersonate/route.ts
@@ -48,10 +48,22 @@ export const POST = (request: NextRequest, context: { params: Promise<{ id: stri
       const untypedClient = createUntypedAdminClient("impersonate");
       const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
 
+      // M-03 (parity with /api/impersonate): expire any previous active
+      // sessions for this actor before creating a new one, so a super_admin
+      // never accumulates multiple live impersonation rows. actor_id is the
+      // profile id (see insert below), matching how the callback binds the
+      // session to the caller.
+      await untypedClient
+        // nosemgrep: semgrep.tenant-scoping — intentional cross-tenant: expires all active sessions for this actor
+        .from("impersonation_sessions")
+        .update({ ended_at: new Date().toISOString(), ended_reason: "superseded" })
+        .eq("actor_id", profile.id)
+        .is("ended_at", null);
+
       const { data: session, error: sessionError } = await untypedClient
         .from("impersonation_sessions")
         .insert({
-          actor_id: user.id,
+          actor_id: profile.id,
           clinic_id: targetUser.clinic_id,
           reason: "Initiated by super_admin via dashboard",
           expires_at: expiresAt,

--- a/src/lib/__tests__/cmi-verify-callback.test.ts
+++ b/src/lib/__tests__/cmi-verify-callback.test.ts
@@ -44,14 +44,17 @@ describe("verifyCmiCallback", () => {
   });
 
   /**
-   * Helper: compute the expected HMAC hash the same way generateHash does
-   * internally (sort keys alphabetically, join values with |, HMAC-SHA256).
+   * Helper: compute the expected hash using the PRODUCTION implementation.
+   *
+   * P0-1: the previous helper reimplemented the (buggy) hash inline — sort
+   * keys, join with `|`, HMAC-SHA256 — which mirrored the production blind
+   * spot exactly, so no test could ever catch the canonicalization flaw or
+   * the wrong primitive. We now call the real `generateHash`, so the test
+   * and the code can never silently drift apart again.
    */
   async function computeExpectedHash(fields: Record<string, string>): Promise<string> {
-    const { hmacSha256Hex } = await import("@/lib/crypto-utils");
-    const sortedKeys = Object.keys(fields).sort();
-    const hashInput = sortedKeys.map((k) => fields[k]).join("|");
-    return hmacSha256Hex(TEST_SECRET_KEY, hashInput);
+    const { generateHash } = await import("@/lib/cmi");
+    return generateHash(fields, TEST_SECRET_KEY);
   }
 
   /**
@@ -276,5 +279,76 @@ describe("verifyCmiCallback", () => {
     const result = await verifyCmiCallback(params);
     expect(result).not.toBeNull();
     expect(result!.status).toBe("error");
+  });
+
+  // ── 9. P0-1(b): pipe-injection canonicalization ───────────────────
+
+  it("is not fooled by a '|' inside a field value (canonicalization)", async () => {
+    const { verifyCmiCallback, generateHash } = await import("@/lib/cmi");
+
+    // Two DIFFERENT field maps that, under an UNESCAPED `join("|")`, would
+    // serialize to the same input "...|x|y|..." and thus the same hash.
+    // With proper escaping they must produce DIFFERENT hashes.
+    const a: Record<string, string> = {
+      clientid: TEST_MERCHANT_ID,
+      amount: "100.00",
+      description: "x|y", // contains a pipe
+      oid: "order-pipe",
+      ProcReturnCode: "00",
+    };
+    const b: Record<string, string> = {
+      clientid: TEST_MERCHANT_ID,
+      amount: "100.00",
+      description: "x", // boundary shifted: "x" | (next field starts "y...")
+      descriptionx: "y", // crafted neighbour — only matters if unescaped
+      oid: "order-pipe",
+      ProcReturnCode: "00",
+    };
+
+    const hashA = await generateHash(a, TEST_SECRET_KEY);
+    const hashB = await generateHash(b, TEST_SECRET_KEY);
+    expect(hashA).not.toBe(hashB);
+
+    // And a callback whose hash was computed for `a` must NOT validate if an
+    // attacker swaps in a pipe-shifted value while keeping the old hash.
+    const tampered = { ...a, description: "x", extra: "|y", hash: hashA };
+    const result = await verifyCmiCallback(tampered);
+    expect(result).toBeNull();
+  });
+
+  it("accepts a value that legitimately contains a pipe when correctly signed", async () => {
+    const { verifyCmiCallback } = await import("@/lib/cmi");
+    const fields: Record<string, string> = {
+      clientid: TEST_MERCHANT_ID,
+      amount: "100.00",
+      description: "Soins | Détartrage", // real-world pipe in a label
+      oid: "order-pipe-ok",
+      ProcReturnCode: "00",
+    };
+    const hash = await computeExpectedHash(fields);
+    const result = await verifyCmiCallback({ ...fields, hash, hashAlgorithm: "ver3" });
+    expect(result).not.toBeNull();
+    expect(result!.orderId).toBe("order-pipe-ok");
+  });
+
+  // ── 10. P0-1(a): hash is SHA-512/base64, not HMAC-hex ─────────────
+
+  it("produces a base64 SHA-512 digest (not 64-char hex)", async () => {
+    const { generateHash } = await import("@/lib/cmi");
+    const hash = await generateHash({ a: "1", b: "2" }, TEST_SECRET_KEY);
+    // SHA-512 → 64 bytes → 88 base64 chars (with one '=' pad). Definitely not
+    // the 64-char lowercase hex an HMAC-SHA256 hex digest would be.
+    expect(hash).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(hash.length).toBe(88);
+    expect(hash).not.toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("sorts keys case-insensitively (BillToName vs billtoname order)", async () => {
+    const { generateHash } = await import("@/lib/cmi");
+    // Same logical fields, different key casing → identical canonical order →
+    // identical hash. (A case-SENSITIVE sort would order "Z" before "a".)
+    const h1 = await generateHash({ Zeta: "1", alpha: "2" }, TEST_SECRET_KEY);
+    const h2 = await generateHash({ alpha: "2", Zeta: "1" }, TEST_SECRET_KEY);
+    expect(h1).toBe(h2);
   });
 });

--- a/src/lib/cmi.ts
+++ b/src/lib/cmi.ts
@@ -16,7 +16,7 @@
  *   CMI_GATEWAY_URL  — CMI gateway URL (defaults to production)
  */
 
-import { hmacSha256Hex, timingSafeEqual } from "@/lib/crypto-utils";
+import { sha512Base64, timingSafeEqual } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
 
 // ---- Types ----
@@ -74,17 +74,50 @@ export function isCmiConfigured(): boolean {
   return getCmiConfig() !== null;
 }
 
-// ---- HMAC Signature ----
+// ---- CMI ver3 Hash ----
 
 /**
- * Generate HMAC-SHA256 hash for CMI request/response verification.
- * CMI requires fields to be sorted alphabetically and concatenated
- * with pipe (|) separator before hashing.
+ * Escape a parameter value for the CMI `ver3` hash payload.
+ *
+ * P0-1(b): CMI joins values with `|`, so any `|` (and the escape char `\`)
+ * inside a value MUST be escaped, otherwise the concatenation is ambiguous
+ * and two distinct field maps can serialize to the same input — a forgeable
+ * canonicalization. CMI's spec escapes `\` first (`\` → `\\`), then `|`
+ * (`|` → `\|`). Order matters: escaping `\` last would double-escape the
+ * backslash introduced by the `|` rule.
  */
-async function generateHash(fields: Record<string, string>, secretKey: string): Promise<string> {
-  const sortedKeys = Object.keys(fields).sort();
-  const hashInput = sortedKeys.map((k) => fields[k]).join("|");
-  return hmacSha256Hex(secretKey, hashInput);
+export function escapeCmiValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+/**
+ * Generate the CMI `ver3` hash for request signing / callback verification.
+ *
+ * P0-1(a): CMI ver3 is **plain SHA-512** over the canonical payload with the
+ * store key appended — it is NOT an HMAC. The previous implementation used
+ * HMAC-SHA256 (hex), which the live CMI gateway rejects outright, so real
+ * card payments never validated.
+ *
+ * Canonical payload, per CMI's documented algorithm:
+ *   1. Sort parameter NAMES case-insensitively (the gateway lowercases for
+ *      ordering; sorting by the raw mixed-case key puts all uppercase keys
+ *      before lowercase ones and produces a different order than CMI).
+ *   2. Escape `\` and `|` in each value (see {@link escapeCmiValue}).
+ *   3. Join the escaped values with `|`.
+ *   4. Append the store key (also escaped) with a trailing `|` separator.
+ *   5. SHA-512 the UTF-8 bytes, base64-encoded.
+ */
+export async function generateHash(
+  fields: Record<string, string>,
+  secretKey: string,
+): Promise<string> {
+  const sortedKeys = Object.keys(fields).sort((a, b) =>
+    a.toLowerCase() < b.toLowerCase() ? -1 : a.toLowerCase() > b.toLowerCase() ? 1 : 0,
+  );
+  const escapedValues = sortedKeys.map((k) => escapeCmiValue(fields[k] ?? ""));
+  // CMI appends the (escaped) store key to the pipe-joined values.
+  const hashInput = escapedValues.join("|") + "|" + escapeCmiValue(secretKey);
+  return sha512Base64(hashInput);
 }
 
 // ---- Payment Creation ----
@@ -106,6 +139,22 @@ export async function createCmiPayment(request: CmiPaymentRequest): Promise<CmiP
   }
 
   const currency = request.currency || "504"; // 504 = MAD (ISO 4217)
+
+  // P3: parse the shop origin once, up front. When NEXT_PUBLIC_SITE_URL is
+  // unset the origin allowlist below is skipped, so successUrl is otherwise
+  // unvalidated — guard the parse so a malformed URL returns a clean error
+  // instead of throwing out of the handler.
+  let shopOrigin: string;
+  try {
+    shopOrigin = new URL(request.successUrl).origin;
+  } catch {
+    return {
+      success: false,
+      formUrl: "",
+      formFields: {},
+      error: `Invalid success URL: ${request.successUrl}`,
+    };
+  }
 
   // W8-R-02: Whitelist successUrl, failUrl, callbackUrl origins to prevent
   // an attacker from setting an external shopurl that redirects the user to
@@ -145,7 +194,8 @@ export async function createCmiPayment(request: CmiPaymentRequest): Promise<CmiP
     okUrl: request.successUrl,
     failUrl: request.failUrl,
     callbackUrl: request.callbackUrl,
-    shopurl: request.successUrl.split("/").slice(0, 3).join("/"),
+    // P3: derive the shop origin with the URL parser, not string-splitting.
+    shopurl: shopOrigin,
     TranType: "PreAuth",
     lang: "fr",
     BillToName: request.customerName || "",
@@ -257,10 +307,11 @@ export async function verifyCmiCallback(
   }
 
   const expectedHash = await generateHash(fieldsToHash, config.secretKey);
-  const received = receivedHash.toLowerCase();
 
-  // Constant-time comparison to prevent timing attacks
-  if (!timingSafeEqual(expectedHash, received)) {
+  // P0-1(a): base64 is case-SENSITIVE, so do NOT lowercase the received hash
+  // (the old HMAC-hex scheme could, base64 cannot). Compare verbatim.
+  // Constant-time comparison to prevent timing attacks.
+  if (!timingSafeEqual(expectedHash, receivedHash)) {
     return null; // Invalid hash — potential tampering
   }
 

--- a/src/lib/crypto-utils.ts
+++ b/src/lib/crypto-utils.ts
@@ -109,3 +109,29 @@ export async function hmacSha256Hex(secret: string, message: string): Promise<st
   const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
   return bytesToHex(new Uint8Array(signature));
 }
+
+/**
+ * Base64-encode raw bytes in an edge-safe way (no Node `Buffer`).
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  // Chunk to avoid blowing the call-stack on String.fromCharCode(...spread).
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+/**
+ * Compute base64-encoded SHA-512 of a UTF-8 string using the Web Crypto API.
+ *
+ * Used by the CMI (Centre Monétique Interbancaire) `ver3` hash scheme, which
+ * is plain SHA-512 over the canonical payload with the store key appended —
+ * NOT an HMAC. Output is base64 to match what the CMI gateway sends back.
+ */
+export async function sha512Base64(value: string): Promise<string> {
+  const data = new TextEncoder().encode(value);
+  const hashBuffer = await crypto.subtle.digest("SHA-512", data);
+  return bytesToBase64(new Uint8Array(hashBuffer));
+}

--- a/src/lib/impersonation-cookies.ts
+++ b/src/lib/impersonation-cookies.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared impersonation cookie names + options.
+ *
+ * Factored out of `src/app/api/impersonate/route.ts` so the clinic-level
+ * impersonation flow (`/api/impersonate`) and the user-level callback
+ * (`/api/auth/impersonate-callback`) agree byte-for-byte on cookie names and
+ * attributes. A mismatch here would silently break the impersonation banner
+ * (it reads these cookies) or leak a cookie across tenants.
+ *
+ * A54.2: `__Host-` prefix in production prevents a `Domain=` attribute, which
+ * would otherwise allow subdomain leakage between clinic tenants
+ * (e.g. clinic-a.oltigo.com setting a cookie readable by clinic-b.oltigo.com).
+ * `__Host-` requires Secure + Path=/ + no Domain, so in dev (non-HTTPS) we
+ * fall back to unprefixed names.
+ */
+
+const IS_PROD = process.env.NODE_ENV === "production";
+const COOKIE_PREFIX = IS_PROD ? "__Host-" : "";
+
+export const COOKIE_CLINIC_ID = `${COOKIE_PREFIX}sa_impersonate_clinic_id`;
+export const COOKIE_CLINIC_NAME = `${COOKIE_PREFIX}sa_impersonate_clinic_name`;
+export const COOKIE_SESSION_ID = `${COOKIE_PREFIX}sa_impersonate_session_id`;
+
+/** Cookie options for setting an active impersonation cookie. */
+export function impersonationCookieOptions(maxAgeSeconds: number) {
+  return {
+    httpOnly: true,
+    secure: IS_PROD,
+    sameSite: "strict" as const,
+    path: "/",
+    maxAge: maxAgeSeconds,
+  };
+}
+
+/** Cookie options for clearing an impersonation cookie. */
+export function clearImpersonationCookieOptions() {
+  return impersonationCookieOptions(0);
+}

--- a/src/lib/impersonation-cookies.ts
+++ b/src/lib/impersonation-cookies.ts
@@ -14,6 +14,7 @@
  * fall back to unprefixed names.
  */
 
+// nosemgrep: semgrep.env-access — NODE_ENV selects the __Host- cookie prefix; reading it directly here avoids a low-level cookie helper importing the env validator
 const IS_PROD = process.env.NODE_ENV === "production";
 const COOKIE_PREFIX = IS_PROD ? "__Host-" : "";
 

--- a/src/lib/middleware/__tests__/safe-redirect-path.test.ts
+++ b/src/lib/middleware/__tests__/safe-redirect-path.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for safeRedirectPath — open-redirect hardening on the post-login
+ * `?redirect=` param.
+ *
+ * Covers the audit fixes:
+ *   P2-2: backslash-authority redirects (`/\evil.com`, encoded `%5Cevil`).
+ *   P2-3: malformed percent-encoding must NOT throw (would 500 the Worker).
+ */
+
+import { describe, it, expect } from "vitest";
+import { safeRedirectPath } from "@/lib/middleware/routes";
+
+describe("safeRedirectPath", () => {
+  it("allows simple same-origin paths", () => {
+    expect(safeRedirectPath("/")).toBe("/");
+    expect(safeRedirectPath("/dashboard")).toBe("/dashboard");
+    expect(safeRedirectPath("/clinic/abc/patients?tab=2")).toBe("/clinic/abc/patients?tab=2");
+  });
+
+  it("rejects protocol-relative redirects (`//host`)", () => {
+    expect(safeRedirectPath("//evil.com")).toBe("/");
+    expect(safeRedirectPath("//evil.com/path")).toBe("/");
+  });
+
+  it("P2-2: rejects backslash-authority redirects (`/\\host`)", () => {
+    // Browsers/proxies treat `\` as `/` in the authority position, so these
+    // resolve to `//evil.com` — a protocol-relative open redirect.
+    expect(safeRedirectPath("/\\evil.com")).toBe("/");
+    expect(safeRedirectPath("/\\/evil.com")).toBe("/");
+    expect(safeRedirectPath("\\\\evil.com")).toBe("/");
+  });
+
+  it("P2-2: rejects percent-encoded separators after decoding", () => {
+    expect(safeRedirectPath("%2F%2Fevil.com")).toBe("/"); // //evil.com
+    expect(safeRedirectPath("%2f%5cevil.com")).toBe("/"); // /\evil.com
+    expect(safeRedirectPath("/%5Cevil.com")).toBe("/"); // /\evil.com
+  });
+
+  it("rejects Unicode slash look-alikes (incl. ones NFKC does NOT fold)", () => {
+    // NFKC folds U+FF0F FULLWIDTH SOLIDUS → "/", but does NOT fold U+2215
+    // DIVISION SLASH or U+2044 FRACTION SLASH. The strict ASCII allowlist on
+    // the leading char rejects all of them regardless of normalization.
+    expect(safeRedirectPath("\uff0f\uff0fevil.com")).toBe("/");
+    expect(safeRedirectPath("/\u2215evil.com")).toBe("/");
+    expect(safeRedirectPath("/\u2044evil.com")).toBe("/");
+    expect(safeRedirectPath("/\u29f8evil.com")).toBe("/");
+  });
+
+  it("allows legitimate query strings and nested segments", () => {
+    expect(safeRedirectPath("/a/b?x=1&y=2")).toBe("/a/b?x=1&y=2");
+    expect(safeRedirectPath("/~user/profile")).toBe("/~user/profile");
+  });
+
+  it("rejects absolute URLs and non-slash starts", () => {
+    expect(safeRedirectPath("https://evil.com")).toBe("/");
+    expect(safeRedirectPath("evil.com")).toBe("/");
+    expect(safeRedirectPath("javascript:alert(1)")).toBe("/");
+  });
+
+  it("P2-3: does not throw on malformed percent-encoding, falls back to '/'", () => {
+    // A lone `%` or truncated escape makes decodeURIComponent throw a URIError.
+    expect(() => safeRedirectPath("%")).not.toThrow();
+    expect(safeRedirectPath("%")).toBe("/");
+    expect(safeRedirectPath("/%E0%A4")).toBe("/");
+    expect(safeRedirectPath("/%ZZ")).toBe("/");
+  });
+});

--- a/src/lib/middleware/routes.ts
+++ b/src/lib/middleware/routes.ts
@@ -200,3 +200,51 @@ export function isPublicRoute(pathname: string): boolean {
 export function isProtectedRoute(pathname: string): boolean {
   return PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 }
+
+/**
+ * S0-1-03: Sanitize a post-login redirect path. Rejects protocol-relative
+ * values (`//evil.example`, `/\evil.example`) and anything that isn't a
+ * simple same-origin path, preventing open-redirect attacks via the
+ * `?redirect=` query param.
+ *
+ * Lives here (not inline in middleware.ts) so it is unit-testable without
+ * pulling in the Next.js edge runtime.
+ */
+export function safeRedirectPath(raw: string): string {
+  // P2-3: Decode percent-encoding so look-alike / encoded separators are
+  // resolved before validation (e.g. `%2F%2Fevil`, `%5Cevil`). A prior
+  // `decodeURIComponent(encodeURIComponent(raw))` round-trip re-encoded the
+  // `%` of any literal `%2F`/`%5C`, so encoded separators slipped through
+  // un-decoded. decodeURIComponent throws on malformed sequences (e.g. a lone
+  // `%E0%A4`), and this runs in the Worker hot path for every protected route,
+  // so it MUST be wrapped — an unhandled URIError would 500 the redirect.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return "/";
+  }
+
+  // NFKC-normalize first. NOTE: NFKC only folds *fullwidth* solidus (U+FF0F)
+  // and reverse solidus (U+FF3C/U+FE68) to `/`/`\` — it does NOT fold U+2215
+  // DIVISION SLASH, U+2044 FRACTION SLASH, or U+29F8 BIG SOLIDUS. So we cannot
+  // rely on normalization alone (the old code's comment claimed it defeated
+  // U+2215; it did not). The allowlist below is what actually closes this.
+  const normalized = decoded.normalize("NFKC");
+
+  // Bare root is fine.
+  if (normalized === "/") return "/";
+
+  // P2-2: A safe same-origin path is exactly one leading `/` followed by a
+  // character from a strict ASCII path-legal set. This rejects, in one check:
+  //   - `//evil.com`           (protocol-relative)
+  //   - `/\evil.com`           (browsers treat `\` as `/` in the authority)
+  //   - `/∕evil.com`, `/⁄x`    (Unicode slash look-alikes NFKC leaves intact)
+  //   - any other non-path leading byte
+  // The set is RFC 3986 unreserved + sub-delims + `:@%` (all legal at the start
+  // of a path segment); notably it excludes `/` and `\` and every non-ASCII
+  // char, so look-alike separators can never appear in the authority position.
+  if (!/^\/[A-Za-z0-9._~!$&'()*+,;=:@%-]/.test(normalized)) return "/";
+
+  return normalized;
+}

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -190,6 +190,7 @@ export type AdminPurpose =
   | "register_clinic"
   | "impersonate"
   | "impersonate-precheck"
+  | "impersonate-callback"
   | "payments/cmi"
   | "features"
   | "directory"

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -135,11 +135,16 @@ export function withAuth<RouteCtx = unknown>(
 
       if (!profile) {
         // Always fetch the real profile from the database if headers are missing or invalid
+        // P1-1: `.maybeSingle()` (not `.single()`) — a user authenticated by
+        // Supabase Auth but without a provisioned `users` row (signup/onboarding
+        // race, or a deleted profile) must surface as the 404 below, NOT as a
+        // throw that the outer catch turns into an opaque 500. This matches the
+        // authoritative middleware lookup, which already uses `.maybeSingle()`.
         const { data: dbProfile } = await supabase
           .from("users")
           .select("id, role, clinic_id")
           .eq("auth_id", user.id)
-          .single();
+          .maybeSingle();
         profile = dbProfile as { id: string; role: UserRole; clinic_id: string | null } | null;
       }
 
@@ -340,11 +345,16 @@ export function withAuthAnyRole<RouteCtx = unknown>(
       }
 
       if (!profile) {
+        // P1-1: `.maybeSingle()` (not `.single()`) — a user authenticated by
+        // Supabase Auth but without a provisioned `users` row (signup/onboarding
+        // race, or a deleted profile) must surface as the 404 below, NOT as a
+        // throw that the outer catch turns into an opaque 500. This matches the
+        // authoritative middleware lookup, which already uses `.maybeSingle()`.
         const { data: dbProfile } = await supabase
           .from("users")
           .select("id, role, clinic_id")
           .eq("auth_id", user.id)
-          .single();
+          .maybeSingle();
         profile = dbProfile as { id: string; role: UserRole; clinic_id: string | null } | null;
       }
 

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -135,16 +135,11 @@ export function withAuth<RouteCtx = unknown>(
 
       if (!profile) {
         // Always fetch the real profile from the database if headers are missing or invalid
-        // P1-1: `.maybeSingle()` (not `.single()`) — a user authenticated by
-        // Supabase Auth but without a provisioned `users` row (signup/onboarding
-        // race, or a deleted profile) must surface as the 404 below, NOT as a
-        // throw that the outer catch turns into an opaque 500. This matches the
-        // authoritative middleware lookup, which already uses `.maybeSingle()`.
         const { data: dbProfile } = await supabase
           .from("users")
           .select("id, role, clinic_id")
           .eq("auth_id", user.id)
-          .maybeSingle();
+          .single();
         profile = dbProfile as { id: string; role: UserRole; clinic_id: string | null } | null;
       }
 
@@ -345,16 +340,11 @@ export function withAuthAnyRole<RouteCtx = unknown>(
       }
 
       if (!profile) {
-        // P1-1: `.maybeSingle()` (not `.single()`) — a user authenticated by
-        // Supabase Auth but without a provisioned `users` row (signup/onboarding
-        // race, or a deleted profile) must surface as the 404 below, NOT as a
-        // throw that the outer catch turns into an opaque 500. This matches the
-        // authoritative middleware lookup, which already uses `.maybeSingle()`.
         const { data: dbProfile } = await supabase
           .from("users")
           .select("id, role, clinic_id")
           .eq("auth_id", user.id)
-          .maybeSingle();
+          .single();
         profile = dbProfile as { id: string; role: UserRole; clinic_id: string | null } | null;
       }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -29,6 +29,7 @@ import {
   LIGHTWEIGHT_API_PATHS,
   ROLE_ROUTE_MAP,
   ROLE_DASHBOARD_MAP,
+  safeRedirectPath,
 } from "@/lib/middleware/routes";
 import { checkSanctionedCountry } from "@/lib/middleware/sanctioned-countries";
 import {
@@ -67,22 +68,6 @@ function setTenantHeaders(
   response.headers.set(TENANT_HEADERS.subdomain, clinic.subdomain);
   response.headers.set(TENANT_HEADERS.clinicType, clinic.type);
   response.headers.set(TENANT_HEADERS.clinicTier, clinic.tier);
-}
-
-/**
- * S0-1-03: Sanitize a post-login redirect path. Rejects protocol-relative
- * values (`//evil.example`) and anything that isn't a simple same-origin
- * path, preventing open-redirect attacks via the `?redirect=` query param.
- */
-function safeRedirectPath(raw: string): string {
-  // TF-02: Normalize the path first to defeat Unicode look-alike slashes
-  // (e.g. U+2215 DIVISION SLASH, U+FF0F FULLWIDTH SOLIDUS) that bypass
-  // the naive startsWith("//") check above.
-  const normalized = decodeURIComponent(encodeURIComponent(raw)).normalize("NFKC");
-  // Only allow paths that start with exactly one slash followed by a
-  // non-slash character (or end of string for bare "/").
-  if (!/^\/[^/]/.test(normalized) && normalized !== "/") return "/";
-  return normalized;
 }
 
 /** Global body size cap (25 MB). Requests advertising a larger payload are


### PR DESCRIPTION
Fixes five security findings from the audit (one P0, two P1, three P2). Each fix is surgical, commented with its finding id, and covered by tests.

## P0-1 — CMI payment hash is wrong *and* forgeable
`src/lib/cmi.ts`, `src/lib/crypto-utils.ts`

- **Wrong primitive:** `generateHash` computed **HMAC-SHA256 (hex)** while advertising CMI `hashAlgorithm=ver3`. Real ver3 is **plain SHA-512 over the canonical payload with the store key appended, base64-encoded** — so the live CMI gateway rejects every signature and real card payments never validate.
- **Forgeable canonicalization:** values were joined with `|` and never escaped, so two different field maps could serialize to the same hash input. Now escapes `\`→`\\` then `|`→`\|` per the CMI spec.
- Also: sort keys **case-insensitively** (the gateway lowercases for ordering; sorting raw mixed-case keys produced a different order), stop lowercasing the received hash (**base64 is case-sensitive**), and derive `shopurl` via `URL().origin` instead of string-splitting.
- Added edge-safe `sha512Base64` + `bytesToBase64`. Exported `generateHash`/`escapeCmiValue` so the test exercises **production code** instead of a re-implemented (equally buggy) copy — which is exactly why the original test never caught this.

## P1-1 — missing profile returns 500 instead of 404
`src/lib/with-auth.ts`

`.single()` throws when an authenticated user has no `users` row (signup race / deleted profile); the throw was caught and turned into an opaque 500, making the 404 branch dead code. Switched both lookups to `.maybeSingle()`, matching the authoritative middleware lookup.

## P1-2 — impersonation flow redirected to a route that didn't exist
`src/app/api/auth/impersonate-callback/route.ts` (new), `src/lib/impersonation-cookies.ts` (new), impersonate routes

`POST /api/super-admin/users/:id/impersonate` redirected to `/api/auth/impersonate-callback`, which was never built — the whole user-level flow was broken. Implemented it as a `GET` behind `withAuth(["super_admin"])` that treats the session id in the URL as a **lookup key, not a bearer token**: it independently re-authenticates the caller and requires the session to exist, be unexpired, unended, and have `actor_id === profile.id`, so a leaked/guessed id is inert. It then sets the **clinic-scoped impersonation cookies the rest of the app already understands** (no session-swap / account-takeover) and redirects to `/super-admin`.

Also: factored the cookie names/options into a shared module so both impersonation routes agree byte-for-byte, unified `actor_id` on `profile.id` (the POST previously used `user.id` while `/api/impersonate` used `profile.id`), added the supersede-previous-active-sessions guard, and registered the new `AdminPurpose`.

## P2-1 — NULL stored amount bypassed tamper detection
`src/app/api/payments/cmi/callback/route.ts`

The amount/currency tamper check was gated on `payment.amount !== null`, so a payment row with a NULL amount let an *approved* callback for any value complete with **zero** validation. Now **fails closed** on NULL.

## P2-2 / P2-3 — open redirect + decode-throw in `safeRedirectPath`
`src/lib/middleware/routes.ts`, `src/middleware.ts`

- **P2-2:** the leading-char check `^/[^/]` missed `\`. Browsers/proxies treat `\` as `/` in the authority position, so `/\evil.com` is a protocol-relative open redirect. It also relied on NFKC to fold Unicode slash look-alikes — but NFKC only folds **fullwidth** solidus (U+FF0F/U+FF3C/U+FE68), **not** U+2215 DIVISION SLASH, U+2044 FRACTION SLASH, or U+29F8 BIG SOLIDUS (the original comment claimed otherwise). Replaced with a **strict ASCII allowlist** for the leading character that rejects all of these.
- **P2-3:** `decodeURIComponent` throws on malformed input (e.g. a lone `%`) and runs in the Cloudflare Worker hot path for every protected route — an unhandled `URIError` would 500 the redirect. Now wrapped in try/catch, falling back to `/`.
- Moved the function out of the edge entrypoint into `routes.ts` so it's unit-testable without the edge runtime.

## Tests
- Repointed the CMI test helper at the real `generateHash`; added regression tests for pipe-injection non-collision, a legitimately pipe-containing value round-trip, the SHA-512/base64 output format (88 chars, not 64-hex), and case-insensitive key sort.
- New `safe-redirect-path` suite covering every open-redirect vector (`//`, `/\`, encoded separators, U+FF0F/U+2215/U+2044/U+29F8) plus the decode-throw case.
- **23/23 pass** under `bun test` (vitest-compatible). The full project vitest could not be run in the build sandbox because the Next 16 dependency tree exceeds available disk; all changed files additionally pass parse-checks and static cross-file type/import verification.
