### PR TITLE
security: harden service-role bypass call sites (3 fixes)

### DIFF
--- a/src/app/api/admin/ai-config/route.ts
+++ b/src/app/api/admin/ai-config/route.ts
@@ -1,18 +1,25 @@
 /**
  * Admin AI Configuration API
  *
- * GET  — list all provider configs, feature toggles, and usage stats
+ * GET  — list provider configs, feature toggles, and usage stats
  * PATCH — update a provider config (API key, active state, budget)
  * POST — update feature toggles
  *
- * GET is readable by super_admin and clinic_admin (the clinic admin AI pages
- * at /admin/ai-config and /admin/ai-routing render status, spend, and budget
- * data from it). Writes (PATCH/POST) stay super_admin only because provider
- * configs and feature toggles are platform-global, not per-clinic.
+ * GET is readable by super_admin and clinic_admin, but the response is
+ * role-scoped to prevent clinic admins from seeing platform financials:
+ *
+ *   super_admin  — full provider configs (budgets, usage, operational
+ *                  metadata, has_api_key) + feature toggles + usage aggregates.
+ *   clinic_admin — minimal provider listing (id, display_name, is_active,
+ *                  routing_tier only; no budgets, costs, or key metadata) +
+ *                  feature toggles. usage is always {}.
+ *
+ * Writes (PATCH/POST) stay super_admin only because provider configs and
+ * feature toggles are platform-global, not per-clinic.
  *
  * API keys are encrypted with AES-256-GCM (PHI_ENCRYPTION_KEY)
  * before insert/update via `encryptProviderKey`. Keys are never returned in
- * the GET response — only a `has_api_key` boolean.
+ * the GET response — only a `has_api_key` boolean (super_admin only).
  *
  * Any write invalidates the in-memory config cache so the next /api/ai call
  * picks up the new state immediately on the same instance.
@@ -27,30 +34,13 @@ import { createUntypedAdminClient } from "@/lib/supabase-server";
 import { withAuth } from "@/lib/with-auth";
 import type { AuthContext } from "@/lib/with-auth";
 
-// ── GET: List all AI configs ──
+// ── GET: List AI configs (role-scoped) ──
 
-async function handleGet(_req: NextRequest, _auth: AuthContext) {
+async function handleGet(_req: NextRequest, auth: AuthContext) {
   const supabase = createUntypedAdminClient("ai-config-list");
+  const isClinicAdmin = auth.profile.role === "clinic_admin";
 
-  const { data: providers, error: provErr } = await supabase // nosemgrep: semgrep.tenant-scoping
-    .from("ai_provider_configs")
-    .select(
-      "id, provider, display_name, api_key_encrypted, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, input_tokens_this_month, output_tokens_this_month, cost_this_month_cents, rate_limited_until, last_error, last_used_at, created_at, updated_at",
-    )
-    .order("routing_tier", { ascending: false });
-
-  if (provErr) {
-    // Table may not exist yet if migration hasn't run
-    if (provErr.code === "42P01" || provErr.message?.includes("does not exist")) {
-      return apiSuccess({ providers: [], toggles: [], usage: {} });
-    }
-    logger.error("Failed to fetch AI provider configs", {
-      context: "ai-config",
-      error: provErr.message,
-    });
-    return apiError("Failed to fetch AI configurations", 500);
-  }
-
+  // ── Feature toggles — returned to both roles ──
   const { data: toggles, error: toggleErr } = await supabase // nosemgrep: semgrep.tenant-scoping
     .from("ai_feature_toggles")
     .select("id, feature_key, display_name, description, is_enabled, min_tier")
@@ -62,6 +52,47 @@ async function handleGet(_req: NextRequest, _auth: AuthContext) {
       error: toggleErr.message,
     });
     return apiError("Failed to fetch feature toggles", 500);
+  }
+
+  // ── clinic_admin: minimal provider listing, no platform financials ──
+  if (isClinicAdmin) {
+    const { data: providers, error: provErr } = await supabase // nosemgrep: semgrep.tenant-scoping
+      .from("ai_provider_configs")
+      .select("id, provider, display_name, is_active, routing_tier")
+      .order("routing_tier", { ascending: false });
+
+    if (provErr) {
+      if (provErr.code === "42P01" || provErr.message?.includes("does not exist")) {
+        return apiSuccess({ providers: [], toggles: toggles ?? [], usage: {} });
+      }
+      logger.error("Failed to fetch AI provider configs", {
+        context: "ai-config",
+        error: provErr.message,
+      });
+      return apiError("Failed to fetch AI configurations", 500);
+    }
+
+    return apiSuccess({ providers: providers ?? [], toggles: toggles ?? [], usage: {} });
+  }
+
+  // ── super_admin: full response including platform financials ──
+  const { data: providers, error: provErr } = await supabase // nosemgrep: semgrep.tenant-scoping
+    .from("ai_provider_configs")
+    .select(
+      "id, provider, display_name, api_key_encrypted, is_active, routing_tier, fallback_provider, monthly_budget_cents, requests_this_month, tokens_this_month, input_tokens_this_month, output_tokens_this_month, cost_this_month_cents, rate_limited_until, last_error, last_used_at, created_at, updated_at",
+    )
+    .order("routing_tier", { ascending: false });
+
+  if (provErr) {
+    // Table may not exist yet if migration hasn't run
+    if (provErr.code === "42P01" || provErr.message?.includes("does not exist")) {
+      return apiSuccess({ providers: [], toggles: toggles ?? [], usage: {} });
+    }
+    logger.error("Failed to fetch AI provider configs", {
+      context: "ai-config",
+      error: provErr.message,
+    });
+    return apiError("Failed to fetch AI configurations", 500);
   }
 
   // Aggregate per-provider usage stats for the current month from logs.

--- a/src/lib/data/directory.ts
+++ b/src/lib/data/directory.ts
@@ -165,7 +165,7 @@ async function fetchDirectoryDoctors(): Promise<DirectoryDoctor[]> {
     // Fetch all doctors from active clinics
     const { data: doctors, error: doctorsError } = await supabase
       .from("users")
-      .select("id, name, phone, email, avatar_url, metadata, clinic_id")
+      .select("id, name, phone, avatar_url, metadata, clinic_id")
       .eq("role", "doctor")
       .order("name", { ascending: true });
 

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -176,10 +176,12 @@ export async function createTenantClient(clinicId: string) {
 }
 
 /**
- * R-01: Every call site must declare its purpose so auditors can
- * verify each admin-client usage is intentional and appropriately scoped.
+ * R-01: Every call site must declare an audit label so each admin-client
+ * usage is traceable in structured logs. This is a LOG LABEL ONLY — it
+ * provides no access control. The real gate is always the handler's
+ * withAuth([roles]) / verifyCronSecret / webhook signature check.
  */
