### PR TITLE
fix: resolve Semgrep code-scanning findings from PR #1086

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -44,8 +44,9 @@ rules:
           # Negative lookahead: match any quoted table name that is NOT one
           # of the genuinely non-clinic-keyed tables.
           #
-          # Schema audit (supabase/migrations/) shows the following tables
-          # are the only ones with NO clinic_id column:
+          # Schema audit (supabase/migrations/) shows these tables have NO
+          # clinic_id column, so the rule exempts them directly (other
+          # non-clinic-keyed tables are handled via inline `nosemgrep`):
           #   - `clinics`            — the tenant table itself; querying it
           #                             directly is the service-level pattern.
           #   - `ai_provider_configs`— global provider config; no clinic_id.
@@ -55,6 +56,11 @@ rules:
           #                             00005_schema_gaps.sql). Targeting is done
           #                             via the `target`/`target_label` columns,
           #                             not tenant ownership.
+          #   - `demo_leads`         — public landing-page demo requests
+          #                             (migration 00191). The submitter is not
+          #                             yet a tenant, so the table has NO
+          #                             clinic_id column; RLS restricts reads to
+          #                             super_admin. Cross-tenant by design.
           #
           # All other queue / processed-events tables (notification_queue,
           # processed_stripe_events, processed_whatsapp_messages,
@@ -69,7 +75,7 @@ rules:
           # annotated rather than whitelisted, so a future bare
           # .from("users").select("*") still triggers a warning.
           regex: |-
-            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements)["']).*$
+            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads)["']).*$
       # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
       # makes this query tenant-scoped. Semgrep normalises JS string quotes,
       # but both variants are kept for belt-and-suspenders parity with the

--- a/src/app/api/admin/clinic-comparison/route.ts
+++ b/src/app/api/admin/clinic-comparison/route.ts
@@ -44,6 +44,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 async function handleGet(_request: NextRequest, _auth: AuthContext) {
   try {
+    // Deliberate cross-tenant super_admin read: this route is gated to
+    // super_admin (ALLOWED_ROLES) and aggregates metrics across all clinics.
+    // The per-table reads below are annotated for the same reason.
+    // nosemgrep: admin-client-guard
     const admin = createAdminClient("super_admin");
 
     const now = Date.now();

--- a/src/app/api/patient/documents/route.ts
+++ b/src/app/api/patient/documents/route.ts
@@ -103,6 +103,11 @@ async function insertDocument(
     metadata: Record<string, unknown>;
   },
 ): Promise<PatientFileRow | null> {
+  // `row` carries clinic_id (see the typed parameter above) and patient_files
+  // is clinic-keyed; every read path filters .eq("clinic_id", ...). The insert
+  // passes a variable, not an inline { clinic_id, ... } literal, so the
+  // tenant-scoping matcher can't see the key, so suppress that false positive.
+  // nosemgrep: tenant-scoping
   const { data, error } = await supabase
     .from("patient_files")
     .insert(row)


### PR DESCRIPTION
Resolves the three GitHub Advanced Security (Semgrep) findings raised on #1086. They were non-blocking review comments, so #1086 merged with them still present on `main`; this is the follow-up that clears them. Each fix applies the resolution prescribed by the rule's own message.

### Findings & fixes

| # | File | Rule | Resolution |
|---|------|------|-----------|
| 1 | `src/app/api/admin/clinic-comparison/route.ts` | `admin-client-guard` | `// nosemgrep: admin-client-guard` |
| 2 | `src/app/api/leads/route.ts` (`demo_leads`) | `tenant-scoping` | whitelist `demo_leads` in `.semgrep/tenant-scoping.yml` |
| 3 | `src/app/api/patient/documents/route.ts` (`patient_files`) | `tenant-scoping` | `// nosemgrep: tenant-scoping` on the insert |

**1. clinic-comparison — intentional cross-tenant read.** The `createAdminClient("super_admin")` call powers a super-admin aggregation across all clinics. The route is gated to `super_admin` and the per-table reads below it are already annotated; this annotates the client construction itself, exactly as the rule message instructs for deliberate cross-tenant access.

**2. demo_leads — table has no `clinic_id`.** Public landing-page demo requests (migration `00191`) come from prospects who are not yet tenants, so the table has no `clinic_id` column and is readable only by `super_admin` via RLS. It joins the existing service-table exemptions (`clinics`, `ai_provider_configs`, `ai_task_configs`, `announcements`). The route was already on the `check-tenant-scoping.mjs` allowlist; this adds the matching Semgrep exemption.

**3. patient_files — matcher false positive.** This table *is* clinic-keyed and every read path filters `.eq("clinic_id", ...)`. The insert fires only because it passes a typed `row` variable (which carries `clinic_id`) instead of an inline `{ clinic_id, ... }` literal — the form the rule already exempts. Same pattern as the existing `ai_memories.insert(rows)` suppression, so it's annotated inline rather than whitelisted (a future bare `.from("patient_files")` should still trigger).

### Verification

Ran Semgrep 1.167 (the engine GHAS uses) against the repo's own `.semgrep/` ruleset on the three files: **3 findings → 0**, no new findings introduced. `prettier --check` clean. Change is 18 lines across 3 files (comments + one regex token).
