### PR TITLE
feat(auth): make 2FA optional + self-serve from dashboard

### DIFF
--- a/src/app/(super-admin)/super-admin/dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.tsx
@@ -17,6 +17,7 @@ import {
   ArrowDown,
   Percent,
   Download,
+  ShieldCheck,
 } from "lucide-react";
 import Link from "next/link";
 import { useState, useEffect, useCallback, useRef } from "react";
@@ -272,6 +273,14 @@ export default function SuperAdminDashboardPage() {
             <Button variant="outline" size="sm">
               <Megaphone className="h-4 w-4 mr-1" />
               {t(locale, "superAdmin.announce")}
+            </Button>
+          </Link>
+          {/* Optional 2FA: enrolment is no longer forced at login — admins can
+              enable two-factor authentication from here at any time. */}
+          <Link href="/setup-2fa?next=%2Fsuper-admin%2Fdashboard">
+            <Button variant="outline" size="sm">
+              <ShieldCheck className="h-4 w-4 mr-1" />
+              Sécurité (2FA)
             </Button>
           </Link>
         </div>

--- a/src/lib/middleware/__tests__/mfa-enforcement.test.ts
+++ b/src/lib/middleware/__tests__/mfa-enforcement.test.ts
@@ -76,28 +76,26 @@ describe("enforceMfa", () => {
     expect(result).toBeNull();
   });
 
-  it("redirects super_admin to enrollment when no verified TOTP factor exists (R1)", async () => {
+  it("passes super_admin with no enrolled factor (enrollment is optional)", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }, []),
       "super_admin",
       "/admin",
       `${URL_BASE}/admin`,
     );
-    expect(result).not.toBeNull();
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("Location")).toMatch(/\/setup-2fa\?required=1&next=%2Fadmin$/);
+    // Optional-enrollment model: an un-enrolled admin is NOT forced to /setup-2fa.
+    expect(result).toBeNull();
   });
 
