### PR TITLE
feat(dashboards): live admin & doctor dashboards via Supabase Realtime

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -5,5 +5,5 @@ import { getDashboardStats } from "@/lib/data/dashboard";
 export default async function AdminDashboardPage() {
   const profile = await requireAuth();
   const stats = await getDashboardStats(profile.clinic_id!);
-  return <AdminDashboardView stats={stats} />;
+  return <AdminDashboardView stats={stats} clinicId={profile.clinic_id!} />;
 }

--- a/src/app/(doctor)/doctor/dashboard/page.tsx
+++ b/src/app/(doctor)/doctor/dashboard/page.tsx
@@ -11,6 +11,7 @@ export default async function DoctorDashboardPage() {
       patients={data.patients}
       waitingRoom={data.waitingRoom}
       invoices={data.invoices}
+      clinicId={profile.clinic_id!}
     />
   );
 }

--- a/src/components/admin/admin-dashboard-view.tsx
+++ b/src/components/admin/admin-dashboard-view.tsx
@@ -11,7 +11,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { RealtimeIndicator } from "@/components/ui/realtime-indicator";
 import type { DashboardStats, RecentActivityItem } from "@/lib/data/dashboard";
+import { useRealtimeRefresh } from "@/lib/hooks/use-realtime-refresh";
 import { t } from "@/lib/i18n";
 import { formatCurrency, formatDisplayDate } from "@/lib/utils";
 
@@ -27,12 +29,16 @@ const activityVariant: Record<string, "default" | "success" | "warning" | "destr
   config: "warning",
 };
 
+const REALTIME_TABLES = ["appointments", "payments"] as const;
+
 interface AdminDashboardViewProps {
   stats: DashboardStats;
+  clinicId: string;
 }
 
