### PR TITLE
fix(ui): honor asChild in DropdownMenuTrigger (fixes #418 on every super-admin page)

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -54,7 +54,24 @@ interface DropdownMenuTriggerProps extends React.ComponentProps<"button"> {
   asChild?: boolean;
 }
 
-function DropdownMenuTrigger({ className, children, ...props }: DropdownMenuTriggerProps) {
+function DropdownMenuTrigger({ className, children, asChild, ...props }: DropdownMenuTriggerProps) {
+  // When `asChild` is set, merge the trigger's props (including the open/close
+  // onClick injected by <DropdownMenu>) onto the single child element instead
+  // of rendering our own <button>. Rendering a <button> here while the caller
+  // also passes a <button> child produces invalid nested <button><button>
+  // markup, which the browser reparents on hydration and triggers React #418
+  // (hydration mismatch) on every page using this trigger.
+  if (asChild && React.isValidElement(children)) {
+    const child = children as React.ReactElement<React.ButtonHTMLAttributes<HTMLButtonElement>>;
+    return React.cloneElement(child, {
+      ...props,
+      className: cn(child.props.className, className),
+      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        child.props.onClick?.(e);
+        props.onClick?.(e);
+      },
+    });
+  }
   return (
     <button type="button" className={cn("outline-none", className)} {...props}>
       {children}


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## The finding (from end-to-end testing)

My authenticated end-to-end test found React **#418 (hydration mismatch) firing on every super-admin page**. Pages stayed interactive (React recovers by re-rendering client-side), but it's a real defect causing a flash + perf cost on every navigation.

## Root cause (pinpointed with a real authenticated dev session)

I reproduced it in a **non-minified dev build** logged in against the real backend. The dev overlay named it exactly:

```
In HTML, <button> cannot be a descendant of <button>. This will cause a hydration error.
<DropdownMenuTrigger asChild={true}>
  <button asChild={true} ...>          ← trigger renders its OWN <button>
    <button class="relative inline-flex ...">   ← wrapping the caller's <button>
```

`DropdownMenuTrigger` (`src/components/ui/dropdown-menu.tsx`) declared an `asChild` prop but **ignored it** — it always rendered its own `<button>` and let `asChild` leak onto that button as a DOM attribute. So the documented pattern

```tsx
<DropdownMenuTrigger asChild><button>…</button></DropdownMenuTrigger>
```

always produced invalid nested `<button><button>`. The browser reparents that during parsing, so the server HTML never matches the client tree → **#418**. The super-admin shell header alone has two such triggers (notifications + user menu), so it fired on **every** `/super-admin/*` page.

## Fix

Implement `asChild` properly (the Radix `Slot` pattern): when `asChild` is set and the child is a valid element, **clone the child and merge** the trigger's props onto it — `className` + the open/close `onClick` injected by `<DropdownMenu>`, merged with the child's own `onClick` — instead of rendering a wrapper `<button>`. Non-`asChild` usage is unchanged. One-file change; fixes all **7+** call sites (notification-bell, super-admin shell, appointment-card, team, features, subscriptions, billing).

## Verification

Reproduced and fixed with a headless browser + authenticated dev session against the real Supabase backend:
- **Before:** `#418` + *"button cannot be a descendant of button"* on every super-admin page.
- **After:** `/super-admin/dashboard` and `/super-admin/subscriptions` → **0 hydration errors, 0 page errors**.
- `tsc --noEmit` clean · ESLint clean.

## Severity

Recoverable (the app was already interactive), so this is a polish/perf + correctness fix, not a functional unblock — but it eliminates a hydration error on every authenticated page load.