### PR TITLE
fix: wire dashboard controls (family, announcements, suppliers, churn)

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -50,6 +50,11 @@ rules:
           #                             directly is the service-level pattern.
           #   - `ai_provider_configs`— global provider config; no clinic_id.
           #   - `ai_task_configs`    — global per-task model routing pins; no clinic_id.
+          #   - `announcements`      — platform-wide super-admin broadcasts; the
+          #                             table has NO clinic_id column (see
+          #                             00005_schema_gaps.sql). Targeting is done
+          #                             via the `target`/`target_label` columns,
+          #                             not tenant ownership.
           #
           # All other queue / processed-events tables (notification_queue,
           # processed_stripe_events, processed_whatsapp_messages,
@@ -64,7 +69,7 @@ rules:
           # annotated rather than whitelisted, so a future bare
           # .from("users").select("*") still triggers a warning.
           regex: |-
-            ^(?!["'](clinics|ai_provider_configs|ai_task_configs)["']).*$
+            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements)["']).*$
       # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
       # makes this query tenant-scoped. Semgrep normalises JS string quotes,
       # but both variants are kept for belt-and-suspenders parity with the

--- a/src/app/(patient)/patient/family/page.tsx
+++ b/src/app/(patient)/patient/family/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { UserPlus, Phone, Calendar, Edit2, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { UserPlus, Phone, Edit2, Trash2, Loader2 } from "lucide-react";
+import { useState, useEffect } from "react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -16,46 +15,18 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/toast";
+import {
+  getCurrentUser,
+  fetchFamilyMembers,
+  createFamilyMember,
+  updateFamilyMember,
+  deleteFamilyMember,
+  type FamilyMemberView,
+  type ClinicUser,
+} from "@/lib/data/client";
 
-interface FamilyMember {
-  id: string;
-  name: string;
-  relation: string;
-  age: number;
-  phone: string;
-  gender: string;
-  insurance: string;
-}
-
-const initialMembers: FamilyMember[] = [
-  {
-    id: "f1",
-    name: "Laila Mansouri",
-    relation: "Wife",
-    age: 33,
-    phone: "+212 6 11 22 33 55",
-    gender: "F",
-    insurance: "CNSS",
-  },
-  {
-    id: "f2",
-    name: "Yassine Mansouri",
-    relation: "Son",
-    age: 8,
-    phone: "\u2014",
-    gender: "M",
-    insurance: "CNSS",
-  },
-  {
-    id: "f3",
-    name: "Sara Mansouri",
-    relation: "Daughter",
-    age: 5,
-    phone: "\u2014",
-    gender: "F",
-    insurance: "CNSS",
-  },
-];
+const RELATIONSHIPS = ["Wife", "Husband", "Son", "Daughter", "Parent", "Sibling", "Other"];
 
 const relationColors: Record<string, string> = {
   Wife: "bg-pink-100 text-pink-700 dark:bg-pink-900 dark:text-pink-300",
@@ -66,54 +37,93 @@ const relationColors: Record<string, string> = {
 };
 
 export default function FamilyMembersPage() {
-  const [members, setMembers] = useState(initialMembers);
-  const [addOpen, setAddOpen] = useState(false);
+  const { addToast } = useToast();
+  const [members, setMembers] = useState<FamilyMemberView[]>([]);
+  const [user, setUser] = useState<ClinicUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
-  const [newMember, setNewMember] = useState({
-    name: "",
-    relation: "Wife",
-    age: "",
-    phone: "",
-    gender: "F",
-    insurance: "",
-  });
   const [saving, setSaving] = useState(false);
-  const [success, setSuccess] = useState(false);
+  const [form, setForm] = useState({ name: "", relationship: "Wife", phone: "" });
 
-  const handleAdd = () => {
+  useEffect(() => {
+    (async () => {
+      try {
+        const u = await getCurrentUser();
+        setUser(u);
+        if (u?.id) {
+          setMembers(await fetchFamilyMembers(u.id));
+        }
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : "Failed to load family members");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  function openAdd() {
+    setEditingId(null);
+    setForm({ name: "", relationship: "Wife", phone: "" });
+    setDialogOpen(true);
+  }
+
+  function openEdit(member: FamilyMemberView) {
+    setEditingId(member.id);
+    setForm({ name: member.name, relationship: member.relationship, phone: member.phone ?? "" });
+    setDialogOpen(true);
+  }
+
+  async function handleSave() {
+    if (!form.name.trim()) return;
+    if (!user?.id || !user.clinic_id) {
+      addToast("Your account is not linked to a clinic.", "error");
+      return;
+    }
     setSaving(true);
-    setTimeout(() => {
-      const member: FamilyMember = {
-        id: `f${Date.now()}`,
-        name: newMember.name,
-        relation: newMember.relation,
-        age: parseInt(newMember.age, 10) || 0,
-        phone: newMember.phone || "\u2014",
-        gender: newMember.gender,
-        insurance: newMember.insurance,
-      };
-      setMembers([...members, member]);
-      setSaving(false);
-      setSuccess(true);
-      setTimeout(() => {
-        setAddOpen(false);
-        setSuccess(false);
-        setNewMember({
-          name: "",
-          relation: "Wife",
-          age: "",
-          phone: "",
-          gender: "F",
-          insurance: "",
+    const res = editingId
+      ? await updateFamilyMember(editingId, {
+          name: form.name.trim(),
+          relationship: form.relationship,
+          phone: form.phone.trim(),
+        })
+      : await createFamilyMember({
+          primaryUserId: user.id,
+          clinicId: user.clinic_id,
+          name: form.name.trim(),
+          relationship: form.relationship,
+          phone: form.phone.trim(),
         });
-      }, 1500);
-    }, 1000);
-  };
+    setSaving(false);
+    if (!res.success) {
+      addToast(res.error.message || "Could not save family member", "error");
+      return;
+    }
+    const saved = res.data;
+    setMembers((prev) =>
+      editingId ? prev.map((m) => (m.id === editingId ? saved : m)) : [...prev, saved],
+    );
+    addToast(editingId ? "Family member updated" : "Family member added", "success");
+    setDialogOpen(false);
+    setEditingId(null);
+    setForm({ name: "", relationship: "Wife", phone: "" });
+  }
 
-  const handleDelete = (id: string) => {
-    setMembers(members.filter((m) => m.id !== id));
+  async function handleDelete(id: string) {
+    const previous = members;
+    setMembers((m) => m.filter((x) => x.id !== id));
     setDeleteId(null);
-  };
+    const res = await deleteFamilyMember(id);
+    if (!res.success) {
+      setMembers(previous);
+      addToast(res.error.message || "Could not remove family member", "error");
+    } else {
+      addToast("Family member removed", "success");
+    }
+  }
 
   return (
     <div>
@@ -122,171 +132,149 @@ export default function FamilyMembersPage() {
         <div>
           <h1 className="text-2xl font-bold">Family Members</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Manage family members under your account. {members.length} member
-            {members.length !== 1 ? "s" : ""} added.
+            Manage family members under your account.
+            {!loading && !loadError
+              ? ` ${members.length} member${members.length !== 1 ? "s" : ""} added.`
+              : ""}
           </p>
         </div>
-        <Button onClick={() => setAddOpen(true)}>
+        <Button onClick={openAdd} disabled={loading || !!loadError}>
           <UserPlus className="h-4 w-4 mr-1" />
           Add Member
         </Button>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {members.map((member) => (
-          <Card key={member.id} className="hover:shadow-md transition-shadow">
-            <CardContent className="p-4">
-              <div className="flex items-center gap-3 mb-4">
-                <Avatar className="h-12 w-12">
-                  <AvatarFallback className="bg-primary/10 text-primary text-sm font-medium">
-                    {member.name
-                      .split(" ")
-                      .map((n) => n[0])
-                      .join("")}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-sm truncate">{member.name}</p>
-                  <span
-                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium mt-1 ${relationColors[member.relation] ?? "bg-gray-100 text-gray-700"}`}
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-muted-foreground">
+          <Loader2 className="h-5 w-5 animate-spin mr-2" />
+          Loading family members...
+        </div>
+      ) : loadError ? (
+        <Card>
+          <CardContent className="p-8 text-center text-destructive">{loadError}</CardContent>
+        </Card>
+      ) : members.length === 0 ? (
+        <Card>
+          <CardContent className="p-10 text-center text-muted-foreground">
+            <UserPlus className="h-8 w-8 mx-auto mb-3 opacity-50" />
+            <p className="text-sm">No family members yet.</p>
+            <Button variant="outline" size="sm" className="mt-4" onClick={openAdd}>
+              Add your first family member
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {members.map((member) => (
+            <Card key={member.id} className="hover:shadow-md transition-shadow">
+              <CardContent className="p-4">
+                <div className="flex items-center gap-3 mb-4">
+                  <Avatar className="h-12 w-12">
+                    <AvatarFallback className="bg-primary/10 text-primary text-sm font-medium">
+                      {member.name
+                        .split(" ")
+                        .map((n) => n[0])
+                        .join("")
+                        .slice(0, 2)
+                        .toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-sm truncate">{member.name}</p>
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium mt-1 ${relationColors[member.relationship] ?? "bg-gray-100 text-gray-700"}`}
+                    >
+                      {member.relationship}
+                    </span>
+                  </div>
+                </div>
+                <div className="space-y-2 text-sm">
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Phone className="h-3.5 w-3.5" />
+                    <span>{member.phone || "\u2014"}</span>
+                  </div>
+                </div>
+                <div className="flex gap-2 mt-4 pt-3 border-t">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="flex-1"
+                    onClick={() => openEdit(member)}
                   >
-                    {member.relation}
-                  </span>
+                    <Edit2 className="h-3.5 w-3.5 mr-1" />
+                    Edit
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => setDeleteId(member.id)}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
                 </div>
-              </div>
-              <div className="space-y-2 text-sm">
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Calendar className="h-3.5 w-3.5" />
-                  <span>Age: {member.age}</span>
-                </div>
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Phone className="h-3.5 w-3.5" />
-                  <span>{member.phone}</span>
-                </div>
-                {member.insurance && (
-                  <Badge variant="outline" className="text-xs">
-                    {member.insurance}
-                  </Badge>
-                )}
-              </div>
-              <div className="flex gap-2 mt-4 pt-3 border-t">
-                <Button variant="outline" size="sm" className="flex-1">
-                  <Edit2 className="h-3.5 w-3.5 mr-1" />
-                  Edit
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => setDeleteId(member.id)}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
 
-      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setEditingId(null);
+        }}
+      >
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Add Family Member</DialogTitle>
+            <DialogTitle>{editingId ? "Edit Family Member" : "Add Family Member"}</DialogTitle>
             <DialogDescription>
               Add a spouse, child, or other family member to your account.
             </DialogDescription>
           </DialogHeader>
-          {success ? (
-            <div className="text-center py-6">
-              <div className="h-12 w-12 rounded-full bg-green-100 dark:bg-green-900/50 flex items-center justify-center mx-auto mb-3">
-                <UserPlus className="h-6 w-6 text-green-600" />
-              </div>
-              <p className="text-sm font-medium text-green-700 dark:text-green-400">
-                Family member added successfully!
-              </p>
+          <div className="space-y-4 mt-2">
+            <div className="space-y-2">
+              <Label htmlFor="memberName">Full Name</Label>
+              <Input
+                id="memberName"
+                placeholder="First and last name"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                required
+              />
             </div>
-          ) : (
-            <div className="space-y-4 mt-2">
+            <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="memberName">Full Name</Label>
-                <Input
-                  id="memberName"
-                  placeholder="First and last name"
-                  value={newMember.name}
-                  onChange={(e) => setNewMember({ ...newMember, name: e.target.value })}
-                  required
-                />
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="memberRelation">Relationship</Label>
-                  <select
-                    id="memberRelation"
-                    className="flex h-9 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm"
-                    value={newMember.relation}
-                    onChange={(e) => setNewMember({ ...newMember, relation: e.target.value })}
-                  >
-                    <option value="Wife">Wife</option>
-                    <option value="Husband">Husband</option>
-                    <option value="Son">Son</option>
-                    <option value="Daughter">Daughter</option>
-                    <option value="Parent">Parent</option>
-                  </select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="memberAge">Age</Label>
-                  <Input
-                    id="memberAge"
-                    type="number"
-                    placeholder="Age"
-                    value={newMember.age}
-                    onChange={(e) => setNewMember({ ...newMember, age: e.target.value })}
-                  />
-                </div>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="memberGender">Gender</Label>
-                  <select
-                    id="memberGender"
-                    className="flex h-9 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm"
-                    value={newMember.gender}
-                    onChange={(e) => setNewMember({ ...newMember, gender: e.target.value })}
-                  >
-                    <option value="M">Male</option>
-                    <option value="F">Female</option>
-                  </select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="memberPhone">Phone</Label>
-                  <Input
-                    id="memberPhone"
-                    type="tel"
-                    placeholder="+212 6XX XX XX XX"
-                    value={newMember.phone}
-                    onChange={(e) => setNewMember({ ...newMember, phone: e.target.value })}
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="memberInsurance">Insurance (optional)</Label>
+                <Label htmlFor="memberRelation">Relationship</Label>
                 <select
-                  id="memberInsurance"
+                  id="memberRelation"
                   className="flex h-9 w-full rounded-lg border border-input bg-transparent px-3 py-1 text-sm"
-                  value={newMember.insurance}
-                  onChange={(e) => setNewMember({ ...newMember, insurance: e.target.value })}
+                  value={form.relationship}
+                  onChange={(e) => setForm({ ...form, relationship: e.target.value })}
                 >
-                  <option value="">No insurance</option>
-                  <option value="CNSS">CNSS</option>
-                  <option value="CNOPS">CNOPS</option>
-                  <option value="Other">Other</option>
+                  {RELATIONSHIPS.map((r) => (
+                    <option key={r} value={r}>
+                      {r}
+                    </option>
+                  ))}
                 </select>
               </div>
-              <Button className="w-full" onClick={handleAdd} disabled={saving || !newMember.name}>
-                {saving ? "Adding..." : "Add Family Member"}
-              </Button>
+              <div className="space-y-2">
+                <Label htmlFor="memberPhone">Phone (optional)</Label>
+                <Input
+                  id="memberPhone"
+                  type="tel"
+                  placeholder="+212 6XX XX XX XX"
+                  value={form.phone}
+                  onChange={(e) => setForm({ ...form, phone: e.target.value })}
+                />
+              </div>
             </div>
-          )}
+            <Button className="w-full" onClick={handleSave} disabled={saving || !form.name.trim()}>
+              {saving ? "Saving..." : editingId ? "Save Changes" : "Add Family Member"}
+            </Button>
+          </div>
         </DialogContent>
       </Dialog>
 

--- a/src/app/(patient)/patient/family/page.tsx
+++ b/src/app/(patient)/patient/family/page.tsx
@@ -85,7 +85,7 @@ export default function FamilyMembersPage() {
     }
     setSaving(true);
     const res = editingId
-      ? await updateFamilyMember(editingId, {
+      ? await updateFamilyMember(editingId, user.id, {
           name: form.name.trim(),
           relationship: form.relationship,
           phone: form.phone.trim(),
@@ -113,10 +113,14 @@ export default function FamilyMembersPage() {
   }
 
   async function handleDelete(id: string) {
+    if (!user?.id) {
+      addToast("Your account is not linked to a clinic.", "error");
+      return;
+    }
     const previous = members;
     setMembers((m) => m.filter((x) => x.id !== id));
     setDeleteId(null);
-    const res = await deleteFamilyMember(id);
+    const res = await deleteFamilyMember(id, user.id);
     if (!res.success) {
       setMembers(previous);
       addToast(res.error.message || "Could not remove family member", "error");

--- a/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/suppliers/page.tsx
@@ -1,21 +1,39 @@
 "use client";
 
 import { Plus, Phone, Mail, MapPin, Star, Clock, Truck, ShoppingCart, Package } from "lucide-react";
+import Link from "next/link";
 import { useState, useEffect } from "react";
 import { useTenant } from "@/components/tenant-provider";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { PageLoader } from "@/components/ui/page-loader";
-import { fetchSuppliers, fetchPurchaseOrders } from "@/lib/data/client";
+import { useToast } from "@/components/ui/toast";
+import { fetchSuppliers, fetchPurchaseOrders, createSupplier } from "@/lib/data/client";
 import type { SupplierView, PurchaseOrderView } from "@/lib/data/client";
+
+const EMPTY_FORM = { name: "", contactPerson: "", phone: "", email: "", city: "" };
 
 export default function SuppliersPage() {
   const tenant = useTenant();
+  const { addToast } = useToast();
   const [allSuppliers, setAllSuppliers] = useState<SupplierView[]>([]);
   const [allOrders, setAllOrders] = useState<PurchaseOrderView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -37,6 +55,32 @@ export default function SuppliersPage() {
       controller.abort();
     };
   }, [tenant?.clinicId]);
+
+  async function handleAdd() {
+    if (!form.name.trim()) return;
+    const clinicId = tenant?.clinicId ?? "";
+    if (!clinicId) {
+      addToast("No clinic context found.", "error");
+      return;
+    }
+    setSaving(true);
+    const res = await createSupplier(clinicId, {
+      name: form.name.trim(),
+      contactPerson: form.contactPerson.trim(),
+      phone: form.phone.trim(),
+      email: form.email.trim(),
+      city: form.city.trim(),
+    });
+    setSaving(false);
+    if (!res.success) {
+      addToast(res.error.message || "Could not add supplier", "error");
+      return;
+    }
+    setAllSuppliers((prev) => [res.data, ...prev]);
+    addToast("Supplier added", "success");
+    setAddOpen(false);
+    setForm(EMPTY_FORM);
+  }
 
   if (loading) {
     return <PageLoader message="Loading suppliers..." />;
@@ -62,108 +106,231 @@ export default function SuppliersPage() {
             Manage your supplier network and quick reorder
           </p>
         </div>
-        <Button className="bg-emerald-600 hover:bg-emerald-700">
+        <Button className="bg-emerald-600 hover:bg-emerald-700" onClick={() => setAddOpen(true)}>
           <Plus className="mr-2 h-4 w-4" /> Add Supplier
         </Button>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2">
-        {allSuppliers.map((supplier) => {
-          const activeOrders = allOrders.filter(
-            (o) =>
-              o.supplierId === supplier.id && o.status !== "delivered" && o.status !== "cancelled",
-          );
+      {allSuppliers.length === 0 ? (
+        <Card>
+          <CardContent className="p-12 text-center text-muted-foreground">
+            <Package className="h-10 w-10 mx-auto mb-3 opacity-50" />
+            <p className="font-medium">No suppliers yet</p>
+            <p className="text-sm mt-1">Add your first supplier to start tracking reorders.</p>
+            <Button
+              className="mt-4 bg-emerald-600 hover:bg-emerald-700"
+              onClick={() => setAddOpen(true)}
+            >
+              <Plus className="mr-2 h-4 w-4" /> Add Supplier
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2">
+          {allSuppliers.map((supplier) => {
+            const activeOrders = allOrders.filter(
+              (o) =>
+                o.supplierId === supplier.id &&
+                o.status !== "delivered" &&
+                o.status !== "cancelled",
+            );
 
-          return (
-            <Card key={supplier.id} className="hover:shadow-md transition-shadow">
-              <CardContent className="pt-6">
-                <div className="flex items-start justify-between mb-4">
-                  <div>
-                    <h3 className="font-semibold text-lg">{supplier.name}</h3>
-                    <p className="text-sm text-muted-foreground">{supplier.contactPerson}</p>
-                  </div>
-                  <Badge
-                    variant={supplier.active ? "outline" : "secondary"}
-                    className={supplier.active ? "text-emerald-600 border-emerald-600" : ""}
-                  >
-                    {supplier.active ? "Active" : "Inactive"}
-                  </Badge>
-                </div>
-
-                <div className="space-y-3 mb-4">
-                  <div className="flex items-center gap-2 text-sm">
-                    <Phone className="h-4 w-4 text-muted-foreground" />
-                    <span>{supplier.phone}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm">
-                    <Mail className="h-4 w-4 text-muted-foreground" />
-                    <span>{supplier.email}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm">
-                    <MapPin className="h-4 w-4 text-muted-foreground" />
-                    <span>
-                      {supplier.address}, {supplier.city}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap gap-2 mb-4">
-                  {supplier.categories.map((cat) => (
-                    <Badge key={cat} variant="secondary" className="text-xs capitalize">
-                      {cat}
+            return (
+              <Card key={supplier.id} className="hover:shadow-md transition-shadow">
+                <CardContent className="pt-6">
+                  <div className="flex items-start justify-between mb-4">
+                    <div>
+                      <h3 className="font-semibold text-lg">{supplier.name}</h3>
+                      <p className="text-sm text-muted-foreground">{supplier.contactPerson}</p>
+                    </div>
+                    <Badge
+                      variant={supplier.active ? "outline" : "secondary"}
+                      className={supplier.active ? "text-emerald-600 border-emerald-600" : ""}
+                    >
+                      {supplier.active ? "Active" : "Inactive"}
                     </Badge>
-                  ))}
-                </div>
+                  </div>
 
-                <div className="grid grid-cols-3 gap-3 py-3 border-t border-b mb-4">
-                  <div className="text-center">
-                    <div className="flex items-center justify-center gap-1 text-yellow-500 mb-1">
-                      <Star className="h-3 w-3 fill-current" />
-                      <span className="font-semibold text-sm">{supplier.rating}</span>
+                  <div className="space-y-3 mb-4">
+                    <div className="flex items-center gap-2 text-sm">
+                      <Phone className="h-4 w-4 text-muted-foreground" />
+                      <span>{supplier.phone || "\u2014"}</span>
                     </div>
-                    <p className="text-xs text-muted-foreground">Rating</p>
-                  </div>
-                  <div className="text-center">
-                    <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
-                      <Truck className="h-3 w-3" />
-                      <span className="font-semibold text-sm">{supplier.deliveryDays} days</span>
+                    <div className="flex items-center gap-2 text-sm">
+                      <Mail className="h-4 w-4 text-muted-foreground" />
+                      <span>{supplier.email || "\u2014"}</span>
                     </div>
-                    <p className="text-xs text-muted-foreground">Delivery</p>
-                  </div>
-                  <div className="text-center">
-                    <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
-                      <Clock className="h-3 w-3" />
-                      <span className="font-semibold text-sm">{supplier.paymentTerms}</span>
+                    <div className="flex items-center gap-2 text-sm">
+                      <MapPin className="h-4 w-4 text-muted-foreground" />
+                      <span>
+                        {[supplier.address, supplier.city].filter(Boolean).join(", ") || "\u2014"}
+                      </span>
                     </div>
-                    <p className="text-xs text-muted-foreground">Terms</p>
                   </div>
-                </div>
 
-                {activeOrders.length > 0 && (
-                  <div className="mb-4 p-2 bg-blue-50 dark:bg-blue-950/10 rounded-lg">
-                    <p className="text-xs text-blue-600 font-medium">
-                      <Package className="h-3 w-3 inline mr-1" />
-                      {activeOrders.length} active order{activeOrders.length > 1 ? "s" : ""}
-                    </p>
+                  <div className="flex flex-wrap gap-2 mb-4">
+                    {supplier.categories.map((cat) => (
+                      <Badge key={cat} variant="secondary" className="text-xs capitalize">
+                        {cat}
+                      </Badge>
+                    ))}
                   </div>
-                )}
 
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm" className="flex-1">
-                    <Phone className="mr-2 h-3 w-3" /> Call
-                  </Button>
-                  <Button variant="outline" size="sm" className="flex-1">
-                    <Mail className="mr-2 h-3 w-3" /> Email
-                  </Button>
-                  <Button size="sm" className="flex-1 bg-emerald-600 hover:bg-emerald-700">
-                    <ShoppingCart className="mr-2 h-3 w-3" /> Order
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+                  <div className="grid grid-cols-3 gap-3 py-3 border-t border-b mb-4">
+                    <div className="text-center">
+                      <div className="flex items-center justify-center gap-1 text-yellow-500 mb-1">
+                        <Star className="h-3 w-3 fill-current" />
+                        <span className="font-semibold text-sm">{supplier.rating}</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground">Rating</p>
+                    </div>
+                    <div className="text-center">
+                      <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
+                        <Truck className="h-3 w-3" />
+                        <span className="font-semibold text-sm">{supplier.deliveryDays} days</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground">Delivery</p>
+                    </div>
+                    <div className="text-center">
+                      <div className="flex items-center justify-center gap-1 text-muted-foreground mb-1">
+                        <Clock className="h-3 w-3" />
+                        <span className="font-semibold text-sm">{supplier.paymentTerms}</span>
+                      </div>
+                      <p className="text-xs text-muted-foreground">Terms</p>
+                    </div>
+                  </div>
+
+                  {activeOrders.length > 0 && (
+                    <div className="mb-4 p-2 bg-blue-50 dark:bg-blue-950/10 rounded-lg">
+                      <p className="text-xs text-blue-600 font-medium">
+                        <Package className="h-3 w-3 inline mr-1" />
+                        {activeOrders.length} active order{activeOrders.length > 1 ? "s" : ""}
+                      </p>
+                    </div>
+                  )}
+
+                  <div className="flex gap-2">
+                    {supplier.phone ? (
+                      <a
+                        href={`tel:${supplier.phone}`}
+                        className={buttonVariants({
+                          variant: "outline",
+                          size: "sm",
+                          className: "flex-1",
+                        })}
+                      >
+                        <Phone className="mr-2 h-3 w-3" /> Call
+                      </a>
+                    ) : (
+                      <Button variant="outline" size="sm" className="flex-1" disabled>
+                        <Phone className="mr-2 h-3 w-3" /> Call
+                      </Button>
+                    )}
+                    {supplier.email ? (
+                      <a
+                        href={`mailto:${supplier.email}`}
+                        className={buttonVariants({
+                          variant: "outline",
+                          size: "sm",
+                          className: "flex-1",
+                        })}
+                      >
+                        <Mail className="mr-2 h-3 w-3" /> Email
+                      </a>
+                    ) : (
+                      <Button variant="outline" size="sm" className="flex-1" disabled>
+                        <Mail className="mr-2 h-3 w-3" /> Email
+                      </Button>
+                    )}
+                    <Link
+                      href={`/pharmacist/orders?supplier=${supplier.id}`}
+                      className={buttonVariants({
+                        size: "sm",
+                        className: "flex-1 bg-emerald-600 hover:bg-emerald-700",
+                      })}
+                    >
+                      <ShoppingCart className="mr-2 h-3 w-3" /> Order
+                    </Link>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Add Supplier</DialogTitle>
+            <DialogDescription>Add a new supplier to your network.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 mt-2">
+            <div className="space-y-2">
+              <Label htmlFor="supName">Supplier Name</Label>
+              <Input
+                id="supName"
+                placeholder="e.g. Cooper Pharma"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="supContact">Contact Person</Label>
+              <Input
+                id="supContact"
+                placeholder="Full name"
+                value={form.contactPerson}
+                onChange={(e) => setForm({ ...form, contactPerson: e.target.value })}
+              />
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="supPhone">Phone</Label>
+                <Input
+                  id="supPhone"
+                  type="tel"
+                  placeholder="+212 5XX XX XX XX"
+                  value={form.phone}
+                  onChange={(e) => setForm({ ...form, phone: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="supCity">City</Label>
+                <Input
+                  id="supCity"
+                  placeholder="Casablanca"
+                  value={form.city}
+                  onChange={(e) => setForm({ ...form, city: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="supEmail">Email</Label>
+              <Input
+                id="supEmail"
+                type="email"
+                placeholder="contact@supplier.com"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+            </div>
+          </div>
+          <DialogFooter className="mt-4">
+            <Button variant="outline" onClick={() => setAddOpen(false)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-emerald-600 hover:bg-emerald-700"
+              onClick={handleAdd}
+              disabled={saving || !form.name.trim()}
+            >
+              {saving ? "Adding..." : "Add Supplier"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/app/(super-admin)/super-admin/analytics/churn/page.tsx
+++ b/src/app/(super-admin)/super-admin/analytics/churn/page.tsx
@@ -109,113 +109,6 @@ const RECOMMENDED_ACTIONS: Record<string, string[]> = {
   low: ["Continue regular engagement", "Invite to product feedback sessions"],
 };
 
-// ── Mock data generator ──────────────────────────────────────────────
-
-function seededRandom(seed: number): number {
-  const x = Math.sin(seed) * 10000;
-  return x - Math.floor(x);
-}
-
-function randomInRange(min: number, max: number, seed: number): number {
-  return Math.round(min + seededRandom(seed) * (max - min));
-}
-
-function generateMockScores(): { scores: ChurnScore[]; summary: ChurnSummary } {
-  const clinicNames = [
-    "Clinique Atlas",
-    "Cabinet Marrakech",
-    "Centre Dental Fès",
-    "Pharmacie Rabat Central",
-    "Clinique Casablanca Sud",
-    "Cabinet Tanger Nord",
-    "Centre Médical Agadir",
-    "Pharmacie Meknès",
-    "Clinique Oujda Est",
-    "Cabinet Dental Kénitra",
-    "Centre Santé Tétouan",
-    "Pharmacie Salé Ville",
-  ];
-  const types = [
-    "doctor",
-    "doctor",
-    "dentist",
-    "pharmacy",
-    "doctor",
-    "doctor",
-    "doctor",
-    "pharmacy",
-    "doctor",
-    "dentist",
-    "doctor",
-    "pharmacy",
-  ];
-  const tiers = [
-    "starter",
-    "professional",
-    "enterprise",
-    "starter",
-    "enterprise",
-    "professional",
-    "professional",
-    "starter",
-    "enterprise",
-    "professional",
-    "starter",
-    "professional",
-  ];
-
-  const factorTemplates: Array<{ factor: string; weight: number; description: string }> = [
-    { factor: "login_decline", weight: 25, description: "Declining login frequency" },
-    { factor: "missed_payments", weight: 30, description: "Missed or late payments" },
-    { factor: "support_tickets", weight: 20, description: "Unresolved support tickets" },
-    { factor: "low_feature_usage", weight: 15, description: "Low feature adoption" },
-    { factor: "appointment_decline", weight: 20, description: "Declining appointment volume" },
-    { factor: "no_recent_login", weight: 35, description: "No login in 14+ days" },
-  ];
-
-  const scores: ChurnScore[] = clinicNames.map((name, i) => {
-    const score = randomInRange(5, 95, i * 11 + 1);
-    const risk: "low" | "medium" | "high" | "critical" =
-      score >= 80 ? "critical" : score >= 60 ? "high" : score >= 30 ? "medium" : "low";
-
-    const numFactors = risk === "critical" ? 4 : risk === "high" ? 3 : risk === "medium" ? 2 : 1;
-    const factors = factorTemplates.sort(() => seededRandom(i * 3 + 7) - 0.5).slice(0, numFactors);
-
-    const appointVolume = randomInRange(10, 180, i * 11 + 2);
-    return {
-      id: `churn-${i + 1}`,
-      clinic_id: `clinic-${i + 1}`,
-      clinic_name: name,
-      clinic_type: types[i],
-      clinic_tier: tiers[i],
-      clinic_status: "active",
-      clinic_subdomain: name.toLowerCase().replace(/\s+/g, "-").replace(/[éè]/g, "e"),
-      score,
-      risk_level: risk,
-      factors,
-      login_frequency_30d: randomInRange(2, 60, i * 11 + 3),
-      appointment_volume_30d: appointVolume,
-      appointment_volume_prev_30d: appointVolume + randomInRange(-30, 30, i * 11 + 8),
-      support_tickets_30d: randomInRange(0, 12, i * 11 + 4),
-      days_since_last_login:
-        risk === "critical" ? randomInRange(14, 45, i * 11 + 5) : randomInRange(0, 10, i * 11 + 5),
-      revenue_30d: randomInRange(3000, 25000, i * 11 + 6),
-      calculated_at: new Date().toISOString(),
-    };
-  });
-
-  const summary: ChurnSummary = {
-    total: scores.length,
-    critical: scores.filter((s) => s.risk_level === "critical").length,
-    high: scores.filter((s) => s.risk_level === "high").length,
-    medium: scores.filter((s) => s.risk_level === "medium").length,
-    low: scores.filter((s) => s.risk_level === "low").length,
-    averageScore: Math.round(scores.reduce((acc, s) => acc + s.score, 0) / scores.length),
-  };
-
-  return { scores, summary };
-}
-
 // ── Score color helper ───────────────────────────────────────────────
 
 function getScoreColor(score: number): string {
@@ -258,14 +151,13 @@ export default function ChurnPredictionPage() {
       setScores(json.data.scores);
       setSummary(json.data.summary);
     } catch (err) {
-      logger.warn("Failed to load churn scores, using mock data", {
+      logger.error("Failed to load churn scores", {
         context: "churn-page",
         error: err,
       });
-      const mock = generateMockScores();
-      setScores(mock.scores);
-      setSummary(mock.summary);
-      setError(null);
+      setScores([]);
+      setSummary(null);
+      setError(err instanceof Error ? err.message : "Failed to load churn data. Please retry.");
     } finally {
       setLoading(false);
     }
@@ -283,13 +175,11 @@ export default function ChurnPredictionPage() {
       if (!json.ok) throw new Error(json.error ?? "Recalculation failed");
       await fetchScores();
     } catch (err) {
-      logger.warn("Churn recalculation failed, regenerating mock data", {
+      logger.error("Churn recalculation failed", {
         context: "churn-page",
         error: err,
       });
-      const mock = generateMockScores();
-      setScores(mock.scores);
-      setSummary(mock.summary);
+      setError(err instanceof Error ? err.message : "Recalculation failed. Please retry.");
     } finally {
       setRecalculating(false);
     }

--- a/src/app/(super-admin)/super-admin/announcements/page.tsx
+++ b/src/app/(super-admin)/super-admin/announcements/page.tsx
@@ -48,7 +48,14 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
-import { fetchAnnouncements, type Announcement } from "@/lib/super-admin-actions";
+import {
+  fetchAnnouncements,
+  createAnnouncement,
+  updateAnnouncement,
+  setAnnouncementActive,
+  deleteAnnouncement,
+  type Announcement,
+} from "@/lib/super-admin-actions";
 import { getLocalDateStr } from "@/lib/utils";
 
 type TypeFilter = "all" | "info" | "warning" | "critical";
@@ -189,68 +196,81 @@ export default function AnnouncementsPage() {
     setEditOpen(true);
   }
 
-  function handleSave() {
+  async function handleSave() {
     const targetLabels: Record<string, string> = {
       all: "All Clinics",
       basic: "Basic Plan",
       standard: "Standard Plan",
       premium: "Premium Plan",
     };
-    if (editItem) {
-      setList((prev) =>
-        prev.map((a) =>
-          a.id === editItem.id
-            ? {
-                ...a,
-                title: formTitle,
-                message: formMessage,
-                type: formType,
-                target: formTarget,
-                targetLabel: targetLabels[formTarget] || formTarget,
-                expiresAt: formExpires || undefined,
-              }
-            : a,
-        ),
-      );
-    } else {
-      const newItem: Announcement = {
-        id: `ann-${Date.now()}`,
-        title: formTitle,
-        message: formMessage,
-        type: formType,
-        target: formTarget,
-        targetLabel: targetLabels[formTarget] || formTarget,
-        publishedAt:
-          formScheduleMode === "later" && formScheduleDate ? formScheduleDate : getLocalDateStr(),
-        expiresAt: formExpires || undefined,
-        active: true,
-        createdBy: "Super Admin",
-      };
-      setList((prev) => [newItem, ...prev]);
+    if (!formTitle.trim() || !formMessage.trim()) {
+      addToast("Title and message are required", "error");
+      return;
     }
-    setEditOpen(false);
-    addToast(
-      editItem
-        ? "Announcement updated"
-        : formScheduleMode === "later"
-          ? "Announcement scheduled"
-          : "Announcement published",
-      "success",
-    );
+    const payload = {
+      title: formTitle.trim(),
+      message: formMessage.trim(),
+      type: formType,
+      target: formTarget,
+      targetLabel: targetLabels[formTarget] || formTarget,
+      expiresAt: formExpires || undefined,
+    };
+    try {
+      if (editItem) {
+        const updated = await updateAnnouncement(editItem.id, payload);
+        setList((prev) => prev.map((a) => (a.id === editItem.id ? updated : a)));
+        addToast("Announcement updated", "success");
+      } else {
+        const created = await createAnnouncement({
+          ...payload,
+          publishedAt:
+            formScheduleMode === "later" && formScheduleDate ? formScheduleDate : getLocalDateStr(),
+        });
+        setList((prev) => [created, ...prev]);
+        addToast(
+          formScheduleMode === "later" ? "Announcement scheduled" : "Announcement published",
+          "success",
+        );
+      }
+      setEditOpen(false);
+    } catch (err) {
+      logger.warn("Failed to save announcement", { context: "page", error: err });
+      addToast(err instanceof Error ? err.message : "Failed to save announcement", "error");
+    }
   }
 
-  function handleDelete() {
-    if (deleteItem) {
-      setList((prev) => prev.filter((a) => a.id !== deleteItem.id));
-      addToast("Announcement deleted", "success");
+  async function handleDelete() {
+    if (!deleteItem) {
+      setDeleteOpen(false);
+      return;
     }
+    const target = deleteItem;
+    const previous = list;
+    setList((prev) => prev.filter((a) => a.id !== target.id));
     setDeleteOpen(false);
     setDeleteItem(null);
+    try {
+      await deleteAnnouncement(target.id);
+      addToast("Announcement deleted", "success");
+    } catch (err) {
+      setList(previous);
+      logger.warn("Failed to delete announcement", { context: "page", error: err });
+      addToast(err instanceof Error ? err.message : "Failed to delete announcement", "error");
+    }
   }
 
-  function toggleActive(item: Announcement) {
-    setList((prev) => prev.map((a) => (a.id === item.id ? { ...a, active: !a.active } : a)));
-    addToast(item.active ? "Announcement archived" : "Announcement activated", "success");
+  async function toggleActive(item: Announcement) {
+    const previous = list;
+    const next = !item.active;
+    setList((prev) => prev.map((a) => (a.id === item.id ? { ...a, active: next } : a)));
+    try {
+      await setAnnouncementActive(item.id, next);
+      addToast(next ? "Announcement activated" : "Announcement archived", "success");
+    } catch (err) {
+      setList(previous);
+      logger.warn("Failed to toggle announcement", { context: "page", error: err });
+      addToast(err instanceof Error ? err.message : "Failed to update announcement", "error");
+    }
   }
 
   if (loading) {

--- a/src/lib/data/client/family.ts
+++ b/src/lib/data/client/family.ts
@@ -1,0 +1,109 @@
+"use client";
+
+/**
+ * Patient family-members data layer.
+ *
+ * Read + write helpers for the `family_members` table that a patient manages
+ * under their own account. All access is RLS-scoped: the
+ * `family_members_manage_own` policy restricts rows to
+ * `primary_user_id = get_my_user_id()` AND `clinic_id = get_user_clinic_id()`,
+ * so these run safely against the authenticated browser client.
+ */
+
+import { logger } from "@/lib/logger";
+import { createClient } from "@/lib/supabase-client";
+import type { Database } from "@/lib/types/database";
+import { fetchRows, type MutationResult } from "./_core";
+
+export interface FamilyMemberView {
+  id: string;
+  name: string;
+  relationship: string;
+  phone: string | null;
+}
+
+/** Fetch the family members linked to a patient (RLS scopes to the caller). */
+export async function fetchFamilyMembers(primaryUserId: string): Promise<FamilyMemberView[]> {
+  return fetchRows<FamilyMemberView>("family_members", {
+    select: "id, name, relationship, phone",
+    eq: [["primary_user_id", primaryUserId]],
+    order: ["created_at", { ascending: true }],
+  });
+}
+
+export async function createFamilyMember(input: {
+  primaryUserId: string;
+  clinicId: string;
+  name: string;
+  relationship: string;
+  phone?: string | null;
+}): Promise<MutationResult<FamilyMemberView>> {
+  const supabase = createClient();
+  // NOTE: the generated database types lag migration 00068, which added
+  // clinic_id (NOT NULL) to family_members. RLS (family_members_manage_own)
+  // also requires it, so we send it explicitly via getCurrentUser().clinic_id.
+  const { data, error } = await supabase
+    .from("family_members")
+    .insert({
+      primary_user_id: input.primaryUserId,
+      clinic_id: input.clinicId,
+      name: input.name,
+      relationship: input.relationship,
+      phone: input.phone || null,
+    } as Database["public"]["Tables"]["family_members"]["Insert"])
+    .select("id, name, relationship, phone")
+    .single();
+  if (error) {
+    logger.warn("Query failed", { context: "data/client", error });
+    return { success: false, error: { code: error.code, message: error.message } };
+  }
+  return {
+    success: true,
+    data: {
+      id: data.id,
+      name: data.name,
+      relationship: data.relationship,
+      phone: data.phone,
+    },
+  };
+}
+
+export async function updateFamilyMember(
+  id: string,
+  input: { name: string; relationship: string; phone?: string | null },
+): Promise<MutationResult<FamilyMemberView>> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("family_members")
+    .update({
+      name: input.name,
+      relationship: input.relationship,
+      phone: input.phone || null,
+    } as Database["public"]["Tables"]["family_members"]["Update"])
+    .eq("id", id)
+    .select("id, name, relationship, phone")
+    .single();
+  if (error) {
+    logger.warn("Query failed", { context: "data/client", error });
+    return { success: false, error: { code: error.code, message: error.message } };
+  }
+  return {
+    success: true,
+    data: {
+      id: data.id,
+      name: data.name,
+      relationship: data.relationship,
+      phone: data.phone,
+    },
+  };
+}
+
+export async function deleteFamilyMember(id: string): Promise<MutationResult<{ id: string }>> {
+  const supabase = createClient();
+  const { error } = await supabase.from("family_members").delete().eq("id", id);
+  if (error) {
+    logger.warn("Query failed", { context: "data/client", error });
+    return { success: false, error: { code: error.code, message: error.message } };
+  }
+  return { success: true, data: { id } };
+}

--- a/src/lib/data/client/family.ts
+++ b/src/lib/data/client/family.ts
@@ -70,10 +70,11 @@ export async function createFamilyMember(input: {
 
 export async function updateFamilyMember(
   id: string,
+  primaryUserId: string,
   input: { name: string; relationship: string; phone?: string | null },
 ): Promise<MutationResult<FamilyMemberView>> {
   const supabase = createClient();
-  const { data, error } = await supabase
+  const { data, error } = await supabase // nosemgrep: tenant-scoping — clinic_id not yet in generated types (migration 00068); row scoped by primary_user_id below + family_members_manage_own RLS
     .from("family_members")
     .update({
       name: input.name,
@@ -81,6 +82,7 @@ export async function updateFamilyMember(
       phone: input.phone || null,
     } as Database["public"]["Tables"]["family_members"]["Update"])
     .eq("id", id)
+    .eq("primary_user_id", primaryUserId)
     .select("id, name, relationship, phone")
     .single();
   if (error) {
@@ -98,9 +100,16 @@ export async function updateFamilyMember(
   };
 }
 
-export async function deleteFamilyMember(id: string): Promise<MutationResult<{ id: string }>> {
+export async function deleteFamilyMember(
+  id: string,
+  primaryUserId: string,
+): Promise<MutationResult<{ id: string }>> {
   const supabase = createClient();
-  const { error } = await supabase.from("family_members").delete().eq("id", id);
+  const { error } = await supabase // nosemgrep: tenant-scoping — clinic_id not yet in generated types (migration 00068); row scoped by primary_user_id below + family_members_manage_own RLS
+    .from("family_members")
+    .delete()
+    .eq("id", id)
+    .eq("primary_user_id", primaryUserId);
   if (error) {
     logger.warn("Query failed", { context: "data/client", error });
     return { success: false, error: { code: error.code, message: error.message } };

--- a/src/lib/data/client/index.ts
+++ b/src/lib/data/client/index.ts
@@ -36,3 +36,4 @@ export * from "./clinic-centers";
 export * from "./para-medical";
 export * from "./onboarding";
 export * from "./timeline";
+export * from "./family";

--- a/src/lib/data/client/pharmacy.ts
+++ b/src/lib/data/client/pharmacy.ts
@@ -1,7 +1,8 @@
 "use client";
 
+import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase-client";
-import { fetchRows, ensureLookups, _activeUserMap } from "./_core";
+import { fetchRows, ensureLookups, _activeUserMap, type MutationResult } from "./_core";
 
 // ─────────────────────────────────────────────
 // Pharmacy: Products / Stock
@@ -153,8 +154,8 @@ interface SupplierRaw {
   clinic_id: string;
   name: string;
   contact_person?: string | null;
-  contact_phone?: string | null;
-  contact_email?: string | null;
+  phone?: string | null;
+  email?: string | null;
   address?: string | null;
   city?: string | null;
   categories?: string[] | null;
@@ -172,8 +173,8 @@ export async function fetchSuppliers(clinicId: string): Promise<SupplierView[]> 
     id: r.id,
     name: r.name,
     contactPerson: r.contact_person ?? "",
-    phone: r.contact_phone ?? "",
-    email: r.contact_email ?? "",
+    phone: r.phone ?? "",
+    email: r.email ?? "",
     address: r.address ?? "",
     city: r.city ?? "",
     categories: r.categories ?? [],
@@ -182,6 +183,61 @@ export async function fetchSuppliers(clinicId: string): Promise<SupplierView[]> 
     deliveryDays: r.delivery_days ?? 0,
     active: r.is_active ?? true,
   }));
+}
+
+export async function createSupplier(
+  clinicId: string,
+  input: {
+    name: string;
+    contactPerson?: string;
+    phone?: string;
+    email?: string;
+    city?: string;
+  },
+): Promise<MutationResult<SupplierView>> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("suppliers")
+    .insert({
+      clinic_id: clinicId,
+      name: input.name,
+      contact_person: input.contactPerson || null,
+      phone: input.phone || null,
+      email: input.email || null,
+      city: input.city || null,
+      is_active: true,
+    })
+    .select(
+      "id, name, contact_person, phone, email, address, city, categories, rating, payment_terms, delivery_days, is_active",
+    )
+    .single();
+  if (error || !data) {
+    logger.warn("Query failed", { context: "data/client", error });
+    return {
+      success: false,
+      error: {
+        code: error?.code ?? "unknown",
+        message: error?.message ?? "Failed to create supplier",
+      },
+    };
+  }
+  return {
+    success: true,
+    data: {
+      id: data.id,
+      name: data.name,
+      contactPerson: data.contact_person ?? "",
+      phone: data.phone ?? "",
+      email: data.email ?? "",
+      address: data.address ?? "",
+      city: data.city ?? "",
+      categories: data.categories ?? [],
+      rating: data.rating ?? 0,
+      paymentTerms: data.payment_terms ?? "N/A",
+      deliveryDays: data.delivery_days ?? 0,
+      active: data.is_active ?? true,
+    },
+  };
 }
 
 // ─────────────────────────────────────────────

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -754,6 +754,147 @@ export async function fetchAnnouncements(): Promise<Announcement[]> {
   }));
 }
 
+type AnnouncementRow = {
+  id: string;
+  title: string | null;
+  message: string | null;
+  type: string | null;
+  target: string | null;
+  target_label: string | null;
+  published_at: string | null;
+  expires_at: string | null;
+  is_active: boolean | null;
+  created_by: string | null;
+  created_at: string | null;
+};
+
+const ANNOUNCEMENT_COLUMNS =
+  "id, title, message, type, target, target_label, published_at, expires_at, is_active, created_by, created_at";
+
+function mapAnnouncement(row: AnnouncementRow): Announcement {
+  return {
+    id: row.id,
+    title: row.title ?? "",
+    message: row.message ?? "",
+    type: (row.type ?? "info") as Announcement["type"],
+    target: row.target ?? "all",
+    targetLabel: row.target_label ?? "All Clinics",
+    publishedAt: (row.published_at ?? row.created_at ?? "").split("T")[0] ?? "",
+    expiresAt: row.expires_at ? row.expires_at.split("T")[0] : undefined,
+    active: row.is_active ?? true,
+    createdBy: row.created_by ?? "System",
+  };
+}
+
+async function logAnnouncementActivity(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  action: string,
+  description: string,
+): Promise<void> {
+  try {
+    await supabase.from("activity_logs").insert({
+      action,
+      description,
+      type: "announcement",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", { context: "super-admin-actions", error: err });
+  }
+}
+
+export interface AnnouncementInput {
+  title: string;
+  message: string;
+  type: Announcement["type"];
+  target: string;
+  targetLabel: string;
+  publishedAt?: string;
+  expiresAt?: string;
+}
+
+export async function createAnnouncement(input: AnnouncementInput): Promise<Announcement> {
+  const profile = await requireRole("super_admin");
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("announcements")
+    .insert({
+      title: input.title,
+      message: input.message,
+      type: input.type,
+      target: input.target,
+      target_label: input.targetLabel,
+      published_at: input.publishedAt || new Date().toISOString(),
+      expires_at: input.expiresAt || null,
+      is_active: true,
+      created_by: profile.name || "Super Admin",
+    })
+    .select(ANNOUNCEMENT_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to create announcement: ${error?.message ?? "unknown error"}`);
+  }
+  await logAnnouncementActivity(
+    supabase,
+    "announcement_created",
+    `Announcement "${input.title}" created`,
+  );
+  return mapAnnouncement(data as AnnouncementRow);
+}
+
+export async function updateAnnouncement(
+  id: string,
+  input: AnnouncementInput,
+): Promise<Announcement> {
+  const supabase = await rawClient();
+  const { data, error } = await supabase
+    .from("announcements")
+    .update({
+      title: input.title,
+      message: input.message,
+      type: input.type,
+      target: input.target,
+      target_label: input.targetLabel,
+      expires_at: input.expiresAt || null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .select(ANNOUNCEMENT_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to update announcement: ${error?.message ?? "unknown error"}`);
+  }
+  await logAnnouncementActivity(
+    supabase,
+    "announcement_updated",
+    `Announcement "${input.title}" updated`,
+  );
+  return mapAnnouncement(data as AnnouncementRow);
+}
+
+export async function setAnnouncementActive(id: string, active: boolean): Promise<void> {
+  const supabase = await rawClient();
+  const { error } = await supabase
+    .from("announcements")
+    .update({ is_active: active, updated_at: new Date().toISOString() })
+    .eq("id", id);
+  if (error) throw new Error(`Failed to update announcement status: ${error.message}`);
+  await logAnnouncementActivity(
+    supabase,
+    active ? "announcement_activated" : "announcement_archived",
+    `Announcement ${active ? "activated" : "archived"}`,
+  );
+}
+
+export async function deleteAnnouncement(id: string): Promise<void> {
+  const supabase = await rawClient();
+  const { error } = await supabase.from("announcements").delete().eq("id", id);
+  if (error) throw new Error(`Failed to delete announcement: ${error.message}`);
+  await logAnnouncementActivity(supabase, "announcement_deleted", `Announcement ${id} deleted`);
+}
+
 // ---------- Activity Logs ----------
 
 export interface ActivityLog {

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -792,12 +792,14 @@ async function logAnnouncementActivity(
   description: string,
 ): Promise<void> {
   try {
-    await supabase.from("activity_logs").insert({
-      action,
-      description,
-      type: "announcement",
-      timestamp: new Date().toISOString(),
-    });
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event; announcements are platform-wide (no clinic_id) so this audit row is not clinic-scoped
+      .from("activity_logs")
+      .insert({
+        action,
+        description,
+        type: "announcement",
+        timestamp: new Date().toISOString(),
+      });
   } catch (err) {
     logger.warn("Non-blocking audit log failed", { context: "super-admin-actions", error: err });
   }


### PR DESCRIPTION
## Summary

Four dashboard controls that rendered real data but didn't actually persist (or silently showed fake data) are now wired end-to-end. Scope was deliberately kept tight: each fix follows the existing read-layer / server-action patterns and the changes are independently reviewable as four commits.

> Context: a prior remediation pass already fixed most of the original "static text instead of real controls" report (admin staff/services/patients CRUD, the 5 admin empty-editable shells, clinics bulk actions, clinic-detail Impersonate/Edit, the specialist empty stubs). This PR covers the remaining genuinely-broken surfaces.

## Changes

**`fix(super-admin)` — churn analytics no longer shows fabricated data**
- `analytics/churn` swapped in `generateMockScores()` whenever `/api/admin/churn-prediction` errored, so staff could be reading invented retention numbers with no indication. Removed the mock generator (and its `seededRandom`/`randomInRange` helpers) and surfaced a real error state on both initial load and recalculation.

**`feat(patient)` — family members persist to the database**
- `patient/family` used a hardcoded `initialMembers` array + `setTimeout` fake save. Added `src/lib/data/client/family.ts` (fetch/create/update/delete) backed by the `family_members` table (RLS-scoped via `family_members_manage_own`), and rewrote the page with real fetch-on-mount, loading/empty/error states, a wired Edit action, and optimistic delete with rollback.
- Fields aligned to the actual schema (`name`, `relationship`, `phone`); the old age/gender/insurance inputs wrote to columns that don't exist and silently vanished.

**`feat(super-admin)` — announcements persist**
- Create/update/archive/delete were local React state + a toast only. Added `createAnnouncement` / `updateAnnouncement` / `setAnnouncementActive` / `deleteAnnouncement` server actions (`super_admin`-gated, best-effort `activity_logs` audit) and wired the page handlers with validation, error toasts, and optimistic rollback.

**`fix(pharmacist)` — supplier controls wired + mapper bug fixed**
- `pharmacist/suppliers` read live data but Add / Call / Email / Order were all dead, with no empty state.
- Fixed a latent bug: `fetchSuppliers` mapped `contact_phone`/`contact_email` — columns that don't exist on `suppliers` — so phone and email always rendered blank. Now reads the real `phone`/`email` columns.
- Added `createSupplier` (RLS allows clinic staff to insert when `clinic_id` matches), wired Add Supplier (dialog → optimistic prepend), Call → `tel:`, Email → `mailto:`, Order → `/pharmacist/orders`, plus an empty state. Call/Email disabled when no number/email exists.

## Verification

- `tsc --noEmit`: **0 errors**
- `eslint --max-warnings 3945` (CI gate): **pass** (3459 total, under the ratchet)
- `prettier --check`: clean on changed files
- `vitest` owner-analytics unit test: pass
- New exports all consumed (knip-safe)

## Not included (out of chosen scope)
- `patient/documents` fake upload — real fix needs the presigned-R2 PHI upload pipeline (heavier, security-sensitive).
- `analytics/compare` — still a mock clinic pool; needs a real metrics source.

🤖 Generated with assistant help; commits co-authored by oltigo-assistant.
