### PR TITLE
feat(super-admin): AI emergency-stop fallback, provider first-run guide, marketplace filters + bulk

### DIFF
--- a/src/app/(super-admin)/super-admin/marketplace/page.tsx
+++ b/src/app/(super-admin)/super-admin/marketplace/page.tsx
@@ -5,9 +5,12 @@ import { Package, Search, Loader2, CheckCircle2, XCircle, X } from "lucide-react
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/toast";
 import { logger } from "@/lib/logger";
+import { updateFeatureDefinition } from "@/lib/super-admin-actions";
 
 interface Feature {
   id: string;
@@ -35,6 +38,10 @@ export default function MarketplacePage() {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [catFilter, setCatFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<"all" | "enabled" | "disabled">("all");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const { addToast } = useToast();
 
   const loadFeatures = useCallback(async () => {
     try {
@@ -70,9 +77,80 @@ export default function MarketplacePage() {
         (f.description ?? "").toLowerCase().includes(q) ||
         f.key.toLowerCase().includes(q);
       const matchCat = catFilter === "all" || (f.category ?? "core") === catFilter;
-      return matchSearch && matchCat;
+      const matchStatus =
+        statusFilter === "all" ||
+        (statusFilter === "enabled" ? f.global_enabled : !f.global_enabled);
+      return matchSearch && matchCat && matchStatus;
     });
-  }, [features, search, catFilter]);
+  }, [features, search, catFilter, statusFilter]);
+
+  // Keep the selection in sync with what's currently visible.
+  const visibleIds = useMemo(() => filtered.map((f) => f.id), [filtered]);
+  const selectedVisible = useMemo(
+    () => visibleIds.filter((id) => selected.has(id)),
+    [visibleIds, selected],
+  );
+  const allVisibleSelected = visibleIds.length > 0 && selectedVisible.length === visibleIds.length;
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const toggleSelectAllVisible = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        visibleIds.forEach((id) => next.delete(id));
+      } else {
+        visibleIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelected(new Set());
+
+  // MK-7: bulk enable/disable selected features (global_enabled), with optimistic
+  // update + reconcile-on-failure via the super_admin-gated server action.
+  const bulkSetEnabled = async (enabled: boolean) => {
+    const ids = visibleIds.filter((id) => selected.has(id));
+    if (ids.length === 0 || bulkBusy) return;
+    setBulkBusy(true);
+    const prev = features;
+    setFeatures((cur) =>
+      cur.map((f) => (selected.has(f.id) ? { ...f, global_enabled: enabled } : f)),
+    );
+    try {
+      const results = await Promise.allSettled(
+        ids.map((id) => updateFeatureDefinition(id, { globalEnabled: enabled })),
+      );
+      const failed = results.filter((r) => r.status === "rejected").length;
+      if (failed === 0) {
+        addToast(
+          `${ids.length} feature${ids.length === 1 ? "" : "s"} ${enabled ? "enabled" : "disabled"}`,
+          "success",
+        );
+        clearSelection();
+      } else {
+        addToast(
+          `${ids.length - failed} updated, ${failed} failed — reloading`,
+          failed === ids.length ? "error" : "warning",
+        );
+        await loadFeatures();
+      }
+    } catch (err) {
+      logger.warn("Bulk feature update failed", { context: "marketplace-page", error: err });
+      addToast("Bulk update failed", "error");
+      setFeatures(prev);
+    } finally {
+      setBulkBusy(false);
+    }
+  };
 
   const totalFeatures = features.length;
   const enabledFeatures = features.filter((f) => f.global_enabled).length;
@@ -148,8 +226,64 @@ export default function MarketplacePage() {
               {c === "all" ? "All" : c}
             </button>
           ))}
