### PR TITLE
fix(geo): friendly page (not a JSON blob) when an admin navigation is geo-blocked

### DIFF
--- a/src/lib/__tests__/geo-restriction.test.ts
+++ b/src/lib/__tests__/geo-restriction.test.ts
@@ -106,4 +106,39 @@ describe("geo-restriction", () => {
     const req = createMockRequest("/admin/settings", { "cf-ipcountry": "MA" });
     expect(checkGeoRestriction(req)).toBeNull();
   });
+
+  it("returns an HTML page for blocked browser navigations (not a JSON blob)", async () => {
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
+    process.env.GEO_RESTRICT_ADMIN = "MA";
+    const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
+    const req = createMockRequest("/dashboard", {
+      "cf-ipcountry": "US",
+      accept: "text/html,application/xhtml+xml",
+    });
+    const result = checkGeoRestriction(req);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(403);
+    expect(result?.headers.get("content-type")).toContain("text/html");
+    const body = await result!.text();
+    expect(body).toContain("<html");
+    expect(body).toContain("GEO_RESTRICTED");
+    // Surfaces the detected country so the operator understands the cause.
+    expect(body).toContain("US");
+  });
+
+  it("returns JSON for blocked API requests (client error-handling unchanged)", async () => {
+    delete process.env.ADMIN_GEO_RESTRICTION_ENABLED;
+    process.env.GEO_RESTRICT_ADMIN = "MA";
+    const { checkGeoRestriction } = await import("@/lib/middleware/geo-restriction");
+    const req = createMockRequest("/api/admin/usage", {
+      "cf-ipcountry": "US",
+      accept: "application/json",
+    });
+    const result = checkGeoRestriction(req);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(403);
+    expect(result?.headers.get("content-type")).toContain("application/json");
+    const json = await result!.json();
+    expect(json.code).toBe("GEO_RESTRICTED");
+  });
 });

--- a/src/lib/middleware/geo-restriction.ts
+++ b/src/lib/middleware/geo-restriction.ts
@@ -76,11 +76,72 @@ export function checkGeoRestriction(request: NextRequest): NextResponse | null {
       country: upper,
       pathname,
     });
+
+    // For browser page navigations (e.g. /dashboard, /admin) return a clear,
+    // self-explanatory HTML page instead of a raw JSON blob. A JSON 403 on a
+    // top-level navigation renders as a broken/blank page and looks like the
+    // app is "dead" — the operator has no idea their location is the cause.
+    // API/fetch requests keep the JSON 403 so client error-handling (which
+    // already detects `code: "GEO_RESTRICTED"`) is unchanged.
+    const accept = request.headers.get("accept") ?? "";
+    const isApiRoute = pathname.startsWith("/api");
+    const isNavigation = !isApiRoute && accept.includes("text/html");
+
+    if (isNavigation) {
+      return new NextResponse(geoBlockedHtml(upper), {
+        status: 403,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
     return NextResponse.json(
-      { error: "Access denied from your location", code: "GEO_RESTRICTED" },
+      { error: "Access denied from your location", code: "GEO_RESTRICTED", country: upper },
       { status: 403 },
     );
   }
 
   return null;
+}
+
+/**
+ * Self-contained HTML for a geo-blocked admin navigation. No external assets
+ * or inline scripts, so it is safe under the strict CSP. Bilingual (FR/EN)
+ * because the platform's operators are in Morocco but support may be elsewhere.
+ */
+function geoBlockedHtml(country: string): string {
+  return `<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex" />
+<title>Accès restreint depuis votre région · Oltigo</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; background:#f4f1ea; color:#0b0f0e; padding:24px; }
+  .card { max-width:30rem; width:100%; background:#fff; border:1px solid rgba(0,0,0,.1); border-radius:14px;
+    padding:32px; box-shadow:0 10px 30px rgba(0,0,0,.06); }
+  h1 { font-size:1.25rem; margin:0 0 12px; }
+  p { font-size:.95rem; line-height:1.55; margin:0 0 12px; color:#33403c; }
+  .muted { font-size:.8rem; color:#6b7672; margin-top:20px; }
+  code { background:#f0ede6; padding:1px 6px; border-radius:5px; }
+</style>
+</head>
+<body>
+  <main class="card" role="main">
+    <h1>Accès restreint depuis votre région</h1>
+    <p>Pour des raisons de sécurité, l'espace d'administration d'Oltigo n'est accessible
+       que depuis certaines régions. Votre connexion semble provenir de
+       <code>${country}</code>, qui n'est pas autorisée.</p>
+    <p><strong>English:</strong> For security reasons, the Oltigo admin area is restricted
+       to specific regions. Your connection appears to originate from
+       <code>${country}</code>, which is not allowed.</p>
+    <p>Si vous êtes l'administrateur et devez accéder depuis cette région, ajoutez votre
+       pays à <code>GEO_RESTRICT_ADMIN</code> (ou définissez
+       <code>ADMIN_GEO_RESTRICTION_ENABLED=false</code>) dans la configuration du déploiement.</p>
+    <p class="muted">Code: GEO_RESTRICTED · Oltigo</p>
+  </main>
+</body>
+</html>`;
 }


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## #6 — Geo-restriction UX

### Problem
Admin routes (`/admin`, `/dashboard`, `/api/admin`) are geo-restricted to Morocco (`MA`) by default (`src/lib/middleware/geo-restriction.ts`). When a **browser navigation** (e.g. opening `/dashboard`) was blocked, the middleware returned a **JSON 403** (`{ code: "GEO_RESTRICTED" }`). In a browser that renders as a broken/blank page — so an operator outside the allowed region just sees a "dead" app with no explanation. This is a strong candidate for the "everything looks static / nothing works" experience when browsing from outside Morocco (or via a VPN/misdetected IP).

### Fix
- A blocked **browser navigation** (`Accept: text/html`, non-`/api`) now returns a small, self-contained **bilingual (FR/EN) HTML page** that:
  - explains access is restricted by region,
  - shows the **detected country code**, and
  - tells the operator exactly how to allow their region (`GEO_RESTRICT_ADMIN`, or `ADMIN_GEO_RESTRICTION_ENABLED=false`).
- **API/fetch** requests keep the **JSON 403** so existing client handling (which already detects `code: "GEO_RESTRICTED"`) is unchanged.
- The page has **no inline scripts**, so it is safe under the strict CSP.

### Security posture: unchanged
Same routes, same allowed countries, same 403 status. Only the *blocked-response UX* improves — this does **not** widen access.

### Tests
`src/lib/__tests__/geo-restriction.test.ts` — **11 pass** (9 existing + 2 new: HTML for navigation, JSON for API). `tsc` + ESLint clean on the changed files.

---

## #5 — Mock / non-persistent UI: audit result

I also audited the management surface for the "fake success" anti-pattern (buttons that toast success but never persist). **No code change is included for #5 because I found no remaining mock controls** — details in the PR discussion / my message to the maintainer. In short: every super-admin + admin page with a success toast persists through a real mechanism (REST API, server action, data-layer module, or the Supabase client), the historically-flagged mock controls were wired in #1104–#1108, and the "can't change anything" symptom was the hydration freeze fixed in #1113.