### PR TITLE
feat(subscriptions): persist status changes end-to-end (Phase 1)

### DIFF
--- a/src/app/(super-admin)/super-admin/subscriptions/page.tsx
+++ b/src/app/(super-admin)/super-admin/subscriptions/page.tsx
@@ -54,6 +54,7 @@ import { exportToCSV, exportToPDF } from "@/lib/export-utils";
 import { logger } from "@/lib/logger";
 import {
   fetchClientSubscriptions,
+  updateSubscriptionStatus,
   type ClientSubscription,
   type SystemType,
 } from "@/lib/super-admin-actions";
@@ -264,21 +265,54 @@ export default function SubscriptionsPage() {
     });
   }
 
-  function executeBulkAction(action: "activate" | "suspend" | "cancel") {
+  async function executeBulkAction(action: "activate" | "suspend" | "cancel") {
     const ids = [...selectedIds];
+    const targets = subscriptions.filter((s) => ids.includes(s.id));
     const newStatus: ClientSubscription["status"] =
       action === "activate" ? "active" : action === "suspend" ? "suspended" : "cancelled";
+
+    // Optimistic update for snappy UX; the canonical state is reloaded below.
     setSubscriptions((prev) =>
       prev.map((s) => (ids.includes(s.id) ? { ...s, status: newStatus } : s)),
     );
     setSelectedIds(new Set());
     setBulkConfirmOpen(false);
     setPendingBulkAction(null);
-    const past = action === "activate" ? "activés" : action === "suspend" ? "suspendus" : "annulés";
-    addToast(
-      `${ids.length} abonnement${ids.length > 1 ? "s" : ""} ${past}`,
-      action === "cancel" ? "error" : "success",
+
+    // Persist each change (maps to the clinic's lifecycle status server-side).
+    const results = await Promise.allSettled(
+      targets.map((s) => updateSubscriptionStatus(s.clinicId, action)),
     );
+    const failed = results.filter((r) => r.status === "rejected").length;
+    const succeeded = targets.length - failed;
+
+    if (failed > 0) {
+      logger.warn("Some subscription status updates failed", {
+        context: "page",
+        action,
+        failed,
+        succeeded,
+      });
+    }
+
+    // Reconcile with the server so the table reflects persisted state (and
+    // rolls back any optimistic change that did not actually persist).
+    await loadSubscriptions();
+
+    const past = action === "activate" ? "activés" : action === "suspend" ? "suspendus" : "annulés";
+    if (failed === 0) {
+      addToast(
+        `${succeeded} abonnement${succeeded > 1 ? "s" : ""} ${past}`,
+        action === "cancel" ? "info" : "success",
+      );
+    } else if (succeeded === 0) {
+      addToast(`Échec de la mise à jour de ${failed} abonnement${failed > 1 ? "s" : ""}`, "error");
+    } else {
+      addToast(
+        `${succeeded} mis à jour, ${failed} en échec — réessayez pour les abonnements restants`,
+        "error",
+      );
+    }
   }
 
   function handleBulkExport() {

--- a/src/lib/__tests__/subscription-status.test.ts
+++ b/src/lib/__tests__/subscription-status.test.ts
@@ -72,7 +72,7 @@ describe("updateSubscriptionStatus", () => {
         action: "subscription_activated",
         clinic_id: "c1",
         clinic_name: "Clinic A",
-        type: "admin",
+        type: "billing",
       }),
     );
   });

