### PR TITLE
fix(rate-limit): CSP-safe graceful 429 page (I3)

### DIFF
--- a/src/lib/middleware/rate-limiting.ts
+++ b/src/lib/middleware/rate-limiting.ts
@@ -97,45 +97,63 @@ export async function applyRateLimit(
     // The dedicated `globalPageLimiter` is now independent of API rules.
     const allowed = await globalPageLimiter.check(`global_${rateLimitKey}`);
     if (!allowed) {
-      // QA-B3-fix: For HTML page navigations, return a human-readable HTML
-      // 429 page instead of a raw JSON body. Previously the JSON
-      // { error: "RATE_LIMIT_EXCEEDED" } was shown verbatim in the browser
-      // when an admin navigated quickly between pages.
+      // QA-B3-fix / I3: For HTML page navigations, return a human-readable HTML
+      // 429 page instead of a raw JSON body. The page must be CSP-safe: the
+      // strict middleware CSP blocks inline/`javascript:` scripts, so recovery
+      // uses a `<meta http-equiv="refresh">` auto-retry (no JS) plus a plain
+      // static link rather than a dead `javascript:history.back()` button.
+      const retryAfterSec = 15;
       const html = `<!DOCTYPE html>
 <html lang="fr">
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <meta http-equiv="refresh" content="${retryAfterSec}"/>
   <title>Trop de requêtes — Oltigo</title>
   <style>
-    body{font-family:system-ui,sans-serif;background:#fafafa;color:#111;display:flex;
-         align-items:center;justify-content:center;min-height:100vh;margin:0;padding:1rem}
+    :root{color-scheme:light dark}
+    body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;background:#fafafa;
+         color:#111827;display:flex;align-items:center;justify-content:center;min-height:100vh;
+         margin:0;padding:1rem}
     .card{background:#fff;border:1px solid #e5e7eb;border-radius:.75rem;padding:2rem 2.5rem;
-          max-width:420px;text-align:center;box-shadow:0 1px 4px rgba(0,0,0,.06)}
+          max-width:440px;text-align:center;box-shadow:0 1px 4px rgba(0,0,0,.06)}
+    .icon{margin:0 auto 1rem;display:block}
     h1{font-size:1.25rem;font-weight:600;margin:0 0 .5rem}
-    p{color:#6b7280;font-size:.9rem;margin:.5rem 0 1.5rem;line-height:1.5}
-    a{display:inline-block;background:#111;color:#fff;text-decoration:none;
-      padding:.5rem 1.25rem;border-radius:.5rem;font-size:.875rem}
-    a:hover{background:#374151}
+    p{color:#6b7280;font-size:.9rem;margin:.5rem 0;line-height:1.5}
+    .hint{font-size:.8rem;color:#9ca3af;margin-top:1.25rem}
+    a{display:inline-block;margin-top:1.25rem;background:#005a3b;color:#fff;text-decoration:none;
+      padding:.55rem 1.4rem;border-radius:.5rem;font-size:.875rem}
+    a:hover{background:#00472f}
   </style>
 </head>
 <body>
   <div class="card">
+    <svg class="icon" width="40" height="40" viewBox="0 0 24 24" fill="none"
+         stroke="#005a3b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+         role="img" aria-label="Patientez">
+      <circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/>
+    </svg>
     <h1>Trop de requêtes</h1>
-    <p>Vous avez effectué trop de requêtes en peu de temps.<br/>
-    Veuillez patienter quelques secondes et réessayer.</p>
-    <a href="javascript:history.back()">← Retour</a>
+    <p>Vous avez effectué trop de requêtes en peu de temps.</p>
+    <p>Cette page se rechargera automatiquement dans ${retryAfterSec} secondes.
+    Vous pouvez aussi patienter quelques instants, puis réessayer.</p>
+    <a href="/">Retour à l'accueil</a>
+    <p class="hint">Si le problème persiste, ralentissez votre navigation
+    ou contactez le support.</p>
   </div>
 </body>
 </html>`;
       const response = withSecurityHeaders(
         new NextResponse(html, {
           status: 429,
-          headers: { "Content-Type": "text/html; charset=utf-8" },
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+          },
         }),
         csp,
       );
-      response.headers.set("Retry-After", "60");
+      response.headers.set("Retry-After", String(retryAfterSec));
       return { response };
     }
   }


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Addresses I3 (bare full-page 429) from the QA reports.

## Problem
The page-navigation 429 page's only recovery affordance was `href="javascript:history.back()"` — **`javascript:` URIs are blocked by the strict middleware CSP**, so the button was dead, and there was no auto-retry.

## Fix
Rewrote the 429 HTML response to be CSP-safe and graceful:
- Auto-retry via `<meta http-equiv="refresh">` (no JS, CSP-safe) aligned to a 15s window.
- Plain static link (no `javascript:`), brand-coloured styling, inline SVG icon.
- Clearer French guidance (“la page se rechargera automatiquement…”).
- `Cache-Control: no-store` so a stale 429 isn't cached.
- `Retry-After` header aligned to the auto-refresh interval.

The JSON 429 path for API/fetch requests is unchanged.

## Testing
- `tsc --noEmit` ✅ · eslint ✅ · prettier ✅
- `vitest run` rate-limit suites ✅ (25 tests) and full suite ✅ 1894 passed
- Note: the prefetch/429-storm softening was handled separately in #1097 (sidebar `prefetch={false}`).