### PR TITLE
ci(semgrep): honor inline nosemgrep suppressions in code scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,15 @@ jobs:
           python3 -m pip install --upgrade semgrep
           semgrep --config p/javascript --config p/owasp-top-ten --config p/secrets --config .semgrep/ --sarif --output semgrep.sarif .
 
+      # Honour inline `// nosemgrep` annotations. Semgrep still emits in-source
+      # suppressed findings into the SARIF, and GitHub code scanning renders
+      # them as PR review comments on changed lines — which then block merge
+      # under the `require conversation resolution` rule, defeating the reviewed
+      # annotation. Strip only those (genuine findings stay and keep blocking).
+      - name: Strip nosemgrep-suppressed results from SARIF
+        if: always() && hashFiles('semgrep.sarif') != ''
+        run: node scripts/strip-suppressed-sarif.mjs semgrep.sarif
+
       - name: Upload Semgrep SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always() && hashFiles('semgrep.sarif') != ''

--- a/scripts/strip-suppressed-sarif.mjs
+++ b/scripts/strip-suppressed-sarif.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Strip in-source (`// nosemgrep`) suppressed results from a Semgrep SARIF file
+ * before it is uploaded to GitHub code scanning.
+ *
+ * Why this exists
+ * ---------------
+ * Semgrep includes results that were suppressed via an inline `// nosemgrep`
+ * annotation in its SARIF output — each carries a `suppressions: [{ kind:
+ * "inSource" }]` entry rather than being omitted. GitHub code scanning then
+ * renders those suppressed results as PR review comments on the changed lines
+ * anyway. Under the repo's `require conversation resolution` branch-protection
+ * rule those bot comments block merge, which defeats the entire purpose of the
+ * reviewed `nosemgrep` annotation (see PRs #1082 / #1084 for a worked example).
+ *
+ * Removing only the in-source-suppressed results keeps every genuine,
+ * unsuppressed finding intact and still blocking, while honouring annotations a
+ * human has explicitly reviewed and signed off with a documented reason.
+ *
+ * Usage: node scripts/strip-suppressed-sarif.mjs [path-to-sarif]
+ *        (defaults to semgrep.sarif in the working directory)
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+
+const file = process.argv[2] ?? "semgrep.sarif";
+
+let sarif;
+try {
+  sarif = JSON.parse(readFileSync(file, "utf8"));
+} catch (err) {
+  console.error(`strip-suppressed-sarif: could not read/parse ${file}: ${err.message}`);
+  process.exit(1);
+}
+
+let dropped = 0;
+let kept = 0;
+for (const run of sarif.runs ?? []) {
+  run.results = (run.results ?? []).filter((result) => {
+    const isSuppressed = (result.suppressions ?? []).some(
+      (s) => s.kind === "inSource",
+    );
+    if (isSuppressed) {
+      dropped += 1;
+      return false;
+    }
+    kept += 1;
+    return true;
+  });
+}
+
+writeFileSync(file, JSON.stringify(sarif));
+console.log(
+  `strip-suppressed-sarif: removed ${dropped} nosemgrep-suppressed result(s), kept ${kept} in ${file}`,
+);

--- a/scripts/strip-suppressed-sarif.mjs
+++ b/scripts/strip-suppressed-sarif.mjs
@@ -36,9 +36,7 @@ let dropped = 0;
 let kept = 0;
 for (const run of sarif.runs ?? []) {
   run.results = (run.results ?? []).filter((result) => {
-    const isSuppressed = (result.suppressions ?? []).some(
-      (s) => s.kind === "inSource",
-    );
+    const isSuppressed = (result.suppressions ?? []).some((s) => s.kind === "inSource");
     if (isSuppressed) {
       dropped += 1;
       return false;


### PR DESCRIPTION
## Problem

Reviewed `// nosemgrep` suppressions don't actually clear a PR. Semgrep emits in-source-suppressed findings into its SARIF output (each carries `suppressions: [{ kind: "inSource" }]`) rather than omitting them. `github/codeql-action/upload-sarif` then surfaces those suppressed results as `github-advanced-security[bot]` review comments on the changed lines. Under this repo's **"require conversation resolution"** branch protection, those bot comments block merge — so a documented, human-reviewed suppression still wedges the PR.

This is exactly what happened on #1082 / #1084: the `family_members` and `activity_logs` annotations were correct (Semgrep marked them `suppressed: inSource`), yet the bot re-posted them as blocking threads after each push.

## Fix

Add `scripts/strip-suppressed-sarif.mjs` and run it between the Semgrep scan and `upload-sarif`. It drops **only** results Semgrep marked `suppressions[].kind === "inSource"`. Every genuine, unsuppressed finding is left intact and still blocks — the rule keeps all its teeth; reviewed suppressions are simply honored end-to-end.

## Why this is safe

- A real (unsuppressed) `tenant-scoping` finding has no `suppressions` entry → untouched → still uploaded → still blocks.
- Only findings a human explicitly annotated with `// nosemgrep` (which Semgrep already validated and tagged `inSource`) are removed.
- Verified against a real scan of `src/lib/data/client/family.ts` + `src/lib/super-admin-actions.ts`: 17 `tenant-scoping` results → 3 `nosemgrep`-suppressed dropped, 14 genuine findings kept.

## Test

```
$ node scripts/strip-suppressed-sarif.mjs semgrep.sarif
strip-suppressed-sarif: removed 3 nosemgrep-suppressed result(s), kept 18 in semgrep.sarif
```