### PR TITLE
fix(super-admin): scope notifications query by clinic_id

### DIFF
--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -498,17 +498,25 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
 
         const { data: profile } = await supabase
           .from("users")
-          .select("id")
+          .select("id, clinic_id")
           .eq("auth_id", user.id)
           .single();
         if (!profile || !mountedRef.current) return;
 
-        const { data } = await supabase
+        // F-A96-02 / AGENTS.md rule #1: scope by clinic_id for tenant
+        // isolation (defense-in-depth alongside RLS). user_id already pins
+        // the result to the current user; clinic_id is applied when the
+        // profile has one (super_admin has clinic_id = null and is unscoped).
+        let notifQuery = supabase
           .from("notifications")
           .select("id, title, body, sent_at, is_read")
-          .eq("user_id", profile.id)
-          .order("sent_at", { ascending: false })
-          .limit(10);
+          .eq("user_id", profile.id);
+
+        if (profile.clinic_id) {
+          notifQuery = notifQuery.eq("clinic_id", profile.clinic_id);
+        }
+
+        const { data } = await notifQuery.order("sent_at", { ascending: false }).limit(10);
 
         if (!mountedRef.current) return;
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

The super-admin layout's `loadNotifications()` in `src/components/layouts/super-admin-layout-shell.tsx` queried the `notifications` table filtering only by `user_id`, with no `clinic_id` scoping. This violates **AGENTS.md rule #1** (always filter by `clinic_id` as defense-in-depth alongside RLS).

- Profile lookup now selects `id, clinic_id`.
- The notifications query is scoped with a conditional `.eq("clinic_id", profile.clinic_id)` when the profile has a clinic. This mirrors the pattern already used and accepted in `src/app/api/notifications/route.ts` (F-A96-02).
- Behavior is preserved for `super_admin` (whose `clinic_id` is `null`, so the query stays scoped only by their own `user_id`, exactly as before). The change adds defense-in-depth for any non-null-clinic profile that renders this shell.

## Context: the other audit items were already fixed

While investigating the RLS/tenant concerns raised, I verified against the current `main` that the rest of the items in `docs/audit/open-actions.md` are **already resolved** (that doc is stale):

1. `booking_atomic_insert` no longer references a non-existent `doctors` table — fixed in `00143_fix_booking_atomic_insert_doctors_ref.sql` (validates doctor/patient against `users`, service against `services`, all by `clinic_id`).
2. `src/app/api/booking/route.ts` already calls the atomic `booking_atomic_insert` RPC (advisory-lock + insert in one transaction); the non-atomic insert-then-count path is gone.
3. `src/app/api/notifications/route.ts` already scopes by `clinic_id` (F-A96-02).
4. No duplicate `00072` migration prefix exists in the repo.

Note on the original RLS question: the configuration (`rls_enabled=true`, `rls_forced=false` on all public tables) is the **intended** state per `docs/adr/0011-no-force-rls.md`. Enabling FORCE RLS would break the SECURITY DEFINER tenant layer — so no change there.

## Testing

- `npx tsc --noEmit` — no type errors for the changed file.
- `npx eslint src/components/layouts/super-admin-layout-shell.tsx` — 0 errors (1 pre-existing, unrelated warning on the `buildCommandItems` effect).
- lint-staged (eslint --fix + prettier) ran clean in the pre-commit hook.

## Limitations

- This is a client-side UI query; RLS remains the authoritative enforcement layer. The change is defense-in-depth and convention alignment, not a sole security boundary.