+          <span className="mx-1 h-4 w-px bg-border" aria-hidden />
+          {(["all", "enabled", "disabled"] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                statusFilter === s
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background hover:bg-muted border-border"
+              }`}
+            >
+              {s === "all" ? "All status" : s === "enabled" ? "Enabled" : "Disabled"}
+            </button>
+          ))}
         </div>
       </div>
+
+      {/* MK-7: bulk selection + enable/disable */}
+      {!loading && filtered.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border bg-muted/30 px-3 py-2">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={allVisibleSelected}
+              onChange={toggleSelectAllVisible}
+              className="h-4 w-4 rounded border-border"
+            />
+            Select all ({visibleIds.length})
+          </label>
+          {selectedVisible.length > 0 && (
+            <>
+              <span className="text-xs font-medium">{selectedVisible.length} selected</span>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={bulkBusy}
+                  onClick={() => void bulkSetEnabled(true)}
+                >
+                  {bulkBusy && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+                  Enable
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={bulkBusy}
+                  onClick={() => void bulkSetEnabled(false)}
+                >
+                  Disable
+                </Button>
+                <Button size="sm" variant="ghost" onClick={clearSelection} disabled={bulkBusy}>
+                  Clear
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
 
       {/* Feature Grid */}
       {loading ? (
@@ -190,10 +324,20 @@ export default function MarketplacePage() {
           {filtered.map((feature) => {
             const cat = feature.category ?? "core";
             return (
-              <Card key={feature.id} className="relative overflow-hidden">
+              <Card
+                key={feature.id}
+                className={`relative overflow-hidden ${selected.has(feature.id) ? "ring-2 ring-primary" : ""}`}
+              >
                 <CardHeader className="pb-3">
                   <div className="flex items-start justify-between">
                     <div className="flex items-center gap-3">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(feature.id)}
+                        onChange={() => toggleSelect(feature.id)}
+                        aria-label={`Select ${feature.name}`}
+                        className="h-4 w-4 rounded border-border"
+                      />
                       <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
                         <Package className="h-5 w-5 text-primary" />
                       </div>

--- a/src/app/(super-admin)/super-admin/settings/ai/emergency-stop.tsx
+++ b/src/app/(super-admin)/super-admin/settings/ai/emergency-stop.tsx
@@ -35,6 +35,7 @@ export function EmergencyStop() {
   const [state, setState] = useState<KillSwitchState | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [forceStopOpen, setForceStopOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
   const [working, setWorking] = useState(false);
 
@@ -73,6 +74,7 @@ export function EmergencyStop() {
           enabled ? "success" : "error",
         );
         setDialogOpen(false);
+        setForceStopOpen(false);
         setConfirmText("");
         await fetchState();
       } else {
@@ -90,24 +92,90 @@ export function EmergencyStop() {
     // notice with a retry instead of an indefinite spinner.
     if (loadFailed) {
       return (
-        <Card className="border-destructive/30">
-          <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
-            <div className="flex items-center gap-3">
-              <AlertTriangle className="h-5 w-5 text-destructive" />
-              <div>
-                <p className="text-sm font-medium">AI emergency stop status unavailable</p>
-                <p className="text-xs text-muted-foreground">
-                  Couldn&apos;t reach the kill-switch service. The emergency stop can&apos;t be
-                  shown or toggled until this loads. If AI must be stopped now, set the{" "}
-                  <span className="font-mono">AI_DISABLED</span> environment variable.
-                </p>
+        <>
+          <Card className="border-destructive/30">
+            <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
+              <div className="flex items-center gap-3">
+                <AlertTriangle className="h-5 w-5 text-destructive" />
+                <div>
+                  <p className="text-sm font-medium">AI emergency stop status unavailable</p>
+                  <p className="text-xs text-muted-foreground">
+                    Couldn&apos;t reach the kill-switch service, so the current state is unknown.
+                    You can still force a stop below, or set the{" "}
+                    <span className="font-mono">AI_DISABLED</span> environment variable.
+                  </p>
+                </div>
               </div>
-            </div>
-            <Button variant="outline" size="sm" onClick={() => void fetchState()}>
-              Retry
-            </Button>
-          </CardContent>
-        </Card>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={() => void fetchState()}>
+                  Retry
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setForceStopOpen(true)}
+                  disabled={working}
+                >
+                  <OctagonX className="mr-1 h-3.5 w-3.5" />
+                  Force emergency stop
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* AI-7: manual stop that works independently of the (failed) status check. */}
+          <Dialog
+            open={forceStopOpen}
+            onOpenChange={(open) => {
+              setForceStopOpen(open);
+              if (!open) setConfirmText("");
+            }}
+          >
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2 text-destructive">
+                  <AlertTriangle className="h-5 w-5" />
+                  Force emergency stop — all AI
+                </DialogTitle>
+                <DialogDescription>
+                  The current kill-switch state couldn&apos;t be loaded, but this still writes the
+                  platform-wide stop flag directly: every AI feature is disabled and all provider
+                  spend halts. If feature-flag storage is also unavailable, this will fail with a
+                  message telling you to use the <span className="font-mono">AI_DISABLED</span>{" "}
+                  environment variable instead.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-2">
+                <p className="text-sm font-medium">
+                  Type <span className="font-mono font-bold">STOP</span> to confirm:
+                </p>
+                <Input
+                  value={confirmText}
+                  onChange={(e) => setConfirmText(e.target.value)}
+                  placeholder="STOP"
+                  autoFocus
+                />
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setForceStopOpen(false)}
+                  disabled={working}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => void flip(false)}
+                  disabled={working || confirmText.trim().toUpperCase() !== "STOP"}
+                >
+                  {working && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                  Stop all AI now
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </>
       );
     }
     return (

--- a/src/app/(super-admin)/super-admin/settings/ai/page.tsx
+++ b/src/app/(super-admin)/super-admin/settings/ai/page.tsx
@@ -471,6 +471,38 @@ export default function AISettingsPage() {
           </span>
         </h2>
 
+        {/* AI-8: first-run guidance when the catalogue is present but nothing is active yet. */}
+        {providers.length > 0 && activeCount === 0 && !loadError && (
+          <Card className="mb-3 border-primary/30 bg-primary/5">
+            <CardContent className="p-4">
+              <div className="flex items-start gap-3">
+                <Zap className="mt-0.5 h-5 w-5 text-primary" />
+                <div className="text-sm">
+                  <p className="font-medium">Get started — activate your first AI provider</p>
+                  <ol className="mt-1 list-decimal space-y-0.5 pl-4 text-muted-foreground">
+                    <li>
+                      Pick a provider below and click <span className="font-medium">Get Key</span>{" "}
+                      to create an API key on their site.
+                    </li>
+                    <li>
+                      Paste the key into the provider&apos;s field and press{" "}
+                      <span className="font-medium">Save</span>.
+                    </li>
+                    <li>
+                      Flip the <span className="font-medium">Active</span> switch, then optionally
+                      set a monthly budget.
+                    </li>
+                  </ol>
+                  <p className="mt-1 text-muted-foreground">
+                    <span className="font-medium">Cloudflare Workers AI</span> needs no key — it
+                    stays available as the free fallback while you configure the rest.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
         <div className="space-y-3">
           {providers.length === 0 && !loadError && (
             <Card>


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Product improvements from the QA report (set A) — all on surfaces that still exist after #1110 removed the in-app builders.

## AI Settings (`/super-admin/settings/ai`)
- **AI-7 — manual emergency stop that works even when the status check fails.** Previously, if `/api/admin/ai-kill-switch` (GET) failed, the section showed only a *Retry* (my earlier AI-2 fix). Now the degraded state also offers a **Force emergency stop** button (type-`STOP` confirm) that writes the kill-switch flag directly via POST, independent of the failed status read. If feature-flag storage is also unavailable, the server's existing 503 tells the operator to use `AI_DISABLED`.
- **AI-8 — first-run provider guidance.** When the provider catalogue is present but **none is active yet**, a concise 3-step *Get started* card appears (get key → save → activate), noting Workers AI is the free always-on fallback. (A full modal wizard wasn't needed — the provider cards already have key/budget/activation; the gap was guidance.)

## Marketplace (`/super-admin/marketplace`)
- **MK-6 — status filter.** Added an **Enabled / Disabled / All status** filter alongside the existing category pills.
- **MK-7 — bulk actions.** Added per-feature selection (checkboxes + *Select all*) and a **bulk Enable/Disable** bar. Uses the existing `super_admin`-gated `updateFeatureDefinition` server action with optimistic update + reconcile-from-server on partial failure (honest success / partial / error toasts).

## Not done (with reasons)
- **MK-5** ("Create your first feature" CTA): features come from the platform `feature_definitions` catalogue (seed/migration), not created ad-hoc, so a create button would be misleading. The existing explanatory empty state already covers the intent.

## Tested
- `tsc --noEmit` ✅ · `eslint --max-warnings 3457` ✅ (0 errors, 3444 warnings) · `prettier --check` ✅
- `vitest run` ✅ **1922 passed** / 84 skipped
- `next build` ✅
- No unit tests added (per repo instruction); the marketplace bulk path reuses the already-tested `updateFeatureDefinition` action.

## Note
- MK-7 makes the Marketplace able to flip `global_enabled`, which overlaps the dedicated Feature Matrix page by design — both manage `feature_definitions`. The bulk bar is the time-saver the QA asked for; fine-grained per-tier control stays on the Feature Matrix.