### PR TITLE
Implement valid fixes from tasks 2.txt audit (deploy wiring, branding validation, dashboard perf)

### DIFF
--- a/src/app/(admin)/admin/patients/page.tsx
+++ b/src/app/(admin)/admin/patients/page.tsx
@@ -39,7 +39,7 @@ import {
   getCurrentUser,
   fetchPatients,
   fetchAppointments,
-  fetchPrescriptions,
+  fetchPatientPrescriptions,
   type PatientView,
   type AppointmentView,
   type PrescriptionView,
@@ -54,7 +54,11 @@ export default function AdminPatientDatabasePage() {
   const [selectedPatient, setSelectedPatient] = useState<Patient | null>(null);
   const [patientsList, setPatientsList] = useState<Patient[]>([]);
   const [appointmentsList, setAppointmentsList] = useState<AppointmentView[]>([]);
-  const [prescriptionsList, setPrescriptionsList] = useState<PrescriptionView[]>([]);
+  const [clinicId, setClinicId] = useState<string | null>(null);
+  // B6: the selected patient's prescriptions are loaded on demand instead of
+  // pulling every prescription in the clinic up front.
+  const [selectedRx, setSelectedRx] = useState<PrescriptionView[]>([]);
+  const [rxLoading, setRxLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -76,15 +80,14 @@ export default function AdminPatientDatabasePage() {
         setLoading(false);
         return;
       }
-      const [p, a, rx] = await Promise.all([
+      setClinicId(user.clinic_id);
+      const [p, a] = await Promise.all([
         fetchPatients(user.clinic_id),
         fetchAppointments(user.clinic_id),
-        fetchPrescriptions(user.clinic_id),
       ]);
       if (controller.signal.aborted) return;
       setPatientsList(p);
       setAppointmentsList(a);
-      setPrescriptionsList(rx);
       setLoading(false);
     }
     load().catch((err) => {
@@ -98,9 +101,31 @@ export default function AdminPatientDatabasePage() {
     };
   }, []);
 
+  // B6: load the selected patient's prescriptions on demand.
+  useEffect(() => {
+    if (!selectedPatient || !clinicId) {
+      setSelectedRx([]);
+      return;
+    }
+    const controller = new AbortController();
+    const patientId = selectedPatient.id;
+    setRxLoading(true);
+    setSelectedRx([]);
+    fetchPatientPrescriptions(clinicId, patientId)
+      .then((rx) => {
+        if (!controller.signal.aborted) setSelectedRx(rx);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setSelectedRx([]);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setRxLoading(false);
+      });
+    return () => controller.abort();
+  }, [selectedPatient, clinicId]);
+
   const patients = patientsList;
   const appointments = appointmentsList;
-  const prescriptions = prescriptionsList;
 
   const filtered = patients.filter(
     (p) =>
@@ -126,9 +151,6 @@ export default function AdminPatientDatabasePage() {
 
   const getPatientAppts = (patientId: string) =>
     appointments.filter((a) => a.patientId === patientId);
-
-  const getPatientPrescriptions = (patientId: string) =>
-    prescriptions.filter((rx) => rx.patientId === patientId);
 
   const openEditDialog = (patient: Patient) => {
     setEditing(patient);
@@ -445,30 +467,36 @@ export default function AdminPatientDatabasePage() {
 
                 <TabsContent value="prescriptions">
                   <div className="space-y-2 mt-2">
-                    {getPatientPrescriptions(selectedPatient.id).length === 0 && (
+                    {rxLoading && (
+                      <p className="text-sm text-muted-foreground text-center py-4">
+                        Loading prescriptions…
+                      </p>
+                    )}
+                    {!rxLoading && selectedRx.length === 0 && (
                       <p className="text-sm text-muted-foreground text-center py-4">
                         No prescriptions
                       </p>
                     )}
-                    {getPatientPrescriptions(selectedPatient.id).map((rx) => (
-                      <div key={rx.id} className="border rounded-lg p-3">
-                        <div className="flex items-center justify-between mb-2">
-                          <p className="text-sm font-medium flex items-center gap-1">
-                            <Pill className="h-3.5 w-3.5" />
-                            {rx.doctorName}
-                          </p>
-                          <span className="text-xs text-muted-foreground">{rx.date}</span>
-                        </div>
-                        <div className="space-y-1">
-                          {rx.medications.map((med, i) => (
-                            <p key={i} className="text-xs text-muted-foreground">
-                              <span className="font-medium text-foreground">{med.name}</span> —{" "}
-                              {med.dosage} for {med.duration}
+                    {!rxLoading &&
+                      selectedRx.map((rx) => (
+                        <div key={rx.id} className="border rounded-lg p-3">
+                          <div className="flex items-center justify-between mb-2">
+                            <p className="text-sm font-medium flex items-center gap-1">
+                              <Pill className="h-3.5 w-3.5" />
+                              {rx.doctorName}
                             </p>
-                          ))}
+                            <span className="text-xs text-muted-foreground">{rx.date}</span>
+                          </div>
+                          <div className="space-y-1">
+                            {rx.medications.map((med, i) => (
+                              <p key={i} className="text-xs text-muted-foreground">
+                                <span className="font-medium text-foreground">{med.name}</span> —{" "}
+                                {med.dosage} for {med.duration}
+                              </p>
+                            ))}
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      ))}
                   </div>
                 </TabsContent>
               </Tabs>

--- a/src/app/(super-admin)/super-admin/agent-builder/page.tsx
+++ b/src/app/(super-admin)/super-admin/agent-builder/page.tsx
@@ -98,6 +98,63 @@ function inferServices(specialty: string): string[] {
   ];
 }
 
+type ClinicType =
+  | "doctor"
+  | "dentist"
+  | "pharmacy"
+  | "clinic"
+  | "hospital"
+  | "laboratory"
+  | "veterinary";
+
+/** Map a free-text specialty to the clinic_type the provisioning API expects. */
+function inferClinicType(specialty: string): ClinicType {
+  const lower = specialty.toLowerCase();
+  if (lower.includes("dent")) return "dentist";
+  if (lower.includes("pharma")) return "pharmacy";
+  if (lower.includes("vet")) return "veterinary";
+  if (lower.includes("lab")) return "laboratory";
+  if (lower.includes("hospital") || lower.includes("hôpital")) return "hospital";
+  return "clinic";
+}
+
+const EMAIL_RE = /^[\w.-]+@[\w.-]+\.\w+$/;
+
+/**
+ * Return the list of human-readable fields still required before the design
+ * can be deployed. The provisioning API requires name, subdomain, owner email
+ * and a valid clinic type; specialty/city/phone make the generated site usable.
+ */
+function missingForDeploy(config: ClinicConfig): string[] {
+  const missing: string[] = [];
+  if (!config.name.trim()) missing.push("clinic name");
+  if (!config.subdomain.trim()) missing.push("subdomain");
+  if (!config.specialty.trim()) missing.push("specialty");
+  if (!config.city.trim()) missing.push("city");
+  if (!config.phone.trim()) missing.push("phone number");
+  if (!config.email.trim() || !EMAIL_RE.test(config.email.trim())) missing.push("a valid email");
+  return missing;
+}
+
+/** Build the request body for POST /api/admin/onboarding-provision. */
+function buildProvisionBody(config: ClinicConfig) {
+  return {
+    clinic_name: config.name.trim(),
+    clinic_type: inferClinicType(config.specialty),
+    tier: "vitrine" as const,
+    subdomain: config.subdomain.trim(),
+    owner_name: config.name.trim(),
+    owner_email: config.email.trim(),
+    owner_phone: config.phone.trim() || undefined,
+    city: config.city.trim() || undefined,
+    specialty: config.specialty.trim() || undefined,
+    // Carry the builder's design through so the live site matches the preview.
+    primary_color: config.colors[0],
+    secondary_color: config.colors[1],
+    template_id: config.template,
+  };
+}
+
 function processUserMessage(
   input: string,
   currentConfig: ClinicConfig,
@@ -262,7 +319,15 @@ export default function AgentBuilderPage() {
   const [config, setConfig] = useState<ClinicConfig>(
     () => loadDraft()?.config ?? createEmptyConfig(),
   );
+  const [deploying, setDeploying] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  const pushAssistantMessage = useCallback((content: string) => {
+    setMessages((prev) => [
+      ...prev,
+      { id: generateId(), role: "assistant", content, timestamp: new Date() },
+    ]);
+  }, []);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -324,6 +389,64 @@ export default function AgentBuilderPage() {
     sessionStorage.removeItem(LOCAL_STORAGE_KEY);
   };
 
+  const handleDeploy = useCallback(async () => {
+    if (deploying) return;
+
+    const missing = missingForDeploy(config);
+    if (missing.length > 0) {
+      pushAssistantMessage(
+        `Before I can deploy, I still need: ${missing.join(", ")}. Add ${
+          missing.length > 1 ? "those" : "that"
+        } and click **Deploy** again.`,
+      );
+      return;
+    }
+
+    setDeploying(true);
+    pushAssistantMessage(`🚀 Deploying **${config.name}** to ${config.subdomain}.oltigo.com…`);
+
+    try {
+      const res = await fetch("/api/admin/onboarding-provision", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(buildProvisionBody(config)),
+      });
+
+      const json = (await res.json().catch(() => null)) as
+        | { ok: true; data: { clinicId: string; subdomain: string } }
+        | { ok: false; error?: { message?: string } }
+        | null;
+
+      if (!res.ok || !json || json.ok !== true) {
+        const reason =
+          (json && json.ok === false && json.error?.message) ||
+          (res.status === 403
+            ? "you need super-admin access to deploy"
+            : res.status === 409
+              ? "that subdomain is already in use — try another name"
+              : `the server returned ${res.status}`);
+        pushAssistantMessage(
+          `❌ Deploy failed: ${reason}. Nothing was created — you can try again.`,
+        );
+        return;
+      }
+
+      const url = `https://${json.data.subdomain}.oltigo.com`;
+      pushAssistantMessage(
+        `✅ **${config.name}** is live!\n\n🔗 ${url}\n\nThe clinic record, subdomain, and design have been provisioned. You can refine services, schedule, and content from the clinic's admin dashboard.`,
+      );
+      // Clear the saved draft now that it has been deployed.
+      sessionStorage.removeItem(LOCAL_STORAGE_KEY);
+    } catch {
+      pushAssistantMessage(
+        "❌ Deploy failed: couldn't reach the server. Check your connection and try again.",
+      );
+    } finally {
+      setDeploying(false);
+    }
+  }, [config, deploying, pushAssistantMessage]);
+
   return (
     <div className="flex h-[calc(100vh-4rem)] flex-col lg:flex-row">
       {/* Chat Panel */}
@@ -347,9 +470,15 @@ export default function AgentBuilderPage() {
               <RotateCcw className="mr-1 h-3.5 w-3.5" />
               <span className="hidden sm:inline text-xs">Reset</span>
             </Button>
-            <Button variant="default" size="sm" title="Deploy Site">
-              <Rocket className="mr-1 h-3.5 w-3.5" />
-              <span className="text-xs">Deploy</span>
+            <Button
+              variant="default"
+              size="sm"
+              title="Deploy Site"
+              onClick={handleDeploy}
+              disabled={deploying}
+            >
+              <Rocket className={`mr-1 h-3.5 w-3.5 ${deploying ? "animate-pulse" : ""}`} />
+              <span className="text-xs">{deploying ? "Deploying…" : "Deploy"}</span>
             </Button>
           </div>
         </div>

--- a/src/app/api/admin/onboarding-provision/route.ts
+++ b/src/app/api/admin/onboarding-provision/route.ts
@@ -79,6 +79,9 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       specialty,
       whatsapp_number,
       payment_gateway,
+      primary_color,
+      secondary_color,
+      template_id,
     } = result.data;
 
     const typedAdmin = createAdminClient("super_admin");
@@ -99,6 +102,11 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
           owner_email,
           phone: owner_phone ?? null,
           city: city ?? null,
+          // Design/branding from the agent builder (optional). When absent,
+          // the columns stay null and getPublicBranding() applies defaults.
+          primary_color: primary_color ?? null,
+          secondary_color: secondary_color ?? null,
+          template_id: template_id ?? null,
           config: {
             locale: "fr",
             currency: "MAD",

--- a/src/app/api/onboarding/wizard/route.ts
+++ b/src/app/api/onboarding/wizard/route.ts
@@ -8,6 +8,7 @@ import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
 import { invalidateAllSubdomainCaches } from "@/lib/subdomain-cache";
 import { TEMPLATE_PRESETS } from "@/lib/template-presets";
+import { hexColor, templateId } from "@/lib/validations/primitives";
 import { sendTextMessage } from "@/lib/whatsapp";
 
 // ---------------------------------------------------------------------------
@@ -37,9 +38,12 @@ const scheduleEntrySchema = z.object({
 });
 
 const brandingSchema = z.object({
-  primary_color: z.string().max(20).optional(),
-  secondary_color: z.string().max(20).optional(),
-  template_id: z.string().max(50).optional(),
+  // A8: enforce real hex colours and a known template id so we never persist
+  // branding the public site can't render. Defaults are still applied from the
+  // preset below when fields are omitted.
+  primary_color: hexColor.optional(),
+  secondary_color: hexColor.optional(),
+  template_id: templateId.optional(),
 });
 
 const wizardSchema = z.object({

--- a/src/lib/data/client/_core.ts
+++ b/src/lib/data/client/_core.ts
@@ -102,6 +102,8 @@ export async function fetchRows<T>(
     eq?: [string, unknown][];
     order?: [string, { ascending: boolean }];
     limit?: number;
+    /** Zero-based inclusive [from, to] window for offset pagination. */
+    range?: [number, number];
     gte?: [string, unknown];
     lte?: [string, unknown];
     inFilter?: [string, unknown[]];
@@ -134,6 +136,11 @@ export async function fetchRows<T>(
   // Apply an upper-bound limit to prevent unbounded result sets.
   // Callers can override with a smaller value via opts.limit.
   q = q.limit(opts?.limit ?? 1000);
+  // Offset pagination window (applied after limit so "load more" callers get
+  // a bounded page rather than the whole table).
+  if (opts?.range) {
+    q = q.range(opts.range[0], opts.range[1]);
+  }
   const { data, error } = await q;
   if (error) {
     logger.error("Query failed", { context: "data/client", table, error });

--- a/src/lib/data/client/prescriptions.ts
+++ b/src/lib/data/client/prescriptions.ts
@@ -28,6 +28,18 @@ interface PrescriptionRaw {
   created_at: string;
 }
 
+function mapPrescription(r: PrescriptionRaw): PrescriptionView {
+  return {
+    id: r.id,
+    patientId: r.patient_id,
+    patientName: _activeUserMap?.get(r.patient_id)?.name ?? "Patient",
+    doctorName: _activeUserMap?.get(r.doctor_id)?.name ?? "Doctor",
+    date: r.created_at?.split("T")[0] ?? "",
+    medications: r.items ?? [],
+    notes: r.notes ?? undefined,
+  };
+}
+
 export async function fetchPrescriptions(
   clinicId: string,
   doctorId?: string,
@@ -39,13 +51,24 @@ export async function fetchPrescriptions(
     eq,
     order: ["created_at", { ascending: false }],
   });
-  return rows.map((r) => ({
-    id: r.id,
-    patientId: r.patient_id,
-    patientName: _activeUserMap?.get(r.patient_id)?.name ?? "Patient",
-    doctorName: _activeUserMap?.get(r.doctor_id)?.name ?? "Doctor",
-    date: r.created_at?.split("T")[0] ?? "",
-    medications: r.items ?? [],
-    notes: r.notes ?? undefined,
-  }));
+  return rows.map(mapPrescription);
+}
+
+/**
+ * B6: fetch a single patient's prescriptions on demand. Lets dashboards avoid
+ * loading every prescription in the clinic just to populate a detail panel.
+ */
+export async function fetchPatientPrescriptions(
+  clinicId: string,
+  patientId: string,
+): Promise<PrescriptionView[]> {
+  await ensureLookups(clinicId);
+  const rows = await fetchRows<PrescriptionRaw>("prescriptions", {
+    eq: [
+      ["clinic_id", clinicId],
+      ["patient_id", patientId],
+    ],
+    order: ["created_at", { ascending: false }],
+  });
+  return rows.map(mapPrescription);
 }

--- a/src/lib/data/public.ts
+++ b/src/lib/data/public.ts
@@ -228,6 +228,22 @@ async function fetchBrandingFromDb(
   // Fallback to config JSONB for phone/address/email when direct columns are null
   const cfg = (data.config ?? {}) as ClinicConfigJson;
 
+  // A7: defaults below keep the site renderable, but a clinic missing core
+  // branding usually means an incomplete provisioning/onboarding. Surface it
+  // once per cache TTL so it can be backfilled rather than silently masked.
+  const missingBranding = [
+    !data.name && "name",
+    !data.primary_color && "primary_color",
+    !data.template_id && "template_id",
+  ].filter((field): field is string => Boolean(field));
+  if (missingBranding.length > 0) {
+    logger.warn("Clinic branding incomplete — applying defaults", {
+      context: "data/public:fetchBrandingFromDb",
+      clinicId,
+      missingFields: missingBranding,
+    });
+  }
+
   return {
     logoUrl: data.logo_url ?? null,
     faviconUrl: data.favicon_url ?? null,

--- a/src/lib/validations/primitives.ts
+++ b/src/lib/validations/primitives.ts
@@ -43,6 +43,20 @@ export const phoneNumber = z
   .regex(/^\+?[0-9 ()\-]{8,30}$/, "Invalid phone number format");
 
 /**
+ * A CSS hex colour: #RGB, #RRGGBB, or #RRGGBBAA (case-insensitive).
+ * Used for clinic branding so we never persist an unrenderable colour.
+ */
+export const hexColor = z
+  .string()
+  .regex(
+    /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/,
+    "Invalid hex colour (expected #RRGGBB)",
+  );
+
+/** The layout template ids a clinic site can render (see src/lib/templates.ts). */
+export const templateId = z.enum(["modern", "classic", "elegant", "bold", "minimal", "arabic"]);
+
+/**
  * Validate Moroccan phone numbers.
  * Accepted formats: +212 6XXXXXXXX, +212 7XXXXXXXX, 06XXXXXXXX, 07XXXXXXXX
  * (with or without spaces/dashes).

--- a/src/lib/validations/super-admin.ts
+++ b/src/lib/validations/super-admin.ts
@@ -36,6 +36,12 @@ export const clinicProvisionSchema = z.object({
   specialty: z.string().max(200).optional(),
   whatsapp_number: z.string().max(30).optional(),
   payment_gateway: z.enum(["cmi", "stripe", "cash"]).optional(),
+  // Optional design/branding carried over from the agent builder so the
+  // deployed site reflects the previewed design immediately. Kept optional
+  // and backward-compatible with the existing super-admin onboarding wizard.
+  primary_color: z.string().max(20).optional(),
+  secondary_color: z.string().max(20).optional(),
+  template_id: z.enum(["modern", "classic", "minimal"]).optional(),
 });
 
 export const churnPredictionQuerySchema = z.object({


### PR DESCRIPTION
## What this is

These changes come from reconciling the `tasks 2.txt` audit against the actual codebase. A large part of that audit was stale or hallucinated (it referenced files that don't exist, and several findings were already fixed in-tree). This PR implements only the **genuinely-valid** items, each verified against the real code.

Full repo `tsc --noEmit` passes with **0 errors** and Prettier is clean on all touched files. The full test suite / app were **not** run locally (sandbox constraints) — CI is the authoritative gate.

## Commits (4, file-disjoint)

### `feat(agent-builder)` — wire the Deploy button (was a no-op)
The Deploy button rendered but had **no `onClick`** — clicking it did nothing. It now:
- validates required fields (name, subdomain, specialty, city, phone, email) with an inline message listing what's missing;
- POSTs to `/api/admin/onboarding-provision` — the **super-admin** path (the `onboarding/wizard` route is owner-scoped and 403s for super-admins, so the audit's suggested call would have failed);
- maps `ClinicConfig → clinicProvisionSchema` (specialty → `clinic_type`) and carries the builder's design (primary/secondary colour + `template_id`) onto the new clinic so the live site matches the preview (columns already exist; `getPublicBranding()` defaults them when null);
- shows a deploying state, the live URL on success, and surfaces 403 / 409-subdomain-taken / network errors without leaving partial state.

### `fix(onboarding)` — validate branding hex + template id on the wizard
`brandingSchema` accepted any `string<=20` for colours and any `string<=50` for `template_id`. Adds reusable `hexColor` + `templateId` validators (in `primitives.ts`) and enforces them so we never persist an unrenderable colour or unknown template. Preset defaults still apply when fields are omitted.

### `fix(public)` — warn when clinic branding is incomplete
`getPublicBranding()` already applies `DEFAULT_BRANDING` field-by-field, but silently. Adds a single warning (inside the cached fetch, so once per TTL) listing the missing core fields (`name` / `primary_color` / `template_id`) so broken provisioning gets noticed instead of masked.

### `perf(admin/patients)` — lazy-load prescriptions + pagination primitive
The admin patients dashboard fetched **every** patient, appointment **and** prescription in the clinic on mount before first paint. Prescriptions only appear in a selected patient's detail tab, so they now load on demand via a new `fetchPatientPrescriptions(clinicId, patientId)` — removing one of three blocking queries with no per-row impact. Also adds offset `range` pagination support to `fetchRows` for future list paging.

## Deliberately **not** included (needs runtime QA)

- **`select("*")` → explicit columns (A17-01):** real, but it's **19 routes** (admin/inventory/referrals/etc.), not the "booking/appointments/patients" routes the audit named. Narrowing changes the API response shape that flows to clients, so it needs per-route consumer tracing + runtime testing, not a blind sweep.
- **Full patient-list pagination + server-side search, and the doctor patients page:** the list search is client-side and the doctor page renders prescription/visit **counts per row**, so naive pagination would regress search and those counts.

## For context: audit items that were already done or fictional (no action)
- Already in-tree: subdomain KV cache (P-02), doctor-unavailability queue (A73-F2), Supabase pooler support, branding defaults.
- Fictional: DCI drug DB / `ai/auto-suggest` scan (A73-F5) — no such files; rate-limiter "O(n log n) Map sort" in `with-auth.ts` (P-01) — no such code, and `lru-cache` isn't a dependency.