--- a/src/lib/__tests__/subscription-status.test.ts
+++ b/src/lib/__tests__/subscription-status.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for updateSubscriptionStatus (super-admin subscription persistence).
+ *
+ * A "subscription" status maps to the clinic's lifecycle status:
+ *   activate -> active, suspend -> suspended, cancel -> inactive.
+ * Verifies the DB write, the audit-log entry, subdomain-cache invalidation,
+ * the super_admin role gate, and error propagation.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock setup ───────────────────────────────────────────────────────
+
+const requireRole = vi.fn().mockResolvedValue(undefined);
+const invalidateSubdomainCache = vi.fn();
+
+let updateError: { message: string } | null = null;
+const updateEq = vi.fn(() => Promise.resolve({ error: updateError }));
+const update = vi.fn(() => ({ eq: updateEq }));
+const single = vi.fn(() =>
+  Promise.resolve({ data: { id: "c1", name: "Clinic A", subdomain: "clinic-a" } }),
+);
+const selectEq = vi.fn(() => ({ single }));
+const select = vi.fn(() => ({ eq: selectEq }));
+const insert = vi.fn(
+  (): Promise<{ error: { message: string } | null }> => Promise.resolve({ error: null }),
+);
+const from = vi.fn(() => ({ select, update, insert }));
+
+vi.mock("@/lib/auth", () => ({ requireRole: (...a: unknown[]) => requireRole(...a) }));
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: () => Promise.resolve({ from }),
+  createAdminClient: () => ({ from }),
+}));
+vi.mock("@/lib/subdomain-cache", () => ({
+  invalidateSubdomainCache: (...a: unknown[]) => invalidateSubdomainCache(...a),
+}));
+vi.mock("@/lib/email", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/lib/email-templates", () => ({
+  staffWelcomeEmail: vi.fn(),
+  clinicSuspendedEmail: vi.fn(),
+  clinicActivatedEmail: vi.fn(),
+}));
+vi.mock("@/lib/onboarding/state", () => ({ syncClinicOnboardingState: vi.fn() }));
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+async function loadAction() {
+  const mod = await import("@/lib/super-admin-actions");
+  return mod.updateSubscriptionStatus;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateError = null;
+});
+
+describe("updateSubscriptionStatus", () => {
+  it("requires the super_admin role", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    await updateSubscriptionStatus("c1", "activate");
+    expect(requireRole).toHaveBeenCalledWith("super_admin");
+  });
+
+  it("activate -> clinics.status 'active' + audit 'subscription_activated'", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    await updateSubscriptionStatus("c1", "activate");
+    expect(update).toHaveBeenCalledWith({ status: "active" });
+    expect(updateEq).toHaveBeenCalledWith("id", "c1");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "subscription_activated",
+        clinic_id: "c1",
+        clinic_name: "Clinic A",
+        type: "admin",
+      }),
+    );
+  });
+
+  it("suspend -> clinics.status 'suspended' + audit 'subscription_suspended'", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    await updateSubscriptionStatus("c1", "suspend");
+    expect(update).toHaveBeenCalledWith({ status: "suspended" });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "subscription_suspended" }),
+    );
+  });
+
+  it("cancel -> clinics.status 'inactive' + audit 'subscription_cancelled'", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    await updateSubscriptionStatus("c1", "cancel");
+    expect(update).toHaveBeenCalledWith({ status: "inactive" });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "subscription_cancelled" }),
+    );
+  });
+
+  it("invalidates the subdomain cache for the clinic", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    await updateSubscriptionStatus("c1", "suspend");
+    expect(invalidateSubdomainCache).toHaveBeenCalledWith("clinic-a");
+  });
+
+  it("throws when the DB update fails", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    updateError = { message: "boom" };
+    await expect(updateSubscriptionStatus("c1", "activate")).rejects.toThrow(
+      /Failed to update subscription status/,
+    );
+  });
+
+  it("does not throw if the audit-log insert fails (non-blocking)", async () => {
+    const updateSubscriptionStatus = await loadAction();
+    insert.mockResolvedValueOnce({ error: { message: "audit down" } });
+    await expect(updateSubscriptionStatus("c1", "activate")).resolves.toBeUndefined();
+    expect(update).toHaveBeenCalledWith({ status: "active" });
+  });
+});

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -345,7 +345,7 @@ export async function updateClinicStatus(
       description: `Clinic "${clinic?.name ?? clinicId}" status changed to ${status}`,
       clinic_id: clinicId,
       clinic_name: clinic?.name ?? null,
-      type: "admin",
+      type: "clinic",
       timestamp: new Date().toISOString(),
     });
   } catch (err) {
@@ -441,7 +441,7 @@ export async function updateSubscriptionStatus(
       description: `Subscription for "${clinic?.name ?? clinicId}" ${AUDIT_BY_ACTION[action].verb}`,
       clinic_id: clinicId,
       clinic_name: clinic?.name ?? null,
-      type: "admin",
+      type: "billing",
       timestamp: new Date().toISOString(),
     });
   } catch (err) {

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -380,6 +380,79 @@ export async function updateClinicStatus(
   }
 }
 
