### PR TITLE
fix(audit): close Task 14 (AI-worker 501 smoke probe) + Task 10 (edge-function type checking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,32 @@ jobs:
       - name: Run Knip
         run: npx knip
 
+  # Audit Task 10: type-check the Supabase Edge Functions (Deno). They run
+  # outside the Next.js tsconfig (which excludes supabase/functions), so this
+  # is the only gate covering them — including parse-medical-document, which
+  # decrypts and parses PHI. All three functions type-check clean today.
+  # Starts non-blocking (continue-on-error) so the gate cannot block the
+  # pipeline on its first real run; promote to blocking once it is green in CI.
+  edge-functions:
+    runs-on: ubuntu-latest
+    name: Edge Functions Type Check (Deno)
+    steps:
+      # C-14: Pin all GH Actions to full SHA to prevent tag-mutation supply-chain attacks
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.x
+
+      - name: Type check edge functions
+        # --no-lock: the functions import from esm.sh (a CDN that can rebuild
+        # artifacts), so a committed lockfile would cause spurious integrity
+        # failures. Imports are version-pinned in the URLs instead.
+        run: deno check --no-lock -c supabase/functions/deno.json supabase/functions/*/index.ts
+        continue-on-error: true
+
   # F-009 / F-054: Dedicated RLS integration test job that runs in parallel
   # with `ci` — never skipped due to lint or build failures. This is the
   # single highest-leverage quality investment: a malformed RLS policy in a

--- a/scripts/smoke-post-deploy.mjs
+++ b/scripts/smoke-post-deploy.mjs
@@ -40,6 +40,15 @@ const SMOKE_AI_COOKIE = process.env.SMOKE_AI_COOKIE || "";
 const SMOKE_AI_AUTH_HEADER = process.env.SMOKE_AI_AUTH_HEADER || "";
 const SMOKE_AI_EXPECT_STATUS = Number(process.env.SMOKE_AI_EXPECT_STATUS || 200);
 
+// Audit Task 14: paths that are 501 stubs in the main Worker and MUST be
+// zone-routed to the separate `webs-alots-ai` Worker in production. Comma-
+// separated; set empty to skip. /api/builder/sandbox can be added once its
+// unauthenticated GET behaviour is confirmed (it is POST-only today).
+const SMOKE_AI_WORKER_PATHS = (process.env.SMOKE_AI_WORKER_PATHS || "/api/copilotkit")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
 /** Routes that must respond with a status below `maxStatus`. */
 const ROUTES = [
   { path: "/", maxStatus: 400 },
@@ -298,6 +307,47 @@ async function checkAuthNoindex() {
   }
 }
 
+/**
+ * Audit Task 14 — Layer 7: dual-Worker AI routing split.
+ *
+ * /api/copilotkit (and /api/builder/sandbox) are STUBS in the main
+ * `webs-alots` Worker that return HTTP 501. In production, Cloudflare zone
+ * routes must send these paths to the separate `webs-alots-ai` Worker BEFORE
+ * the main Worker sees them. The built-in failure signature of a missing or
+ * misordered route is therefore a 501 served from the main Worker — exactly
+ * what this probe catches. A correctly routed unauthenticated call is rejected
+ * by the AI Worker (typically 401/403/405), never answered by the 501 stub.
+ */
+async function checkAiWorkerRouting() {
+  if (SMOKE_AI_WORKER_PATHS.length === 0) {
+    console.log("· ai routing: skipped (SMOKE_AI_WORKER_PATHS empty)");
+    return;
+  }
+  for (const path of SMOKE_AI_WORKER_PATHS) {
+    try {
+      const { status, text } = await fetchText(BASE + path);
+      // 501 is the definitive stub signature; the "Route moved" body marker is
+      // stub-specific too and guards against the status code being changed.
+      const servedByStub = status === 501 || /"error"\s*:\s*"Route moved"/.test(text);
+      log(
+        !servedByStub,
+        servedByStub
+          ? `ai routing: ${path} → HTTP ${status} served by the 501 STUB in the main Worker — ` +
+              `the Cloudflare zone route to webs-alots-ai is missing or misordered`
+          : `ai routing: ${path} → HTTP ${status} (reached webs-alots-ai, not the 501 stub)`,
+      );
+      // Informational only: a routed unauthenticated call should be rejected.
+      if (!servedByStub && status >= 400 && ![401, 403, 405].includes(status)) {
+        console.log(
+          `· ai routing: ${path} returned ${status} (expected 401/403/405 unauthenticated) — review`,
+        );
+      }
+    } catch (err) {
+      log(false, `ai routing: ${path} request failed (${err?.message || err})`);
+    }
+  }
+}
+
 async function checkOptionalAiEndpoint() {
   if (!SMOKE_AI_PATH) {
     console.log("· ai smoke: skipped (SMOKE_AI_PATH not configured)");
@@ -355,6 +405,7 @@ async function checkOptionalAiEndpoint() {
   await checkHealthJson();
   await checkSecurityHeaders();
   await checkAuthNoindex();
+  await checkAiWorkerRouting();
   await checkOptionalAiEndpoint();
   console.log("");
   if (failures > 0) {

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
+  },
+  "fmt": {
+    "lineWidth": 100
+  }
+}

--- a/supabase/functions/parse-medical-document/index.ts
+++ b/supabase/functions/parse-medical-document/index.ts
@@ -79,7 +79,7 @@ Retourne UNIQUEMENT ce JSON (sans Markdown):
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Convert a hex string to a Uint8Array backed by a concrete ArrayBuffer. */
-function hexToBytes(hex: string): Uint8Array {
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
   if (hex.length % 2 !== 0) throw new Error("Invalid hex string");
   // Allocate a concrete ArrayBuffer so Web Crypto APIs accept the result
   // without further casting (avoids ArrayBufferLike vs ArrayBuffer mismatch).
@@ -106,8 +106,8 @@ async function decryptBuffer(encrypted: Uint8Array, phiKeyHex: string): Promise<
 
   // `.slice()` on a Uint8Array returns Uint8Array<ArrayBufferLike>; we need
   // a concrete ArrayBuffer for crypto.subtle APIs. Copy into new ArrayBuffers.
-  let iv: Uint8Array;
-  let ciphertext: Uint8Array;
+  let iv: Uint8Array<ArrayBuffer>;
+  let ciphertext: Uint8Array<ArrayBuffer>;
 
   // Detect versioned format (first byte == 0x01)
   if (encrypted[0] === 0x01 && encrypted.length > 13) {
@@ -145,10 +145,13 @@ async function getR2PresignedUrl(
   expiresIn = 60,
 ): Promise<string> {
   const endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
-  const url = `${endpoint}/${bucketName}/${key}`;
+  // aws4fetch has no top-level `expiresIn` option — presigned-URL expiry is
+  // set via the X-Amz-Expires query param. Putting it in the URL both fixes
+  // the type error and actually enforces the intended expiry window (the
+  // previous `expiresIn` property was silently ignored at runtime).
+  const url = `${endpoint}/${bucketName}/${key}?X-Amz-Expires=${expiresIn}`;
   const request = await aws.sign(new Request(url, { method: "GET" }), {
     aws: { signQuery: true },
-    expiresIn,
   });
   return request.url;
 }

--- a/supabase/functions/send-appointment-reminders/index.ts
+++ b/supabase/functions/send-appointment-reminders/index.ts
@@ -197,7 +197,11 @@ Deno.serve(async (req: Request) => {
     if (!appointments?.length) continue;
 
     // Load already-sent reminders for this window to avoid re-sending.
-    const appointmentIds = appointments.map((a: Appointment) => a.id);
+    // supabase-js mis-infers these to-one (`!patient_id`) joins as arrays;
+    // the runtime rows are object-shaped, so cast through `unknown` to the
+    // Appointment shape that models reality. See send query above.
+    const rows = appointments as unknown as Appointment[];
+    const appointmentIds = rows.map((a) => a.id);
     const { data: alreadySent } = await supabase
       .from("appointment_reminders")
       .select("appointment_id")
@@ -212,7 +216,7 @@ Deno.serve(async (req: Request) => {
     // hit the credentials table once per appointment.
     const tokenCache = new Map<string, string | null>();
 
-    for (const appt of appointments as Appointment[]) {
+    for (const appt of rows) {
       if (alreadySentIds.has(appt.id)) continue;
 
       const clinic = appt.clinic;


### PR DESCRIPTION
## Summary

Closes the two genuinely-open, code-fixable items from the 2026-06-09 audit (re-verified against current `main`). Most other audit items were already handled by the team; these two were not.

### Task 14 — guard the dual-Worker AI routing split
`scripts/smoke-post-deploy.mjs` now asserts `/api/copilotkit` does **not** return the `501` stub from the main Worker — the failure signature of a missing/misordered Cloudflare zone route to `webs-alots-ai`. Configurable via `SMOKE_AI_WORKER_PATHS`. `/api/builder/sandbox` is POST-only, so it is excluded from the default probe.

### Task 10 — Supabase Edge Functions under type checking
- Added `supabase/functions/deno.json` (strict Deno config).
- Added a **non-blocking** `edge-functions` CI job running `deno check` on all three functions. Started non-blocking on purpose — promote to blocking once it is green in CI.
- `deno check` surfaced **real pre-existing type errors**; fixed (behavior-preserving):
  - **`parse-medical-document`**: annotate crypto buffers as `Uint8Array<ArrayBuffer>`; fix the R2 presigned-URL expiry to use the `X-Amz-Expires` query param. The previous top-level `expiresIn` option was **silently ignored by aws4fetch**, so the intended 60s expiry never applied — this is a latent bug fix, not just a type fix.
  - **`send-appointment-reminders`**: cast supabase-js to-one joins through `unknown` (they are mis-inferred as arrays; runtime rows are object-shaped).

## Verification
- `deno check` clean on all three functions (`notify-booking`, `parse-medical-document`, `send-appointment-reminders`).
- `ci.yml` validated as well-formed YAML; new job mirrors the existing `knip` job and SHA-pins `denoland/setup-deno@667a34c` (v2.0.4).
- Smoke script parses and the new probe is wired into the run sequence.

> Note: the full `tsc`/`eslint`/`vitest`/`bun` suite was **not** run for this change (the dependency tree exceeds the build sandbox's disk). The Deno-side checks above were run for real. CI will exercise the rest.

🤖 Generated with assistant