-export function AdminDashboardView({ stats }: AdminDashboardViewProps) {
+export function AdminDashboardView({ stats, clinicId }: AdminDashboardViewProps) {
   const [locale] = useLocale();
+  const realtimeStatus = useRealtimeRefresh(clinicId, REALTIME_TABLES);
 
   const totalPatients = stats.totalPatients;
   const totalAppts = stats.totalAppointments;
@@ -75,7 +81,10 @@ export function AdminDashboardView({ stats }: AdminDashboardViewProps) {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">{t(locale, "dashboard.admin")}</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold">{t(locale, "dashboard.admin")}</h1>
+          <RealtimeIndicator status={realtimeStatus} />
+        </div>
         <Link href="/admin/notifications">
           <Button variant="outline" className="flex items-center gap-2">
             <MessageSquare className="h-4 w-4" />

--- a/src/components/doctor/doctor-dashboard-view.tsx
+++ b/src/components/doctor/doctor-dashboard-view.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/dialog";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
+import { RealtimeIndicator } from "@/components/ui/realtime-indicator";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/toast";
 import { updateAppointmentStatus } from "@/lib/data/client";
@@ -42,6 +43,7 @@ import type {
   DoctorInvoiceView,
 } from "@/lib/data/dashboard";
 import { useOptimisticUpdate } from "@/lib/hooks/use-optimistic-update";
+import { useRealtimeRefresh } from "@/lib/hooks/use-realtime-refresh";
 import { t } from "@/lib/i18n";
 import type { TranslationKey } from "@/lib/i18n";
 import { logger } from "@/lib/logger";
@@ -78,11 +80,14 @@ const statusVariant: Record<
   cancelled: "secondary",
 };
 
+const REALTIME_TABLES = ["appointments", "waiting_queue"] as const;
+
 interface DoctorDashboardViewProps {
   initialAppointments: DoctorAppointmentView[];
   patients: DoctorPatientView[];
   waitingRoom: DoctorWaitingRoomEntry[];
   invoices: DoctorInvoiceView[];
+  clinicId: string;
 }
 
 export function DoctorDashboardView({
@@ -90,8 +95,10 @@ export function DoctorDashboardView({
   patients,
   waitingRoom: waitingRoomEntries,
   invoices,
+  clinicId,
 }: DoctorDashboardViewProps) {
   const [locale] = useLocale();
+  const realtimeStatus = useRealtimeRefresh(clinicId, REALTIME_TABLES);
   const {
     data: appointmentList,
     mutate: mutateAppointments,
@@ -323,7 +330,10 @@ export function DoctorDashboardView({
     <div>
       {/* Personalized greeting */}
       <div className="mb-6">
-        <h1 className="text-2xl font-bold">{greeting}</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold">{greeting}</h1>
+          <RealtimeIndicator status={realtimeStatus} />
+        </div>
         <p className="text-muted-foreground text-sm mt-1">
           {isNewDoctor
             ? t(locale, "dashboard.welcomeDoctor" as TranslationKey)

--- a/src/components/ui/realtime-indicator.tsx
+++ b/src/components/ui/realtime-indicator.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { RealtimeStatus } from "@/lib/hooks/use-realtime-refresh";
+import { cn } from "@/lib/utils";
+
+const LABELS: Record<RealtimeStatus, string> = {
+  connecting: "Connecting…",
+  live: "Live",
+  offline: "Offline",
+};
+
+const DOT: Record<RealtimeStatus, string> = {
+  connecting: "bg-amber-400 animate-pulse",
+  live: "bg-emerald-500",
+  offline: "bg-muted-foreground/40",
+};
+
+/**
+ * Small connection-status pill for live-updating views. Pairs with
+ * `useRealtimeRefresh`. Announces changes politely to screen readers.
+ */
+export function RealtimeIndicator({
+  status,
+  className,
+}: {
+  status: RealtimeStatus;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn("inline-flex items-center gap-1.5 text-xs text-muted-foreground", className)}
+      role="status"
+      aria-live="polite"
+    >
+      <span className={cn("h-2 w-2 rounded-full", DOT[status])} aria-hidden="true" />
+      {LABELS[status]}
+    </span>
+  );
+}

--- a/src/lib/hooks/use-realtime-refresh.ts
+++ b/src/lib/hooks/use-realtime-refresh.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/data/client";
+
+export type RealtimeStatus = "connecting" | "live" | "offline";
+
+/**
+ * Subscribe to Postgres change events for the given tables (scoped to a
+ * clinic) and trigger a server-component refresh when the data changes.
+ *
+ * Uses `router.refresh()` so the existing server-side data loaders
+ * (e.g. `getDashboardStats` / `getDoctorDashboardData`) stay the single
+ * source of truth — no duplicated client-side query logic and RLS keeps
+ * applying on the server.
+ *
+ * The tables MUST be members of the `supabase_realtime` publication (see
+ * migration `00189_realtime_dashboard_tables.sql`) and must expose a
+ * `clinic_id` column for the per-tenant filter. Bursts of changes (e.g. a
+ * booking that writes an appointment + a payment in one transaction) are
+ * debounced into a single refresh.
+ *
+ * @param clinicId  Tenant to scope the subscription to. When null/undefined
+ *                  (e.g. super-admins with no clinic) the hook is inert.
+ * @param tables    Stable list of table names to watch. Pass a module-level
+ *                  constant so the effect does not re-subscribe each render.
+ */
+export function useRealtimeRefresh(
+  clinicId: string | null | undefined,
+  tables: readonly string[],
+): RealtimeStatus {
+  const router = useRouter();
+  const [status, setStatus] = useState<RealtimeStatus>("connecting");
+
+  // Join to a primitive so the effect's dependency is stable across renders
+  // even if the caller passes a fresh array literal.
+  const tableKey = tables.join(",");
+
+  useEffect(() => {
+    if (!clinicId) return;
+
+    const supabase = createClient();
+    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const scheduleRefresh = () => {
+      if (refreshTimer) clearTimeout(refreshTimer);
+      refreshTimer = setTimeout(() => router.refresh(), 500);
+    };
+
+    let channel = supabase.channel(`dashboard:${clinicId}`);
+    for (const table of tableKey.split(",")) {
+      channel = channel.on(
+        "postgres_changes",
+        { event: "*", schema: "public", table, filter: `clinic_id=eq.${clinicId}` },
+        scheduleRefresh,
+      );
+    }
+
+    channel.subscribe((state) => {
+      if (state === "SUBSCRIBED") {
+        setStatus("live");
+      } else if (state === "CHANNEL_ERROR" || state === "TIMED_OUT" || state === "CLOSED") {
+        setStatus("offline");
+      } else {
+        setStatus("connecting");
+      }
+    });
+
+    return () => {
+      if (refreshTimer) clearTimeout(refreshTimer);
+      supabase.removeChannel(channel);
+    };
+  }, [clinicId, tableKey, router]);
+
+  return status;
+}

--- a/supabase/migrations/00189_realtime_dashboard_tables.sql
+++ b/supabase/migrations/00189_realtime_dashboard_tables.sql
@@ -1,0 +1,38 @@
+-- 00189_realtime_dashboard_tables.sql
+--
+-- Enable Supabase Realtime for the admin & doctor dashboards.
+--
+-- The dashboards subscribe to `appointments` (bookings + status changes) and
+-- `payments` (revenue) through postgres_changes, scoped per clinic by RLS
+-- and a `clinic_id=eq.<id>` filter. Before this migration only
+-- `patient_vitals` and `waiting_queue` were members of the
+-- `supabase_realtime` publication, so appointment/payment changes were never
+-- broadcast — the receptionist waiting room's `appointments` subscription
+-- silently received nothing.
+--
+-- Idempotent: `ALTER PUBLICATION ... ADD TABLE` raises if the table is
+-- already a member, so each add is guarded by a membership check. Safe to
+-- re-run.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'appointments'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.appointments;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'payments'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.payments;
+  END IF;
+END $$;


### PR DESCRIPTION
## What

Wires the **admin** and **doctor** dashboards to update live, reusing the receptionist waiting-room realtime pattern.

- **`useRealtimeRefresh` hook** — subscribes to `postgres_changes` per clinic and calls `router.refresh()` (debounced 500ms), so the existing server loaders (`getDashboardStats` / `getDoctorDashboardData`) stay the single source of truth and RLS keeps applying server-side.
- **`RealtimeIndicator`** — live / connecting / offline status pill (`role="status"`, `aria-live="polite"`).
- Admin dashboard watches `appointments` + `payments`; doctor dashboard watches `appointments` + `waiting_queue`.

## Migration `00189`

Adds `appointments` + `payments` to the `supabase_realtime` publication. Previously **only** `patient_vitals` + `waiting_queue` were members, so the receptionist waiting room's existing `appointments` subscription was silently inert. Idempotent (guarded membership checks; safe to re-run).

## Notes

- Addresses the corrected remediation plan **R2/R3** (original Task 11/12).
- This repo uses **Bun** and I built this in an environment without `node_modules`, so I could not run `tsc` / `eslint` locally — relying on CI. Verified against existing precedents (`src/modules/vitals/stream.ts`, `src/components/receptionist/realtime-waiting-room.tsx`).
