### PR TITLE
fix(super-admin): add missing h1s + nav aria-expanded (QA report follow-up)

### DIFF
--- a/src/app/(super-admin)/super-admin/analytics/page.tsx
+++ b/src/app/(super-admin)/super-admin/analytics/page.tsx
@@ -130,6 +130,13 @@ export default function MultiClinicAnalyticsPage() {
         )}
       </div>
 
+      <div>
+        <h1 className="text-2xl font-bold">Multi-Clinic Analytics</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Revenue, appointments, and churn risk across all clinics
+        </p>
+      </div>
+
       <div className="grid gap-4 md:grid-cols-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">

--- a/src/app/(super-admin)/super-admin/system/page.tsx
+++ b/src/app/(super-admin)/super-admin/system/page.tsx
@@ -334,6 +334,7 @@ export default function SystemStatusPage() {
               { label: "System Status" },
             ]}
           />
+          <h1 className="text-2xl font-bold">System Status</h1>
           <div className="flex items-center gap-3 text-sm">
             <Link href="/super-admin/system/health" className="text-primary underline">
               Health

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -283,6 +283,7 @@ function SidebarNav({ pathname }: { pathname: string }) {
             <button
               type="button"
               onClick={() => toggleGroup(group.key)}
+              aria-expanded={isExpanded}
               className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground transition-colors"
             >
               <group.icon className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Follow-up to the **2026-06-17 Super Admin dashboard QA report**. The large majority of that report's 27 findings were already resolved by the recent remediation push (#1062, #1063, #1067, #1068). This PR closes the few **accessibility** items that were still open in `main`.

## Changes
- **Analytics page** (`/super-admin/analytics`): add a top-level `<h1>` — was the only heading missing. _(report issue #6)_
- **System Status page** (`/super-admin/system`): add a top-level `<h1>`. _(report issue #6)_
- **Sidebar nav**: add `aria-expanded` to the collapsible group toggle buttons. Collapse behaviour already worked; this just exposes the open/closed state to assistive tech. _(report issue #25)_

## Intentionally NOT changed
- **Footer `/privacy` href** _(report issue #12)_: every footer link is already consistently slash-less, and `trailingSlash: true` in `next.config.ts` normalizes them at the edge. Adding a trailing slash to only `/privacy` would *re-introduce* the inconsistency the report flagged.

## Report items that need a product/ops decision (not a code fix)
- **#14** pricing-model reconciliation — three conflicting sources of truth
- **#3** rate-limit thresholds for super-admin sessions (raw-JSON leak itself is gone — pages now use loading/error states)
- **#2 / #21** CNDP filing, **#15** overdue retention purges, **#16** consent-evidence control — real-world compliance/ops actions

## Already fixed in `main` (verified)
#1 AI Builder 404, #4 subscriptions, #7 clinic status fallback, #13 Export CSV, #17/#18/#19 live KPI/health data.

## Notes
Local build not run (this environment lacks the repo's npm toolchain). Changes are minimal JSX additions copied from existing committed patterns; CI will validate.
