### PR TITLE
feat(features): persist Feature Matrix toggles end-to-end (Phase 1)

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -66,6 +66,14 @@ rules:
           #                             table with NO clinic_id column; RLS gives
           #                             super_admin full access and authenticated
           #                             users read-only on active rows.
+          #   - `feature_definitions`— platform-wide feature catalogue (global
+          #                             on/off + tier availability) managed by
+          #                             super_admin; NO clinic_id column. Per-
+          #                             clinic overrides live in the separate
+          #                             clinic_feature_overrides table.
+          #   - `pricing_tiers`      — platform-wide subscription tier catalogue
+          #                             managed by super_admin; NO clinic_id
+          #                             column.
           #
           # All other queue / processed-events tables (notification_queue,
           # processed_stripe_events, processed_whatsapp_messages,
@@ -80,7 +88,7 @@ rules:
           # annotated rather than whitelisted, so a future bare
           # .from("users").select("*") still triggers a warning.
           regex: |-
-            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads|document_templates)["']).*$
+            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads|document_templates|feature_definitions|pricing_tiers)["']).*$
       # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
       # makes this query tenant-scoped. Semgrep normalises JS string quotes,
       # but both variants are kept for belt-and-suspenders parity with the

--- a/src/app/(super-admin)/super-admin/features/page.tsx
+++ b/src/app/(super-admin)/super-admin/features/page.tsx
@@ -16,7 +16,6 @@ import {
   ChevronDown,
   FileSpreadsheet,
   FileText,
-  Info,
   AlertTriangle,
 } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
@@ -54,6 +53,8 @@ import { exportToCSV, exportToPDF } from "@/lib/export-utils";
 import { logger } from "@/lib/logger";
 import {
   fetchFeatureDefinitions,
+  updateFeatureDefinition,
+  bulkSetFeatureTier,
   fetchClinics,
   type FeatureDefinition,
 } from "@/lib/super-admin-actions";
@@ -188,52 +189,74 @@ export default function FeatureTogglesPage() {
     }
   };
 
