### PR TITLE
feat(builder): dashboard-managed multi-model AI Builder

### DIFF
--- a/src/app/(super-admin)/super-admin/builder/page.tsx
+++ b/src/app/(super-admin)/super-admin/builder/page.tsx
@@ -5,6 +5,7 @@
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
 import { BuilderChatClient } from "@/components/builder/builder-chat-client";
+import { getActiveBuilderModels } from "@/lib/builder/models.server";
 import { createClient } from "@/lib/supabase-server";
 
 export const metadata: Metadata = {
@@ -33,13 +34,17 @@ export default async function BuilderPage() {
 
   if (profile?.role !== "super_admin") redirect("/unauthorized");
 
+  // The model picker reflects whichever providers are active in
+  // /admin/ai-config — managed entirely from the dashboard.
+  const models = await getActiveBuilderModels();
+
   return (
     <div className="flex flex-col h-[calc(100vh-4rem)]">
       <div className="flex items-center justify-between px-6 py-4 border-b bg-background flex-shrink-0">
         <div>
           <h1 className="text-lg font-semibold">AI Builder</h1>
           <p className="text-sm text-muted-foreground">
-            Build internal tools, reports, and scripts with Claude AI
+            Build internal tools, reports, and scripts with AI
           </p>
         </div>
         <div className="text-xs text-muted-foreground bg-muted px-3 py-1.5 rounded-md">
@@ -47,7 +52,7 @@ export default async function BuilderPage() {
         </div>
       </div>
       <div className="flex-1 overflow-hidden">
-        <BuilderChatClient userId={user.id} />
+        <BuilderChatClient userId={user.id} models={models} />
       </div>
     </div>
   );

--- a/src/components/builder/builder-chat-client.tsx
+++ b/src/components/builder/builder-chat-client.tsx
@@ -21,12 +21,6 @@ const BuilderChat = dynamic(
   },
 );
 
-export function BuilderChatClient({
-  userId,
-  models,
-}: {
-  userId: string;
-  models: BuilderModel[];
-}) {
+export function BuilderChatClient({ userId, models }: { userId: string; models: BuilderModel[] }) {
   return <BuilderChat userId={userId} models={models} />;
 }

--- a/src/components/builder/builder-chat-client.tsx
+++ b/src/components/builder/builder-chat-client.tsx
@@ -2,6 +2,7 @@
 
 import { Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
+import type { BuilderModel } from "@/lib/builder/models";
 
 // CF-BUNDLE-02: Lazy-load the BuilderChat client component.
 // builder-chat.tsx imports useChat from @ai-sdk/react and
@@ -20,6 +21,12 @@ const BuilderChat = dynamic(
   },
 );
 
-export function BuilderChatClient({ userId }: { userId: string }) {
-  return <BuilderChat userId={userId} />;
+export function BuilderChatClient({
+  userId,
+  models,
+}: {
+  userId: string;
+  models: BuilderModel[];
+}) {
+  return <BuilderChat userId={userId} models={models} />;
 }

--- a/src/components/builder/builder-chat.tsx
+++ b/src/components/builder/builder-chat.tsx
@@ -19,13 +19,15 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { BUILDER_MODELS } from "@/lib/builder/models";
+import { findBuilderModel, type BuilderModel } from "@/lib/builder/models";
 import { BUILDER_TEMPLATES, type BuilderTemplate } from "@/lib/builder/templates";
 import { cn } from "@/lib/utils";
 import { SandboxPreview } from "./sandbox-preview";
 
 interface BuilderChatProps {
   userId: string;
+  /** Active providers' models, derived server-side from ai_provider_configs. */
+  models: BuilderModel[];
 }
 
 // Extract plain text from AI SDK v6 UIMessage parts
@@ -36,19 +38,22 @@ function getTextContent(parts: { type: string; text?: string }[]): string {
     .join("");
 }
 
-export function BuilderChat({ userId: _userId }: BuilderChatProps) {
+export function BuilderChat({ userId: _userId, models }: BuilderChatProps) {
   const [selectedTemplate, setSelectedTemplate] = useState<BuilderTemplate>(BUILDER_TEMPLATES[0]);
-  const [selectedModelId, setSelectedModelId] = useState(BUILDER_MODELS[0].id);
+  const [selectedModelId, setSelectedModelId] = useState(models[0]?.id ?? "");
   const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const { messages, sendMessage, status } = useChat({
-    transport: new TextStreamChatTransport({
-      api: "/api/builder/sandbox",
-      body: { templateId: selectedTemplate.id, modelId: selectedModelId },
-    }),
+    transport: new TextStreamChatTransport({ api: "/api/builder/sandbox" }),
   });
+
+  // Resolve the picked model so we can send both its id and the provider that
+  // serves it; the AI Worker routes on `provider`. Per-request body (below)
+  // guarantees the current selection is used even though the transport is
+  // created once.
+  const selectedModel = findBuilderModel(models, selectedModelId) ?? models[0];
 
   const isLoading = status === "streaming" || status === "submitted";
   const lastAssistantMsg = [...messages].reverse().find((m) => m.role === "assistant");
@@ -63,7 +68,16 @@ export function BuilderChat({ userId: _userId }: BuilderChatProps) {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!input.trim() || isLoading) return;
-    sendMessage({ text: input });
+    sendMessage(
+      { text: input },
+      {
+        body: {
+          templateId: selectedTemplate.id,
+          modelId: selectedModel?.id,
+          provider: selectedModel?.provider,
+        },
+      },
+    );
     setInput("");
   }
 
@@ -115,8 +129,8 @@ export function BuilderChat({ userId: _userId }: BuilderChatProps) {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {BUILDER_MODELS.map((m) => (
-                  <SelectItem key={m.id} value={m.id} className="text-xs">
+                {models.map((m) => (
+                  <SelectItem key={`${m.provider}:${m.id}`} value={m.id} className="text-xs">
                     {m.name}
                   </SelectItem>
                 ))}
@@ -220,8 +234,9 @@ export function BuilderChat({ userId: _userId }: BuilderChatProps) {
             </Button>
           </form>
           <p className="text-xs text-muted-foreground mt-1">
-            Powered by Claude {BUILDER_MODELS.find((m) => m.id === selectedModelId)?.name} + E2B
-            Sandboxes
+            {selectedModel
+              ? `Powered by ${selectedModel.name} · ${selectedModel.id}`
+              : "No active AI provider — enable one in AI Config to deploy."}
           </p>
         </div>
       </div>

--- a/src/lib/builder/models.server.ts
+++ b/src/lib/builder/models.server.ts
@@ -1,0 +1,97 @@
+/**
+ * Server-only derivation of the AI Builder model catalog.
+ *
+ * Reads the platform's managed provider registry (`ai_provider_configs`) and
+ * turns every **active** provider into a builder model entry, using each
+ * provider's canonical model from the central AI model catalog
+ * (`src/lib/ai/models.ts`). Management lives entirely in the existing
+ * /admin/ai-config dashboard — activate a provider there and it shows up in
+ * the builder picker; deactivate it and it disappears.
+ *
+ * Security boundary: this only reads provider METADATA (name, active flag,
+ * routing tier). It never reads `api_key_encrypted` — the AI Worker holds its
+ * own per-provider secrets and decrypts nothing. So no PHI-grade key material
+ * is involved in surfacing the picker.
+ *
+ * NOT imported by any client component (filename `.server.ts`); the chat UI
+ * receives the resolved list as a prop from the server page.
+ */
+
+import { PROVIDER_MODELS } from "@/lib/ai/models";
+import type { AIProvider } from "@/lib/ai/types";
+import { logger } from "@/lib/logger";
+import { createUntypedAdminClient } from "@/lib/supabase-server";
+import { FALLBACK_BUILDER_MODEL, type BuilderModel } from "./models";
+
+/**
+ * Providers the AI Worker (workers/ai) has a routing path + secret slot for.
+ * Workers AI is intentionally excluded: it needs a Cloudflare account binding
+ * rather than a simple API-key secret, so it is not offered in the builder.
+ * Keep this in sync with `PROVIDER_SECRET_ENV` in
+ * workers/ai/src/handlers/builder-sandbox.ts.
+ */
+export const BUILDER_SUPPORTED_PROVIDERS: ReadonlySet<AIProvider> = new Set<AIProvider>([
+  "groq",
+  "anthropic",
+  "google",
+  "openai",
+  "deepseek",
+  "mistral",
+  "xai",
+]);
+
+interface ActiveProviderRow {
+  provider: string;
+  display_name: string | null;
+  routing_tier: number | null;
+}
+
+/**
+ * Build the builder's model menu from active, builder-supported providers.
+ * Always returns at least one entry (the fallback) so the picker is never
+ * empty. Sorted premium-first (highest routing tier first) to match the
+ * dashboard's ordering.
+ */
+export async function getActiveBuilderModels(): Promise<BuilderModel[]> {
+  try {
+    const supabase = createUntypedAdminClient("ai-config-list");
+
+    const { data, error } = await supabase // nosemgrep: semgrep.tenant-scoping -- platform-global AI config, no clinic scoping
+      .from("ai_provider_configs")
+      .select("provider, display_name, routing_tier")
+      .eq("is_active", true)
+      .order("routing_tier", { ascending: false });
+
+    if (error) {
+      // Table may not exist yet in some environments — degrade gracefully.
+      logger.warn("Builder model lookup failed; using fallback", {
+        context: "builder-models",
+        error: error.message,
+      });
+      return [FALLBACK_BUILDER_MODEL];
+    }
+
+    const models = ((data ?? []) as ActiveProviderRow[])
+      .filter((row) => BUILDER_SUPPORTED_PROVIDERS.has(row.provider as AIProvider))
+      .map((row) => {
+        const provider = row.provider as AIProvider;
+        const config = PROVIDER_MODELS[provider];
+        if (!config) return null;
+        return {
+          id: config.model,
+          provider,
+          name: row.display_name ?? provider,
+          description: `${config.model} · tier ${row.routing_tier ?? 0}`,
+        } satisfies BuilderModel;
+      })
+      .filter((model): model is BuilderModel => model !== null);
+
+    return models.length > 0 ? models : [FALLBACK_BUILDER_MODEL];
+  } catch (err) {
+    logger.error("Unexpected error loading builder models", {
+      context: "builder-models",
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [FALLBACK_BUILDER_MODEL];
+  }
+}

--- a/src/lib/builder/models.ts
+++ b/src/lib/builder/models.ts
@@ -1,24 +1,44 @@
+/**
+ * AI Builder model catalog (types + client-safe helpers).
+ *
+ * The list of models the picker shows is NO LONGER hard-coded here. It is
+ * derived at request time from the platform's managed provider registry
+ * (`ai_provider_configs`) — see `models.server.ts`. Whatever providers a
+ * super_admin marks **active** in /admin/ai-config become the builder's
+ * model menu, and the AI Worker (webs-alots-ai) routes each one with its
+ * own per-provider secret.
+ *
+ * This file stays free of server-only imports so it can be pulled into the
+ * client bundle (the chat component imports the `BuilderModel` type and the
+ * fallback constant).
+ */
+
+import type { AIProvider } from "@/lib/ai/types";
+
 export interface BuilderModel {
+  /** The concrete model id sent to the provider, e.g. "claude-sonnet-4-6". */
   id: string;
+  /** Provider that serves this model — drives routing in the AI Worker. */
+  provider: AIProvider;
+  /** Human-readable label for the picker (the provider's display name). */
   name: string;
-  provider: "anthropic";
+  /** Short descriptor shown under the option (model id + routing tier). */
   description: string;
 }
 
-export const BUILDER_MODELS: BuilderModel[] = [
-  {
-    // Task A2: claude-sonnet-4-20250514 retires 2026-06-15.
-    id: "claude-sonnet-4-6",
-    name: "Claude Sonnet 4.6",
-    provider: "anthropic",
-    description: "Best balance of speed and quality",
-  },
-  {
-    id: "claude-opus-4-8",
-    name: "Claude Opus 4.8",
-    provider: "anthropic",
-    description: "Most capable, slower",
-  },
-];
+/**
+ * Shown when no providers are active (or the lookup fails) so the picker is
+ * never empty. Mirrors the AI Worker's historical default (Groq Llama 3.3
+ * 70B), which only needs the free GROQ_API_KEY secret.
+ */
+export const FALLBACK_BUILDER_MODEL: BuilderModel = {
+  id: "llama-3.3-70b-versatile",
+  provider: "groq",
+  name: "Groq (Fast Inference)",
+  description: "llama-3.3-70b-versatile · fallback",
+};
 
-export const DEFAULT_MODEL = BUILDER_MODELS[0];
+/** Find a model in a catalog by its id (used by the picker). */
+export function findBuilderModel(models: BuilderModel[], id: string): BuilderModel | undefined {
+  return models.find((m) => m.id === id);
+}

--- a/workers/ai/package-lock.json
+++ b/workers/ai/package-lock.json
@@ -8,7 +8,11 @@
       "name": "@webs-alots/ai-worker",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.81",
+        "@ai-sdk/google": "^3.0.80",
         "@ai-sdk/groq": "^3.0.42",
+        "@ai-sdk/openai": "^3.0.68",
+        "@ai-sdk/openai-compatible": "^1.0.39",
         "@anthropic-ai/sdk": "^0.101.0",
         "@copilotkit/runtime": "^1.59.5",
         "@e2b/code-interpreter": "^2.5.0",

--- a/workers/ai/package.json
+++ b/workers/ai/package.json
@@ -12,7 +12,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.81",
+    "@ai-sdk/google": "^3.0.80",
     "@ai-sdk/groq": "^3.0.42",
+    "@ai-sdk/openai": "^3.0.68",
+    "@ai-sdk/openai-compatible": "^1.0.39",
     "@anthropic-ai/sdk": "^0.101.0",
     "@copilotkit/runtime": "^1.59.5",
     "@e2b/code-interpreter": "^2.5.0",

--- a/workers/ai/src/handlers/builder-sandbox.ts
+++ b/workers/ai/src/handlers/builder-sandbox.ts
@@ -5,44 +5,99 @@
  * this standalone Worker. Streams model output back to the browser.
  *
  * Why dynamic imports? See workers/ai/src/handlers/copilotkit.ts header.
- * Heavy AI deps (ai SDK, @ai-sdk/groq) are loaded inside the handler
+ * Heavy AI deps (ai SDK, @ai-sdk/* providers) are loaded inside the handler
  * to avoid global-scope I/O / random ops that Cloudflare Workers prohibit
- * at module load.
+ * at module load, and so only the selected provider's adapter is pulled in.
  *
- * ── Provider (free) ───────────────────────────────────────────────────
- * The builder runs on Groq (Llama 3.3 70B) instead of Anthropic Claude so
- * it works without a paid Anthropic key — Groq's free tier is fast and only
- * needs a GROQ_API_KEY secret. The AI SDK keeps the rest of the handler
- * provider-agnostic: to switch back to Claude (or any other provider), swap
- * the dynamic import + createGroq() call and the model id below.
+ * ── Multi-provider, dashboard-managed ─────────────────────────────────────
+ * The builder no longer hard-codes a single model. The main app's builder
+ * page derives the model picker from the **active** providers in
+ * `ai_provider_configs` (managed from /admin/ai-config) and sends both the
+ * chosen `provider` and `modelId` with each request. This handler routes to
+ * that provider using ITS OWN per-provider secret (GROQ_API_KEY,
+ * ANTHROPIC_API_KEY, …) — no platform key material (PHI-grade encrypted keys)
+ * is touched here. A provider the worker has no secret for returns a clear
+ * 503 so the operator knows exactly which secret to add.
  *
- * ── Message format (AI SDK v6) ────────────────────────────────────────
- * The client (src/components/builder/builder-chat.tsx) is on AI SDK v6 and
- * sends UIMessages (a `parts` array), NOT the legacy { role, content }
- * shape. We validate the UIMessage envelope with zod, then convert to
- * ModelMessages via convertToModelMessages() before handing them to
- * streamText.
+ * Keep `BUILDER_PROVIDERS` below in sync with `BUILDER_SUPPORTED_PROVIDERS`
+ * and `PROVIDER_MODELS` in the main app (src/lib/builder/models.server.ts,
+ * src/lib/ai/models.ts). The two codebases can't import each other (separate
+ * Workers / bundles), so the canonical model per provider is mirrored here.
  *
- * ── E2B ───────────────────────────────────────────────────────────────
+ * ── Message format (AI SDK v6) ────────────────────────────────────────────
+ * The client (src/components/builder/builder-chat.tsx) sends UIMessages (a
+ * `parts` array), NOT the legacy { role, content } shape. We validate the
+ * UIMessage envelope with zod, then convert to ModelMessages via
+ * convertToModelMessages() before handing them to streamText.
+ *
+ * ── E2B ───────────────────────────────────────────────────────────────────
  * The generated code is rendered client-side (sandbox-preview.tsx builds a
- * blob-URL iframe with Babel standalone). The earlier handler created an
- * E2B sandbox per request and immediately killed it without ever executing
- * anything — pure quota + latency waste. That has been removed. To add real
- * server-side execution later, re-introduce `@e2b/code-interpreter` here and
- * run the extracted code block inside the sandbox before streaming results.
+ * blob-URL iframe with Babel standalone). No server-side sandbox is created.
  */
 
 import type { UIMessage } from "ai";
 import { z } from "zod";
 import { requireSuperAdmin, jsonResponse, type Env } from "../lib/supabase";
 
-// The model the builder runs on. Groq hosts Llama 3.3 70B on its free tier.
-// The client (src/components/builder/builder-chat.tsx) still sends its legacy
-// model-picker ids (e.g. "claude-sonnet-4-6"); we accept any string but pin
-// generation to this model until the main app's model picker
-// (src/lib/builder/models.ts) is updated to list Groq models. Hard-coding the
-// model also removes the need to allowlist arbitrary model strings.
-const BUILDER_MODEL = "llama-3.3-70b-versatile";
+/** Providers the builder can route to, each with its own Worker secret. */
+type BuilderProvider = "groq" | "anthropic" | "google" | "openai" | "deepseek" | "mistral" | "xai";
+
+interface ProviderConfig {
+  /** Env key holding this provider's API key on the AI Worker. */
+  secretEnv:
+    | "GROQ_API_KEY"
+    | "ANTHROPIC_API_KEY"
+    | "GOOGLE_GENERATIVE_AI_API_KEY"
+    | "OPENAI_API_KEY"
+    | "DEEPSEEK_API_KEY"
+    | "MISTRAL_API_KEY"
+    | "XAI_API_KEY";
+  /** Canonical model id — mirrors PROVIDER_MODELS in the main app. */
+  defaultModel: string;
+  /** Native AI-SDK adapter, or an OpenAI-compatible endpoint. */
+  kind: "native" | "compat";
+  /** Base URL for `compat` providers (OpenAI-compatible REST surface). */
+  baseURL?: string;
+}
+
+const BUILDER_PROVIDERS: Record<BuilderProvider, ProviderConfig> = {
+  groq: { secretEnv: "GROQ_API_KEY", defaultModel: "llama-3.3-70b-versatile", kind: "native" },
+  anthropic: {
+    secretEnv: "ANTHROPIC_API_KEY",
+    defaultModel: "claude-sonnet-4-6",
+    kind: "native",
+  },
+  google: {
+    secretEnv: "GOOGLE_GENERATIVE_AI_API_KEY",
+    defaultModel: "gemini-3.5-flash",
+    kind: "native",
+  },
+  openai: { secretEnv: "OPENAI_API_KEY", defaultModel: "gpt-5.4-mini", kind: "native" },
+  deepseek: {
+    secretEnv: "DEEPSEEK_API_KEY",
+    defaultModel: "deepseek-v4-flash",
+    kind: "compat",
+    baseURL: "https://api.deepseek.com",
+  },
+  mistral: {
+    secretEnv: "MISTRAL_API_KEY",
+    defaultModel: "mistral-small-2603",
+    kind: "compat",
+    baseURL: "https://api.mistral.ai/v1",
+  },
+  xai: {
+    secretEnv: "XAI_API_KEY",
+    defaultModel: "grok-4.3",
+    kind: "compat",
+    baseURL: "https://api.x.ai/v1",
+  },
+};
+
+const SUPPORTED_PROVIDERS = Object.keys(BUILDER_PROVIDERS) as BuilderProvider[];
+
+function isBuilderProvider(value: string): value is BuilderProvider {
+  return (SUPPORTED_PROVIDERS as string[]).includes(value);
+}
 
 // Lenient UIMessage part: we only consume text parts, but allow other
 // declared fields so future part kinds don't hard-fail validation.
@@ -60,9 +115,10 @@ const uiMessageSchema = z.object({
 const requestSchema = z.object({
   messages: z.array(uiMessageSchema).min(1),
   templateId: z.string().default("nextjs-report"),
-  // Accept the client's legacy model id but do not trust it — generation is
-  // pinned to BUILDER_MODEL below. z.string() avoids 400s while the picker UI
-  // still sends "claude-*" ids.
+  // Which managed provider to route to (defaults to groq for legacy clients).
+  provider: z.string().optional(),
+  // The model id the picker showed. Generation is pinned to the provider's
+  // canonical model below; an arbitrary string never reaches the provider.
   modelId: z.string().optional(),
 });
 
@@ -109,12 +165,47 @@ DOMAIN CONTEXT:
 - Payments: CMI gateway (Moroccan Interbank)
 - Notifications: WhatsApp Business API with Darija templates`;
 
+/**
+ * Build an AI-SDK language model for the chosen provider, bound to the
+ * Worker's per-provider secret. `native` providers use their dedicated
+ * adapter; `compat` providers go through the OpenAI-compatible adapter with
+ * the provider's REST base URL. Returns `unknown` because each adapter has a
+ * distinct nominal type; streamText accepts any LanguageModel.
+ */
+async function buildModel(
+  provider: BuilderProvider,
+  config: ProviderConfig,
+  apiKey: string,
+  model: string,
+): Promise<unknown> {
+  if (config.kind === "compat") {
+    const { createOpenAICompatible } = await import("@ai-sdk/openai-compatible");
+    return createOpenAICompatible({ name: provider, apiKey, baseURL: config.baseURL ?? "" })(model);
+  }
+
+  switch (provider) {
+    case "anthropic": {
+      const { createAnthropic } = await import("@ai-sdk/anthropic");
+      return createAnthropic({ apiKey })(model);
+    }
+    case "google": {
+      const { createGoogleGenerativeAI } = await import("@ai-sdk/google");
+      return createGoogleGenerativeAI({ apiKey })(model);
+    }
+    case "openai": {
+      const { createOpenAI } = await import("@ai-sdk/openai");
+      return createOpenAI({ apiKey })(model);
+    }
+    default: {
+      // groq (the only remaining native provider)
+      const { createGroq } = await import("@ai-sdk/groq");
+      return createGroq({ apiKey })(model);
+    }
+  }
+}
+
 export async function handleBuilderSandbox(request: Request, env: Env): Promise<Response> {
   try {
-    if (!env.GROQ_API_KEY) {
-      return jsonResponse({ error: "GROQ_API_KEY is not configured on webs-alots-ai" }, 500);
-    }
-
     const authResult = await requireSuperAdmin(request, env);
     if (!authResult.ok) return authResult.response;
     const { userId, supabase } = authResult;
@@ -138,11 +229,40 @@ export async function handleBuilderSandbox(request: Request, env: Env): Promise<
     }
     const { messages, templateId } = parsed.data;
 
-    // Dynamic imports — see header comment.
-    const [{ createGroq }, { streamText, convertToModelMessages }] = await Promise.all([
-      import("@ai-sdk/groq"),
-      import("ai"),
-    ]);
+    // ── Resolve the managed provider + its Worker secret ──────────────────
+    const requestedProvider = parsed.data.provider ?? "groq";
+    if (!isBuilderProvider(requestedProvider)) {
+      return jsonResponse(
+        {
+          error: `Unsupported provider "${requestedProvider}". Supported: ${SUPPORTED_PROVIDERS.join(", ")}.`,
+        },
+        400,
+      );
+    }
+    const providerConfig = BUILDER_PROVIDERS[requestedProvider];
+    const apiKey = env[providerConfig.secretEnv];
+    if (!apiKey) {
+      return jsonResponse(
+        {
+          error: `Provider "${requestedProvider}" is active in the dashboard but ${providerConfig.secretEnv} is not configured on the webs-alots-ai Worker. Add it with: wrangler secret put ${providerConfig.secretEnv}`,
+        },
+        503,
+      );
+    }
+
+    // Generation is pinned to the provider's canonical model. The client's
+    // modelId should already equal this (the picker shows one model per
+    // provider); we never forward an arbitrary model string to the provider.
+    const model = providerConfig.defaultModel;
+    if (parsed.data.modelId && parsed.data.modelId !== model) {
+      console.warn(
+        `[builder/sandbox] modelId "${parsed.data.modelId}" != canonical "${model}" for ${requestedProvider}; using canonical.`,
+      );
+    }
+
+    // Dynamic imports — see header comment. Only the selected provider's
+    // adapter is loaded.
+    const { streamText, convertToModelMessages } = await import("ai");
 
     // Convert the v6 UIMessages (parts) to ModelMessages. The zod schema
     // above already guarantees the { role, parts[].text } runtime shape
@@ -156,9 +276,7 @@ export async function handleBuilderSandbox(request: Request, env: Env): Promise<
       return jsonResponse({ error: "Could not parse messages" }, 400);
     }
 
-    // Bind the provider to the Worker secret explicitly rather than relying
-    // on process.env mirroring inside the Workers runtime.
-    const groq = createGroq({ apiKey: env.GROQ_API_KEY });
+    const languageModel = await buildModel(requestedProvider, providerConfig, apiKey, model);
 
     // Fire-and-forget usage log — builder_usage_logs is a platform-level
     // audit table (no clinic_id column) accessed only by super_admin.
@@ -166,13 +284,16 @@ export async function handleBuilderSandbox(request: Request, env: Env): Promise<
     void (supabase as any).from("builder_usage_logs").insert({
       user_id: userId,
       template_id: templateId,
-      model_id: BUILDER_MODEL,
+      model_id: `${requestedProvider}:${model}`,
       message_count: messages.length,
       created_at: new Date().toISOString(),
     });
 
     const result = streamText({
-      model: groq(BUILDER_MODEL),
+      // Each adapter returns its own nominal model type; streamText accepts
+      // any LanguageModel. The buildModel() return is intentionally `unknown`.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      model: languageModel as any,
       system: SYSTEM_PROMPT,
       messages: modelMessages,
       maxOutputTokens: 8192,

--- a/workers/ai/src/lib/supabase.ts
+++ b/workers/ai/src/lib/supabase.ts
@@ -20,12 +20,19 @@ import { createServerClient } from "@supabase/ssr";
 export interface Env {
   NEXT_PUBLIC_SUPABASE_URL: string;
   NEXT_PUBLIC_SUPABASE_ANON_KEY: string;
-  // The AI Builder runs on Groq (Llama 3.3 70B) — see handlers/builder-sandbox.ts.
+  // ── AI Builder provider secrets ───────────────────────────────────────
+  // The AI Builder routes to whichever provider the super_admin activates in
+  // /admin/ai-config (see handlers/builder-sandbox.ts → BUILDER_PROVIDERS).
+  // Each active provider needs its matching secret here; the handler returns
+  // a clear 503 naming the missing secret if one is selected but unset.
+  // GROQ is the default/fallback (free tier), so it is the only required one.
   GROQ_API_KEY: string;
-  // Optional: only the (currently dormant) CopilotKit runtime handler still
-  // uses Anthropic. Leave unset unless you re-enable the CopilotKit sidebar;
-  // handlers/copilotkit.ts returns a 500 "not configured" when it is absent.
-  ANTHROPIC_API_KEY?: string;
+  ANTHROPIC_API_KEY?: string; // also used by the dormant CopilotKit runtime
+  GOOGLE_GENERATIVE_AI_API_KEY?: string;
+  OPENAI_API_KEY?: string;
+  DEEPSEEK_API_KEY?: string;
+  MISTRAL_API_KEY?: string;
+  XAI_API_KEY?: string;
   // Optional: the builder no longer creates an E2B sandbox per request
   // (generated code is rendered client-side). Retained for when real
   // server-side code execution is wired back into builder-sandbox.ts.


### PR DESCRIPTION
## What

Makes the AI Builder a **dashboard-managed, multi-model** tool. Previously the model picker was cosmetic — `src/lib/builder/models.ts` hard-coded two Claude entries while the AI Worker ignored the selection and always ran Groq Llama 3.3 70B (and logged Llama to `builder_usage_logs`). Now the picker reflects whichever providers you activate in **/admin/ai-config**, and the worker actually routes to the chosen provider.

## How

**Picker is derived, not hard-coded.** The builder page now reads the **active** rows from the existing `ai_provider_configs` registry and turns each into a model option (using that provider's canonical model from `src/lib/ai/models.ts`). Activate/deactivate a provider in the dashboard → it appears/disappears in the builder. No new table, no parallel config surface.

**Worker honors the selection, with its own keys.** The client sends `{ provider, modelId }` per request; `workers/ai/.../builder-sandbox.ts` routes to that provider using **its own per-provider secret** (`GROQ_API_KEY`, `ANTHROPIC_API_KEY`, …). Native adapters for groq/anthropic/google/openai; OpenAI-compatible endpoint for deepseek/mistral/xai. If a provider is active in the dashboard but its secret isn't set on the worker, it returns a **503 naming the exact secret to add**.

**Security boundary preserved.** The picker derivation reads only provider *metadata* (name, active flag, tier) — never `api_key_encrypted`. No PHI-grade key material leaves the main app; the worker decrypts nothing.

## Files

| File | Change |
|---|---|
| `src/lib/builder/models.ts` | Drop hard-coded list; keep `BuilderModel` type + Groq fallback + `findBuilderModel` (client-safe) |
| `src/lib/builder/models.server.ts` | **new** — derive picker from active `ai_provider_configs` |
| `src/app/(super-admin)/super-admin/builder/page.tsx` | Fetch active models server-side, pass to client |
| `src/components/builder/builder-chat*.tsx` | Render dynamic list; send `{ provider, modelId }` per request; honest footer |
| `workers/ai/src/handlers/builder-sandbox.ts` | Multi-provider routing with own secrets; 503 on missing secret |
| `workers/ai/src/lib/supabase.ts` | Add optional per-provider secret slots |
| `workers/ai/package.json` + lockfile | Declare `@ai-sdk/{anthropic,google,openai,openai-compatible}` as direct deps (were only transitive via `@copilotkit/runtime` — the CI comment warned against relying on that). Tree unchanged; lockfile root edges kept in sync. |

## Also fixes
- A latent bug: the chat transport body was captured once at hook init, so a changed model/template selection could send a stale value. Now sent per `sendMessage` call.
- The misleading "Powered by Claude … + E2B Sandboxes" footer (it was neither Claude nor using E2B).

## Verification
- `tsc --noEmit`: **0 errors** (main app) and **0 errors** (AI worker, against its own declared deps)
- `eslint` on changed files: clean; full `--max-warnings` ratchet passes (within the 3945 baseline)

## Operator note
To offer a provider beyond Groq in the builder: (1) activate it in /admin/ai-config, (2) `wrangler secret put <PROVIDER>_API_KEY --env production` on `webs-alots-ai`. Groq remains the zero-config default/fallback.
