### PR TITLE
security: ADR-0011 — never enable FORCE ROW LEVEL SECURITY (+ CI & pgTAP guards)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,25 @@ jobs:
             exit 1
           fi
 
+      # ADR-0011: FORCE ROW LEVEL SECURITY must never be enabled. The tenant
+      # layer (public booking + the get_user_clinic_id / get_user_role /
+      # is_clinic_staff RLS helpers) is built on SECURITY DEFINER functions that
+      # read across the RLS boundary via the owner's bypass; FORCE strips that
+      # bypass -> broken public bookings + RLS-helper recursion, while closing
+      # neither the anon nor the service_role path (service_role bypasses via
+      # the BYPASSRLS role attribute, which FORCE does not touch).
+      # Companion DB assertion: supabase/tests/no_force_rls.test.sql.
+      - name: Guard against FORCE ROW LEVEL SECURITY
+        run: |
+          HITS=$(grep -rniE 'force[[:space:]]+row[[:space:]]+level[[:space:]]+security' supabase/migrations/ 2>/dev/null \
+            | grep -viE 'no[[:space:]]+force[[:space:]]+row[[:space:]]+level[[:space:]]+security' \
+            | grep -viE ':[0-9]+:[[:space:]]*--' || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::FORCE ROW LEVEL SECURITY found in a migration. It breaks the SECURITY DEFINER tenant layer and closes no real bypass. See docs/adr/0011-no-force-rls.md:"
+            echo "$HITS"
+            exit 1
+          fi
+
       # CI-01: Check for pending DB migrations. Fails if migration files
       # have been added but the migration-check workflow hasn't verified them.
       - name: Migration file check

--- a/docs/adr/0011-no-force-rls.md
+++ b/docs/adr/0011-no-force-rls.md
@@ -31,7 +31,7 @@ the tenant layer while closing no real bypass. Three facts establish this:
    follows the same pattern: SECURITY DEFINER, granted to `anon`, it validates
    that `doctor_id` / `service_id` / `patient_id` belong to the supplied
    `clinic_id` by reading `users` / `services` directly. Its own comment states:
-   *"SECURITY DEFINER bypasses RLS, so we enforce tenant scoping manually."*
+   _"SECURITY DEFINER bypasses RLS, so we enforce tenant scoping manually."_
 
 2. **FORCE strips exactly the bypass those functions rely on.** With FORCE on,
    the owner is no longer exempt, so:
@@ -41,13 +41,13 @@ the tenant layer while closing no real bypass. Three facts establish this:
      `1` without FORCE and `0` with it.
    - The RLS helpers' read of `users` becomes subject to `users`' own policies,
      which call the helpers again → `infinite recursion detected in policy for
-     relation "users"` / empty results → **authenticated staff and admins are
+relation "users"` / empty results → **authenticated staff and admins are
      locked out of their own rows.** The blast radius is the whole tenant layer,
      not just booking.
 
 3. **FORCE closes nothing here.** The roles that carry tenant traffic — `anon`
    and `authenticated` — are not table owners and are already fully subject to
-   RLS *without* FORCE. The one role that bypasses RLS, `service_role`, does so
+   RLS _without_ FORCE. The one role that bypasses RLS, `service_role`, does so
    via the `BYPASSRLS` **role attribute**, which FORCE does not touch. So FORCE
    adds zero protection against either the public path or the service-role path;
    it only removes the owner bypass, and no application traffic connects as the
@@ -60,7 +60,7 @@ mandatory application-level `clinic_id` scoping**, not the sole tenant guard.
 > not a superuser, so FORCE subjects it to RLS and the breakage above is real.
 > On the local `supabase start` stack `postgres` is a superuser and always
 > bypasses RLS, so the breakage does **not** reproduce locally. That is why this
-> decision is pinned by a *structural* guard (assert nothing is force-enabled)
+> decision is pinned by a _structural_ guard (assert nothing is force-enabled)
 > rather than a live FORCE-toggle test — see Consequences.
 
 ## Decision
@@ -74,7 +74,7 @@ Enforced two ways:
    (`Guard against FORCE ROW LEVEL SECURITY`) rejects any migration that enables
    FORCE, with no live database required.
 2. **Database, `rls` job** — `supabase/tests/no_force_rls.test.sql` asserts that
-   no `public` table is force-enabled, that RLS stays *enabled* on the core PHI
+   no `public` table is force-enabled, that RLS stays _enabled_ on the core PHI
    tables, and that the tenant-critical helpers remain SECURITY DEFINER. Any of
    those flips fails the build loudly.
 

--- a/docs/adr/0011-no-force-rls.md
+++ b/docs/adr/0011-no-force-rls.md
@@ -1,0 +1,110 @@
+# ADR-0011: Do Not Enable FORCE ROW LEVEL SECURITY
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-19
+
+## Context
+
+All `public` tables have RLS **enabled but not forced**
+(`relrowsecurity = true`, `relforcerowsecurity = false`). A recurring
+recommendation (Supabase Security Advisor / external review) is to additionally
+run `ALTER TABLE … FORCE ROW LEVEL SECURITY` on every table so that even the
+table owner is subject to RLS.
+
+In this codebase that change is **all downside, no upside** — it would take down
+the tenant layer while closing no real bypass. Three facts establish this:
+
+1. **Tenant isolation depends on SECURITY DEFINER functions that read across the
+   RLS boundary using the owner's bypass.** The RLS policy helpers
+   `get_user_clinic_id()`, `get_user_role()`, `is_clinic_staff()`,
+   `is_clinic_admin()` (migration `00002`) are `SECURITY DEFINER` and read
+   `FROM users`. The `users` policies themselves (`admin_users_all`,
+   `doctor_users_select`, `receptionist_users_select`) **call those helpers**.
+   They are SECURITY DEFINER precisely so the helper's read of `users` uses the
+   owner's RLS bypass instead of re-triggering `users`' own policies. The
+   public-booking RPC `booking_atomic_insert` (migrations `00074` / `00143`)
+   follows the same pattern: SECURITY DEFINER, granted to `anon`, it validates
+   that `doctor_id` / `service_id` / `patient_id` belong to the supplied
+   `clinic_id` by reading `users` / `services` directly. Its own comment states:
+   *"SECURITY DEFINER bypasses RLS, so we enforce tenant scoping manually."*
+
+2. **FORCE strips exactly the bypass those functions rely on.** With FORCE on,
+   the owner is no longer exempt, so:
+   - `booking_atomic_insert`'s validation reads return zero rows for an `anon`
+     caller with no clinic context → `INVALID_TENANT` → **every public booking
+     fails**. Minimal reproduction: an identical SECURITY DEFINER probe returns
+     `1` without FORCE and `0` with it.
+   - The RLS helpers' read of `users` becomes subject to `users`' own policies,
+     which call the helpers again → `infinite recursion detected in policy for
+     relation "users"` / empty results → **authenticated staff and admins are
+     locked out of their own rows.** The blast radius is the whole tenant layer,
+     not just booking.
+
+3. **FORCE closes nothing here.** The roles that carry tenant traffic — `anon`
+   and `authenticated` — are not table owners and are already fully subject to
+   RLS *without* FORCE. The one role that bypasses RLS, `service_role`, does so
+   via the `BYPASSRLS` **role attribute**, which FORCE does not touch. So FORCE
+   adds zero protection against either the public path or the service-role path;
+   it only removes the owner bypass, and no application traffic connects as the
+   table owner.
+
+This matches the model in `AGENTS.md`: RLS is **defense-in-depth behind
+mandatory application-level `clinic_id` scoping**, not the sole tenant guard.
+
+> **Environment note.** On Supabase **cloud**, `postgres` (the table owner) is
+> not a superuser, so FORCE subjects it to RLS and the breakage above is real.
+> On the local `supabase start` stack `postgres` is a superuser and always
+> bypasses RLS, so the breakage does **not** reproduce locally. That is why this
+> decision is pinned by a *structural* guard (assert nothing is force-enabled)
+> rather than a live FORCE-toggle test — see Consequences.
+
+## Decision
+
+**Keep RLS enabled but never forced on `public` tables.** Do not add
+`ALTER TABLE … FORCE ROW LEVEL SECURITY` to any migration.
+
+Enforced two ways:
+
+1. **CI, always-on** — a grep guard in `.github/workflows/ci.yml`
+   (`Guard against FORCE ROW LEVEL SECURITY`) rejects any migration that enables
+   FORCE, with no live database required.
+2. **Database, `rls` job** — `supabase/tests/no_force_rls.test.sql` asserts that
+   no `public` table is force-enabled, that RLS stays *enabled* on the core PHI
+   tables, and that the tenant-critical helpers remain SECURITY DEFINER. Any of
+   those flips fails the build loudly.
+
+The genuine residual risk a "force everything" reflex is trying to address —
+`service_role` bypassing RLS — is handled where it actually lives: mandatory
+app-level `clinic_id` scoping (`AGENTS.md` rule #1), the `check-tenant-scoping`
+CI guard, and the per-RPC manual tenant validation in SECURITY DEFINER functions
+(pinned by `booking_atomic_insert.test.sql`).
+
+## Alternatives Considered
+
+1. **Enable FORCE on all tables (the original suggestion).** Rejected: breaks
+   public booking and the RLS helper layer (recursion / lockout) as shown above,
+   while closing neither the `anon` nor the `service_role` path.
+2. **Make every SECURITY DEFINER function FORCE-safe (e.g. a dedicated
+   `BYPASSRLS` validation role) and then enable FORCE.** Rejected for now: a
+   substantial refactor of ~40 functions and the helper layer to earn a setting
+   that provides no security benefit in this architecture. Revisit only if a
+   concrete owner-bypass threat (application traffic connecting as the table
+   owner) ever materializes.
+3. **Disable RLS and rely solely on app-level scoping.** Rejected: removes the
+   defense-in-depth layer `AGENTS.md` requires.
+
+## Consequences
+
+- **Positive**: The tenant layer and public booking keep working; the decision
+  is documented and machine-enforced, so a future advisor flag or well-meaning
+  PR cannot silently re-introduce the outage.
+- **Negative**: The Supabase advisor "RLS not forced" hint will keep showing;
+  dismiss it with a link to this ADR.
+- **Risk**: If a future table genuinely needs FORCE (a leaf table with no
+  SECURITY DEFINER dependency and no owner-path traffic), this ADR and
+  `supabase/tests/no_force_rls.test.sql` must be updated together, deliberately.

--- a/supabase/tests/README.md
+++ b/supabase/tests/README.md
@@ -25,6 +25,6 @@ running them does not leave fixtures behind.
 - `booking_atomic_insert.test.sql` — pins the cross-tenant validation in the
   `booking_atomic_insert` SECURITY DEFINER RPC. See audit finding A2-03.
 - `no_force_rls.test.sql` — pins that no `public` table has `FORCE ROW LEVEL
-  SECURITY` enabled, that RLS stays enabled on the core PHI tables, and that the
+SECURITY` enabled, that RLS stays enabled on the core PHI tables, and that the
   tenant helpers stay SECURITY DEFINER. FORCE would break the booking RPC and
   the RLS-helper layer while closing no real bypass. See `docs/adr/0011-no-force-rls.md`.

--- a/supabase/tests/README.md
+++ b/supabase/tests/README.md
@@ -24,3 +24,7 @@ running them does not leave fixtures behind.
 
 - `booking_atomic_insert.test.sql` — pins the cross-tenant validation in the
   `booking_atomic_insert` SECURITY DEFINER RPC. See audit finding A2-03.
+- `no_force_rls.test.sql` — pins that no `public` table has `FORCE ROW LEVEL
+  SECURITY` enabled, that RLS stays enabled on the core PHI tables, and that the
+  tenant helpers stay SECURITY DEFINER. FORCE would break the booking RPC and
+  the RLS-helper layer while closing no real bypass. See `docs/adr/0011-no-force-rls.md`.

--- a/supabase/tests/no_force_rls.test.sql
+++ b/supabase/tests/no_force_rls.test.sql
@@ -1,0 +1,140 @@
+-- ============================================================================
+-- ADR-0011: FORCE ROW LEVEL SECURITY must never be enabled on public tables.
+-- ============================================================================
+--
+-- Tenant isolation in this database is built on SECURITY DEFINER functions that
+-- read ACROSS the RLS boundary using the table owner's RLS bypass:
+--
+--   * get_user_clinic_id() / get_user_role() / is_clinic_staff() — the helpers
+--     that the `users` policies (admin_users_all, doctor_users_select, …)
+--     themselves call. They are SECURITY DEFINER precisely so their read of
+--     `users` does NOT re-trigger `users`' own policies.
+--   * booking_atomic_insert() — SECURITY DEFINER, granted to `anon`; validates
+--     doctor/service/patient ↔ clinic by reading users/services directly.
+--
+-- `ALTER TABLE … FORCE ROW LEVEL SECURITY` removes exactly that owner bypass.
+-- With FORCE on:
+--   * booking_atomic_insert's validation reads return 0 rows for an anon caller
+--     → INVALID_TENANT → every public booking fails. (Minimal repro: an
+--     identical SECURITY DEFINER probe returns 1 without FORCE and 0 with it.)
+--   * the RLS helpers' read of `users` becomes subject to `users`' policies,
+--     which call the helpers again → infinite recursion / empty → staff and
+--     admins are locked out of their own rows.
+-- FORCE closes nothing: anon/authenticated are already fully subject to RLS
+-- without it, and service_role bypasses via the BYPASSRLS role attribute, which
+-- FORCE does not touch. Full rationale: docs/adr/0011-no-force-rls.md.
+--
+-- This test pins the *structural* invariant rather than toggling FORCE live:
+-- the breakage only reproduces where the table owner (postgres) is not a
+-- superuser (Supabase cloud). On the local `supabase start` stack postgres is a
+-- superuser and bypasses RLS even under FORCE, so a live toggle would not
+-- reproduce it. The grep guard in .github/workflows/ci.yml is the always-on
+-- companion to this test.
+--
+-- The `rls` CI job runs this with `psql -f` (not pg_prove), where a pgTAP
+-- `not ok` does NOT set a non-zero exit code. The load-bearing assertions are
+-- therefore ALSO re-stated as hard RAISEs under ON_ERROR_STOP so a regression
+-- fails the build, not just the TAP log.
+--
+-- Run locally:
+--   psql "$SUPABASE_DB_URL" -f supabase/tests/no_force_rls.test.sql
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
+SELECT plan(3);
+
+-- 1. No public BASE table may have FORCE ROW LEVEL SECURITY enabled.
+SELECT is(
+  (SELECT count(*)::int
+     FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND c.relforcerowsecurity),
+  0,
+  'no public table has FORCE ROW LEVEL SECURITY enabled (ADR-0011)'
+);
+
+-- 2. RLS stays ENABLED on the core PHI / tenant tables — guards the opposite
+--    regression (someone "fixing" the advisor flag by disabling RLS entirely).
+SELECT is(
+  (SELECT count(*)::int
+     FROM (VALUES ('users'),('clinics'),('appointments'),('payments'),
+                  ('medical_records'),('prescriptions'),('consultation_notes')
+          ) AS t(rel)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public' AND c.relname = t.rel AND c.relrowsecurity
+    )),
+  0,
+  'RLS is enabled on every core PHI/tenant table'
+);
+
+-- 3. The tenant-critical helpers + booking RPC remain SECURITY DEFINER. If a
+--    future change makes them SECURITY INVOKER, the FORCE analysis above no
+--    longer holds and ADR-0011 must be revisited.
+SELECT is(
+  (SELECT count(*)::int
+     FROM (VALUES ('get_user_clinic_id'),('get_user_role'),
+                  ('is_clinic_staff'),('booking_atomic_insert')
+          ) AS t(fn)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_proc p
+        JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public' AND p.proname = t.fn AND p.prosecdef
+    )),
+  0,
+  'tenant helpers and booking_atomic_insert are SECURITY DEFINER'
+);
+
+SELECT * FROM finish();
+
+-- ── Hard gate ───────────────────────────────────────────────────────────────
+-- pgTAP `not ok` does not fail `psql -f`; re-assert the invariants as RAISEs.
+DO $$
+DECLARE
+  v_forced  text;
+  v_rls_off text;
+  v_invoker text;
+BEGIN
+  SELECT string_agg(c.relname, ', ' ORDER BY c.relname) INTO v_forced
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relforcerowsecurity;
+  IF v_forced IS NOT NULL THEN
+    RAISE EXCEPTION
+      'FORCE ROW LEVEL SECURITY is enabled on public table(s): %. This breaks the SECURITY DEFINER tenant layer (public booking + RLS helpers) and closes neither the anon nor the service_role path. See docs/adr/0011-no-force-rls.md.',
+      v_forced;
+  END IF;
+
+  SELECT string_agg(t.rel, ', ') INTO v_rls_off
+    FROM (VALUES ('users'),('clinics'),('appointments'),('payments'),
+                 ('medical_records'),('prescriptions'),('consultation_notes')) AS t(rel)
+   WHERE NOT EXISTS (
+     SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public' AND c.relname = t.rel AND c.relrowsecurity);
+  IF v_rls_off IS NOT NULL THEN
+    RAISE EXCEPTION
+      'RLS is DISABLED on core tenant table(s): %. RLS must stay enabled (ADR-0011).',
+      v_rls_off;
+  END IF;
+
+  SELECT string_agg(t.fn, ', ') INTO v_invoker
+    FROM (VALUES ('get_user_clinic_id'),('get_user_role'),
+                 ('is_clinic_staff'),('booking_atomic_insert')) AS t(fn)
+   WHERE NOT EXISTS (
+     SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = t.fn AND p.prosecdef);
+  IF v_invoker IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Tenant function(s) no longer SECURITY DEFINER: %. Revisit ADR-0011 before changing this.',
+      v_invoker;
+  END IF;
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## What

Documents and **enforces** the decision to never enable `FORCE ROW LEVEL SECURITY` on `public` tables. No migration, no runtime or schema change — an ADR plus two guardrails.

## Why

A recurring suggestion (Supabase Security Advisor / external review) is to `ALTER TABLE … FORCE ROW LEVEL SECURITY` everywhere. In this architecture that is **all downside, no upside**: it would break the tenant layer while closing no real bypass.

FORCE removes the table **owner's** RLS bypass, which the `SECURITY DEFINER` tenant layer is built on:

- **Public booking breaks.** `booking_atomic_insert` (SECURITY DEFINER, granted to `anon`) validates that `doctor_id` / `service_id` / `patient_id` belong to the supplied `clinic_id` by reading `users` / `services` directly — its own comment says *"SECURITY DEFINER bypasses RLS, so we enforce tenant scoping manually."* Under FORCE those reads return **0 rows** for an `anon` caller with no clinic context → `INVALID_TENANT` → **every public booking fails**.
- **The RLS helper layer recurses / locks out.** `get_user_clinic_id()`, `get_user_role()`, `is_clinic_staff()` read `users`, and the `users` policies (`admin_users_all`, `doctor_users_select`, `receptionist_users_select`) **call those helpers**. Under FORCE the helper's read of `users` re-enters `users`' own policies → recursion / empty results → staff and admins are locked out of their own rows.
- **It closes nothing.** `anon` and `authenticated` are already fully subject to RLS *without* FORCE. The one role that bypasses RLS — `service_role` — does so via the `BYPASSRLS` **role attribute**, which FORCE does not touch. No application traffic connects as the table owner.

This is consistent with `AGENTS.md`: RLS is **defense-in-depth behind mandatory app-level `clinic_id` scoping**, not the sole tenant guard.

### Minimal reproduction

An identical `SECURITY DEFINER` probe that reads a clinic-scoped row returns `1` with RLS **enabled-not-forced** (current prod) and `0` with **FORCE** on — the booking failure in miniature. Full write-up in the ADR.

> **Environment note:** the breakage reproduces where the table owner (`postgres`) is **not** a superuser — i.e. Supabase **cloud**. On the local `supabase start` stack `postgres` is a superuser and bypasses RLS even under FORCE, so a live FORCE-toggle test would *not* reproduce it. That is why the DB test pins the **structural** invariant (nothing is force-enabled) and the grep guard is the always-on companion.

## Changes

- `docs/adr/0011-no-force-rls.md` — decision of record: proof, blast radius, why FORCE closes neither the `anon` nor `service_role` path, and the two enforcement points.
- `.github/workflows/ci.yml` — always-on grep guard (no DB) rejecting `FORCE ROW LEVEL SECURITY` in any migration; mirrors the existing `app.clinic_id` guards. Correctly ignores `NO FORCE …` and commented lines.
- `supabase/tests/no_force_rls.test.sql` — pgTAP test (runs in the `rls` job) asserting: no `public` table is force-enabled, RLS stays **enabled** on the core PHI tables, and the tenant helpers + booking RPC stay `SECURITY DEFINER`. Load-bearing checks are re-stated as hard `RAISE`s under `ON_ERROR_STOP` because the `rls` job runs `psql -f`, where a pgTAP `not ok` does not set a non-zero exit code.
- `supabase/tests/README.md` — lists the new test.

## Test plan

- [x] CI grep guard is green on the current tree.
- [x] Planting `ALTER TABLE x FORCE ROW LEVEL SECURITY;` in a migration trips the guard; `NO FORCE …` and commented lines do **not** false-trigger.
- [x] `ci.yml` parses; the new step aligns with the existing 80 steps (no tabs, correct nesting).
- [x] `no_force_rls.test.sql` balances (`$$`, `plan(3)`, `ROLLBACK`) and uses the correct catalog columns (`relforcerowsecurity`, `relrowsecurity`, `prosecdef`).
- [ ] `rls` job runs `no_force_rls.test.sql` green against the local Supabase DB (CI).

## Out of scope

This does **not** close the `service_role` path — nothing built on FORCE could. That is handled separately by mandatory app-level `clinic_id` scoping (`AGENTS.md` rule #1) and the `check-tenant-scoping` guard. Happy to follow up on the specific routes flagged in the audit.

🤖 Authored with assistant help; reviewed before opening.
