### PR TITLE
feat(super-admin/referrals): show referring -> referred doctor names

### DIFF
--- a/src/app/(super-admin)/super-admin/referrals/page.tsx
+++ b/src/app/(super-admin)/super-admin/referrals/page.tsx
@@ -35,6 +35,8 @@ interface Referral {
   clinic_id: string;
   referring_doctor_id: string;
   referred_to_doctor_id: string;
+  referring_doctor_name: string | null;
+  referred_to_doctor_name: string | null;
   patient_id: string;
   reason: string | null;
   status: ReferralStatus;
@@ -221,6 +223,8 @@ export default function ReferralsPage() {
             <thead>
               <tr className="border-b bg-muted/50">
                 <th className="text-left p-3 font-medium">Clinique</th>
+                <th className="text-left p-3 font-medium">Médecin référent</th>
+                <th className="text-left p-3 font-medium">Médecin destinataire</th>
                 <th className="text-left p-3 font-medium">Motif</th>
                 <th className="text-left p-3 font-medium">Statut</th>
                 <th className="text-left p-3 font-medium">Date</th>
@@ -229,7 +233,7 @@ export default function ReferralsPage() {
             <tbody>
               {loading && (
                 <tr>
-                  <td colSpan={4} className="py-8 text-center text-muted-foreground">
+                  <td colSpan={6} className="py-8 text-center text-muted-foreground">
                     <Loader2 className="h-5 w-5 animate-spin inline mr-2" />
                     Chargement des références…
                   </td>
@@ -237,7 +241,7 @@ export default function ReferralsPage() {
               )}
               {!loading && filtered.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="py-8 text-center text-muted-foreground">
+                  <td colSpan={6} className="py-8 text-center text-muted-foreground">
                     {geoBlocked || fetchError
                       ? "Données indisponibles — voir le message ci-dessus."
                       : "Aucune référence trouvée."}
@@ -249,6 +253,8 @@ export default function ReferralsPage() {
                   <td className="p-3 font-medium">
                     {referral.clinics?.name ?? "Clinique inconnue"}
                   </td>
+                  <td className="p-3">{referral.referring_doctor_name ?? "—"}</td>
+                  <td className="p-3">{referral.referred_to_doctor_name ?? "—"}</td>
                   <td className="p-3 text-muted-foreground">{referral.reason ?? "—"}</td>
                   <td className="p-3">
                     <Badge variant={STATUS_VARIANTS[referral.status]} className="text-xs">

--- a/src/app/(super-admin)/super-admin/referrals/page.tsx
+++ b/src/app/(super-admin)/super-admin/referrals/page.tsx
@@ -1,7 +1,16 @@
 /* eslint-disable i18next/no-literal-string -- Admin/super-admin internal surface: French UI strings are the intended output language; adding them to the i18n keyset would inflate the translation backlog for internal-only tooling. */
 "use client";
 
-import { Gift, Check, Clock, Users, Loader2, AlertTriangle, MapPin, RefreshCw } from "lucide-react";
+import {
+  CheckCheck,
+  Check,
+  Clock,
+  Users,
+  Loader2,
+  AlertTriangle,
+  MapPin,
+  RefreshCw,
+} from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -178,7 +187,7 @@ export default function ReferralsPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground">Acceptées</CardTitle>
-            <Gift className="h-4 w-4 text-blue-600" />
+            <CheckCheck className="h-4 w-4 text-blue-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{loading ? "—" : accepted}</div>

--- a/src/app/(super-admin)/super-admin/usage-dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/usage-dashboard/page.tsx
@@ -21,6 +21,7 @@ import { logger } from "@/lib/logger";
 
 interface ClinicUsageRow {
   clinicId: string;
+  clinicName?: string | null;
   resourceType: string;
   totalUnits: number;
   totalCostUsd: number;
@@ -142,13 +143,21 @@ export default function UsageDashboardPage() {
   // Aggregate usage by clinic
   const clinicTotals = allUsage.reduce(
     (acc, row) => {
-      if (!acc[row.clinicId]) acc[row.clinicId] = { totalCost: 0, resources: {} };
+      if (!acc[row.clinicId])
+        acc[row.clinicId] = { totalCost: 0, resources: {}, name: row.clinicName ?? null };
+      if (row.clinicName) acc[row.clinicId].name = row.clinicName;
       acc[row.clinicId].totalCost += row.totalCostUsd;
       acc[row.clinicId].resources[row.resourceType] = row.totalUnits;
       return acc;
     },
-    {} as Record<string, { totalCost: number; resources: Record<string, number> }>,
+    {} as Record<
+      string,
+      { totalCost: number; resources: Record<string, number>; name: string | null }
+    >,
   );
+
+  // Map of clinicId -> display name, for the detail header.
+  const clinicNameById = (id: string): string => clinicTotals[id]?.name ?? `${id.slice(0, 8)}…`;
 
   const topConsumers = Object.entries(clinicTotals)
     .sort(([, a], [, b]) => b.totalCost - a.totalCost)
@@ -283,7 +292,9 @@ export default function UsageDashboardPage() {
                   }`}
                 >
                   <div>
-                    <span className="font-mono text-sm">{clinicId.slice(0, 8)}…</span>
+                    <span className="text-sm font-medium">
+                      {data.name ?? `${clinicId.slice(0, 8)}…`}
+                    </span>
                     <div className="mt-1 flex gap-2">
                       {Object.entries(data.resources).map(([rt, units]) => (
                         <Badge key={rt} variant="secondary" className="text-xs">
@@ -304,7 +315,7 @@ export default function UsageDashboardPage() {
       {selectedClinic && (
         <Card>
           <CardHeader>
-            <CardTitle>Clinique : {selectedClinic.slice(0, 8)}…</CardTitle>
+            <CardTitle>Clinique : {clinicNameById(selectedClinic)}</CardTitle>
           </CardHeader>
           <CardContent>
             {detailLoading ? (

--- a/src/app/api/admin/referrals/route.ts
+++ b/src/app/api/admin/referrals/route.ts
@@ -31,7 +31,38 @@ async function handleGet(_request: NextRequest, _auth: AuthContext) {
       return apiInternalError("Failed to fetch referrals");
     }
 
-    return apiSuccess({ referrals: data ?? [] });
+    // Enrich with the referring/referred DOCTOR names — that is the point of a
+    // "references between doctors" view; the IDs alone are meaningless to an
+    // operator. Patient names are intentionally NOT resolved here: this is a
+    // cross-tenant, platform-operator view and patient identity is PHI that
+    // must stay masked by default (see env.ts → enforcePhiMaskingPolicy).
+    const rows = (data ?? []) as Array<{
+      referring_doctor_id: string | null;
+      referred_to_doctor_id: string | null;
+      [key: string]: unknown;
+    }>;
+    const doctorIds = [
+      ...new Set(
+        rows
+          .flatMap((r) => [r.referring_doctor_id, r.referred_to_doctor_id])
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    const nameById = new Map<string, string>();
+    if (doctorIds.length > 0) {
+      const { data: doctors } = await supabase
+        .from("users") // nosemgrep: semgrep.tenant-scoping — super-admin cross-tenant referral overview; resolves staff (doctor) names only, no patient PHI
+        .select("id, name")
+        .in("id", doctorIds);
+      for (const d of doctors ?? []) nameById.set(d.id as string, d.name as string);
+    }
+    const enriched = rows.map((r) => ({
+      ...r,
+      referring_doctor_name: nameById.get(r.referring_doctor_id as string) ?? null,
+      referred_to_doctor_name: nameById.get(r.referred_to_doctor_id as string) ?? null,
+    }));
+
+    return apiSuccess({ referrals: enriched });
   } catch (err) {
     logger.error("Unexpected error fetching referrals", { context: "referrals-api", error: err });
     return apiInternalError("Failed to fetch referrals");

--- a/src/app/api/admin/usage/quota/route.ts
+++ b/src/app/api/admin/usage/quota/route.ts
@@ -56,7 +56,21 @@ async function handleGet(request: NextRequest, auth: AuthContext) {
     }
 
     const allUsage = await getAllClinicsMonthlyUsage(supabase);
-    return apiSuccess({ usage: allUsage });
+
+    // Enrich with clinic names so the dashboard can show a human-readable
+    // label instead of a truncated UUID (which is meaningless to an operator).
+    const clinicIds = [...new Set(allUsage.map((r) => r.clinicId))];
+    const nameById = new Map<string, string>();
+    if (clinicIds.length > 0) {
+      const { data: clinics } = await supabase
+        .from("clinics") // nosemgrep: semgrep.tenant-scoping — super-admin cross-tenant usage overview
+        .select("id, name")
+        .in("id", clinicIds);
+      for (const c of clinics ?? []) nameById.set(c.id as string, c.name as string);
+    }
+    const enriched = allUsage.map((r) => ({ ...r, clinicName: nameById.get(r.clinicId) ?? null }));
+
+    return apiSuccess({ usage: enriched });
   } catch (err) {
     logger.error("quota-api: unexpected error", { context: "quota-api", error: err });
     return apiInternalError("Failed to fetch quota data");

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -37,6 +37,7 @@ import {
   GitCompareArrows,
   MessageSquare,
   HeartPulse,
+  Stethoscope,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -137,10 +138,10 @@ const navGroups: NavGroup[] = [
       },
       { href: "/super-admin/pricing", label: "Tarifs & Offres", icon: DollarSign },
       { href: "/super-admin/subscriptions", label: "Abonnements", icon: Receipt },
-      { href: "/super-admin/referrals", label: "Références méd.", icon: Gift },
+      { href: "/super-admin/referrals", label: "Références méd.", icon: Stethoscope },
       { href: "/super-admin/referral-program", label: "Prog. parrainage", icon: Gift },
-      { href: "/super-admin/usage", label: "Métriques usage", icon: Gauge },
-      { href: "/super-admin/usage-dashboard", label: "Dashboard usage", icon: BarChart3 },
+      { href: "/super-admin/usage", label: "Activité cliniques", icon: Gauge },
+      { href: "/super-admin/usage-dashboard", label: "Coûts & quotas", icon: BarChart3 },
     ],
   },
   {


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Show referring → referred doctor names on `Références méd.`

Follow-up flagged in #1118. The `Références méd.` view exists to track **referrals between doctors**, but the table only showed clinic / reason / status / date — the `referring_doctor_id` and `referred_to_doctor_id` were fetched from the DB and then **discarded**, so you couldn't see *who referred whom* (the entire point of the page).

### Changes
- **`/api/admin/referrals`** now enriches each row with `referring_doctor_name` and `referred_to_doctor_name` via a single `users` lookup over the distinct doctor ids (same safe pattern as the usage-dashboard clinic-name enrichment in #1118).
- The table adds **“Médecin référent”** and **“Médecin destinataire”** columns.

### PHI decision (deliberate)
The row also has a `patient_id`, and my earlier review noted the patient was missing too — but I am **not** exposing patient names here. This is a **cross-tenant, platform-operator** view, and patient identity is PHI that must stay masked by default (`env.ts → enforcePhiMaskingPolicy`, Law 09-08). Surfacing every clinic's patient names to the platform admin would be an unjustified PHI exposure. Only **staff (doctor)** names are resolved and shown.

### Testing
`tsc --noEmit` clean · ESLint clean. API change is additive (adds two name fields per row).

### Note
Stacks on **#1118** (both touch `referrals/page.tsx`). If #1118 is merged first this diff narrows to just these two files; otherwise it includes #1118's commit.