### PR TITLE
feat(pricing): persist tier edits end-to-end (Phase 1)

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -66,6 +66,14 @@ rules:
           #                             table with NO clinic_id column; RLS gives
           #                             super_admin full access and authenticated
           #                             users read-only on active rows.
+          #   - `feature_definitions`— platform-wide feature catalogue (global
+          #                             on/off + tier availability) managed by
+          #                             super_admin; NO clinic_id column. Per-
+          #                             clinic overrides live in the separate
+          #                             clinic_feature_overrides table.
+          #   - `pricing_tiers`      — platform-wide subscription tier catalogue
+          #                             managed by super_admin; NO clinic_id
+          #                             column.
           #
           # All other queue / processed-events tables (notification_queue,
           # processed_stripe_events, processed_whatsapp_messages,
@@ -80,7 +88,7 @@ rules:
           # annotated rather than whitelisted, so a future bare
           # .from("users").select("*") still triggers a warning.
           regex: |-
-            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads|document_templates)["']).*$
+            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads|document_templates|feature_definitions|pricing_tiers)["']).*$
       # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
       # makes this query tenant-scoped. Semgrep normalises JS string quotes,
       # but both variants are kept for belt-and-suspenders parity with the

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -54,6 +54,7 @@ import {
   fetchClientSubscriptions,
   fetchPricingTiers,
   fetchFeatureToggles,
+  updatePricingTier,
   type ClientSubscription,
   type PricingTierRow,
   type FeatureToggleRow,
@@ -326,7 +327,7 @@ export default function PricingPage() {
     setConfirmSaveOpen(true);
   }
 
-  function confirmSaveTier() {
+  async function confirmSaveTier() {
     if (!editingTierId) return;
 
     const oldTier = tiers.find((t) => t.id === editingTierId);
@@ -335,54 +336,70 @@ export default function PricingPage() {
     const oldPrice = oldTier.pricing[selectedSystem]?.[billingCycle] ?? 0;
     const newPrice = Number(editPriceMin) || 0;
 
-    if (oldPrice !== newPrice) {
-      const cycleLabel: string = billingCycle === "yearly" ? "yearly" : "monthly";
-      const entry: PriceHistoryEntry = {
-        date: new Date().toISOString().split("T")[0] ?? "",
-        system: systemTypeLabels[selectedSystem],
-        cycle: cycleLabel,
-        oldPrice: Math.round(oldPrice),
-        newPrice: Math.round(newPrice),
-      };
-      const updated = [entry, ...priceHistory].slice(0, 50);
-      setPriceHistory(updated);
-      saveHistory(updated);
-    }
+    // Compute the updated tier fields (features + per-system pricing).
+    const newFeatureLabels = editFeatures
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const updatedFeatures = newFeatureLabels.map((label) => {
+      const existing = oldTier.features.find((f) => f.label === label);
+      return existing ?? { key: label.toLowerCase().replace(/\s+/g, "_"), label, included: true };
+    });
+    const removedFeatures = oldTier.features
+      .filter((f) => !newFeatureLabels.includes(f.label))
+      .map((f) => ({ ...f, included: false }));
+    const newFeatures = [...updatedFeatures, ...removedFeatures];
+    const existingForSystem = oldTier.pricing[selectedSystem] ?? { monthly: 0, yearly: 0 };
+    const newPricing = {
+      ...oldTier.pricing,
+      [selectedSystem]: { ...existingForSystem, [billingCycle]: newPrice },
+    };
 
+    const tierId = editingTierId;
+
+    // Optimistic update; reconciled from the server on failure.
     setTiers((prev) =>
-      prev.map((t) => {
-        if (t.id !== editingTierId) return t;
-        const newFeatureLabels = editFeatures
-          .split("\n")
-          .map((l) => l.trim())
-          .filter(Boolean);
-        const updatedFeatures = newFeatureLabels.map((label) => {
-          const existing = t.features.find((f) => f.label === label);
-          return (
-            existing ?? { key: label.toLowerCase().replace(/\s+/g, "_"), label, included: true }
-          );
-        });
-        const removedFeatures = t.features
-          .filter((f) => !newFeatureLabels.includes(f.label))
-          .map((f) => ({ ...f, included: false }));
-        return {
-          ...t,
-          name: editName,
-          pricing: {
-            ...t.pricing,
-            [selectedSystem]: {
-              ...t.pricing[selectedSystem],
-              [billingCycle]: Number(editPriceMin) || 0,
-            },
-          },
-          features: [...updatedFeatures, ...removedFeatures],
-        };
-      }),
+      prev.map((t) =>
+        t.id === tierId ? { ...t, name: editName, pricing: newPricing, features: newFeatures } : t,
+      ),
     );
-
     setEditingTierId(null);
     setConfirmSaveOpen(false);
-    addToast("Tier updated successfully", "success");
+
+    try {
+      await updatePricingTier(tierId, {
+        name: editName,
+        pricing: newPricing,
+        features: newFeatures,
+      });
+
+      // Record the local price-change history only after a successful persist.
+      if (oldPrice !== newPrice) {
+        const cycleLabel: string = billingCycle === "yearly" ? "yearly" : "monthly";
+        const entry: PriceHistoryEntry = {
+          date: new Date().toISOString().split("T")[0] ?? "",
+          system: systemTypeLabels[selectedSystem],
+          cycle: cycleLabel,
+          oldPrice: Math.round(oldPrice),
+          newPrice: Math.round(newPrice),
+        };
+        const updated = [entry, ...priceHistory].slice(0, 50);
+        setPriceHistory(updated);
+        saveHistory(updated);
+      }
+
+      addToast("Tarif enregistré", "success");
+    } catch (err) {
+      logger.warn("Failed to persist pricing tier", { context: "page", error: err });
+      // Reconcile from the server so the UI never shows an unsaved price.
+      try {
+        const fresh = await fetchPricingTiers();
+        setTiers(fresh);
+      } catch {
+        /* leave optimistic state; the error toast tells the user to retry */
+      }
+      addToast("Échec de l'enregistrement du tarif. Veuillez réessayer.", "error");
+    }
   }
 
   // Promotion handlers
@@ -1284,7 +1301,7 @@ export default function PricingPage() {
             <Button variant="outline" onClick={() => setConfirmSaveOpen(false)}>
               Cancel
             </Button>
-            <Button onClick={confirmSaveTier}>
+            <Button onClick={() => void confirmSaveTier()}>
               <Save className="h-4 w-4 mr-1" />
               Confirm & Save
             </Button>

--- a/src/lib/__tests__/pricing-tier.test.ts
+++ b/src/lib/__tests__/pricing-tier.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for updatePricingTier (super-admin pricing persistence).
+ * Verifies the role gate, partial-field writes, the audit entry (billing type),
+ * the no-op path, and error propagation.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireRole = vi.fn().mockResolvedValue(undefined);
+
+let updateError: { message: string } | null = null;
+const updateEq = vi.fn(() => Promise.resolve({ error: updateError }));
+const update = vi.fn(() => ({ eq: updateEq }));
+const single = vi.fn(() => Promise.resolve({ data: { id: "t1", name: "Pro" } }));
+const selectEq = vi.fn(() => ({ single }));
+const select = vi.fn(() => ({ eq: selectEq }));
+const insert = vi.fn(
+  (): Promise<{ error: { message: string } | null }> => Promise.resolve({ error: null }),
+);
+const from = vi.fn(() => ({ select, update, insert }));
+
+vi.mock("@/lib/auth", () => ({ requireRole: (...a: unknown[]) => requireRole(...a) }));
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: () => Promise.resolve({ from }),
+  createAdminClient: () => ({ from }),
+}));
+vi.mock("@/lib/subdomain-cache", () => ({ invalidateSubdomainCache: vi.fn() }));
+vi.mock("@/lib/email", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/lib/email-templates", () => ({
+  staffWelcomeEmail: vi.fn(),
+  clinicSuspendedEmail: vi.fn(),
+  clinicActivatedEmail: vi.fn(),
+}));
+vi.mock("@/lib/onboarding/state", () => ({ syncClinicOnboardingState: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+async function loadAction() {
+  const mod = await import("@/lib/super-admin-actions");
+  return mod.updatePricingTier;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateError = null;
+});
+
+describe("updatePricingTier", () => {
+  it("requires the super_admin role", async () => {
+    const updatePricingTier = await loadAction();
+    await updatePricingTier("t1", { name: "Pro+" });
+    expect(requireRole).toHaveBeenCalledWith("super_admin");
+  });
+
+  it("writes only the provided fields", async () => {
+    const updatePricingTier = await loadAction();
+    const pricing = { doctor: { monthly: 499, yearly: 4990 } };
+    await updatePricingTier("t1", { name: "Pro+", pricing });
+    expect(update).toHaveBeenCalledWith({ name: "Pro+", pricing });
+    expect(updateEq).toHaveBeenCalledWith("id", "t1");
+  });
+
+  it("audit-logs the change with the billing type", async () => {
+    const updatePricingTier = await loadAction();
+    await updatePricingTier("t1", { name: "Pro+" });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "pricing_tier_updated", type: "billing" }),
+    );
+  });
+
+  it("is a no-op when no fields are provided (no DB write)", async () => {
+    const updatePricingTier = await loadAction();
+    await updatePricingTier("t1", {});
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("throws when the DB update fails", async () => {
+    const updatePricingTier = await loadAction();
+    updateError = { message: "boom" };
+    await expect(updatePricingTier("t1", { name: "X" })).rejects.toThrow(
+      /Failed to update pricing tier/,
+    );
+  });
+});

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -1020,6 +1020,59 @@ export async function fetchPricingTiers(): Promise<PricingTierRow[]> {
   }));
 }
 
