### PR TITLE
fix(super-admin/revenue): clearer nav IA + clinic names on usage dashboard

### DIFF
--- a/src/app/(super-admin)/super-admin/referrals/page.tsx
+++ b/src/app/(super-admin)/super-admin/referrals/page.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable i18next/no-literal-string -- Admin/super-admin internal surface: French UI strings are the intended output language; adding them to the i18n keyset would inflate the translation backlog for internal-only tooling. */
 "use client";
 
-import { Gift, Check, Clock, Users, Loader2, AlertTriangle, MapPin, RefreshCw } from "lucide-react";
+import {
+  CheckCheck,
+  Check,
+  Clock,
+  Users,
+  Loader2,
+  AlertTriangle,
+  MapPin,
+  RefreshCw,
+} from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -178,7 +187,7 @@ export default function ReferralsPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground">Acceptées</CardTitle>
-            <Gift className="h-4 w-4 text-blue-600" />
+            <CheckCheck className="h-4 w-4 text-blue-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{loading ? "—" : accepted}</div>

--- a/src/app/(super-admin)/super-admin/usage-dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/usage-dashboard/page.tsx
@@ -21,6 +21,7 @@ import { logger } from "@/lib/logger";
 
 interface ClinicUsageRow {
   clinicId: string;
+  clinicName?: string | null;
   resourceType: string;
   totalUnits: number;
   totalCostUsd: number;
@@ -142,13 +143,21 @@ export default function UsageDashboardPage() {
   // Aggregate usage by clinic
   const clinicTotals = allUsage.reduce(
     (acc, row) => {
-      if (!acc[row.clinicId]) acc[row.clinicId] = { totalCost: 0, resources: {} };
+      if (!acc[row.clinicId])
+        acc[row.clinicId] = { totalCost: 0, resources: {}, name: row.clinicName ?? null };
+      if (row.clinicName) acc[row.clinicId].name = row.clinicName;
       acc[row.clinicId].totalCost += row.totalCostUsd;
       acc[row.clinicId].resources[row.resourceType] = row.totalUnits;
       return acc;
     },
-    {} as Record<string, { totalCost: number; resources: Record<string, number> }>,
+    {} as Record<
+      string,
+      { totalCost: number; resources: Record<string, number>; name: string | null }
+    >,
   );
+
+  // Map of clinicId -> display name, for the detail header.
+  const clinicNameById = (id: string): string => clinicTotals[id]?.name ?? `${id.slice(0, 8)}…`;
 
   const topConsumers = Object.entries(clinicTotals)
     .sort(([, a], [, b]) => b.totalCost - a.totalCost)
@@ -283,7 +292,9 @@ export default function UsageDashboardPage() {
                   }`}
                 >
                   <div>
-                    <span className="font-mono text-sm">{clinicId.slice(0, 8)}…</span>
+                    <span className="text-sm font-medium">
+                      {data.name ?? `${clinicId.slice(0, 8)}…`}
+                    </span>
                     <div className="mt-1 flex gap-2">
                       {Object.entries(data.resources).map(([rt, units]) => (
                         <Badge key={rt} variant="secondary" className="text-xs">
@@ -304,7 +315,7 @@ export default function UsageDashboardPage() {
       {selectedClinic && (
         <Card>
           <CardHeader>
-            <CardTitle>Clinique : {selectedClinic.slice(0, 8)}…</CardTitle>
+            <CardTitle>Clinique : {clinicNameById(selectedClinic)}</CardTitle>
           </CardHeader>
           <CardContent>
             {detailLoading ? (

--- a/src/app/api/admin/usage/quota/route.ts
+++ b/src/app/api/admin/usage/quota/route.ts
@@ -56,7 +56,21 @@ async function handleGet(request: NextRequest, auth: AuthContext) {
     }
 
     const allUsage = await getAllClinicsMonthlyUsage(supabase);
-    return apiSuccess({ usage: allUsage });
+
+    // Enrich with clinic names so the dashboard can show a human-readable
+    // label instead of a truncated UUID (which is meaningless to an operator).
+    const clinicIds = [...new Set(allUsage.map((r) => r.clinicId))];
+    const nameById = new Map<string, string>();
+    if (clinicIds.length > 0) {
+      const { data: clinics } = await supabase
+        .from("clinics") // nosemgrep: semgrep.tenant-scoping — super-admin cross-tenant usage overview
+        .select("id, name")
+        .in("id", clinicIds);
+      for (const c of clinics ?? []) nameById.set(c.id as string, c.name as string);
+    }
+    const enriched = allUsage.map((r) => ({ ...r, clinicName: nameById.get(r.clinicId) ?? null }));
+
+    return apiSuccess({ usage: enriched });
   } catch (err) {
     logger.error("quota-api: unexpected error", { context: "quota-api", error: err });
     return apiInternalError("Failed to fetch quota data");

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -37,6 +37,7 @@ import {
   GitCompareArrows,
   MessageSquare,
   HeartPulse,
+  Stethoscope,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -137,10 +138,10 @@ const navGroups: NavGroup[] = [
       },
       { href: "/super-admin/pricing", label: "Tarifs & Offres", icon: DollarSign },
       { href: "/super-admin/subscriptions", label: "Abonnements", icon: Receipt },
-      { href: "/super-admin/referrals", label: "Références méd.", icon: Gift },
+      { href: "/super-admin/referrals", label: "Références méd.", icon: Stethoscope },
       { href: "/super-admin/referral-program", label: "Prog. parrainage", icon: Gift },
-      { href: "/super-admin/usage", label: "Métriques usage", icon: Gauge },
-      { href: "/super-admin/usage-dashboard", label: "Dashboard usage", icon: BarChart3 },
+      { href: "/super-admin/usage", label: "Activité cliniques", icon: Gauge },
+      { href: "/super-admin/usage-dashboard", label: "Coûts & quotas", icon: BarChart3 },
     ],
   },
   {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## REVENUS nav — information architecture + clinic names (PR B)

Follow-up to #1117. Pure clarity/IA improvements across the revenue section.

### 1. Distinct icons for the two referral navs
`Références méd.` (doctor→patient medical referrals) and `Prog. parrainage` (clinic-acquisition affiliate program) are unrelated but **both used the `Gift` icon** and sit next to each other, so they were indistinguishable. `Références méd.` now uses a **`Stethoscope`** icon (clearly medical, not used elsewhere in the nav); `Gift` stays with parrainage. Also swapped the misused `Gift` on the referrals **“Acceptées”** KPI for `CheckCheck`.

### 2. Clearer nav labels
Two near-identical names that didn't convey what they show:
- **`Métriques usage` → `Activité cliniques`** (per-clinic activity counts — appointments/users)
- **`Dashboard usage` → `Coûts & quotas`** (infra consumption cost in USD + quota status)

### 3. Clinic **names** on the usage dashboard (was: truncated UUIDs)
`Coûts & quotas` listed top consumers and the detail header as `a3f9c2b1…` — you couldn't tell which clinic was burning cost. The all-clinics `/api/admin/usage/quota` response is now **enriched with clinic names** (single `clinics` lookup over the distinct ids in the result), and the dashboard renders the name, falling back to the short id only when a name is unknown. The sister `Activité cliniques` page already showed names, so this brings them in line.

### Testing
`tsc --noEmit` clean · ESLint clean. The API change is additive (adds `clinicName` to each row; existing consumers ignore it).

### Not changed (deliberately)
- Broader icon reuse exists elsewhere in the sidebar (`BarChart3` ×4, etc.); I scoped this to the adjacent-duplicate that caused real confusion rather than re-theming the whole nav.
- `Références méd.` still shows clinic + reason + status + date but not the referring→referred **doctor** names — that needs the referrals API to return them; flagged as a separate follow-up to avoid an API contract change here.