### PR TITLE
feat(pricing): persist promotions to the DB (Phase 1 complete)

### DIFF
--- a/.semgrep/tenant-scoping.yml
+++ b/.semgrep/tenant-scoping.yml
@@ -66,6 +66,10 @@ rules:
           #                             table with NO clinic_id column; RLS gives
           #                             super_admin full access and authenticated
           #                             users read-only on active rows.
+          #   - `promotions`         — platform-wide promotional discounts
+          #                             managed by super_admin (migration 00194);
+          #                             NO clinic_id column (targets tiers via
+          #                             the `tiers` array, not clinics).
           #
           # All other queue / processed-events tables (notification_queue,
           # processed_stripe_events, processed_whatsapp_messages,
@@ -80,7 +84,7 @@ rules:
           # annotated rather than whitelisted, so a future bare
           # .from("users").select("*") still triggers a warning.
           regex: |-
-            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads|document_templates)["']).*$
+            ^(?!["'](clinics|ai_provider_configs|ai_task_configs|announcements|demo_leads|document_templates|promotions)["']).*$
       # Any .eq("clinic_id", ...) anywhere in the surrounding method chain
       # makes this query tenant-scoped. Semgrep normalises JS string quotes,
       # but both variants are kept for belt-and-suspenders parity with the

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -54,6 +54,10 @@ import {
   fetchClientSubscriptions,
   fetchPricingTiers,
   fetchFeatureToggles,
+  fetchPromotions,
+  createPromotion,
+  setPromotionEnabled,
+  deletePromotion,
   type ClientSubscription,
   type PricingTierRow,
   type FeatureToggleRow,
@@ -82,22 +86,7 @@ interface Promotion {
   enabled: boolean;
 }
 
-const STORAGE_KEY_PROMOS = "oltigo_promotions";
 const STORAGE_KEY_HISTORY = "oltigo_price_history";
-
-function isPromotion(v: unknown): v is Promotion {
-  if (typeof v !== "object" || v === null) return false;
-  const o = v as Record<string, unknown>;
-  return (
-    typeof o.id === "string" &&
-    typeof o.name === "string" &&
-    typeof o.discount === "number" &&
-    Array.isArray(o.tiers) &&
-    typeof o.startDate === "string" &&
-    typeof o.endDate === "string" &&
-    typeof o.enabled === "boolean"
-  );
-}
 
 function isHistoryEntry(v: unknown): v is PriceHistoryEntry {
   if (typeof v !== "object" || v === null) return false;
@@ -109,24 +98,6 @@ function isHistoryEntry(v: unknown): v is PriceHistoryEntry {
     typeof o.oldPrice === "number" &&
     typeof o.newPrice === "number"
   );
-}
-
-function loadPromos(): Promotion[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY_PROMOS);
-    if (!raw) return [];
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isPromotion);
-  } catch {
-    return [];
-  }
-}
-
-function savePromos(promos: Promotion[]) {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(STORAGE_KEY_PROMOS, JSON.stringify(promos));
 }
 
 function loadHistory(): PriceHistoryEntry[] {
@@ -190,14 +161,16 @@ export default function PricingPage() {
 
   const loadData = useCallback(async () => {
     try {
-      const [subs, tiersData, togglesData] = await Promise.all([
+      const [subs, tiersData, togglesData, promosData] = await Promise.all([
         fetchClientSubscriptions(),
         fetchPricingTiers(),
         fetchFeatureToggles(),
+        fetchPromotions(),
       ]);
       setSubscriptions(subs);
       setTiers(tiersData);
       setToggles(togglesData);
+      setPromotions(promosData);
     } catch (err) {
       logger.warn("Failed to load pricing page", { context: "page", error: err });
     } finally {
@@ -215,7 +188,6 @@ export default function PricingPage() {
 
   useEffect(() => {
     setPriceHistory(loadHistory());
-    setPromotions(loadPromos());
   }, []);
 
   const stats = {
@@ -395,37 +367,54 @@ export default function PricingPage() {
     setPromoFormOpen(true);
   }
 
-  function handleSavePromo() {
-    const newPromo: Promotion = {
-      id: `promo-${Date.now()}`,
-      name: promoName,
-      discount: Number(promoDiscount) || 0,
-      tiers: promoTiers,
-      startDate: promoStart,
-      endDate: promoEnd,
-      enabled: true,
-    };
-    const updated = [newPromo, ...promotions];
-    setPromotions(updated);
-    savePromos(updated);
+  async function handleSavePromo() {
     setPromoFormOpen(false);
-    addToast("Promotion créée (aperçu — non enregistré)", "info");
+    try {
+      const created = await createPromotion({
+        name: promoName,
+        discount: Number(promoDiscount) || 0,
+        tiers: promoTiers,
+        startDate: promoStart,
+        endDate: promoEnd,
+      });
+      setPromotions((prev) => [created, ...prev]);
+      addToast("Promotion créée", "success");
+    } catch (err) {
+      logger.warn("Failed to create promotion", { context: "page", error: err });
+      addToast("Échec de la création de la promotion. Veuillez réessayer.", "error");
+    }
   }
 
-  function togglePromoEnabled(id: string) {
-    const updated = promotions.map((p) => (p.id === id ? { ...p, enabled: !p.enabled } : p));
-    setPromotions(updated);
-    savePromos(updated);
+  async function togglePromoEnabled(id: string) {
+    const target = promotions.find((p) => p.id === id);
+    if (!target) return;
+    const next = !target.enabled;
+    setPromotions((prev) => prev.map((p) => (p.id === id ? { ...p, enabled: next } : p)));
+    try {
+      await setPromotionEnabled(id, next);
+    } catch (err) {
+      logger.warn("Failed to toggle promotion", { context: "page", error: err });
+      // Roll back the optimistic change.
+      setPromotions((prev) => prev.map((p) => (p.id === id ? { ...p, enabled: !next } : p)));
+      addToast("Échec de la mise à jour de la promotion.", "error");
+    }
   }
 
-  function handleDeletePromo() {
+  async function handleDeletePromo() {
     if (!deletePromoItem) return;
-    const updated = promotions.filter((p) => p.id !== deletePromoItem.id);
-    setPromotions(updated);
-    savePromos(updated);
+    const removed = deletePromoItem;
+    setPromotions((prev) => prev.filter((p) => p.id !== removed.id));
     setDeletePromoOpen(false);
     setDeletePromoItem(null);
-    addToast("Promotion supprimée (aperçu — non enregistré)", "info");
+    try {
+      await deletePromotion(removed.id);
+      addToast("Promotion supprimée", "success");
+    } catch (err) {
+      logger.warn("Failed to delete promotion", { context: "page", error: err });
+      // Roll back the optimistic removal.
+      setPromotions((prev) => [removed, ...prev]);
+      addToast("Échec de la suppression de la promotion.", "error");
+    }
   }
 
   function togglePromoTier(slug: string) {
@@ -1234,7 +1223,7 @@ export default function PricingPage() {
                         <div className="flex items-center gap-2 shrink-0">
                           <Switch
                             checked={promo.enabled}
-                            onCheckedChange={() => togglePromoEnabled(promo.id)}
+                            onCheckedChange={() => void togglePromoEnabled(promo.id)}
                           />
                           <Button
                             variant="ghost"
@@ -1422,7 +1411,7 @@ export default function PricingPage() {
               Cancel
             </Button>
             <Button
-              onClick={handleSavePromo}
+              onClick={() => void handleSavePromo()}
               disabled={!promoName || !promoDiscount || !promoStart || !promoEnd}
             >
               Create Promotion
@@ -1452,7 +1441,7 @@ export default function PricingPage() {
               <Button variant="outline" onClick={() => setDeletePromoOpen(false)}>
                 Annuler
               </Button>
-              <Button variant="destructive" onClick={handleDeletePromo}>
+              <Button variant="destructive" onClick={() => void handleDeletePromo()}>
                 <Trash2 className="h-4 w-4 mr-1" />
                 Supprimer
               </Button>

--- a/src/lib/__tests__/promotions.test.ts
+++ b/src/lib/__tests__/promotions.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the promotions server actions (super-admin Pricing > Promotions).
+ * Verifies the role gate, mapping, create/delete/enable persistence, the
+ * billing audit entries, and error propagation.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireRole = vi.fn().mockResolvedValue(undefined);
+
+let promoRows: Array<Record<string, unknown>> = [];
+let createdRow: Record<string, unknown> = {};
+let createError: { message: string } | null = null;
+let mutError: { message: string } | null = null;
+
+const order = vi.fn(() => Promise.resolve({ data: promoRows, error: null }));
+const select = vi.fn(() => ({ order }));
+const single = vi.fn(() => Promise.resolve({ data: createdRow, error: createError }));
+const insertSelect = vi.fn(() => ({ single }));
+const insert = vi.fn(() => ({
+  select: insertSelect,
+  then: (resolve: (v: { error: null }) => void) => resolve({ error: null }),
+}));
+const mutEq = vi.fn(() => Promise.resolve({ error: mutError }));
+const update = vi.fn(() => ({ eq: mutEq }));
+const del = vi.fn(() => ({ eq: mutEq }));
+const from = vi.fn(() => ({ select, insert, update, delete: del }));
+
+vi.mock("@/lib/auth", () => ({ requireRole: (...a: unknown[]) => requireRole(...a) }));
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: () => Promise.resolve({ from }),
+  createAdminClient: () => ({ from }),
+}));
+vi.mock("@/lib/subdomain-cache", () => ({ invalidateSubdomainCache: vi.fn() }));
+vi.mock("@/lib/email", () => ({ sendEmail: vi.fn() }));
+vi.mock("@/lib/email-templates", () => ({
+  staffWelcomeEmail: vi.fn(),
+  clinicSuspendedEmail: vi.fn(),
+  clinicActivatedEmail: vi.fn(),
+}));
+vi.mock("@/lib/onboarding/state", () => ({ syncClinicOnboardingState: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+async function load() {
+  return await import("@/lib/super-admin-actions");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  promoRows = [];
+  createdRow = {};
+  createError = null;
+  mutError = null;
+});
+
+describe("fetchPromotions", () => {
+  it("maps DB rows to the client shape", async () => {
+    promoRows = [
+      {
+        id: "p1",
+        name: "Summer",
+        discount_percent: 20,
+        tiers: ["pro"],
+        start_date: "2026-06-01",
+        end_date: "2026-07-01",
+        enabled: true,
+      },
+    ];
+    const { fetchPromotions } = await load();
+    const result = await fetchPromotions();
+    expect(requireRole).toHaveBeenCalledWith("super_admin");
+    expect(result).toEqual([
+      {
+        id: "p1",
+        name: "Summer",
+        discount: 20,
+        tiers: ["pro"],
+        startDate: "2026-06-01",
+        endDate: "2026-07-01",
+        enabled: true,
+      },
+    ]);
+  });
+});
+
+describe("createPromotion", () => {
+  it("inserts mapped columns, audits (billing), and returns the created row", async () => {
+    createdRow = {
+      id: "p2",
+      name: "Launch",
+      discount_percent: 15,
+      tiers: ["premium"],
+      start_date: null,
+      end_date: null,
+      enabled: true,
+    };
+    const { createPromotion } = await load();
+    const result = await createPromotion({
+      name: "Launch",
+      discount: 15,
+      tiers: ["premium"],
+      startDate: "",
+      endDate: "",
+    });
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Launch",
+        discount_percent: 15,
+        tiers: ["premium"],
+        start_date: null,
+        end_date: null,
+        enabled: true,
+      }),
+    );
+    // Audit entry (billing type) on activity_logs.
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "promotion_created", type: "billing" }),
+    );
+    expect(result.id).toBe("p2");
+    expect(result.discount).toBe(15);
+  });
+
+  it("throws when the insert fails", async () => {
+    createError = { message: "boom" };
+    const { createPromotion } = await load();
+    await expect(
+      createPromotion({ name: "X", discount: 5, tiers: [], startDate: "", endDate: "" }),
+    ).rejects.toThrow(/Failed to create promotion/);
+  });
+});
+
+describe("setPromotionEnabled", () => {
+  it("updates the enabled flag", async () => {
+    const { setPromotionEnabled } = await load();
+    await setPromotionEnabled("p1", false);
+    expect(update).toHaveBeenCalledWith({ enabled: false });
+    expect(mutEq).toHaveBeenCalledWith("id", "p1");
+  });
+
+  it("throws when the update fails", async () => {
+    mutError = { message: "nope" };
+    const { setPromotionEnabled } = await load();
+    await expect(setPromotionEnabled("p1", true)).rejects.toThrow(/Failed to update promotion/);
+  });
+});
+
+describe("deletePromotion", () => {
+  it("deletes the row and writes a billing audit entry", async () => {
+    const { deletePromotion } = await load();
+    await deletePromotion("p1");
+    expect(del).toHaveBeenCalled();
+    expect(mutEq).toHaveBeenCalledWith("id", "p1");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "promotion_deleted", type: "billing" }),
+    );
+  });
+
+  it("throws when the delete fails", async () => {
+    mutError = { message: "denied" };
+    const { deletePromotion } = await load();
+    await expect(deletePromotion("p1")).rejects.toThrow(/Failed to delete promotion/);
+  });
+});

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -380,6 +380,119 @@ export async function updateClinicStatus(
   }
 }
 
+// ---------- Promotions ----------
+
+export interface PromotionRow {
+  id: string;
+  name: string;
+  discount: number;
+  tiers: string[];
+  startDate: string;
+  endDate: string;
+  enabled: boolean;
+}
+
+// `promotions` (migration 00194) is not yet in the generated Supabase types.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UntypedClient = { from: (table: string) => any };
+
+interface PromotionDbRow {
+  id: string;
+  name: string | null;
+  discount_percent: number | null;
+  tiers: string[] | null;
+  start_date: string | null;
+  end_date: string | null;
+  enabled: boolean | null;
+}
+
+function mapPromotion(row: PromotionDbRow): PromotionRow {
+  return {
+    id: row.id,
+    name: row.name ?? "",
+    discount: row.discount_percent ?? 0,
+    tiers: row.tiers ?? [],
+    startDate: row.start_date ?? "",
+    endDate: row.end_date ?? "",
+    enabled: row.enabled ?? true,
+  };
+}
+
+const PROMOTION_COLS = "id, name, discount_percent, tiers, start_date, end_date, enabled";
+
+export async function fetchPromotions(): Promise<PromotionRow[]> {
+  const supabase = (await rawClient()) as unknown as UntypedClient;
+  const { data, error } = await supabase
+    .from("promotions")
+    .select(PROMOTION_COLS)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return (data as PromotionDbRow[]).map(mapPromotion);
+}
+
+export async function createPromotion(input: {
+  name: string;
+  discount: number;
+  tiers: string[];
+  startDate: string;
+  endDate: string;
+}): Promise<PromotionRow> {
+  const supabase = (await rawClient()) as unknown as UntypedClient;
+  const { data, error } = await supabase
+    .from("promotions")
+    .insert({
+      name: input.name,
+      discount_percent: input.discount,
+      tiers: input.tiers,
+      start_date: input.startDate || null,
+      end_date: input.endDate || null,
+      enabled: true,
+    })
+    .select(PROMOTION_COLS)
+    .single();
+  if (error || !data) throw new Error(`Failed to create promotion: ${error?.message ?? "no data"}`);
+
+  try {
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
+      .from("activity_logs")
+      .insert({
+        action: "promotion_created",
+        description: `Promotion "${input.name}" created`,
+        type: "billing",
+        timestamp: new Date().toISOString(),
+      });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", { context: "super-admin-actions", error: err });
+  }
+
+  return mapPromotion(data as PromotionDbRow);
+}
+
+export async function setPromotionEnabled(id: string, enabled: boolean): Promise<void> {
+  const supabase = (await rawClient()) as unknown as UntypedClient;
+  const { error } = await supabase.from("promotions").update({ enabled }).eq("id", id);
+  if (error) throw new Error(`Failed to update promotion: ${error.message}`);
+}
+
+export async function deletePromotion(id: string): Promise<void> {
+  const supabase = (await rawClient()) as unknown as UntypedClient;
+  const { error } = await supabase.from("promotions").delete().eq("id", id);
+  if (error) throw new Error(`Failed to delete promotion: ${error.message}`);
+
+  try {
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
+      .from("activity_logs")
+      .insert({
+        action: "promotion_deleted",
+        description: `Promotion ${id} deleted`,
+        type: "billing",
+        timestamp: new Date().toISOString(),
+      });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", { context: "super-admin-actions", error: err });
+  }
+}
+
 // ---------- User CRUD ----------
 
 /**

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -453,8 +453,8 @@ export async function createPromotion(input: {
   if (error || !data) throw new Error(`Failed to create promotion: ${error?.message ?? "no data"}`);
 
   try {
-    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
-      .from("activity_logs")
+    await supabase
+      .from("activity_logs") // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
       .insert({
         action: "promotion_created",
         description: `Promotion "${input.name}" created`,
@@ -480,8 +480,8 @@ export async function deletePromotion(id: string): Promise<void> {
   if (error) throw new Error(`Failed to delete promotion: ${error.message}`);
 
   try {
-    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
-      .from("activity_logs")
+    await supabase
+      .from("activity_logs") // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
       .insert({
         action: "promotion_deleted",
         description: `Promotion ${id} deleted`,

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -453,8 +453,8 @@ export async function createPromotion(input: {
   if (error || !data) throw new Error(`Failed to create promotion: ${error?.message ?? "no data"}`);
 
   try {
-    await supabase
-      .from("activity_logs") // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
+      .from("activity_logs")
       .insert({
         action: "promotion_created",
         description: `Promotion "${input.name}" created`,
@@ -480,8 +480,8 @@ export async function deletePromotion(id: string): Promise<void> {
   if (error) throw new Error(`Failed to delete promotion: ${error.message}`);
 
   try {
-    await supabase
-      .from("activity_logs") // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
+    await supabase // nosemgrep: tenant-scoping — global super-admin audit event (promotions are platform-wide, no clinic context)
+      .from("activity_logs")
       .insert({
         action: "promotion_deleted",
         description: `Promotion ${id} deleted`,

--- a/supabase/migrations/00194_promotions.sql
+++ b/supabase/migrations/00194_promotions.sql
@@ -1,0 +1,50 @@
+-- Migration 00194: Global promotions managed by super_admin.
+-- Used by the super-admin/pricing "Promotions" tab to persist promotional
+-- discounts across sessions and operators (previously localStorage-only).
+-- Platform-wide table: NO clinic_id column (promotions target subscription
+-- tiers via the `tiers` array, not individual clinics).
+
+CREATE TABLE IF NOT EXISTS promotions (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name             TEXT        NOT NULL,
+  discount_percent INT         NOT NULL DEFAULT 0 CHECK (discount_percent >= 0 AND discount_percent <= 100),
+  tiers            TEXT[]      NOT NULL DEFAULT '{}',
+  start_date       DATE,
+  end_date         DATE,
+  enabled          BOOLEAN     NOT NULL DEFAULT true,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE promotions ENABLE ROW LEVEL SECURITY;
+
+-- Super admins can do everything.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'promotions'
+    AND policyname = 'super_admin_all_promotions'
+  ) THEN
+    CREATE POLICY "super_admin_all_promotions" ON promotions
+      FOR ALL USING (
+        EXISTS (
+          SELECT 1 FROM users
+          WHERE auth_id = auth.uid() AND role = 'super_admin'
+        )
+      );
+  END IF;
+END $$;
+
+-- Authenticated users can read enabled promotions (for clinic-side display).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'promotions'
+    AND policyname = 'authenticated_read_promotions'
+  ) THEN
+    CREATE POLICY "authenticated_read_promotions" ON promotions
+      FOR SELECT USING (enabled = true AND auth.uid() IS NOT NULL);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_promotions_enabled ON promotions(enabled);
+CREATE INDEX IF NOT EXISTS idx_promotions_created ON promotions(created_at DESC);


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Final Phase-1 persistence item. Promotions were **`localStorage`-only** (per-browser, not shared between operators, lost on clear). This backs them with a real DB table.

## What changed
- **Migration `00194_promotions.sql`** — new global **`promotions`** table (no `clinic_id`; promotions target subscription tiers via a `tiers[]` array). RLS mirrors `document_templates` (migration 00193): super_admin full access + authenticated read of enabled promos.
- **Server actions** (`super-admin-actions.ts`, super_admin-gated via `rawClient()`): `fetchPromotions`, `createPromotion`, `setPromotionEnabled`, `deletePromotion`. Create/delete are audit-logged to `activity_logs` (`billing` type). The table isn't in the generated Supabase types yet, so these use the codebase's established local untyped-client cast.
- **Pricing page**: promotions now load from the DB in `loadData`; create / enable-toggle / delete persist with optimistic update + rollback + honest toasts. Removed the `loadPromos` / `savePromos` / `isPromotion` localStorage helpers.
- **`.semgrep/tenant-scoping.yml`**: whitelisted the global `promotions` table.
- **7 unit tests** — fetch mapping, create + audit, enable, delete + audit, error propagation.

This **completes Phase 1** (subscriptions #1104, pricing tiers #1105, feature matrix #1106, promotions here).

## ⚠️ Migration note
I can't apply/verify the migration against a live DB in this environment — it mirrors the proven `00193` pattern, but please **apply it on staging and smoke-test** the Promotions tab before deploying.

## Testing
- `tsc --noEmit` ✅ · `eslint --max-warnings 3457` ✅ · `prettier --check .` ✅ · i18n ✅
- `vitest run` ✅ **1901 passed** / 84 skipped (+7)
- `next build` ✅

## Merge note
Branched off `main`. Shares the `super-admin-actions` import block and the one `.semgrep` regex line with #1105/#1106, so expect at most a trivial 1–2 line conflict depending on merge order — happy to resolve whichever merges last.