+/**
+ * Persist edits to a pricing tier (super-admin Pricing view).
+ *
+ * Updates the `pricing_tiers` row in place. Only the provided fields are
+ * written (name / per-system pricing JSON / features). Audit-logged to
+ * `activity_logs` with the `billing` type (pricing is a billing concern).
+ */
+export async function updatePricingTier(
+  tierId: string,
+  updates: {
+    name?: string;
+    pricing?: Record<string, { monthly: number; yearly: number }>;
+    features?: { key: string; label: string; included: boolean; limit?: string }[];
+  },
+): Promise<void> {
+  const supabase = await rawClient();
+
+  const payload: {
+    name?: string;
+    pricing?: Record<string, { monthly: number; yearly: number }>;
+    features?: { key: string; label: string; included: boolean; limit?: string }[];
+  } = {};
+  if (updates.name !== undefined) payload.name = updates.name;
+  if (updates.pricing !== undefined) payload.pricing = updates.pricing;
+  if (updates.features !== undefined) payload.features = updates.features;
+  if (Object.keys(payload).length === 0) return;
+
+  const { data: existing } = await supabase
+    .from("pricing_tiers")
+    .select("id, name")
+    .eq("id", tierId)
+    .single();
+
+  const { error } = await supabase.from("pricing_tiers").update(payload).eq("id", tierId);
+  if (error) throw new Error(`Failed to update pricing tier: ${error.message}`);
+
+  // Audit log (non-blocking).
+  try {
+    await supabase.from("activity_logs").insert({
+      action: "pricing_tier_updated",
+      description: `Pricing tier "${existing?.name ?? tierId}" updated`,
+      type: "billing",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", {
+      context: "super-admin-actions",
+      tierId,
+      error: err,
+    });
+  }
+}
+
 // ---------- Feature Toggles ----------
 
 export interface FeatureToggleRow {

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -1058,12 +1058,14 @@ export async function updatePricingTier(
 
   // Audit log (non-blocking).
   try {
-    await supabase.from("activity_logs").insert({
-      action: "pricing_tier_updated",
-      description: `Pricing tier "${existing?.name ?? tierId}" updated`,
-      type: "billing",
-      timestamp: new Date().toISOString(),
-    });
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (pricing catalogue is platform-wide, no clinic context)
+      .from("activity_logs")
+      .insert({
+        action: "pricing_tier_updated",
+        description: `Pricing tier "${existing?.name ?? tierId}" updated`,
+        type: "billing",
+        timestamp: new Date().toISOString(),
+      });
   } catch (err) {
     logger.warn("Non-blocking audit log failed", {
       context: "super-admin-actions",


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Phase 1 of the focus map (#1103), continued: **make the money path real.** Pricing tier edits were UI-only (local state + a "Tier updated successfully" toast, no DB write). This makes them persist.

## What changed
- **`updatePricingTier(tierId, { name?, pricing?, features? })`** server action in `super-admin-actions.ts`. Gated to `super_admin` via `rawClient()`; updates the **`pricing_tiers`** row (only the provided fields), and audit-logs to `activity_logs` with the valid **`billing`** type.
- **Pricing page** `confirmSaveTier`: computes the updated tier, optimistically updates, **awaits** `updatePricingTier`, records the local price-change history **only after** a successful persist, and on failure **reconciles from the server** (so the UI never shows an unsaved price) + shows an error toast.
- **5 unit tests**: role gate, partial-field write, billing audit entry, no-op when no fields change, error propagation.

## Still UI-only (follow-ups, not in this PR)
- Promotions create/delete, the pricing "feature toggles" tab, and the super-admin **features matrix** (`feature_definitions`). All have real tables, so the same pattern applies.

## Note on the audit `type`
I discovered `activity_logs.type` has a CHECK constraint (`clinic|billing|feature|announcement|template|auth`). This PR uses the valid `billing`. Separately, the pre-existing `updateClinicStatus` (and my subscription PR #1104) use an invalid `admin` type — I'm fixing those on the #1104 branch.

## Testing
- `tsc --noEmit` ✅ · `eslint --max-warnings 3457` ✅ · `prettier --check .` ✅ · i18n unaffected (no locale changes)
- `vitest run` ✅ **1899 passed** / 84 skipped (+5)
- `next build` ✅
- Not run locally (no live DB): the actual Supabase write — logic is unit-tested with a mocked client; recommend a quick staging check after merge.