### PR TITLE
fix(super-admin/content): QA report fixes (B1, B3, I2, I3, R1, R3, B4)

### DIFF
--- a/src/app/(super-admin)/super-admin/announcements/page.tsx
+++ b/src/app/(super-admin)/super-admin/announcements/page.tsx
@@ -56,7 +56,7 @@ import {
   deleteAnnouncement,
   type Announcement,
 } from "@/lib/super-admin-actions";
-import { getLocalDateStr } from "@/lib/utils";
+import { getLocalDateStr, formatDisplayDate } from "@/lib/utils";
 
 type TypeFilter = "all" | "info" | "warning" | "critical";
 type StatusFilter = "all" | "active" | "expired" | "scheduled";
@@ -65,12 +65,20 @@ type ScheduleMode = "now" | "later";
 const EXAMPLE_TYPES = [
   {
     icon: ServerCrash,
-    label: "System Update",
-    description: "Notify clinics about platform changes",
+    label: "Mise à jour système",
+    description: "Informer les cliniques des changements de la plateforme",
   },
-  { icon: Wrench, label: "Maintenance Window", description: "Schedule downtime alerts" },
-  { icon: Sparkles, label: "New Feature", description: "Announce new capabilities" },
-  { icon: Bell, label: "General Notice", description: "Share important information" },
+  {
+    icon: Wrench,
+    label: "Fenêtre de maintenance",
+    description: "Planifier des alertes d'indisponibilité",
+  },
+  {
+    icon: Sparkles,
+    label: "Nouvelle fonctionnalité",
+    description: "Annoncer de nouvelles capacités",
+  },
+  { icon: Bell, label: "Avis général", description: "Partager une information importante" },
 ];
 
 const PRIORITY_CONFIG = {
@@ -81,13 +89,13 @@ const PRIORITY_CONFIG = {
     badge: "secondary" as const,
   },
   warning: {
-    label: "Warning",
+    label: "Avertissement",
     color: "text-amber-600",
     bg: "bg-amber-50 border-amber-200",
     badge: "warning" as const,
   },
   critical: {
-    label: "Critical",
+    label: "Critique",
     color: "text-red-600",
     bg: "bg-red-50 border-red-200",
     badge: "destructive" as const,
@@ -198,13 +206,13 @@ export default function AnnouncementsPage() {
 
   async function handleSave() {
     const targetLabels: Record<string, string> = {
-      all: "All Clinics",
-      basic: "Basic Plan",
-      standard: "Standard Plan",
-      premium: "Premium Plan",
+      all: "Toutes les cliniques",
+      basic: "Offre Basique",
+      standard: "Offre Standard",
+      premium: "Offre Premium",
     };
     if (!formTitle.trim() || !formMessage.trim()) {
-      addToast("Title and message are required", "error");
+      addToast("Le titre et le message sont obligatoires", "error");
       return;
     }
     const payload = {
@@ -219,7 +227,7 @@ export default function AnnouncementsPage() {
       if (editItem) {
         const updated = await updateAnnouncement(editItem.id, payload);
         setList((prev) => prev.map((a) => (a.id === editItem.id ? updated : a)));
-        addToast("Announcement updated", "success");
+        addToast("Annonce mise à jour", "success");
       } else {
         const created = await createAnnouncement({
           ...payload,
@@ -227,15 +235,15 @@ export default function AnnouncementsPage() {
             formScheduleMode === "later" && formScheduleDate ? formScheduleDate : getLocalDateStr(),
         });
         setList((prev) => [created, ...prev]);
-        addToast(
-          formScheduleMode === "later" ? "Announcement scheduled" : "Announcement published",
-          "success",
-        );
+        addToast(formScheduleMode === "later" ? "Annonce planifiée" : "Annonce publiée", "success");
       }
       setEditOpen(false);
     } catch (err) {
       logger.warn("Failed to save announcement", { context: "page", error: err });
-      addToast(err instanceof Error ? err.message : "Failed to save announcement", "error");
+      addToast(
+        err instanceof Error ? err.message : "Échec de l'enregistrement de l'annonce",
+        "error",
+      );
     }
   }
 
@@ -251,11 +259,14 @@ export default function AnnouncementsPage() {
     setDeleteItem(null);
     try {
       await deleteAnnouncement(target.id);
-      addToast("Announcement deleted", "success");
+      addToast("Annonce supprimée", "success");
     } catch (err) {
       setList(previous);
       logger.warn("Failed to delete announcement", { context: "page", error: err });
-      addToast(err instanceof Error ? err.message : "Failed to delete announcement", "error");
+      addToast(
+        err instanceof Error ? err.message : "Échec de la suppression de l'annonce",
+        "error",
+      );
     }
   }
 
@@ -265,11 +276,14 @@ export default function AnnouncementsPage() {
     setList((prev) => prev.map((a) => (a.id === item.id ? { ...a, active: next } : a)));
     try {
       await setAnnouncementActive(item.id, next);
-      addToast(next ? "Announcement activated" : "Announcement archived", "success");
+      addToast(next ? "Annonce activée" : "Annonce archivée", "success");
     } catch (err) {
       setList(previous);
       logger.warn("Failed to toggle announcement", { context: "page", error: err });
-      addToast(err instanceof Error ? err.message : "Failed to update announcement", "error");
+      addToast(
+        err instanceof Error ? err.message : "Échec de la mise à jour de l'annonce",
+        "error",
+      );
     }
   }
 
@@ -284,21 +298,18 @@ export default function AnnouncementsPage() {
   return (
     <div>
       <Breadcrumb
-        items={[
-          { label: "Super Admin", href: "/super-admin/dashboard" },
-          { label: "Announcements" },
-        ]}
+        items={[{ label: "Super Admin", href: "/super-admin/dashboard" }, { label: "Annonces" }]}
       />
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">System Announcements</h1>
+          <h1 className="text-2xl font-bold">Annonces système</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Manage announcements visible to clinic owners
+            Gérez les annonces visibles par les propriétaires de cliniques
           </p>
         </div>
         <Button onClick={openCreate}>
           <Plus className="h-4 w-4 mr-1" />
-          New Announcement
+          Nouvelle annonce
         </Button>
       </div>
 
@@ -312,7 +323,7 @@ export default function AnnouncementsPage() {
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Active</p>
+            <p className="text-xs text-muted-foreground mb-1">Actives</p>
             <p className="text-2xl font-bold text-green-600">
               {list.filter((a) => a.active).length}
             </p>
@@ -320,7 +331,7 @@ export default function AnnouncementsPage() {
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Critical</p>
+            <p className="text-xs text-muted-foreground mb-1">Critiques</p>
             <p className="text-2xl font-bold text-red-600">
               {list.filter((a) => a.type === "critical").length}
             </p>
@@ -328,7 +339,7 @@ export default function AnnouncementsPage() {
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Expired</p>
+            <p className="text-xs text-muted-foreground mb-1">Expirées</p>
             <p className="text-2xl font-bold text-gray-400">
               {list.filter((a) => a.expiresAt && new Date(a.expiresAt) < new Date()).length}
             </p>
@@ -341,7 +352,7 @@ export default function AnnouncementsPage() {
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search announcements..."
+            placeholder="Rechercher des annonces…"
             className="pl-10"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
@@ -354,9 +365,9 @@ export default function AnnouncementsPage() {
               variant={typeFilter === t ? "default" : "outline"}
               size="sm"
               onClick={() => setTypeFilter(t)}
-              className="capitalize text-xs"
+              className="text-xs"
             >
-              {t === "all" ? "All Types" : t}
+              {t === "all" ? "Tous les types" : PRIORITY_CONFIG[t].label}
             </Button>
           ))}
         </div>
@@ -364,17 +375,25 @@ export default function AnnouncementsPage() {
 
       {/* Status Filter */}
       <div className="flex items-center gap-1 mb-4">
-        {(["all", "active", "expired", "scheduled"] as StatusFilter[]).map((s) => (
-          <Button
-            key={s}
-            variant={statusFilter === s ? "default" : "outline"}
-            size="sm"
-            onClick={() => setStatusFilter(s)}
-            className="capitalize text-xs"
-          >
-            {s === "all" ? "All Status" : s}
-          </Button>
-        ))}
+        {(["all", "active", "expired", "scheduled"] as StatusFilter[]).map((s) => {
+          const STATUS_LABELS: Record<StatusFilter, string> = {
+            all: "Tous les statuts",
+            active: "Actives",
+            expired: "Expirées",
+            scheduled: "Planifiées",
+          };
+          return (
+            <Button
+              key={s}
+              variant={statusFilter === s ? "default" : "outline"}
+              size="sm"
+              onClick={() => setStatusFilter(s)}
+              className="text-xs"
+            >
+              {STATUS_LABELS[s]}
+            </Button>
+          );
+        })}
       </div>
 
       {/* Announcements List */}
@@ -391,11 +410,11 @@ export default function AnnouncementsPage() {
                       <div className="flex items-center gap-2 mb-1 flex-wrap">
                         <h3 className="font-semibold text-sm truncate">{item.title}</h3>
                         <Badge variant={PRIORITY_CONFIG[item.type].badge} className="text-[10px]">
-                          {item.type}
+                          {PRIORITY_CONFIG[item.type].label}
                         </Badge>
                         {status === "expired" && (
                           <Badge variant="outline" className="text-[10px]">
-                            Expired
+                            Expirée
                           </Badge>
                         )}
                         {!item.active && status !== "expired" && (
@@ -412,9 +431,11 @@ export default function AnnouncementsPage() {
                         </span>
                         <span className="flex items-center gap-1">
                           <Calendar className="h-3 w-3" />
-                          {item.publishedAt}
+                          {formatDisplayDate(item.publishedAt, "fr", "short")}
                         </span>
-                        {item.expiresAt && <span>Expires: {item.expiresAt}</span>}
+                        {item.expiresAt && (
+                          <span>Expire : {formatDisplayDate(item.expiresAt, "fr", "short")}</span>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -422,7 +443,7 @@ export default function AnnouncementsPage() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      title="Preview"
+                      title="Aperçu"
                       onClick={() => {
                         setPreviewItem(item);
                         setPreviewOpen(true);
@@ -430,13 +451,18 @@ export default function AnnouncementsPage() {
                     >
                       <Eye className="h-3.5 w-3.5" />
                     </Button>
-                    <Button variant="ghost" size="sm" title="Edit" onClick={() => openEdit(item)}>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Modifier"
+                      onClick={() => openEdit(item)}
+                    >
                       <Edit className="h-3.5 w-3.5" />
                     </Button>
                     <Button
                       variant="ghost"
                       size="sm"
-                      title={item.active ? "Archive" : "Activate"}
+                      title={item.active ? "Archiver" : "Activer"}
                       onClick={() => toggleActive(item)}
                     >
                       {item.active ? (
@@ -448,7 +474,7 @@ export default function AnnouncementsPage() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      title="Delete"
+                      title="Supprimer"
                       className="text-red-500"
                       onClick={() => {
                         setDeleteItem(item);
@@ -469,12 +495,12 @@ export default function AnnouncementsPage() {
           <div className="py-8">
             <EmptyState
               icon={Megaphone}
-              title="No announcements yet"
-              description="Create announcements to notify clinic owners about system updates, maintenance windows, new features, and important notices."
+              title="Aucune annonce pour le moment"
+              description="Créez des annonces pour informer les propriétaires de cliniques des mises à jour système, fenêtres de maintenance, nouvelles fonctionnalités et avis importants."
               action={
                 <Button onClick={openCreate}>
                   <Plus className="h-4 w-4 mr-1" />
-                  Create your first announcement
+                  Créer votre première annonce
                 </Button>
               }
             />
@@ -501,8 +527,8 @@ export default function AnnouncementsPage() {
         {filtered.length === 0 && list.length > 0 && (
           <EmptyState
             icon={Search}
-            title="No matching announcements"
-            description="Try adjusting your search or filters to find what you're looking for."
+            title="Aucune annonce correspondante"
+            description="Essayez d'ajuster votre recherche ou vos filtres pour trouver ce que vous cherchez."
           />
         )}
       </div>
@@ -511,7 +537,7 @@ export default function AnnouncementsPage() {
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
         <DialogContent onClose={() => setEditOpen(false)} className="max-w-lg">
           <DialogHeader>
-            <DialogTitle>{editItem ? "Edit Announcement" : "New Announcement"}</DialogTitle>
+            <DialogTitle>{editItem ? "Modifier l'annonce" : "Nouvelle annonce"}</DialogTitle>
             <DialogDescription>
               {editItem
                 ? "Modifier les détails de l'annonce."
@@ -522,9 +548,9 @@ export default function AnnouncementsPage() {
           {!showFormPreview ? (
             <div className="grid gap-4 py-4">
               <div className="space-y-2">
-                <Label>Title</Label>
+                <Label>Titre</Label>
                 <Input
-                  placeholder="Announcement title"
+                  placeholder="Titre de l'annonce"
                   value={formTitle}
                   onChange={(e) => setFormTitle(e.target.value)}
                 />
@@ -532,7 +558,7 @@ export default function AnnouncementsPage() {
               <div className="space-y-2">
                 <Label>Message</Label>
                 <Textarea
-                  placeholder="Write the announcement message..."
+                  placeholder="Rédigez le message de l'annonce…"
                   className="min-h-[100px]"
                   value={formMessage}
                   onChange={(e) => setFormMessage(e.target.value)}
@@ -540,14 +566,14 @@ export default function AnnouncementsPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Priority</Label>
+                  <Label>Priorité</Label>
                   <Select
                     value={formType}
                     onValueChange={(v) => setFormType(v as "info" | "warning" | "critical")}
                   >
                     <SelectTrigger>
                       <SelectValue
-                        placeholder="Select priority"
+                        placeholder="Sélectionner une priorité"
                         value={PRIORITY_CONFIG[formType].label}
                       />
                     </SelectTrigger>
@@ -561,46 +587,46 @@ export default function AnnouncementsPage() {
                       <SelectItem value="warning">
                         <span className="flex items-center gap-2">
                           <span className="h-2 w-2 rounded-full bg-amber-500" />
-                          Warning
+                          Avertissement
                         </span>
                       </SelectItem>
                       <SelectItem value="critical">
                         <span className="flex items-center gap-2">
                           <span className="h-2 w-2 rounded-full bg-red-500" />
-                          Critical
+                          Critique
                         </span>
                       </SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
                 <div className="space-y-2">
-                  <Label>Target Audience</Label>
+                  <Label>Public cible</Label>
                   <Select value={formTarget} onValueChange={setFormTarget}>
                     <SelectTrigger>
                       <SelectValue
-                        placeholder="Select audience"
+                        placeholder="Sélectionner un public"
                         value={
                           formTarget === "all"
-                            ? "All Clinics"
+                            ? "Toutes les cliniques"
                             : formTarget === "basic"
-                              ? "Basic Plan"
+                              ? "Offre Basique"
                               : formTarget === "standard"
-                                ? "Standard Plan"
-                                : "Premium Plan"
+                                ? "Offre Standard"
+                                : "Offre Premium"
                         }
                       />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="all">All Clinics</SelectItem>
-                      <SelectItem value="basic">Basic Plan</SelectItem>
-                      <SelectItem value="standard">Standard Plan</SelectItem>
-                      <SelectItem value="premium">Premium Plan</SelectItem>
+                      <SelectItem value="all">Toutes les cliniques</SelectItem>
+                      <SelectItem value="basic">Offre Basique</SelectItem>
+                      <SelectItem value="standard">Offre Standard</SelectItem>
+                      <SelectItem value="premium">Offre Premium</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
               </div>
               <div className="space-y-2">
-                <Label>Schedule</Label>
+                <Label>Programmation</Label>
                 <div className="flex items-center gap-2">
                   <Button
                     type="button"
@@ -609,7 +635,7 @@ export default function AnnouncementsPage() {
                     onClick={() => setFormScheduleMode("now")}
                   >
                     <Send className="h-3.5 w-3.5 mr-1" />
-                    Send Now
+                    Envoyer maintenant
                   </Button>
                   <Button
                     type="button"
@@ -618,7 +644,7 @@ export default function AnnouncementsPage() {
                     onClick={() => setFormScheduleMode("later")}
                   >
                     <Clock className="h-3.5 w-3.5 mr-1" />
-                    Schedule
+                    Planifier
                   </Button>
                 </div>
                 {formScheduleMode === "later" && (
@@ -631,40 +657,47 @@ export default function AnnouncementsPage() {
                 )}
               </div>
               <div className="space-y-2">
-                <Label>Expiry Date (optional)</Label>
+                <Label>Date d&apos;expiration (facultatif)</Label>
                 <Input
                   type="date"
                   value={formExpires}
                   onChange={(e) => setFormExpires(e.target.value)}
                 />
+                {formExpires && (
+                  <p className="text-xs text-muted-foreground">
+                    Expire le {formatDisplayDate(formExpires, "fr", "short")}
+                  </p>
+                )}
               </div>
             </div>
           ) : (
             <div className="py-4">
               <p className="text-xs text-muted-foreground mb-3">
-                This is how clinics will see the announcement:
+                Voici comment les cliniques verront l&apos;annonce :
               </p>
               <div className={`rounded-lg p-4 border ${PRIORITY_CONFIG[formType].bg}`}>
                 <div className="flex items-center gap-2 mb-2">
                   {typeIcon(formType)}
-                  <h3 className="font-semibold text-sm">{formTitle || "Untitled"}</h3>
+                  <h3 className="font-semibold text-sm">{formTitle || "Sans titre"}</h3>
                   <Badge variant={PRIORITY_CONFIG[formType].badge} className="text-[10px]">
-                    {formType}
+                    {PRIORITY_CONFIG[formType].label}
                   </Badge>
                 </div>
-                <p className="text-sm">{formMessage || "No message provided."}</p>
+                <p className="text-sm">{formMessage || "Aucun message fourni."}</p>
                 <div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
                   <span className="flex items-center gap-1">
                     <Users className="h-3 w-3" />
-                    {formTarget === "all" ? "All Clinics" : `${formTarget} Plan`}
+                    {formTarget === "all" ? "Toutes les cliniques" : `Offre ${formTarget}`}
                   </span>
                   <span className="flex items-center gap-1">
                     <Calendar className="h-3 w-3" />
                     {formScheduleMode === "later" && formScheduleDate
-                      ? `Scheduled: ${formScheduleDate}`
-                      : "Immediate"}
+                      ? `Planifiée : ${formScheduleDate}`
+                      : "Immédiate"}
                   </span>
-                  {formExpires && <span>Expires: {formExpires}</span>}
+                  {formExpires && (
+                    <span>Expire : {formatDisplayDate(formExpires, "fr", "short")}</span>
+                  )}
                 </div>
               </div>
             </div>
@@ -679,11 +712,11 @@ export default function AnnouncementsPage() {
                 onClick={() => setShowFormPreview(!showFormPreview)}
               >
                 <Eye className="h-3.5 w-3.5 mr-1" />
-                {showFormPreview ? "Back to Edit" : "Preview"}
+                {showFormPreview ? "Retour à l'édition" : "Aperçu"}
               </Button>
               <div className="flex items-center gap-2">
                 <Button variant="outline" onClick={() => setEditOpen(false)}>
-                  Cancel
+                  Annuler
                 </Button>
                 <Button onClick={handleSave} disabled={!formTitle || !formMessage}>
                   {editItem
@@ -712,14 +745,16 @@ export default function AnnouncementsPage() {
                 <p className="text-sm">{previewItem.message}</p>
               </div>
               <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                <span>Target: {previewItem.targetLabel}</span>
-                <span>Published: {previewItem.publishedAt}</span>
-                {previewItem.expiresAt && <span>Expires: {previewItem.expiresAt}</span>}
+                <span>Cible : {previewItem.targetLabel}</span>
+                <span>Publiée : {formatDisplayDate(previewItem.publishedAt, "fr", "short")}</span>
+                {previewItem.expiresAt && (
+                  <span>Expire : {formatDisplayDate(previewItem.expiresAt, "fr", "short")}</span>
+                )}
               </div>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setPreviewOpen(false)}>
-                Close
+                Fermer
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -731,24 +766,24 @@ export default function AnnouncementsPage() {
         {deleteItem && (
           <DialogContent onClose={() => setDeleteOpen(false)}>
             <DialogHeader>
-              <DialogTitle>Delete Announcement</DialogTitle>
+              <DialogTitle>Supprimer l&apos;annonce</DialogTitle>
               <DialogDescription>
-                Are you sure you want to delete this announcement? This action cannot be undone.
+                Voulez-vous vraiment supprimer cette annonce ? Cette action est irréversible.
               </DialogDescription>
             </DialogHeader>
             <div className="rounded-lg border p-4 bg-muted/50">
               <p className="text-sm font-medium">{deleteItem.title}</p>
               <p className="text-xs text-muted-foreground mt-1">
-                {deleteItem.type} &middot; {deleteItem.targetLabel}
+                {PRIORITY_CONFIG[deleteItem.type].label} &middot; {deleteItem.targetLabel}
               </p>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setDeleteOpen(false)}>
-                Cancel
+                Annuler
               </Button>
               <Button variant="destructive" onClick={handleDelete}>
                 <Trash2 className="h-4 w-4 mr-1" />
-                Delete
+                Supprimer
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/src/app/(super-admin)/super-admin/feature-flags/page.tsx
+++ b/src/app/(super-admin)/super-admin/feature-flags/page.tsx
@@ -30,9 +30,15 @@ interface FeatureFlagResponse {
   kvAvailable: boolean;
 }
 
+const CATEGORY_LABELS: Record<FeatureFlagCategory, string> = {
+  core: "Fonctionnalités principales",
+  experimental: "Fonctionnalités expérimentales",
+  integration: "Intégrations",
+};
+
 export default function FeatureFlagsPage() {
   const TIER_LABELS: Record<number, string> = {
-    0: "Free",
+    0: "Gratuit",
     1: "Budget",
     2: "Standard",
     3: "Premium",
@@ -63,13 +69,13 @@ export default function FeatureFlagsPage() {
         };
 
         if (!response.ok || !payload.ok || !payload.data) {
-          throw new Error(payload.error ?? "Failed to load feature flags");
+          throw new Error(payload.error ?? "Échec du chargement des indicateurs");
         }
 
         setFlags(payload.data.flags);
         setKvAvailable(payload.data.kvAvailable);
       } catch {
-        addToast("Failed to load feature flags", "error");
+        addToast("Échec du chargement des indicateurs de fonctionnalités", "error");
       } finally {
         setLoading(false);
         setRefreshing(false);
@@ -93,15 +99,18 @@ export default function FeatureFlagsPage() {
       const payload = (await response.json()) as { ok: boolean; error?: string };
 
       if (!response.ok || !payload.ok) {
-        throw new Error(payload.error ?? "Failed to update feature flag");
+        throw new Error(payload.error ?? "Échec de la mise à jour de l'indicateur");
       }
 
       setFlags((currentFlags) =>
         currentFlags.map((flag) => (flag.key === key ? { ...flag, enabled: !currentValue } : flag)),
       );
-      addToast(`Feature ${!currentValue ? "enabled" : "disabled"}`, "success");
+      addToast(`Fonctionnalité ${!currentValue ? "activée" : "désactivée"}`, "success");
     } catch (error) {
-      addToast(error instanceof Error ? error.message : "Failed to update feature flag", "error");
+      addToast(
+        error instanceof Error ? error.message : "Échec de la mise à jour de l'indicateur",
+        "error",
+      );
       await loadFlags(true);
     } finally {
       setUpdating(null);
@@ -131,7 +140,7 @@ export default function FeatureFlagsPage() {
         <div>
           <h1 className="text-2xl font-bold">Feature Flags</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Manage runtime platform toggles without using the wrangler CLI.
+            Activez ou désactivez les fonctionnalités de la plateforme en temps réel.
           </p>
         </div>
         <Button
@@ -145,7 +154,7 @@ export default function FeatureFlagsPage() {
           ) : (
             <RefreshCw className="mr-1 h-4 w-4" />
           )}
-          Refresh
+          Actualiser
         </Button>
       </div>
 
@@ -154,10 +163,11 @@ export default function FeatureFlagsPage() {
           <CardContent className="flex items-start gap-3 p-4">
             <Info className="mt-0.5 h-4 w-4 text-[var(--signal-amber)]" />
             <div>
-              <p className="text-sm font-medium">Feature flag storage unavailable</p>
+              <p className="text-sm font-medium">Stockage des indicateurs indisponible</p>
               <p className="text-xs text-muted-foreground">
-                `FEATURE_FLAGS_KV` is not configured in this environment. Flags are shown for
-                visibility, but updates are disabled.
+                La modification des indicateurs en temps réel n&apos;est pas disponible dans cet
+                environnement. Les indicateurs restent visibles, mais ne peuvent pas être modifiés
+                ici.
               </p>
             </div>
           </CardContent>
@@ -172,7 +182,7 @@ export default function FeatureFlagsPage() {
           .map(([category, categoryFlags]) => (
             <Card key={category} className="mb-6">
               <CardHeader>
-                <CardTitle className="text-base capitalize">{category} Features</CardTitle>
+                <CardTitle className="text-base">{CATEGORY_LABELS[category]}</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 {categoryFlags.map((flag) => (
@@ -187,14 +197,14 @@ export default function FeatureFlagsPage() {
                           variant={flag.enabled ? "success" : "secondary"}
                           className="text-[10px]"
                         >
-                          {flag.enabled ? "Enabled" : "Disabled"}
+                          {flag.enabled ? "Activé" : "Désactivé"}
                         </Badge>
                         <Badge variant="outline" className="text-[10px] uppercase">
                           {flag.source}
                         </Badge>
                         {flag.locked && (
                           <Badge variant="warning" className="text-[10px]">
-                            Locked
+                            Verrouillé
                           </Badge>
                         )}
                       </div>
@@ -202,7 +212,8 @@ export default function FeatureFlagsPage() {
                       <p className="mt-1 text-[11px] text-muted-foreground">{flag.key}</p>
                       {flag.minTier !== null && (
                         <p className="mt-1 text-xs text-muted-foreground">
-                          Requires {TIER_LABELS[flag.minTier] ?? `Tier ${flag.minTier}`} provider
+                          Nécessite un compte{" "}
+                          {TIER_LABELS[flag.minTier] ?? `palier ${flag.minTier}`}
                         </p>
                       )}
                       {flag.lockedReason && (
@@ -223,7 +234,7 @@ export default function FeatureFlagsPage() {
       {!loading && flags.length === 0 && (
         <Card>
           <CardContent className="p-6 text-sm text-muted-foreground">
-            No runtime feature flags are registered yet.
+            Aucun indicateur de fonctionnalité n&apos;est encore enregistré.
           </CardContent>
         </Card>
       )}

--- a/src/app/(super-admin)/super-admin/features/page.tsx
+++ b/src/app/(super-admin)/super-admin/features/page.tsx
@@ -16,6 +16,8 @@ import {
   ChevronDown,
   FileSpreadsheet,
   FileText,
+  Info,
+  AlertTriangle,
 } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -75,6 +77,20 @@ interface ClinicOverride {
 }
 
 const tiers = ["basic", "standard", "premium"];
+
+const TIER_LABELS: Record<string, string> = {
+  basic: "Basique",
+  standard: "Standard",
+  premium: "Premium",
+};
+
+const CATEGORY_LABELS: Record<CategoryFilter, string> = {
+  all: "Toutes",
+  core: "Principales",
+  communication: "Communication",
+  integration: "Intégration",
+  advanced: "Avancées",
+};
 
 export default function FeatureTogglesPage() {
   const { addToast } = useToast();
@@ -178,8 +194,8 @@ export default function FeatureTogglesPage() {
       prev.map((f) => (f.id === featureId ? { ...f, globalEnabled: !f.globalEnabled } : f)),
     );
     addToast(
-      `${feature?.name ?? "Feature"} ${feature?.globalEnabled ? "disabled" : "enabled"} globally`,
-      "success",
+      `${feature?.name ?? "Fonctionnalité"} ${feature?.globalEnabled ? "désactivée" : "activée"} (aperçu — non enregistré)`,
+      "info",
     );
   }
 
@@ -215,8 +231,8 @@ export default function FeatureTogglesPage() {
     );
     setBulkOpen(false);
     addToast(
-      `All features ${bulkAction === "enable" ? "enabled" : "disabled"} for ${bulkTier} tier`,
-      "success",
+      `Aperçu mis à jour : toutes les fonctionnalités ${bulkAction === "enable" ? "activées" : "désactivées"} pour le palier ${TIER_LABELS[bulkTier] ?? bulkTier} (non enregistré)`,
+      "info",
     );
   }
 
@@ -246,12 +262,15 @@ export default function FeatureTogglesPage() {
           }
           return [...prev, newOverride];
         });
-        addToast(`Override set: ${featureKey} ${enabled ? "enabled" : "disabled"}`, "success");
+        addToast(
+          `Dérogation enregistrée : ${featureKey} ${enabled ? "activée" : "désactivée"}`,
+          "success",
+        );
       } else {
-        addToast("Failed to set override", "error");
+        addToast("Échec de l'enregistrement de la dérogation", "error");
       }
     } catch {
-      addToast("Failed to set override", "error");
+      addToast("Échec de l'enregistrement de la dérogation", "error");
     }
   }
 
@@ -268,12 +287,12 @@ export default function FeatureTogglesPage() {
       });
       if (res.ok) {
         setOverrides((prev) => prev.filter((o) => o.feature_key !== featureKey));
-        addToast(`Override cleared for ${featureKey}`, "success");
+        addToast(`Dérogation supprimée pour ${featureKey}`, "success");
       } else {
-        addToast("Failed to clear override", "error");
+        addToast("Échec de la suppression de la dérogation", "error");
       }
     } catch {
-      addToast("Failed to clear override", "error");
+      addToast("Échec de la suppression de la dérogation", "error");
     }
   }
 
@@ -297,7 +316,7 @@ export default function FeatureTogglesPage() {
       Premium: f.availableTiers.includes("premium") ? "Yes" : "No",
     }));
     exportToCSV(rows, `features-${getLocalDateStr()}.csv`);
-    addToast("Feature matrix CSV exported", "success");
+    addToast("Matrice des fonctionnalités exportée en CSV", "success");
   }
 
   function handleExportFeaturesPDF() {
@@ -309,7 +328,7 @@ export default function FeatureTogglesPage() {
       Standard: f.availableTiers.includes("standard") ? "Yes" : "No",
       Premium: f.availableTiers.includes("premium") ? "Yes" : "No",
     }));
-    exportToPDF("Feature Matrix \u2014 Oltigo Health", rows, [
+    exportToPDF("Matrice des fonctionnalités \u2014 Oltigo Health", rows, [
       "Feature",
       "Category",
       "Global",
@@ -317,7 +336,10 @@ export default function FeatureTogglesPage() {
       "Standard",
       "Premium",
     ]);
-    addToast("PDF generated \u2014 use Save as PDF in the print dialog", "success");
+    addToast(
+      "PDF généré \u2014 utilisez « Enregistrer au format PDF » dans la boîte d'impression",
+      "success",
+    );
   }
 
   const enabledCount = features.filter((f) => f.globalEnabled).length;
@@ -329,13 +351,13 @@ export default function FeatureTogglesPage() {
         <Breadcrumb
           items={[
             { label: "Super Admin", href: "/super-admin/dashboard" },
-            { label: "Feature Toggles" },
+            { label: "Fonctionnalités" },
           ]}
         />
         <div className="mb-6">
-          <h1 className="text-2xl font-bold">Feature Toggles</h1>
+          <h1 className="text-2xl font-bold">Fonctionnalités</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Control feature availability per tier and globally
+            Contrôlez la disponibilité des fonctionnalités par palier et globalement
           </p>
         </div>
         <CardSkeleton count={4} className="mb-6" />
@@ -349,14 +371,14 @@ export default function FeatureTogglesPage() {
       <Breadcrumb
         items={[
           { label: "Super Admin", href: "/super-admin/dashboard" },
-          { label: "Feature Toggles" },
+          { label: "Fonctionnalités" },
         ]}
       />
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">Feature Toggles</h1>
+          <h1 className="text-2xl font-bold">Fonctionnalités</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Control feature availability per tier and globally
+            Contrôlez la disponibilité des fonctionnalités par palier et globalement
           </p>
         </div>
         <div className="flex gap-2">
@@ -364,24 +386,24 @@ export default function FeatureTogglesPage() {
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" disabled={filtered.length === 0}>
                 <Download className="h-4 w-4 mr-1" />
-                Export
+                Exporter
                 <ChevronDown className="h-3 w-3 ml-1" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={handleExportFeaturesCSV}>
                 <FileSpreadsheet className="h-4 w-4 mr-2" />
-                Export CSV
+                Exporter en CSV
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleExportFeaturesPDF}>
                 <FileText className="h-4 w-4 mr-2" />
-                Export PDF
+                Exporter en PDF
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
           <Button variant="outline" onClick={() => setBulkOpen(true)}>
             <ToggleLeft className="h-4 w-4 mr-1" />
-            Bulk Actions
+            Actions groupées
           </Button>
         </div>
       </div>
@@ -390,25 +412,25 @@ export default function FeatureTogglesPage() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Total Features</p>
+            <p className="text-xs text-muted-foreground mb-1">Total fonctionnalités</p>
             <p className="text-2xl font-bold">{features.length}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Globally Enabled</p>
+            <p className="text-xs text-muted-foreground mb-1">Activées globalement</p>
             <p className="text-2xl font-bold text-green-600">{enabledCount}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Categories</p>
+            <p className="text-xs text-muted-foreground mb-1">Catégories</p>
             <p className="text-2xl font-bold">4</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Clinics Affected</p>
+            <p className="text-xs text-muted-foreground mb-1">Cliniques concernées</p>
             <p className="text-2xl font-bold">{totalClinics}</p>
           </CardContent>
         </Card>
@@ -417,9 +439,9 @@ export default function FeatureTogglesPage() {
       {/* Tabs for Feature Matrix vs Clinic Overrides */}
       <Tabs defaultValue="matrix">
         <TabsList>
-          <TabsTrigger value="matrix">Feature Matrix</TabsTrigger>
+          <TabsTrigger value="matrix">Matrice des fonctionnalités</TabsTrigger>
           <TabsTrigger value="overrides">
-            Clinic Overrides
+            Dérogations cliniques
             {overrideCount > 0 && (
               <Badge variant="secondary" className="ml-2 text-[10px]">
                 {overrideCount}
@@ -429,12 +451,27 @@ export default function FeatureTogglesPage() {
         </TabsList>
 
         <TabsContent value="matrix">
+          {/* R1/R3: the global + per-tier toggles below are a non-persistent
+              preview — there is no write path for feature_definitions, so a
+              click changes only this view and is discarded on refresh. Make
+              that explicit so an operator never believes a tier-wide change
+              was rolled out to clinics. Persistent, per-clinic changes are
+              made in the "Dérogations cliniques" tab. */}
+          <div className="mb-6 flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm dark:bg-amber-900/20 dark:border-amber-700">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <p className="text-amber-800 dark:text-amber-200">
+              Les bascules globales et par palier ci-dessous sont un aperçu et ne sont pas encore
+              enregistrées. Pour appliquer un changement persistant à une clinique, utilisez
+              l&apos;onglet « Dérogations cliniques ».
+            </p>
+          </div>
+
           {/* Filters */}
           <div className="flex flex-col sm:flex-row gap-3 mb-6">
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
-                placeholder="Search features..."
+                placeholder="Rechercher des fonctionnalités…"
                 className="pl-10"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
@@ -443,38 +480,44 @@ export default function FeatureTogglesPage() {
             <div className="flex items-center gap-1">
               {(
                 ["all", "core", "communication", "integration", "advanced"] as CategoryFilter[]
-              ).map((c) => (
-                <Button
-                  key={c}
-                  variant={catFilter === c ? "default" : "outline"}
-                  size="sm"
-                  onClick={() => setCatFilter(c)}
-                  className="capitalize text-xs"
-                >
-                  {c === "all" ? "All" : c}
-                </Button>
-              ))}
+              ).map((c) => {
+                const count =
+                  c === "all" ? features.length : features.filter((f) => f.category === c).length;
+                return (
+                  <Button
+                    key={c}
+                    variant={catFilter === c ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setCatFilter(c)}
+                    className="text-xs"
+                  >
+                    {CATEGORY_LABELS[c]} ({count})
+                  </Button>
+                );
+              })}
             </div>
           </div>
 
           {/* Feature Matrix */}
           <Card>
             <CardHeader className="py-3 px-4">
-              <CardTitle className="text-base">Feature Matrix</CardTitle>
+              <CardTitle className="text-base">Matrice des fonctionnalités</CardTitle>
             </CardHeader>
             <CardContent className="p-0">
               <div className="table-mobile-scroll">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b text-muted-foreground">
-                      <th className="text-left font-medium py-3 px-4 min-w-[250px]">Feature</th>
-                      <th className="text-center font-medium py-3 px-4">Global</th>
+                      <th className="text-left font-medium py-3 px-4 min-w-[250px]">
+                        Fonctionnalité
+                      </th>
+                      <th className="text-center font-medium py-3 px-4">Globale</th>
                       {tiers.map((tier) => (
-                        <th key={tier} className="text-center font-medium py-3 px-4 capitalize">
-                          {tier}
+                        <th key={tier} className="text-center font-medium py-3 px-4">
+                          {TIER_LABELS[tier] ?? tier}
                         </th>
                       ))}
-                      <th className="text-center font-medium py-3 px-4">Category</th>
+                      <th className="text-center font-medium py-3 px-4">Catégorie</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -517,8 +560,8 @@ export default function FeatureTogglesPage() {
                           </td>
                         ))}
                         <td className="py-3 px-4 text-center">
-                          <Badge variant="outline" className="capitalize text-[10px]">
-                            {feature.category}
+                          <Badge variant="outline" className="text-[10px]">
+                            {CATEGORY_LABELS[feature.category] ?? feature.category}
                           </Badge>
                         </td>
                       </tr>
@@ -526,7 +569,7 @@ export default function FeatureTogglesPage() {
                     {filtered.length === 0 && (
                       <tr>
                         <td colSpan={6} className="py-8 text-center text-muted-foreground">
-                          No features found.
+                          Aucune fonctionnalité trouvée.
                         </td>
                       </tr>
                     )}
@@ -544,11 +587,11 @@ export default function FeatureTogglesPage() {
               <div className="flex items-center justify-between">
                 <CardTitle className="text-base flex items-center gap-2">
                   <Building2 className="h-4 w-4" />
-                  Clinic Feature Overrides
+                  Dérogations de fonctionnalités par clinique
                 </CardTitle>
                 {selectedClinicId && overrideCount > 0 && (
                   <Badge variant="secondary">
-                    {overrideCount} override{overrideCount !== 1 ? "s" : ""}
+                    {overrideCount} dérogation{overrideCount !== 1 ? "s" : ""}
                   </Badge>
                 )}
               </div>
@@ -556,11 +599,11 @@ export default function FeatureTogglesPage() {
             <CardContent>
               <div className="mb-4">
                 {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- custom Select component */}
-                <label className="text-sm font-medium mb-2 block">Select Clinic</label>
+                <label className="text-sm font-medium mb-2 block">Sélectionner une clinique</label>
                 <Select value={selectedClinicId} onValueChange={setSelectedClinicId}>
                   <SelectTrigger className="w-full max-w-md">
                     <SelectValue
-                      placeholder="Choose a clinic..."
+                      placeholder="Choisir une clinique…"
                       value={clinics.find((c) => c.id === selectedClinicId)?.name}
                     />
                   </SelectTrigger>
@@ -584,10 +627,10 @@ export default function FeatureTogglesPage() {
                         <thead>
                           <tr className="border-b text-muted-foreground">
                             <th className="text-left font-medium py-3 px-4 min-w-[250px]">
-                              Feature
+                              Fonctionnalité
                             </th>
-                            <th className="text-center font-medium py-3 px-4">Status</th>
-                            <th className="text-center font-medium py-3 px-4">Override</th>
+                            <th className="text-center font-medium py-3 px-4">Statut</th>
+                            <th className="text-center font-medium py-3 px-4">Dérogation</th>
                             <th className="text-center font-medium py-3 px-4">Actions</th>
                           </tr>
                         </thead>
@@ -613,17 +656,17 @@ export default function FeatureTogglesPage() {
                                 <td className="py-3 px-4 text-center">
                                   {state === "inherited" && (
                                     <Badge variant="outline" className="text-[10px] text-gray-500">
-                                      Inherited
+                                      Hérité
                                     </Badge>
                                   )}
                                   {state === "enabled" && (
                                     <Badge className="text-[10px] bg-green-100 text-green-700 border-green-200">
-                                      Enabled
+                                      Activé
                                     </Badge>
                                   )}
                                   {state === "disabled" && (
                                     <Badge className="text-[10px] bg-red-100 text-red-700 border-red-200">
-                                      Disabled
+                                      Désactivé
                                     </Badge>
                                   )}
                                 </td>
@@ -648,7 +691,7 @@ export default function FeatureTogglesPage() {
                                       variant="ghost"
                                       size="sm"
                                       onClick={() => clearClinicOverride(feature.key)}
-                                      title="Clear override (revert to tier default)"
+                                      title="Effacer la dérogation (revenir au défaut du palier)"
                                     >
                                       <RotateCcw className="h-3.5 w-3.5" />
                                     </Button>
@@ -666,7 +709,7 @@ export default function FeatureTogglesPage() {
 
               {!selectedClinicId && (
                 <p className="text-sm text-muted-foreground text-center py-8">
-                  Select a clinic to manage feature overrides.
+                  Sélectionnez une clinique pour gérer les dérogations de fonctionnalités.
                 </p>
               )}
             </CardContent>
@@ -678,12 +721,21 @@ export default function FeatureTogglesPage() {
       <Dialog open={bulkOpen} onOpenChange={setBulkOpen}>
         <DialogContent onClose={() => setBulkOpen(false)}>
           <DialogHeader>
-            <DialogTitle>Bulk Feature Toggle</DialogTitle>
+            <DialogTitle>Activation groupée des fonctionnalités</DialogTitle>
             <DialogDescription>
-              Enable or disable all features for a specific tier at once.
+              Activez ou désactivez toutes les fonctionnalités pour un palier donné, en une fois.
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
+            <div className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs dark:bg-amber-900/20 dark:border-amber-700">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <p className="text-amber-800 dark:text-amber-200">
+                Cette action met à jour l&apos;aperçu de toutes les fonctionnalités du palier
+                sélectionné. Il s&apos;agit d&apos;un aperçu local : aucune modification n&apos;est
+                enregistrée ni propagée aux cliniques tant qu&apos;une persistance n&apos;est pas
+                disponible.
+              </p>
+            </div>
             <div className="space-y-2">
               {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- control is associated via adjacent Input/sibling element */}
               <label className="text-sm font-medium">Action</label>
@@ -692,19 +744,19 @@ export default function FeatureTogglesPage() {
                 value={bulkAction}
                 onChange={(e) => setBulkAction(e.target.value as "enable" | "disable")}
               >
-                <option value="enable">Enable all features</option>
-                <option value="disable">Disable all features</option>
+                <option value="enable">Activer toutes les fonctionnalités</option>
+                <option value="disable">Désactiver toutes les fonctionnalités</option>
               </select>
             </div>
             <div className="space-y-2">
               {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- control is associated via adjacent Input/sibling element */}
-              <label className="text-sm font-medium">Tier</label>
+              <label className="text-sm font-medium">Palier</label>
               <select
                 className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
                 value={bulkTier}
                 onChange={(e) => setBulkTier(e.target.value)}
               >
-                <option value="basic">Basic</option>
+                <option value="basic">Basique</option>
                 <option value="standard">Standard</option>
                 <option value="premium">Premium</option>
               </select>
@@ -712,11 +764,11 @@ export default function FeatureTogglesPage() {
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setBulkOpen(false)}>
-              Cancel
+              Annuler
             </Button>
             <Button onClick={handleBulkAction}>
               <ToggleLeft className="h-4 w-4 mr-1" />
-              Apply to All Features
+              Appliquer à toutes les fonctionnalités
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/(super-admin)/super-admin/templates/page.tsx
+++ b/src/app/(super-admin)/super-admin/templates/page.tsx
@@ -34,7 +34,7 @@ import { PageLoader } from "@/components/ui/page-loader";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
-import { formatNumber } from "@/lib/utils";
+import { formatNumber, formatDisplayDate } from "@/lib/utils";
 
 interface Template {
   id: string;
@@ -51,6 +51,22 @@ interface Template {
 
 type TypeFilter = "all" | Template["type"];
 type ClinicTypeFilter = "all" | "doctor" | "dentist" | "pharmacy";
+
+const TYPE_LABELS: Record<Template["type"], string> = {
+  prescription: "Ordonnance",
+  invoice: "Facture",
+  report: "Rapport",
+  certificate: "Certificat",
+  consent: "Consentement",
+  letter: "Lettre",
+};
+
+const CLINIC_TYPE_LABELS: Record<string, string> = {
+  all: "Toutes les cliniques",
+  doctor: "Médecin",
+  dentist: "Dentiste",
+  pharmacy: "Pharmacie",
+};
 
 export default function TemplateManagerPage() {
   const [locale] = useLocale();
@@ -83,7 +99,7 @@ export default function TemplateManagerPage() {
       if (!res.ok) throw new Error(json.error ?? `${res.status}`);
       setTemplates(json.data.templates ?? []);
     } catch (err) {
-      setLoadError(err instanceof Error ? err.message : "Failed to load templates");
+      setLoadError(err instanceof Error ? err.message : "Échec du chargement des modèles");
       logger.warn("Failed to load document templates", { error: err });
     } finally {
       setLoading(false);
@@ -164,7 +180,7 @@ export default function TemplateManagerPage() {
         const json = await res.json();
         if (!res.ok) throw new Error(json.error ?? `${res.status}`);
         setTemplates((prev) => prev.map((t) => (t.id === editItem.id ? json.data.template : t)));
-        addToast("Template updated", "success");
+        addToast("Modèle mis à jour", "success");
       } else {
         const res = await fetch("/api/super-admin/templates", {
           method: "POST",
@@ -180,12 +196,12 @@ export default function TemplateManagerPage() {
         const json = await res.json();
         if (!res.ok) throw new Error(json.error ?? `${res.status}`);
         setTemplates((prev) => [json.data.template, ...prev]);
-        addToast("Template created", "success");
+        addToast("Modèle créé", "success");
       }
       setEditOpen(false);
     } catch (err) {
       logger.warn("Failed to save template", { error: err });
-      addToast("Failed to save template. Please try again.", "error");
+      addToast("Échec de l'enregistrement du modèle. Veuillez réessayer.", "error");
     } finally {
       setSaving(false);
     }
@@ -207,10 +223,10 @@ export default function TemplateManagerPage() {
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? `${res.status}`);
       setTemplates((prev) => [json.data.template, ...prev]);
-      addToast(`"${item.name}" duplicated`, "success");
+      addToast(`« ${item.name} » dupliqué`, "success");
     } catch (err) {
       logger.warn("Failed to duplicate template", { error: err });
-      addToast("Failed to duplicate template.", "error");
+      addToast("Échec de la duplication du modèle.", "error");
     }
   }
 
@@ -223,10 +239,10 @@ export default function TemplateManagerPage() {
       });
       if (!res.ok) throw new Error(`${res.status}`);
       setTemplates((prev) => prev.filter((t) => t.id !== deleteItem.id));
-      addToast("Template deleted", "success");
+      addToast("Modèle supprimé", "success");
     } catch (err) {
       logger.warn("Failed to delete template", { error: err });
-      addToast("Failed to delete template.", "error");
+      addToast("Échec de la suppression du modèle.", "error");
     } finally {
       setDeleting(false);
       setDeleteOpen(false);
@@ -246,20 +262,20 @@ export default function TemplateManagerPage() {
         body: JSON.stringify({ id: item.id, active: !item.is_active }),
       });
       if (!res.ok) throw new Error(`${res.status}`);
-      addToast(item.is_active ? "Template deactivated" : "Template activated", "success");
+      addToast(item.is_active ? "Modèle désactivé" : "Modèle activé", "success");
     } catch (err) {
       logger.warn("Failed to toggle template", { error: err });
       setTemplates(previous);
-      addToast("Failed to update template.", "error");
+      addToast("Échec de la mise à jour du modèle.", "error");
     }
   }
 
-  if (loading) return <PageLoader message="Loading templates..." />;
+  if (loading) return <PageLoader message="Chargement des modèles…" />;
 
   if (loadError) {
     return (
       <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">Failed to load templates.</p>
+        <p className="text-red-600 font-medium">Échec du chargement des modèles.</p>
         <p className="text-sm text-muted-foreground mt-1">{loadError}</p>
         <Button
           variant="outline"
@@ -269,7 +285,7 @@ export default function TemplateManagerPage() {
             void loadTemplates();
           }}
         >
-          Try again
+          Réessayer
         </Button>
       </div>
     );
@@ -278,31 +294,31 @@ export default function TemplateManagerPage() {
   return (
     <div>
       <Breadcrumb
-        items={[{ label: "Super Admin", href: "/super-admin/dashboard" }, { label: "Templates" }]}
+        items={[{ label: "Super Admin", href: "/super-admin/dashboard" }, { label: "Modèles" }]}
       />
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">Template Manager</h1>
+          <h1 className="text-2xl font-bold">Gestion des modèles</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Manage document templates for all clinic types
+            Gérez les modèles de documents pour tous les types de cliniques
           </p>
         </div>
         <Button onClick={openCreate}>
           <FilePlus className="h-4 w-4 mr-1" />
-          New Template
+          Nouveau modèle
         </Button>
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Total Templates</p>
+            <p className="text-xs text-muted-foreground mb-1">Total des modèles</p>
             <p className="text-2xl font-bold">{templates.length}</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Active</p>
+            <p className="text-xs text-muted-foreground mb-1">Actifs</p>
             <p className="text-2xl font-bold text-green-600">
               {templates.filter((t) => t.is_active).length}
             </p>
@@ -310,13 +326,13 @@ export default function TemplateManagerPage() {
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Template Types</p>
+            <p className="text-xs text-muted-foreground mb-1">Types de modèles</p>
             <p className="text-2xl font-bold">6</p>
           </CardContent>
         </Card>
         <Card>
           <CardContent className="p-4">
-            <p className="text-xs text-muted-foreground mb-1">Total Usage</p>
+            <p className="text-xs text-muted-foreground mb-1">Utilisation totale</p>
             <p className="text-2xl font-bold">
               {formatNumber(
                 templates.reduce((s, t) => s + t.usage_count, 0),
@@ -332,7 +348,7 @@ export default function TemplateManagerPage() {
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
-              placeholder="Search templates..."
+              placeholder="Rechercher des modèles…"
               className="pl-10"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
@@ -346,9 +362,9 @@ export default function TemplateManagerPage() {
                 variant={clinicTypeFilter === ct ? "default" : "outline"}
                 size="sm"
                 onClick={() => setClinicTypeFilter(ct)}
-                className="capitalize text-xs"
+                className="text-xs"
               >
-                {ct === "all" ? "All Clinics" : ct}
+                {CLINIC_TYPE_LABELS[ct] ?? ct}
               </Button>
             ))}
           </div>
@@ -370,9 +386,9 @@ export default function TemplateManagerPage() {
               variant={typeFilter === t ? "default" : "outline"}
               size="sm"
               onClick={() => setTypeFilter(t)}
-              className="capitalize text-xs"
+              className="text-xs"
             >
-              {t === "all" ? "All Types" : t}
+              {t === "all" ? "Tous les types" : TYPE_LABELS[t]}
             </Button>
           ))}
         </div>
@@ -389,7 +405,7 @@ export default function TemplateManagerPage() {
                 </div>
                 {!tpl.is_active && (
                   <Badge variant="outline" className="text-[10px]">
-                    Inactive
+                    Inactif
                   </Badge>
                 )}
               </div>
@@ -397,16 +413,16 @@ export default function TemplateManagerPage() {
             <CardContent className="space-y-3">
               <p className="text-xs text-muted-foreground">{tpl.description}</p>
               <div className="flex flex-wrap gap-1.5">
-                <Badge variant="secondary" className="text-[10px] capitalize">
-                  {tpl.type}
+                <Badge variant="secondary" className="text-[10px]">
+                  {TYPE_LABELS[tpl.type] ?? tpl.type}
                 </Badge>
-                <Badge variant="outline" className="text-[10px] capitalize">
-                  {tpl.clinic_type === "all" ? "All Clinics" : tpl.clinic_type}
+                <Badge variant="outline" className="text-[10px]">
+                  {CLINIC_TYPE_LABELS[tpl.clinic_type] ?? tpl.clinic_type}
                 </Badge>
               </div>
               <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>Used {formatNumber(tpl.usage_count, locale ?? "fr")} times</span>
-                <span>Updated {tpl.updated_at.slice(0, 10)}</span>
+                <span>Utilisé {formatNumber(tpl.usage_count, locale ?? "fr")} fois</span>
+                <span>Mis à jour {formatDisplayDate(tpl.updated_at, locale ?? "fr", "short")}</span>
               </div>
               <Separator />
               <div className="flex items-center justify-between">
@@ -414,7 +430,7 @@ export default function TemplateManagerPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    title="Preview"
+                    title="Aperçu"
                     onClick={() => {
                       setPreviewItem(tpl);
                       setPreviewOpen(true);
@@ -422,13 +438,13 @@ export default function TemplateManagerPage() {
                   >
                     <Eye className="h-3.5 w-3.5" />
                   </Button>
-                  <Button variant="ghost" size="sm" title="Edit" onClick={() => openEdit(tpl)}>
+                  <Button variant="ghost" size="sm" title="Modifier" onClick={() => openEdit(tpl)}>
                     <Edit className="h-3.5 w-3.5" />
                   </Button>
                   <Button
                     variant="ghost"
                     size="sm"
-                    title="Duplicate"
+                    title="Dupliquer"
                     onClick={() => handleDuplicate(tpl)}
                   >
                     <Copy className="h-3.5 w-3.5" />
@@ -438,7 +454,7 @@ export default function TemplateManagerPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    title={tpl.is_active ? "Deactivate" : "Activate"}
+                    title={tpl.is_active ? "Désactiver" : "Activer"}
                     className={tpl.is_active ? "text-green-600" : "text-gray-400"}
                     onClick={() => toggleActive(tpl)}
                   >
@@ -447,7 +463,7 @@ export default function TemplateManagerPage() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    title="Delete"
+                    title="Supprimer"
                     className="text-red-500"
                     onClick={() => {
                       setDeleteItem(tpl);
@@ -466,8 +482,8 @@ export default function TemplateManagerPage() {
             <FileText className="h-8 w-8 mx-auto mb-2 opacity-50" />
             <p>
               {templates.length === 0
-                ? "No templates yet. Create your first template."
-                : "No templates match your filter."}
+                ? "Aucun modèle pour le moment. Créez votre premier modèle."
+                : "Aucun modèle ne correspond à votre filtre."}
             </p>
           </div>
         )}
@@ -480,36 +496,36 @@ export default function TemplateManagerPage() {
           className="max-w-2xl max-h-[90vh] overflow-y-auto"
         >
           <DialogHeader>
-            <DialogTitle>{editItem ? "Edit Template" : "New Template"}</DialogTitle>
+            <DialogTitle>{editItem ? "Modifier le modèle" : "Nouveau modèle"}</DialogTitle>
             <DialogDescription>
               {editItem
-                ? "Update template details and content."
-                : "Create a new document template."}
+                ? "Mettez à jour les détails et le contenu du modèle."
+                : "Créez un nouveau modèle de document."}
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label>Template Name</Label>
+                <Label>Nom du modèle</Label>
                 <Input
-                  placeholder="e.g. Standard Prescription"
+                  placeholder="ex. Ordonnance standard"
                   value={formName}
                   onChange={(e) => setFormName(e.target.value)}
                 />
               </div>
               <div className="space-y-2">
-                <Label>Document Type</Label>
+                <Label>Type de document</Label>
                 <select
                   className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
                   value={formType}
                   onChange={(e) => setFormType(e.target.value as Template["type"])}
                 >
-                  <option value="prescription">Prescription</option>
-                  <option value="invoice">Invoice</option>
-                  <option value="report">Report</option>
-                  <option value="certificate">Certificate</option>
-                  <option value="consent">Consent Form</option>
-                  <option value="letter">Letter</option>
+                  <option value="prescription">Ordonnance</option>
+                  <option value="invoice">Facture</option>
+                  <option value="report">Rapport</option>
+                  <option value="certificate">Certificat</option>
+                  <option value="consent">Consentement</option>
+                  <option value="letter">Lettre</option>
                 </select>
               </div>
             </div>
@@ -517,34 +533,34 @@ export default function TemplateManagerPage() {
               <div className="space-y-2">
                 <Label>Description</Label>
                 <Input
-                  placeholder="Brief description"
+                  placeholder="Brève description"
                   value={formDesc}
                   onChange={(e) => setFormDesc(e.target.value)}
                 />
               </div>
               <div className="space-y-2">
-                <Label>Clinic Type</Label>
+                <Label>Type de clinique</Label>
                 <select
                   className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
                   value={formClinicType}
                   onChange={(e) => setFormClinicType(e.target.value as Template["clinic_type"])}
                 >
-                  <option value="all">All Clinic Types</option>
-                  <option value="doctor">Doctor</option>
-                  <option value="dentist">Dentist</option>
-                  <option value="pharmacy">Pharmacy</option>
+                  <option value="all">Tous les types de cliniques</option>
+                  <option value="doctor">Médecin</option>
+                  <option value="dentist">Dentiste</option>
+                  <option value="pharmacy">Pharmacie</option>
                 </select>
               </div>
             </div>
             <Separator />
             <div className="space-y-2">
-              <Label>Template Content</Label>
+              <Label>Contenu du modèle</Label>
               <p className="text-xs text-muted-foreground">
-                Use {`{{variable_name}}`} for dynamic placeholders.
+                Utilisez {`{{nom_variable}}`} pour les variables dynamiques.
               </p>
               <textarea
                 className="flex min-h-[200px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                placeholder="Template content with {{placeholders}}..."
+                placeholder="Contenu du modèle avec {{variables}}…"
                 value={formContent}
                 onChange={(e) => setFormContent(e.target.value)}
               />
@@ -552,14 +568,14 @@ export default function TemplateManagerPage() {
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setEditOpen(false)} disabled={saving}>
-              Cancel
+              Annuler
             </Button>
             <Button
               onClick={handleSave}
               disabled={saving || !formName.trim() || !formContent.trim()}
             >
               {saving ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : null}
-              {editItem ? "Update Template" : "Create Template"}
+              {editItem ? "Mettre à jour le modèle" : "Créer le modèle"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -577,25 +593,29 @@ export default function TemplateManagerPage() {
             </DialogHeader>
             <div className="space-y-3 py-4">
               <div className="flex gap-2">
-                <Badge variant="secondary" className="capitalize">
-                  {previewItem.type}
+                <Badge variant="secondary">
+                  {TYPE_LABELS[previewItem.type] ?? previewItem.type}
                 </Badge>
-                <Badge variant="outline" className="capitalize">
-                  {previewItem.clinic_type === "all" ? "All Clinics" : previewItem.clinic_type}
+                <Badge variant="outline">
+                  {CLINIC_TYPE_LABELS[previewItem.clinic_type] ?? previewItem.clinic_type}
                 </Badge>
               </div>
               <div className="rounded-lg border bg-muted/30 p-4">
                 <pre className="text-sm whitespace-pre-wrap font-mono">{previewItem.content}</pre>
               </div>
               <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                <span>Created: {previewItem.created_at.slice(0, 10)}</span>
-                <span>Updated: {previewItem.updated_at.slice(0, 10)}</span>
-                <span>Used: {formatNumber(previewItem.usage_count, locale ?? "fr")} times</span>
+                <span>
+                  Créé : {formatDisplayDate(previewItem.created_at, locale ?? "fr", "short")}
+                </span>
+                <span>
+                  Mis à jour : {formatDisplayDate(previewItem.updated_at, locale ?? "fr", "short")}
+                </span>
+                <span>Utilisé : {formatNumber(previewItem.usage_count, locale ?? "fr")} fois</span>
               </div>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setPreviewOpen(false)}>
-                Close
+                Fermer
               </Button>
               <Button
                 onClick={() => {
@@ -604,7 +624,7 @@ export default function TemplateManagerPage() {
                 }}
               >
                 <Edit className="h-4 w-4 mr-1" />
-                Edit
+                Modifier
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -616,21 +636,21 @@ export default function TemplateManagerPage() {
         {deleteItem && (
           <DialogContent onClose={() => setDeleteOpen(false)}>
             <DialogHeader>
-              <DialogTitle>Delete Template</DialogTitle>
+              <DialogTitle>Supprimer le modèle</DialogTitle>
               <DialogDescription>
-                Are you sure you want to delete this template? This action cannot be undone.
+                Voulez-vous vraiment supprimer ce modèle ? Cette action est irréversible.
               </DialogDescription>
             </DialogHeader>
             <div className="rounded-lg border p-4 bg-muted/50">
               <p className="text-sm font-medium">{deleteItem.name}</p>
               <p className="text-xs text-muted-foreground mt-1">
-                {deleteItem.type} · Used {formatNumber(deleteItem.usage_count, locale ?? "fr")}{" "}
-                times
+                {TYPE_LABELS[deleteItem.type] ?? deleteItem.type} · Utilisé{" "}
+                {formatNumber(deleteItem.usage_count, locale ?? "fr")} fois
               </p>
             </div>
             <DialogFooter>
               <Button variant="outline" onClick={() => setDeleteOpen(false)} disabled={deleting}>
-                Cancel
+                Annuler
               </Button>
               <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
                 {deleting ? (
@@ -638,7 +658,7 @@ export default function TemplateManagerPage() {
                 ) : (
                   <Trash2 className="h-4 w-4 mr-1" />
                 )}
-                Delete
+                Supprimer
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -249,7 +249,20 @@ const notifTypeColor: Record<NotificationType, string> = {
 };
 
 function SidebarNav({ pathname }: { pathname: string }) {
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => getExpandedGroups());
+  // B1 (hydration): seed with the SSR-stable default (all groups expanded) so
+  // the first client render matches the server. localStorage is unavailable
+  // during SSR, so reading it in the useState initializer makes the initial
+  // client render diverge from the server markup and triggers React hydration
+  // error #418. The persisted state is applied after mount instead.
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(
+    () => new Set(navGroups.map((g) => g.key)),
+  );
+
+  useEffect(() => {
+    // Mount-only: apply persisted expand/collapse state after hydration.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setExpandedGroups(getExpandedGroups());
+  }, []);
 
   const toggleGroup = useCallback((key: string) => {
     setExpandedGroups((prev) => {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Addresses the **Super-Admin CONTENT category** QA report (Annonces, Modèles, Fonctionnalités, Feature Flags). Fixes the code-addressable defects and surfaces — with evidence — the places where the report's assumptions differ from the actual code.

## What changed (code)

**B3 — Localization (Medium, all 4 pages).** Fully localized the four pages and every dialog to French: headings, descriptions, filters, table headers, toasts, empty states, preview/delete/create confirmations, and select options. (These files already carry `eslint-disable i18next/no-literal-string` with a comment stating French is the intended output — the English strings were the bug.)

**R1 / R3 — Feature Matrix toggles (the report's core assumption was inverted; see below).** The global toggle, per-tier toggle, and Bulk Action mutate only local React state and then showed a green *success* toast — there is **no write path** for `feature_definitions` (it is `select`-only in `super-admin-actions.ts`; the only feature write API is the separate, working *Clinic Overrides* tab). So they never touched 30 clinics; they silently discarded the change on refresh while claiming success. Changes:
- Added an explicit *preview / not-saved* notice above the Feature Matrix.
- Reworded the global/tier/bulk toasts to be accurate (no false 'rolled out globally').
- Added a scope warning inside the Bulk Action dialog (the destructive-looking control the report flagged in R1).
- Did **not** fabricate a persistence backend (see *Needs a decision*).

**I2 — Internal config leak (Feature Flags).** Removed user-facing references to `FEATURE_FLAGS_KV` and the *wrangler CLI*; replaced with operator-facing French copy.

**I3 — Empty category chips (Fonctionnalités).** The category filter now shows a per-category count (e.g. `Communication (0)`), so empty categories are obvious instead of leading to a silent dead view.

**B4 — US date format (Annonces).** Announcement dates now render `dd/mm/yyyy` via the existing `formatDisplayDate(date, "fr", "short")` helper, and the expiry field shows a French `Expire le …` caption. (Note: the native `<input type="date">` *widget* format is controlled by the browser locale and cannot be forced via markup; the caption makes the selected value unambiguous.)

**B1 — Hydration #418 (partial, scoped).** The super-admin sidebar seeded `useState` for expand/collapse from `localStorage` in the initializer, which diverges from SSR and trips React #418 for returning users. It is now seeded with the SSR-stable default and hydrated after mount. See *Needs a decision* for the broader picture.

## Report vs. code — discrepancies found
- **R1/R3:** Not 'a mis-click changes a feature for all 30 clinics.' The real defect is **fake success on a no-op** — there is no persistence. Evidence: `feature_definitions` has no update/upsert/insert anywhere in `src/`.
- **B2 (CSP `style-src 'unsafe-inline'`) and B5 (Permissions-Policy `document-domain`/`web-share`)** are **already fixed on `main`** in `security-headers.ts` (commented 'QA fix B5' / 'QA B-I3'); no change needed here.

## Needs a product / infra decision (not safe to do blindly in code)
- **R1/R3 persistence:** Should the Feature Matrix global/tier toggles actually persist? That requires a new write API + `feature_definitions` update + super-admin auth + audit log, and it is the highest-blast-radius operation in the console. The reviewer explicitly asked not to exercise it live, so I did not invent unverifiable destructive persistence — flagging for your call.
- **R2 — `FEATURE_FLAGS_KV` / AI kill switch:** infra config (bind the KV namespace in production) or a product decision to hide the page if runtime flags are intentionally unsupported.
- **R4 — weak super-admin auth / MFA:** operational; partially addressed by the MFA-enforcement work already on `main` (#1098).
- **B1 exact prod trigger:** A *fresh* session has empty `localStorage`, so the sidebar fix here targets the returning-user case. The same `localStorage`-seeded-`useState` pattern also exists app-wide in the theme provider and locale switcher; pinpointing the tester's specific #418 needs the minified component stack from that session. I scoped this PR to the super-admin shell rather than broadening blast radius into app-wide providers.

## Testing
- `tsc --noEmit` ✅
- `eslint --max-warnings 3457` ✅ (within baseline; ratchet not increased)
- `vitest run` ✅ 1894 passed / 84 skipped
- `next build` ✅
- `prettier --check .` ✅
- i18n coverage + translation ratchets ✅ (locale JSON untouched)

Not run locally (require browsers/CI services): Playwright E2E, bundle-budget, CodeQL/Semgrep. Changes are UI-string/state-only within existing components, so risk to those gates is low.