-  it("treats an unverified (mid-enrolment) factor as not enrolled", async () => {
+  it("passes clinic_admin with only an unverified (mid-enrolment) factor", async () => {
     const result = await enforceMfa(
       mockSupabase({ currentLevel: "aal1", nextLevel: "aal1" }, [{ status: "unverified" }]),
       "clinic_admin",
       "/admin/settings",
       `${URL_BASE}/admin/settings`,
     );
-    expect(result).not.toBeNull();
-    expect(result?.status).toBe(307);
-    expect(result?.headers.get("Location")).toMatch(/\/setup-2fa\?required=1&next=/);
+    // No verified factor → Supabase reports nextLevel "aal1" → pass-through.
+    expect(result).toBeNull();
   });
 
   it("passes doctor without MFA (not required for role)", async () => {

--- a/src/lib/middleware/mfa-enforcement.ts
+++ b/src/lib/middleware/mfa-enforcement.ts
@@ -8,20 +8,17 @@ import { isMfaEnabled } from "@/lib/env";
 import { secureRedirect } from "@/lib/middleware/security-headers";
 
 /**
- * Enforce MFA requirements for privileged roles.
+ * §3.5 — MFA step-up for privileged roles (optional-enrollment model).
  *
- * Two-stage check for `super_admin` and `clinic_admin`:
+ * 2FA enrollment is **optional**: privileged users (`super_admin` /
+ * `clinic_admin`) are NOT forced to enrol. Enrolment is offered as a
+ * self-service action from the dashboard (links to `/setup-2fa`).
  *
- * 1. **Enrollment gate** — if no verified TOTP factor exists at all, redirect
- *    to `/setup-2fa?required=1&next=<pathname>` so the admin is forced to
- *    enrol before accessing privileged routes. This closes the gap identified
- *    in QA risk R1: an account with no authenticator enrolled had
- *    `nextLevel = "aal1"` (not "aal2"), so the old level-only check never
- *    fired and password-only login succeeded with zero MFA challenge.
- *
- * 2. **Session level gate** — if a verified factor exists but the current
- *    session is at AAL1 (factor not yet used this session), redirect to
- *    `/mfa-verify?next=<pathname>` for step-up authentication.
+ * What is still enforced: **step-up for users who have already enrolled.**
+ * `getAuthenticatorAssuranceLevel()` reports `nextLevel === "aal2"` only when
+ * a verified factor exists, so an admin who voluntarily enabled 2FA is still
+ * challenged at `/mfa-verify` when their session is only at AAL1, while an
+ * un-enrolled admin (`nextLevel === "aal1"`) passes through untouched.
  *
  * Returns `null` when no redirect is needed (pass-through).
  */
@@ -31,29 +28,15 @@ export async function enforceMfa(
   pathname: string,
   requestUrl: string,
 ): Promise<Response | null> {
-  // Allow disabling via env var; defaults to true (enforced). Read through the
-  // centralised env module (src/lib/env.ts) rather than process.env directly.
+  // Allow disabling all MFA logic via env var; defaults to true. Read through
+  // the centralised env module (src/lib/env.ts) rather than process.env.
   if (!isMfaEnabled()) return null;
 
   if (role === "super_admin" || role === "clinic_admin") {
-    // --- Stage 1: enrollment check ---
-    // listFactors() is a lightweight read that does not count against
-    // sign-in rate limits. We filter to verified factors only; an
-    // unverified (mid-enrolment) factor is not yet usable as an MFA factor.
-    const { data: factorsData } = await supabase.auth.mfa.listFactors();
-    const verifiedTotp = (factorsData?.totp ?? []).filter((f) => f.status === "verified");
-
-    if (verifiedTotp.length === 0) {
-      // No verified authenticator — force enrolment first.
-      const redirectUrl = new URL("/setup-2fa", requestUrl);
-      redirectUrl.searchParams.set("required", "1");
-      redirectUrl.searchParams.set("next", pathname);
-      return secureRedirect(redirectUrl);
-    }
-
-    // --- Stage 2: session level check ---
-    // The user has an authenticator enrolled; check whether they have
-    // already used it this session (AAL2) or need a step-up challenge.
+    // Step-up only — never force enrolment. When the user has a verified
+    // factor, `nextLevel` is "aal2"; if the session has not yet used it
+    // (currentLevel "aal1"), require a step-up challenge. Un-enrolled users
+    // report `nextLevel === "aal1"` and fall through with no redirect.
     const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
     if (aalData?.nextLevel === "aal2" && aalData?.currentLevel !== "aal2") {
       const redirectUrl = new URL("/mfa-verify", requestUrl);


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Per product decision: **2FA is now optional** rather than forced at login.

## What changed
- **`mfa-enforcement.ts`** — removed the Stage-1 enrollment gate that redirected un-enrolled `super_admin`/`clinic_admin` to `/setup-2fa`. 
- **Kept Stage-2 step-up**: a user who *does* enroll a verified TOTP factor is still challenged at `/mfa-verify` (Supabase reports `nextLevel === "aal2"` only when a verified factor exists, so un-enrolled admins pass through). `MFA_ENABLED=false` still disables all MFA logic.
- **Dashboard** — added an optional **“Sécurité (2FA)”** action on the super-admin dashboard linking to `/setup-2fa?next=/super-admin/dashboard`, so admins can enable 2FA voluntarily.
- **Tests** — the two former forced-enrollment cases now assert pass-through (optional model); the enrolled-user step-up cases are unchanged.

## Security note
This intentionally reverses the forced-MFA enrollment added in #1098 and softens the QA reports' R4 recommendation. 2FA remains **available and, once enabled, still enforced per-session** — it is simply no longer mandatory to enroll. Confirmed as the desired behavior.

## Testing
- `tsc --noEmit` ✅
- `eslint --max-warnings 3457` ✅ (within baseline)
- `vitest run` ✅ 1894 passed / 84 skipped (incl. updated `mfa-enforcement` + `mfa` suites)
- `next build` ✅ · `prettier --check .` ✅ · i18n ratchets ✅