-  function toggleGlobal(featureId: string) {
+  async function toggleGlobal(featureId: string) {
     const feature = features.find((f) => f.id === featureId);
+    if (!feature) return;
+    const newValue = !feature.globalEnabled;
+    // Optimistic update; reconciled from the server on failure.
     setFeatures((prev) =>
-      prev.map((f) => (f.id === featureId ? { ...f, globalEnabled: !f.globalEnabled } : f)),
+      prev.map((f) => (f.id === featureId ? { ...f, globalEnabled: newValue } : f)),
     );
-    addToast(
-      `${feature?.name ?? "Fonctionnalité"} ${feature?.globalEnabled ? "désactivée" : "activée"} (aperçu — non enregistré)`,
-      "info",
-    );
+    try {
+      await updateFeatureDefinition(featureId, { globalEnabled: newValue });
+      addToast(`${feature.name} ${newValue ? "activée" : "désactivée"} globalement`, "success");
+    } catch (err) {
+      logger.warn("Failed to persist global toggle", { context: "page", error: err });
+      await loadFeatures();
+      addToast("Échec de l'enregistrement. Veuillez réessayer.", "error");
+    }
   }
 
-  function toggleTier(featureId: string, tier: string) {
+  async function toggleTier(featureId: string, tier: string) {
+    const feature = features.find((f) => f.id === featureId);
+    if (!feature) return;
+    const hasTier = feature.availableTiers.includes(tier);
+    const newTiers = hasTier
+      ? feature.availableTiers.filter((t) => t !== tier)
+      : [...feature.availableTiers, tier];
     setFeatures((prev) =>
-      prev.map((f) => {
-        if (f.id !== featureId) return f;
-        const hasTier = f.availableTiers.includes(tier);
-        return {
-          ...f,
-          availableTiers: hasTier
-            ? f.availableTiers.filter((t) => t !== tier)
-            : [...f.availableTiers, tier],
-        };
-      }),
+      prev.map((f) => (f.id === featureId ? { ...f, availableTiers: newTiers } : f)),
     );
+    try {
+      await updateFeatureDefinition(featureId, { availableTiers: newTiers });
+    } catch (err) {
+      logger.warn("Failed to persist tier toggle", { context: "page", error: err });
+      await loadFeatures();
+      addToast("Échec de l'enregistrement. Veuillez réessayer.", "error");
+    }
   }
 
-  function handleBulkAction() {
+  async function handleBulkAction() {
+    const tier = bulkTier;
+    const enable = bulkAction === "enable";
+    setBulkOpen(false);
+    // Optimistic update.
     setFeatures((prev) =>
       prev.map((f) => {
-        if (bulkAction === "enable") {
+        if (enable) {
           return {
             ...f,
-            availableTiers: f.availableTiers.includes(bulkTier)
+            availableTiers: f.availableTiers.includes(tier)
               ? f.availableTiers
-              : [...f.availableTiers, bulkTier],
+              : [...f.availableTiers, tier],
           };
-        } else {
-          return { ...f, availableTiers: f.availableTiers.filter((t) => t !== bulkTier) };
         }
+        return { ...f, availableTiers: f.availableTiers.filter((t) => t !== tier) };
       }),
     );
-    setBulkOpen(false);
-    addToast(
-      `Aperçu mis à jour : toutes les fonctionnalités ${bulkAction === "enable" ? "activées" : "désactivées"} pour le palier ${TIER_LABELS[bulkTier] ?? bulkTier} (non enregistré)`,
-      "info",
-    );
+    try {
+      await bulkSetFeatureTier(tier, enable);
+      // Reconcile from the server so the matrix reflects the persisted state.
+      await loadFeatures();
+      addToast(
+        `Toutes les fonctionnalités ${enable ? "activées" : "désactivées"} pour le palier ${TIER_LABELS[tier] ?? tier}`,
+        "success",
+      );
+    } catch (err) {
+      logger.warn("Failed to persist bulk tier update", { context: "page", error: err });
+      await loadFeatures();
+      addToast("Échec de la mise à jour groupée. Veuillez réessayer.", "error");
+    }
   }
 
   async function toggleClinicOverride(featureKey: string, enabled: boolean) {
@@ -451,21 +474,6 @@ export default function FeatureTogglesPage() {
         </TabsList>
 
         <TabsContent value="matrix">
-          {/* R1/R3: the global + per-tier toggles below are a non-persistent
-              preview — there is no write path for feature_definitions, so a
-              click changes only this view and is discarded on refresh. Make
-              that explicit so an operator never believes a tier-wide change
-              was rolled out to clinics. Persistent, per-clinic changes are
-              made in the "Dérogations cliniques" tab. */}
-          <div className="mb-6 flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm dark:bg-amber-900/20 dark:border-amber-700">
-            <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
-            <p className="text-amber-800 dark:text-amber-200">
-              Les bascules globales et par palier ci-dessous sont un aperçu et ne sont pas encore
-              enregistrées. Pour appliquer un changement persistant à une clinique, utilisez
-              l&apos;onglet « Dérogations cliniques ».
-            </p>
-          </div>
-
           {/* Filters */}
           <div className="flex flex-col sm:flex-row gap-3 mb-6">
             <div className="relative flex-1">
@@ -730,10 +738,9 @@ export default function FeatureTogglesPage() {
             <div className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs dark:bg-amber-900/20 dark:border-amber-700">
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
               <p className="text-amber-800 dark:text-amber-200">
-                Cette action met à jour l&apos;aperçu de toutes les fonctionnalités du palier
-                sélectionné. Il s&apos;agit d&apos;un aperçu local : aucune modification n&apos;est
-                enregistrée ni propagée aux cliniques tant qu&apos;une persistance n&apos;est pas
-                disponible.
+                Cette action met à jour et enregistre la disponibilité de toutes les fonctionnalités
+                pour le palier sélectionné. Le changement s&apos;applique à toutes les cliniques de
+                ce palier.
               </p>
             </div>
             <div className="space-y-2">

--- a/src/lib/__tests__/feature-definition.test.ts
+++ b/src/lib/__tests__/feature-definition.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for updateFeatureDefinition + bulkSetFeatureTier (Feature Matrix
+ * persistence). Verifies the role gate, partial writes, the audit entry
+ * (feature type), the bulk add/skip logic, and error propagation.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireRole = vi.fn().mockResolvedValue(undefined);
+
+let updateError: { message: string } | null = null;
+let bulkRows: { id: string; available_tiers: string[] }[] = [];
+
+const updateEq = vi.fn(() => Promise.resolve({ error: updateError }));
+const update = vi.fn(() => ({ eq: updateEq }));
+const single = vi.fn(() => Promise.resolve({ data: { id: "f1", name: "Booking" } }));
+const selectEq = vi.fn(() => ({ single }));
+// `select` is both chainable (`.eq().single()`) and awaitable (bulk read).
+const select = vi.fn(() => ({
+  eq: selectEq,
+  then: (resolve: (v: { data: typeof bulkRows; error: null }) => void) =>
+    resolve({ data: bulkRows, error: null }),
+}));
+const insert = vi.fn(
+  (): Promise<{ error: { message: string } | null }> => Promise.resolve({ error: null }),
+);
+const from = vi.fn(() => ({ select, update, insert }));
+
+vi.mock("@/lib/auth", () => ({ requireRole: (...a: unknown[]) => requireRole(...a) }));
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: () => Promise.resolve({ from }),
+  createAdminClient: () => ({ from }),
+}));
+vi.mock("@/lib/subdomain-cache", () => ({ invalidateSubdomainCache: vi.fn() }));
+vi.mock("@/lib/email", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/lib/email-templates", () => ({
+  staffWelcomeEmail: vi.fn(),
+  clinicSuspendedEmail: vi.fn(),
+  clinicActivatedEmail: vi.fn(),
+}));
+vi.mock("@/lib/onboarding/state", () => ({ syncClinicOnboardingState: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+async function load() {
+  return await import("@/lib/super-admin-actions");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateError = null;
+  bulkRows = [];
+});
+
+describe("updateFeatureDefinition", () => {
+  it("requires super_admin", async () => {
+    const { updateFeatureDefinition } = await load();
+    await updateFeatureDefinition("f1", { globalEnabled: false });
+    expect(requireRole).toHaveBeenCalledWith("super_admin");
+  });
+
+  it("writes only the provided fields + audits with feature type", async () => {
+    const { updateFeatureDefinition } = await load();
+    await updateFeatureDefinition("f1", { globalEnabled: false });
+    expect(update).toHaveBeenCalledWith({ global_enabled: false });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "feature_definition_updated", type: "feature" }),
+    );
+  });
+
+  it("writes available_tiers when provided", async () => {
+    const { updateFeatureDefinition } = await load();
+    await updateFeatureDefinition("f1", { availableTiers: ["basic", "premium"] });
+    expect(update).toHaveBeenCalledWith({ available_tiers: ["basic", "premium"] });
+  });
+
+  it("is a no-op when no fields are provided", async () => {
+    const { updateFeatureDefinition } = await load();
+    await updateFeatureDefinition("f1", {});
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("throws when the update fails", async () => {
+    const { updateFeatureDefinition } = await load();
+    updateError = { message: "boom" };
+    await expect(updateFeatureDefinition("f1", { globalEnabled: true })).rejects.toThrow(
+      /Failed to update feature definition/,
+    );
+  });
+});
+
+describe("bulkSetFeatureTier", () => {
+  it("adds the tier only to features missing it (skips already-correct)", async () => {
+    bulkRows = [
+      { id: "f1", available_tiers: ["basic"] },
+      { id: "f2", available_tiers: [] },
+    ];
+    const { bulkSetFeatureTier } = await load();
+    await bulkSetFeatureTier("basic", true);
+    // f1 already has basic → skipped; f2 missing → updated once.
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({ available_tiers: ["basic"] });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "feature_tier_bulk_update", type: "feature" }),
+    );
+  });
+
+  it("removes the tier from features that have it", async () => {
+    bulkRows = [
+      { id: "f1", available_tiers: ["basic", "premium"] },
+      { id: "f2", available_tiers: ["premium"] },
+    ];
+    const { bulkSetFeatureTier } = await load();
+    await bulkSetFeatureTier("basic", false);
+    // Only f1 has basic → one update removing it.
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith({ available_tiers: ["premium"] });
+  });
+});

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -997,12 +997,14 @@ export async function updateFeatureDefinition(
   if (error) throw new Error(`Failed to update feature definition: ${error.message}`);
 
   try {
-    await supabase.from("activity_logs").insert({
-      action: "feature_definition_updated",
-      description: `Feature "${existing?.name ?? featureId}" updated`,
-      type: "feature",
-      timestamp: new Date().toISOString(),
-    });
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (feature catalogue is platform-wide, no clinic context)
+      .from("activity_logs")
+      .insert({
+        action: "feature_definition_updated",
+        description: `Feature "${existing?.name ?? featureId}" updated`,
+        type: "feature",
+        timestamp: new Date().toISOString(),
+      });
   } catch (err) {
     logger.warn("Non-blocking audit log failed", {
       context: "super-admin-actions",
@@ -1039,12 +1041,14 @@ export async function bulkSetFeatureTier(tier: string, enabled: boolean): Promis
   }
 
   try {
-    await supabase.from("activity_logs").insert({
-      action: "feature_tier_bulk_update",
-      description: `All features ${enabled ? "enabled" : "disabled"} for tier "${tier}"`,
-      type: "feature",
-      timestamp: new Date().toISOString(),
-    });
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (feature catalogue is platform-wide, no clinic context)
+      .from("activity_logs")
+      .insert({
+        action: "feature_tier_bulk_update",
+        description: `All features ${enabled ? "enabled" : "disabled"} for tier "${tier}"`,
+        type: "feature",
+        timestamp: new Date().toISOString(),
+      });
   } catch (err) {
     logger.warn("Non-blocking audit log failed", {
       context: "super-admin-actions",

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -969,6 +969,91 @@ export async function fetchFeatureDefinitions(): Promise<FeatureDefinition[]> {
   }));
 }
 
+/**
+ * Persist a feature-definition change (super-admin Feature Matrix).
+ *
+ * Writes the global on/off flag and/or the tier availability list to the
+ * `feature_definitions` row. Only the provided fields are updated. Audit-logged
+ * to `activity_logs` with the `feature` type.
+ */
+export async function updateFeatureDefinition(
+  featureId: string,
+  updates: { globalEnabled?: boolean; availableTiers?: string[] },
+): Promise<void> {
+  const supabase = await rawClient();
+
+  const payload: { global_enabled?: boolean; available_tiers?: string[] } = {};
+  if (updates.globalEnabled !== undefined) payload.global_enabled = updates.globalEnabled;
+  if (updates.availableTiers !== undefined) payload.available_tiers = updates.availableTiers;
+  if (Object.keys(payload).length === 0) return;
+
+  const { data: existing } = await supabase
+    .from("feature_definitions")
+    .select("id, name")
+    .eq("id", featureId)
+    .single();
+
+  const { error } = await supabase.from("feature_definitions").update(payload).eq("id", featureId);
+  if (error) throw new Error(`Failed to update feature definition: ${error.message}`);
+
+  try {
+    await supabase.from("activity_logs").insert({
+      action: "feature_definition_updated",
+      description: `Feature "${existing?.name ?? featureId}" updated`,
+      type: "feature",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", {
+      context: "super-admin-actions",
+      featureId,
+      error: err,
+    });
+  }
+}
+
+/**
+ * Bulk-set a single tier across all feature definitions (Feature Matrix bulk
+ * action). Adds or removes `tier` from every feature's `available_tiers`.
+ * Writes a single `feature` audit-log entry rather than one per feature.
+ */
+export async function bulkSetFeatureTier(tier: string, enabled: boolean): Promise<void> {
+  const supabase = await rawClient();
+
+  const { data: rows, error: readError } = await supabase
+    .from("feature_definitions")
+    .select("id, available_tiers");
+  if (readError) throw new Error(`Failed to read feature definitions: ${readError.message}`);
+  if (!rows) return;
+
+  for (const row of rows) {
+    const current: string[] = row.available_tiers ?? [];
+    const has = current.includes(tier);
+    if (enabled === has) continue; // already in desired state
+    const next = enabled ? [...current, tier] : current.filter((t) => t !== tier);
+    const { error } = await supabase
+      .from("feature_definitions")
+      .update({ available_tiers: next })
+      .eq("id", row.id);
+    if (error) throw new Error(`Failed to update feature ${row.id}: ${error.message}`);
+  }
+
+  try {
+    await supabase.from("activity_logs").insert({
+      action: "feature_tier_bulk_update",
+      description: `All features ${enabled ? "enabled" : "disabled"} for tier "${tier}"`,
+      type: "feature",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", {
+      context: "super-admin-actions",
+      tier,
+      error: err,
+    });
+  }
+}
+
 // ---------- Pricing Tiers ----------
 
 export interface PricingTierRow {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Phase 1 of the focus map (#1103), continued. The super-admin **Feature Matrix** global / per-tier / bulk toggles were UI-only (local state + honest "aperçu — non enregistré" messaging from #1099). This wires them to the real `feature_definitions` table.

## What changed
- **`updateFeatureDefinition(id, { globalEnabled?, availableTiers? })`** — super_admin-gated (`rawClient()`); updates `feature_definitions.global_enabled` / `available_tiers` (only provided fields); audit-logged with the valid `feature` type.
- **`bulkSetFeatureTier(tier, enabled)`** — adds/removes a tier across all features in one pass; skips already-correct rows; writes a **single** audit entry.
- **Features page**: `toggleGlobal` / `toggleTier` / `handleBulkAction` now optimistically update, **await** persistence, **reconcile from the server on failure**, and show real success/error toasts. Removed the obsolete "preview / non-saved" matrix banner; reworded the bulk-dialog warning (it now persists and applies to all clinics on the tier).
- **7 unit tests** — role gate, partial writes, `feature` audit type, bulk add/remove/skip, error propagation.

This closes the R1/R3 finding from the Content QA report (the matrix toggles that previously showed fake success).

## Promotions — deferred (needs your decision)
The other remaining Phase-1 item, **promotions**, is stored in **`localStorage`** (`oltigo_promotions`), not a DB table. Persisting it server-side requires a **new table + migration**, which I can't verify against a live DB here and which is lower-value than the core money path. Flagging it for a schema decision rather than inventing an unverifiable migration. (Per-clinic *Clinic Overrides* already persist via the existing API.)

## Testing
- `tsc --noEmit` ✅ · `eslint --max-warnings 3457` ✅ · `prettier --check .` ✅ · i18n unaffected
- `vitest run` ✅ **1901 passed** / 84 skipped (+7)
- `next build` ✅
- Not run locally (no live DB): the actual Supabase writes — logic is unit-tested with a mocked client; recommend a quick staging check after merge.

Based on the latest `main` (includes #1099–#1102), so it should merge cleanly alongside the subscription (#1104) and pricing (#1105) persistence PRs — they touch different functions/files.