-export type AdminPurpose =
+export type AdminAuditLabel =
   | "auth_admin"
   | "cron"
   | "audit_log"
@@ -237,14 +239,16 @@ export type AdminPurpose =
  * onboarding staff accounts, audit log writes). Never expose this client
  * to the browser.
  *
- * R-01: Requires `purpose` so each usage is auditable. Optionally accepts
- * `clinicId` for structured logging (does NOT set tenant context — use
- * createTenantClient for that).
+ * R-01: Requires `auditLabel` so each usage is traceable in structured logs.
+ * NOTE: `auditLabel` is a LOG LABEL ONLY — it provides no access control.
+ * The real gate is always the handler's withAuth([roles]) / verifyCronSecret /
+ * webhook signature check. Optionally accepts `clinicId` for structured
+ * logging (does NOT set tenant context — use createTenantClient for that).
  *
  * @throws Error if SUPABASE_SERVICE_ROLE_KEY is not configured
  */
-export function createAdminClient(purpose: AdminPurpose, clinicId?: string) {
-  logger.debug("Admin client created", { context: "supabase-server", purpose, clinicId });
+export function createAdminClient(auditLabel: AdminAuditLabel, clinicId?: string) {
+  logger.debug("Admin client created", { context: "supabase-server", auditLabel, clinicId });
   const client = createSupabaseClient<Database>(
     getSupabaseUrl(),
     requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
@@ -262,8 +266,8 @@ export function createAdminClient(purpose: AdminPurpose, clinicId?: string) {
  * (e.g. impersonation_sessions, pending_audit_logs). Once the types are
  * regenerated, callers should migrate to createAdminClient() for type safety.
  */
-export function createUntypedAdminClient(purpose: AdminPurpose, clinicId?: string) {
-  logger.debug("Untyped admin client created", { context: "supabase-server", purpose, clinicId });
+export function createUntypedAdminClient(auditLabel: AdminAuditLabel, clinicId?: string) {
+  logger.debug("Untyped admin client created", { context: "supabase-server", auditLabel, clinicId });
   const client = createSupabaseClient(getSupabaseUrl(), requireEnv("SUPABASE_SERVICE_ROLE_KEY"), {
     auth: { autoRefreshToken: false, persistSession: false },
   });
@@ -285,11 +289,11 @@ export function createUntypedAdminClient(purpose: AdminPurpose, clinicId?: strin
  * @param clinicId - The clinic UUID to scope operations to
  * @throws Error if clinicId is missing or invalid
  */
-export function createScopedAdminClient(purpose: AdminPurpose, clinicId: string) {
+export function createScopedAdminClient(auditLabel: AdminAuditLabel, clinicId: string) {
   if (!clinicId || !isValidClinicId(clinicId)) {
     throw new Error(`createScopedAdminClient: invalid clinicId: ${clinicId}`);
   }
-  logger.debug("Scoped admin client created", { context: "supabase-server", purpose, clinicId });
+  logger.debug("Scoped admin client created", { context: "supabase-server", auditLabel, clinicId });
   const client = createSupabaseClient<Database>(
     getSupabaseUrl(),
     requireEnv("SUPABASE_SERVICE_ROLE_KEY"),

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -267,7 +267,11 @@ export function createAdminClient(auditLabel: AdminAuditLabel, clinicId?: string
  * regenerated, callers should migrate to createAdminClient() for type safety.
  */
 export function createUntypedAdminClient(auditLabel: AdminAuditLabel, clinicId?: string) {
-  logger.debug("Untyped admin client created", { context: "supabase-server", auditLabel, clinicId });
+  logger.debug("Untyped admin client created", {
+    context: "supabase-server",
+    auditLabel,
+    clinicId,
+  });
   const client = createSupabaseClient(getSupabaseUrl(), requireEnv("SUPABASE_SERVICE_ROLE_KEY"), {
     auth: { autoRefreshToken: false, persistSession: false },
   });


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## What

Three targeted hardening fixes from the service-role / RLS bypass audit:

### Fix 1 — `api/admin/ai-config` GET: role-scoped response (info disclosure)

`clinic_admin` was able to read platform-global financials (per-provider `monthly_budget_cents`, `cost_this_month_cents`, platform-wide usage aggregates) and API key metadata (`has_api_key`, `api_key_is_encrypted`) from the same GET endpoint as `super_admin`.

**Change:** GET response is now split by role:
- `super_admin` → full response (unchanged)
- `clinic_admin` → minimal provider listing (`id`, `display_name`, `is_active`, `routing_tier` only) + feature toggles + `usage: {}`. No platform financials, no key metadata.

### Fix 2 — `supabase-server.ts`: rename inert `purpose` param to `auditLabel`

`createAdminClient(purpose)`, `createUntypedAdminClient(purpose)`, and `createScopedAdminClient(purpose)` accepted a `purpose: AdminPurpose` param that appeared to provide access control but was **only used in a `logger.debug()` call**. This was a footgun — a future dev could reasonably trust it as a gate.

**Change:** `AdminPurpose` → `AdminAuditLabel`; param renamed `purpose` → `auditLabel`; JSDoc updated to state explicitly _"LOG LABEL ONLY — provides no access control"_.

### Fix 3 — `directory.ts`: drop unused `email` from select

`fetchDirectoryDoctors()` selected `email` from the `users` table but never used it in the returned `DirectoryDoctor` shape. Least-privilege cleanup.

## Tested

- `git diff --stat` confirms exactly 3 files changed
- Grepped: zero remaining `AdminPurpose` references; `purpose` param gone from all three function signatures
- `handleGet` control flow verified: `isClinicAdmin` early-return never reaches the usage-log query or the `maskedProviders` map
- No TypeScript changes to call signatures (callers pass string literals; type rename is backward-compatible)

## Risk

Low. Fix 1 is additive (new early-return path). Fixes 2–3 are rename/field-drop with no runtime behavior change.