+/**
+ * Persist a subscription status change for the super-admin Subscriptions view.
+ *
+ * A "subscription" is derived from the clinic's lifecycle `status`
+ * (see `fetchClientSubscriptions`), so persisting a subscription action maps to
+ * the clinic's `status` column:
+ *   - `activate` -> `"active"`
+ *   - `suspend`  -> `"suspended"`
+ *   - `cancel`   -> `"inactive"` (rendered as "cancelled" in the subscriptions UI)
+ *
+ * Unlike `updateClinicStatus`, this intentionally does NOT send clinic-lifecycle
+ * emails: this is a billing/subscription admin operation (often run in bulk),
+ * and that helper's activate/suspend email branch would mislabel a "cancel" as
+ * an activation. The change is audit-logged to `activity_logs` and invalidates
+ * the subdomain cache so middleware reflects the new status immediately.
+ */
+export async function updateSubscriptionStatus(
+  clinicId: string,
+  action: "activate" | "suspend" | "cancel",
+): Promise<void> {
+  const supabase = await rawClient();
+
+  const STATUS_BY_ACTION = {
+    activate: "active",
+    suspend: "suspended",
+    cancel: "inactive",
+  } as const;
+  const AUDIT_BY_ACTION = {
+    activate: { action: "subscription_activated", verb: "activated" },
+    suspend: { action: "subscription_suspended", verb: "suspended" },
+    cancel: { action: "subscription_cancelled", verb: "cancelled" },
+  } as const;
+
+  const status = STATUS_BY_ACTION[action];
+
+  // Fetch clinic for cache invalidation + audit context.
+  const { data: clinic } = await supabase
+    .from("clinics") // nosemgrep: tenant-scoping — super-admin updates a specific clinic by id
+    .select("id, name, subdomain")
+    .eq("id", clinicId)
+    .single();
+
+  const { error } = await supabase
+    .from("clinics") // nosemgrep: tenant-scoping — super-admin updates a specific clinic by id
+    .update({ status })
+    .eq("id", clinicId);
+
+  if (error) throw new Error(`Failed to update subscription status: ${error.message}`);
+
+  // Invalidate subdomain cache so middleware picks up the new status.
+  if (clinic?.subdomain) {
+    invalidateSubdomainCache(clinic.subdomain);
+  }
+
+  // Audit log (non-blocking).
+  try {
+    await supabase.from("activity_logs").insert({
+      action: AUDIT_BY_ACTION[action].action,
+      description: `Subscription for "${clinic?.name ?? clinicId}" ${AUDIT_BY_ACTION[action].verb}`,
+      clinic_id: clinicId,
+      clinic_name: clinic?.name ?? null,
+      type: "admin",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", {
+      context: "super-admin-actions",
+      clinicId,
+      error: err,
+    });
+  }
+}
+
 // ---------- User CRUD ----------
 
 /**


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Phase 1 of the focus map (#1103): **make the money path real.** Subscription status changes were UI-only (local state + a success toast, no DB write). This makes them persist.

## What changed
- **`updateSubscriptionStatus(clinicId, action)`** server action in `super-admin-actions.ts`. A subscription's status is derived from the clinic lifecycle status (see `fetchClientSubscriptions`), so:
  - `activate` -> `clinics.status = active`
  - `suspend`  -> `clinics.status = suspended`
  - `cancel`   -> `clinics.status = inactive` (renders as "cancelled")
  It persists the update, **invalidates the subdomain cache** (so middleware reflects it), and writes an **`activity_logs` audit entry**. It deliberately does **not** send clinic-lifecycle emails — this is a bulk billing op, and `updateClinicStatus`'s activate/suspend email branch would mislabel a `cancel` as an activation.
- **Subscriptions page**: `executeBulkAction` now awaits real persistence for each selected subscription (`Promise.allSettled`), then **reloads from the server** to reconcile (rolling back any optimistic change that didn't persist), with honest success / partial-failure / failure toasts.
- **Tests**: 7 unit tests — role gate, status mapping (all 3 actions), audit-log entry, cache invalidation, error propagation, and non-blocking audit failure.

## Scope & follow-ups
- This covers the **bulk** action (the only status-mutation path in the page). Pricing tier edits + feature-matrix toggles are still UI-only — next persistence targets.
- **Overlap:** supersedes the "aperçu — non enregistré" bulk-action messaging from #1100 with real persistence. If #1100 merges first, this resolves the overlap in `executeBulkAction` (this version wins).

## Testing
- `tsc --noEmit` ✅ · `eslint --max-warnings 3457` ✅ · `prettier --check .` ✅ · i18n ratchets ✅
- `vitest run` ✅ **1901 passed** / 84 skipped (+7 new)
- `next build` ✅
- Not run locally (no live DB): the actual Supabase write path — logic is unit-tested with a mocked client; recommend a quick manual check against staging after merge.