### PR TITLE
fix(landing): stop hydration crash that left the page non-interactive

### DIFF
--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -262,25 +262,28 @@ export function persistConsent(prefs: CookiePreferences, now: number = Date.now(
 export function CookieConsent() {
   const [locale] = useLocale();
 
-  const [visible, setVisible] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const status = getConsentStatus();
-    return status.kind !== "fresh";
-  });
+  // SSR-stable initial state: both server and the first client render must
+  // produce identical markup (banner hidden) to avoid a hydration mismatch
+  // (React #418). The real consent status is read AFTER mount in the effect
+  // below, which then reveals the banner. Reading localStorage in a useState
+  // initializer here previously rendered the banner on the client but `null`
+  // on the server, corrupting hydration for the whole document.
+  const [visible, setVisible] = useState(false);
 
   const [showPreferences, setShowPreferences] = useState(false);
 
-  const [preferences, setPreferences] = useState<CookiePreferences>(() => {
-    if (typeof window === "undefined") return DEFAULT_PREFERENCES;
-    const status = getConsentStatus();
-    return status.kind === "fresh" ? status.preferences : DEFAULT_PREFERENCES;
-  });
+  const [preferences, setPreferences] = useState<CookiePreferences>(DEFAULT_PREFERENCES);
 
-  // A64: Apply analytics consent side-effect after hydration.
+  // Read stored consent after mount: reveal the banner when consent is not
+  // fresh, and apply analytics consent when it is. Runs once on the client
+  // only, so it can safely touch localStorage without breaking hydration.
   useEffect(() => {
     const status = getConsentStatus();
     if (status.kind === "fresh") {
+      setPreferences(status.preferences);
       applyAnalyticsConsent(status.preferences.analytics);
+    } else {
+      setVisible(true);
     }
   }, []);
 

--- a/src/components/landing/oltigo/components/hero/console-3d.tsx
+++ b/src/components/landing/oltigo/components/hero/console-3d.tsx
@@ -4,6 +4,7 @@ import { ContactShadows, Html, RoundedBox } from "@react-three/drei";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { Component, type ReactNode, useRef } from "react";
 import * as THREE from "three";
+import type { Dictionary } from "@/components/landing/oltigo/i18n/dictionaries";
 import { ConsoleStatic } from "./console-static";
 import { AgendaFace, DossierFace, WhatsappFace } from "./faces";
 
@@ -107,7 +108,7 @@ function FocusReporter({ onFocus }: { onFocus: (i: number) => void }) {
   return null;
 }
 
-function Rig({ onFocus }: { onFocus: (i: number) => void }) {
+function Rig({ onFocus, dict }: { onFocus: (i: number) => void; dict: Dictionary }) {
   const root = useRef<THREE.Group>(null);
 
   useFrame((state) => {
@@ -144,10 +145,10 @@ function Rig({ onFocus }: { onFocus: (i: number) => void }) {
           <AgendaFace />
         </Slab>
         <Slab index={1} baseY={0} xOff={-0.12} breatheRate={0.52} breathePhase={2.1}>
-          <DossierFace />
+          <DossierFace dict={dict} />
         </Slab>
         <Slab index={2} baseY={-1.55} xOff={-0.55} breatheRate={0.74} breathePhase={4.0}>
-          <WhatsappFace />
+          <WhatsappFace dict={dict} />
         </Slab>
       </group>
       {/* one large soft contact shadow on a matte floor */}
@@ -176,7 +177,13 @@ class WebGLBoundary extends Component<{ children: ReactNode }, { failed: boolean
   }
 }
 
-export default function Console3D({ onFocus }: { onFocus: (i: number) => void }) {
+export default function Console3D({
+  onFocus,
+  dict,
+}: {
+  onFocus: (i: number) => void;
+  dict: Dictionary;
+}) {
   return (
     <WebGLBoundary>
       <div className="h-[520px] w-full">
@@ -190,7 +197,7 @@ export default function Console3D({ onFocus }: { onFocus: (i: number) => void })
             gl.toneMappingExposure = 1.0;
           }}
         >
-          <Rig onFocus={onFocus} />
+          <Rig onFocus={onFocus} dict={dict} />
         </Canvas>
       </div>
     </WebGLBoundary>

--- a/src/components/landing/oltigo/components/hero/console-static.tsx
+++ b/src/components/landing/oltigo/components/hero/console-static.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useI18n } from "../../i18n/context";
 import { AgendaFace, DossierFace, WhatsappFace } from "./faces";
 
 /**
@@ -8,6 +9,7 @@ import { AgendaFace, DossierFace, WhatsappFace } from "./faces";
  * soft contact shadow. No looping motion.
  */
 export function ConsoleStatic() {
+  const { dict } = useI18n();
   return (
     <div className="relative mx-auto w-full max-w-[330px] py-4">
       {/* matte floor contact shadow */}
@@ -21,10 +23,10 @@ export function ConsoleStatic() {
           <AgendaFace />
         </div>
         <div className="relative z-20 -mt-6 self-start" style={{ transform: "rotate(1.1deg)" }}>
-          <DossierFace />
+          <DossierFace dict={dict} />
         </div>
         <div className="relative z-10 -mt-6 self-end" style={{ transform: "rotate(-0.8deg)" }}>
-          <WhatsappFace />
+          <WhatsappFace dict={dict} />
         </div>
       </div>
     </div>

--- a/src/components/landing/oltigo/components/hero/faces.tsx
+++ b/src/components/landing/oltigo/components/hero/faces.tsx
@@ -2,7 +2,7 @@
 
 import { Calendar, Check, CheckCheck, Fingerprint, Lock } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import type { Dictionary } from "@/components/landing/oltigo/i18n/dictionaries";
 
 /* ===========================================================================
    The three console faces. Crisp DOM, reused by both the static fallback and
@@ -65,8 +65,7 @@ function FaceRow({ time, row }: { time: string; row: number[] }) {
 }
 
 /** 02 — Encrypted patient dossier with brushed-metal seal. */
-export function DossierFace() {
-  const { dict } = useI18n();
+export function DossierFace({ dict }: { dict: Dictionary }) {
   return (
     <div className="panel panel-high w-[300px] rounded-[14px] p-4">
       <div className="mb-3 flex items-center justify-between">
@@ -110,8 +109,7 @@ export function DossierFace() {
 }
 
 /** 03 — WhatsApp Darija reminder tile, with a looping micro-conversation. */
-export function WhatsappFace() {
-  const { dict } = useI18n();
+export function WhatsappFace({ dict }: { dict: Dictionary }) {
   const [step, setStep] = useState(0); // 0 incoming · 1 reply · 2 ✓✓ confirmed
 
   useEffect(() => {

--- a/src/components/landing/oltigo/components/hero/hero.tsx
+++ b/src/components/landing/oltigo/components/hero/hero.tsx
@@ -106,7 +106,7 @@ export function Hero() {
 
         {/* Object — RIGHT */}
         <div className="relative">
-          {wide ? <Console3D onFocus={setFocus} /> : <ConsoleStatic />}
+          {wide ? <Console3D onFocus={setFocus} dict={dict} /> : <ConsoleStatic />}
 
           {/* Explode captions, synced to the focused layer */}
           <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">

--- a/src/components/landing/oltigo/components/sections/features.tsx
+++ b/src/components/landing/oltigo/components/sections/features.tsx
@@ -12,7 +12,11 @@ import { SectionHeading } from "./section-kit";
 
 export function Features() {
   const { dict } = useI18n();
-  const visuals = [<AgendaFace key="a" />, <DossierFace key="d" />, <WhatsappFace key="w" />];
+  const visuals = [
+    <AgendaFace key="a" />,
+    <DossierFace key="d" dict={dict} />,
+    <WhatsappFace key="w" dict={dict} />,
+  ];
 
   return (
     <section id="features" className="relative border-b border-hairline py-24 sm:py-32">


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## The problem you reported

"Everything is static — I can't click details, options, anything, like reading a journal." The page rendered but didn't respond to clicks.

## Root cause (confirmed with a headless browser against the live site)

I drove a real Chromium browser against **oltigo.com** and captured the console. The page was throwing during hydration, so React abandoned the server HTML and never attached event handlers — hence "static." Two distinct bugs:

### 1. `useI18n()` called inside the react-three-fiber `<Canvas>`
The hero's 3D console (`console-3d.tsx`) renders `DossierFace` / `WhatsappFace`, which call `useI18n()`. But those run inside the r3f `<Canvas>`, which mounts a **separate React reconciler** — outer DOM context does not cross that boundary. So `useI18n()` threw `must be used within <LanguageProvider>` on every render (**7× in production**), tripping React **#418**.

**Fix:** make those two faces pure — they now receive `dict` as a prop. Callers in the normal DOM tree (`console-static`, `features`) read `useI18n()` and pass it; the Canvas caller threads it from `Hero` → `Console3D` → `Rig` → faces. No context needed inside the Canvas.

### 2. `CookieConsent` read `localStorage` in its `useState` initializer
`visible`/`preferences` were initialized by calling `getConsentStatus()` (localStorage). The server rendered the banner hidden (`null`); a new visitor's client rendered the banner — a hydration mismatch. This component is mounted globally in `layout.tsx`, so it corrupted hydration on **every page**.

**Fix:** SSR-stable initial state (hidden), then read consent and reveal the banner in a post-mount `useEffect`.

## Verification

I reproduced and verified with a **non-minified dev build + headless browser probe**:
- **Before:** 7× `useI18n` crashes + a tree-regenerating hydration failure; page effectively frozen.
- **After:** **0 uncaught errors**; interactivity probe passes (DOM responds to clicks).
- `tsc --noEmit` clean; ESLint clean on changed files; existing **cookie-consent unit tests (18) pass**.

## Known, benign remaining item

A JSON-LD `<script nonce>` attribute warning remains on the homepage: the browser strips `nonce` attributes after applying CSP, so server-serialized `nonce="…"` vs client prop differ. React marks it "won't be patched up" but it **does not affect interactivity** (these are non-executable `application/ld+json` data blocks). It's a known Next.js + CSP-nonce behavior; left as-is to avoid CSP regressions.

## Files changed
- `src/components/cookie-consent.tsx`
- `src/components/landing/oltigo/components/hero/faces.tsx`
- `src/components/landing/oltigo/components/hero/console-3d.tsx`
- `src/components/landing/oltigo/components/hero/console-static.tsx`
- `src/components/landing/oltigo/components/hero/hero.tsx`
- `src/components/landing/oltigo/components/sections/features.tsx`