### PR TITLE
fix: harden the add-clinic onboarding flow end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -295,11 +295,6 @@ SENTRY_CSP_REPORT_URI=
 # Set to "true" after all seed users have been deleted in production.
 SEED_USERS_DELETED=false
 
-# ---- Staff Default Password [Optional] ----
-# Default password assigned to newly created staff accounts.
-# Change in production. Generate with: openssl rand -base64 16
-STAFF_DEFAULT_PASSWORD=
-
 # ---- Rate Limiting [Optional] ----
 # Backend: "supabase" (distributed, default when credentials present) or "memory" (local)
 RATE_LIMIT_BACKEND=

--- a/src/app/(super-admin)/super-admin/onboarding/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/page.tsx
@@ -41,12 +41,13 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/toast";
-import { STAFF_DEFAULT_PASSWORD } from "@/lib/constants";
+import { checkSubdomain } from "@/lib/reserved-subdomains";
 import {
   createClinic,
   createUser,
   createService,
   createTimeSlotsForDoctor,
+  activateClinic,
   type CreateUserInput,
   type CreateServiceInput,
 } from "@/lib/super-admin-actions";
@@ -198,7 +199,15 @@ export default function OnboardingPage() {
   // Step 2: Users
   const [users, setUsers] = useState<UserFormData[]>([{ ...DEFAULT_USER }]);
   const [createdUsers, setCreatedUsers] = useState<
-    { id: string; name: string; role: string; email?: string }[]
+    {
+      id: string;
+      name: string;
+      role: string;
+      email?: string;
+      authCreated: boolean;
+      inviteSent: boolean;
+      inviteError?: string;
+    }[]
   >([]);
 
   // Step 3: Services
@@ -321,7 +330,8 @@ export default function OnboardingPage() {
           .replace(/[^a-z0-9\s-]/g, "")
           .trim()
           .replace(/\s+/g, "-")
-          .replace(/--+/g, "-");
+          .replace(/--+/g, "-")
+          .replace(/^-+|-+$/g, "");
       }
       return next;
     });
@@ -411,9 +421,17 @@ export default function OnboardingPage() {
       setError("Le sous-domaine est requis — la clinique a besoin d'une URL pour être accessible");
       return;
     }
-    if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(clinicForm.subdomain)) {
+    // Shared validation (reserved-subdomains.ts) — same rules as the DB trigger
+    // (length 3–40, no reserved words, no hyphen abuse). Gives a clear message
+    // up front instead of a raw DB error after submit (Audit #5).
+    const subdomainRejection = checkSubdomain(clinicForm.subdomain);
+    if (subdomainRejection === "reserved") {
+      setError(`The subdomain "${clinicForm.subdomain}" is reserved. Please choose another.`);
+      return;
+    }
+    if (subdomainRejection === "invalid_format") {
       setError(
-        "Subdomain must contain only lowercase letters, numbers, and hyphens (cannot start or end with a hyphen)",
+        "Subdomain must be 3–40 characters: lowercase letters, numbers, and single hyphens only (cannot start or end with a hyphen).",
       );
       return;
     }
@@ -502,7 +520,15 @@ export default function OnboardingPage() {
     setLoading(true);
     setError(null);
     try {
-      const created: { id: string; name: string; role: string; email?: string }[] = [];
+      const created: {
+        id: string;
+        name: string;
+        role: string;
+        email?: string;
+        authCreated: boolean;
+        inviteSent: boolean;
+        inviteError?: string;
+      }[] = [];
       for (const u of validUsers) {
         const input: CreateUserInput = {
           clinic_id: createdClinicId,
@@ -517,10 +543,18 @@ export default function OnboardingPage() {
           name: user.name,
           role: user.role,
           email: user.email ?? undefined,
+          authCreated: user.authCreated,
+          inviteSent: user.inviteSent,
+          inviteError: user.inviteError,
         });
       }
       setCreatedUsers(created);
-      addToast(`${created.length} staff member(s) created`, "success");
+      const invited = created.filter((u) => u.inviteSent).length;
+      addToast(
+        `${created.length} staff member(s) created` +
+          (invited > 0 ? ` — ${invited} invitation email(s) sent` : ""),
+        "success",
+      );
 
       const doctors = created.filter((u) => u.role === "doctor" || u.role === "clinic_admin");
       setDoctorSlots(
@@ -673,6 +707,10 @@ export default function OnboardingPage() {
       }
       addToast("Time slots configured successfully", "success");
 
+      // Lifecycle (Audit #3): the clinic was created 'inactive'. Now that
+      // onboarding is complete, flip it to 'active' so its subdomain goes live.
+      await activateClinic(createdClinicId);
+
       // Save to recently onboarded
       addRecentClinic({
         id: createdClinicId,
@@ -693,16 +731,31 @@ export default function OnboardingPage() {
     }
   }
 
-  function handleSkipTimeSlots() {
+  async function handleSkipTimeSlots() {
     if (createdClinicId) {
-      addRecentClinic({
-        id: createdClinicId,
-        name: clinicForm.name,
-        type: clinicForm.type || "doctor",
-        tier: clinicForm.tier || "pro",
-        created_at: new Date().toISOString(),
-        status: "active",
-      });
+      setLoading(true);
+      setError(null);
+      try {
+        // Lifecycle (Audit #3): activate the clinic on completion even when
+        // time slots are skipped.
+        await activateClinic(createdClinicId);
+        addRecentClinic({
+          id: createdClinicId,
+          name: clinicForm.name,
+          type: clinicForm.type || "doctor",
+          tier: clinicForm.tier || "pro",
+          created_at: new Date().toISOString(),
+          status: "active",
+        });
+        setCompleted(true);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Failed to activate clinic";
+        setError(msg);
+        addToast(msg, "error");
+      } finally {
+        setLoading(false);
+      }
+      return;
     }
     setCompleted(true);
   }
@@ -977,7 +1030,7 @@ export default function OnboardingPage() {
             <Separator className="my-6" />
             {/* Staff Login Credentials */}
             <div className="bg-muted/50 rounded-lg p-4 text-left text-sm mb-6">
-              <h3 className="font-semibold mb-3">Staff Login Credentials:</h3>
+              <h3 className="font-semibold mb-3">Staff Access:</h3>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
@@ -985,7 +1038,7 @@ export default function OnboardingPage() {
                       <th className="text-left py-2 pr-4 font-medium">Role</th>
                       <th className="text-left py-2 pr-4 font-medium">Name</th>
                       <th className="text-left py-2 pr-4 font-medium">Email (Login)</th>
-                      <th className="text-left py-2 font-medium">Password</th>
+                      <th className="text-left py-2 font-medium">Access</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1000,11 +1053,15 @@ export default function OnboardingPage() {
                             <span className="text-amber-600 italic">No email — cannot log in</span>
                           )}
                         </td>
-                        <td className="py-2 font-mono text-xs">
-                          {u.email ? (
-                            STAFF_DEFAULT_PASSWORD
-                          ) : (
+                        <td className="py-2 text-xs">
+                          {!u.email ? (
                             <span className="text-muted-foreground">—</span>
+                          ) : u.inviteSent ? (
+                            <span className="text-green-600">Invitation email sent</span>
+                          ) : u.authCreated ? (
+                            <span className="text-amber-600">Account created — email not sent</span>
+                          ) : (
+                            <span className="text-destructive">Login not enabled</span>
                           )}
                         </td>
                       </tr>
@@ -1012,9 +1069,17 @@ export default function OnboardingPage() {
                   </tbody>
                 </table>
               </div>
-              {createdUsers.some((u) => u.email) && (
-                <p className="text-xs text-amber-600 mt-3 font-medium">
-                  Important: Please change the default passwords after first login.
+              {createdUsers.some((u) => u.inviteSent) && (
+                <p className="text-xs text-muted-foreground mt-3">
+                  Staff set their own password using the secure invitation link emailed to them —
+                  there is no shared default password.
+                </p>
+              )}
+              {createdUsers.some((u) => u.email && !u.inviteSent) && (
+                <p className="text-xs text-amber-600 mt-2 font-medium">
+                  Some invitation emails could not be sent (email provider or service role not
+                  configured). Use Admin → Staff to resend an invite or share a password-reset link
+                  manually.
                 </p>
               )}
               {createdUsers.some((u) => !u.email) && (
@@ -1052,7 +1117,7 @@ export default function OnboardingPage() {
                     >
                       {clinicForm.subdomain}.oltigo.com/login
                     </a>{" "}
-                    using the credentials above.
+                    using the invitation link emailed to them.
                   </p>
                 )}
                 <p>

--- a/src/app/(super-admin)/super-admin/onboarding/provision/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/provision/page.tsx
@@ -13,6 +13,7 @@ import {
   SkipForward,
   ArrowRight,
   ArrowLeft,
+  Users,
 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
@@ -43,6 +44,7 @@ interface ProvisioningStep {
 
 const STEP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   create_clinic: Building2,
+  create_owner: Users,
   configure_subdomain: Globe,
   setup_tables: Database,
   assign_whatsapp: MessageSquare,
@@ -53,11 +55,6 @@ const CLINIC_TYPES = [
   { value: "doctor", label: "Médecin" },
   { value: "dentist", label: "Dentiste" },
   { value: "pharmacy", label: "Pharmacie" },
-  { value: "clinic", label: "Clinique" },
-  { value: "hospital", label: "Hôpital" },
-  { value: "laboratory", label: "Laboratoire" },
-  { value: "veterinary", label: "Vétérinaire" },
-  { value: "restaurant", label: "Restaurant" },
 ];
 
 const TIERS = [
@@ -65,6 +62,7 @@ const TIERS = [
   { value: "cabinet", label: "Cabinet" },
   { value: "pro", label: "Pro" },
   { value: "premium", label: "Premium" },
+  { value: "saas", label: "SaaS (Mensuel)" },
 ];
 
 const GATEWAYS = [

--- a/src/app/api/admin/onboarding-provision/route.ts
+++ b/src/app/api/admin/onboarding-provision/route.ts
@@ -14,6 +14,7 @@ import { apiSuccess, apiInternalError, apiValidationError } from "@/lib/api-resp
 import { logAuditEvent } from "@/lib/audit-log";
 import { sendEmail } from "@/lib/email";
 import { staffWelcomeEmail } from "@/lib/email-templates";
+import { getSiteUrl } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
 import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
@@ -120,7 +121,7 @@ async function provisionOwnerAccount(
   // Send the set-your-password invitation (best effort — provisioning still
   // succeeds even if the email provider is not configured).
   try {
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+    const siteUrl = getSiteUrl() || "https://oltigo.com";
     const { data: resetLink } = await typedAdmin.auth.admin.generateLink({
       type: "recovery",
       email: ownerEmail,
@@ -202,6 +203,7 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       template_id,
     } = result.data;
 
+    // nosemgrep: admin-client-guard -- super-admin provisioning intentionally uses a service-role client (RLS bypass) for cross-table writes
     const typedAdmin = createAdminClient("super_admin");
     const untypedAdmin = createUntypedAdminClient("super_admin");
     let clinicId: string | null = null;

--- a/src/app/api/admin/onboarding-provision/route.ts
+++ b/src/app/api/admin/onboarding-provision/route.ts
@@ -12,8 +12,12 @@
 import { type NextRequest } from "next/server";
 import { apiSuccess, apiInternalError, apiValidationError } from "@/lib/api-response";
 import { logAuditEvent } from "@/lib/audit-log";
+import { sendEmail } from "@/lib/email";
+import { staffWelcomeEmail } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
+import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
+import { invalidateSubdomainCache } from "@/lib/subdomain-cache";
 import { createAdminClient, createUntypedAdminClient } from "@/lib/supabase-server";
 import type { UserRole } from "@/lib/types/database";
 import { safeParse } from "@/lib/validations/helpers";
@@ -24,11 +28,122 @@ const ALLOWED_ROLES: UserRole[] = ["super_admin"];
 
 const PROVISIONING_STEPS = [
   { key: "create_clinic", label: "Create clinic record" },
+  { key: "create_owner", label: "Create owner account" },
   { key: "configure_subdomain", label: "Configure subdomain" },
   { key: "setup_tables", label: "Setup database tables" },
   { key: "assign_whatsapp", label: "Assign WhatsApp number" },
   { key: "setup_payment", label: "Setup payment gateway" },
 ] as const;
+
+/**
+ * Create (or relink) the clinic owner's login account and send a
+ * set-your-password invitation. Uses the service-role admin client (RLS
+ * bypass) since this runs in a super-admin-gated route. Without this step a
+ * provisioned clinic had NO way to log in at all (Audit #6).
+ */
+async function provisionOwnerAccount(
+  typedAdmin: ReturnType<typeof createAdminClient>,
+  clinicId: string,
+  clinicName: string,
+  ownerName: string,
+  ownerEmail: string,
+  ownerPhone: string | null,
+): Promise<{ ok: boolean; error?: string }> {
+  let authId: string | null = null;
+  try {
+    const oneTimePassword = crypto.randomUUID() + crypto.randomUUID().slice(0, 8);
+    const { data: authUser, error: authError } = await typedAdmin.auth.admin.createUser({
+      email: ownerEmail,
+      password: oneTimePassword,
+      email_confirm: true,
+      user_metadata: {
+        name: ownerName,
+        role: "clinic_admin",
+        clinic_id: clinicId,
+        must_change_password: true,
+      },
+    });
+
+    if (authError) {
+      if (authError.message?.includes("already been registered")) {
+        const { data: list } = await typedAdmin.auth.admin.listUsers();
+        authId = list?.users?.find((u) => u.email === ownerEmail)?.id ?? null;
+      } else {
+        return { ok: false, error: authError.message };
+      }
+    } else {
+      authId = authUser?.user?.id ?? null;
+    }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Auth creation failed" };
+  }
+
+  if (!authId) {
+    return { ok: false, error: "Could not resolve the owner auth account" };
+  }
+
+  // The auth trigger already inserted a users row for this auth_id; update it
+  // in place with the clinic/role rather than inserting a duplicate email.
+  // Service-role client bypasses RLS, so no tenant filter is needed here.
+  // nosemgrep: tenant-scoping -- auth_id-keyed lookup of the trigger-created row (service role)
+  const { data: existing } = await typedAdmin
+    .from("users")
+    .select("id")
+    .eq("auth_id", authId)
+    .maybeSingle();
+
+  if (existing) {
+    // nosemgrep: tenant-scoping -- update is keyed by the unique auth_id (service role)
+    const { error } = await typedAdmin
+      .from("users")
+      .update({
+        clinic_id: clinicId,
+        role: "clinic_admin",
+        name: ownerName,
+        phone: ownerPhone,
+        email: ownerEmail,
+      })
+      .eq("auth_id", authId);
+    if (error) return { ok: false, error: error.message };
+  } else {
+    const { error } = await typedAdmin.from("users").insert({
+      clinic_id: clinicId,
+      role: "clinic_admin",
+      name: ownerName,
+      phone: ownerPhone,
+      email: ownerEmail,
+      auth_id: authId,
+    });
+    if (error) return { ok: false, error: error.message };
+  }
+
+  // Send the set-your-password invitation (best effort — provisioning still
+  // succeeds even if the email provider is not configured).
+  try {
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+    const { data: resetLink } = await typedAdmin.auth.admin.generateLink({
+      type: "recovery",
+      email: ownerEmail,
+      options: { redirectTo: `${siteUrl}/login?reset=true` },
+    });
+    const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
+    const template = staffWelcomeEmail({
+      staffName: ownerName,
+      clinicName,
+      email: ownerEmail,
+      loginUrl,
+      role: "clinic_admin",
+    });
+    await sendEmail({ to: ownerEmail, ...template });
+  } catch (err) {
+    logger.warn("Owner invitation email not sent", {
+      context: "onboarding-provision",
+      error: err,
+    });
+  }
+
+  return { ok: true };
+}
 
 async function updateStep(
   untypedClient: ReturnType<typeof createUntypedAdminClient>,
@@ -91,7 +206,17 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
     const untypedAdmin = createUntypedAdminClient("super_admin");
     let clinicId: string | null = null;
 
-    // Step 1: Create clinic record
+    // Validate the subdomain up front (Audit #5) — clear message instead of a
+    // raw DB trigger / constraint error surfaced later.
+    try {
+      assertAllowedSubdomain(subdomain);
+    } catch (err) {
+      return apiValidationError(err instanceof Error ? err.message : "Invalid subdomain");
+    }
+
+    // Step 1: Create clinic record (as 'inactive' — Audit #3. The clinic is
+    // only flipped to 'active' once all provisioning steps succeed, so a failed
+    // run never leaves a publicly-resolvable but broken tenant.)
     try {
       const { data: clinic, error: clinicError } = await typedAdmin
         .from("clinics")
@@ -100,7 +225,7 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
           type: clinic_type,
           tier,
           subdomain,
-          status: "active",
+          status: "inactive",
           owner_name,
           owner_email,
           phone: owner_phone ?? null,
@@ -131,7 +256,21 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
           context: "onboarding-provision",
           error: clinicError,
         });
-        return apiInternalError("Clinic creation failed — subdomain may already be in use");
+        // Map known constraint errors to clear messages instead of the previous
+        // misleading "subdomain may already be in use" catch-all (Audit #2).
+        if (
+          clinicError.code === "23505" ||
+          /duplicate key|unique constraint/i.test(clinicError.message)
+        ) {
+          return apiValidationError(`The subdomain "${subdomain}" is already in use.`);
+        }
+        if (
+          clinicError.code === "23514" ||
+          /check constraint|violates check/i.test(clinicError.message)
+        ) {
+          return apiValidationError("Invalid clinic type, tier, or subdomain.");
+        }
+        return apiInternalError("Clinic creation failed");
       }
 
       clinicId = clinic.id;
@@ -149,7 +288,27 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       await updateStep(untypedAdmin, clinicId, step.key, "pending");
     }
 
-    // Step 2: Configure subdomain
+    // Step 2: Create the clinic owner login account (Audit #6)
+    try {
+      await updateStep(untypedAdmin, clinicId, "create_owner", "in_progress");
+      const ownerResult = await provisionOwnerAccount(
+        typedAdmin,
+        clinicId,
+        clinic_name,
+        owner_name,
+        owner_email,
+        owner_phone ?? null,
+      );
+      if (ownerResult.ok) {
+        await updateStep(untypedAdmin, clinicId, "create_owner", "completed");
+      } else {
+        await updateStep(untypedAdmin, clinicId, "create_owner", "failed", ownerResult.error);
+      }
+    } catch (err) {
+      await updateStep(untypedAdmin, clinicId, "create_owner", "failed", String(err));
+    }
+
+    // Step 3: Configure subdomain
     try {
       await updateStep(untypedAdmin, clinicId, "configure_subdomain", "in_progress");
 
@@ -176,7 +335,7 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       await updateStep(untypedAdmin, clinicId, "configure_subdomain", "failed", String(err));
     }
 
-    // Step 3: Setup database tables (RLS context)
+    // Step 4: Setup database tables (RLS context)
     try {
       await updateStep(untypedAdmin, clinicId, "setup_tables", "in_progress");
       await updateStep(untypedAdmin, clinicId, "setup_tables", "completed");
@@ -184,7 +343,7 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       await updateStep(untypedAdmin, clinicId, "setup_tables", "failed", String(err));
     }
 
-    // Step 4: Assign WhatsApp number
+    // Step 5: Assign WhatsApp number
     try {
       await updateStep(untypedAdmin, clinicId, "assign_whatsapp", "in_progress");
 
@@ -207,7 +366,7 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       await updateStep(untypedAdmin, clinicId, "assign_whatsapp", "failed", String(err));
     }
 
-    // Step 5: Setup payment gateway
+    // Step 6: Setup payment gateway
     try {
       await updateStep(untypedAdmin, clinicId, "setup_payment", "in_progress");
 
@@ -254,6 +413,15 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
         ];
 
     if (clinicId) {
+      // Lifecycle (Audit #3): only flip the clinic to 'active' when every
+      // provisioning step succeeded. A run with failures stays 'inactive' so it
+      // is never publicly resolvable in a broken state.
+      if (!hasFailures) {
+        // nosemgrep: tenant-scoping -- super-admin activates a specific clinic by id (service role)
+        await typedAdmin.from("clinics").update({ status: "active" }).eq("id", clinicId);
+        invalidateSubdomainCache(subdomain);
+      }
+
       await syncClinicOnboardingState({
         supabase: untypedAdmin,
         clinicId,
@@ -330,4 +498,4 @@ async function handleGet(request: NextRequest, _auth: AuthContext) {
 }
 
 export const POST = withAuth(handlePost, ALLOWED_ROLES);
-export const GET = withAuth(handleGet, ALLOWED_ROLES, { failOpen: true });
+export const GET = withAuth(handleGet, ALLOWED_ROLES);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,15 +1,4 @@
 /**
- * Default password assigned to staff accounts created during onboarding.
- *
- * Read from the `STAFF_DEFAULT_PASSWORD` environment variable so that the
- * value is never committed to source control. Falls back to a generated
- * random string if the env var is not set, ensuring accounts are never
- * created with a well-known password.
- */
-export const STAFF_DEFAULT_PASSWORD =
-  process.env.STAFF_DEFAULT_PASSWORD || `Staff-${crypto.randomUUID()}`;
-
-/**
  * Default IANA timezone used as a last-resort fallback when tenant config
  * does not provide one. Matches the primary deployment locale (Morocco).
  *

--- a/src/lib/onboarding/state.ts
+++ b/src/lib/onboarding/state.ts
@@ -142,28 +142,20 @@ export async function syncClinicOnboardingState({
     payload.last_nudge_at = lastNudgeAt;
   }
 
-  if (existingRow) {
-    const { error: updateError } = await table.update(payload).eq("id", existingRow.id);
-    if (updateError) {
-      logger.warn("Failed to update onboarding state", {
-        context: "onboarding/state",
-        clinicId,
-        error: updateError.message,
-      });
-    }
-    return;
-  }
+  // Single race-safe write keyed on the unique clinic_id index (migration
+  // 00195). Concurrent calls can no longer create duplicate onboarding rows —
+  // the second becomes an UPDATE instead of a second INSERT (Audit #11). We
+  // still read `existingRow` above to merge completed_steps / nudge_count.
+  const { error: upsertError } = await table.upsert(
+    { ...payload, ...(existingRow ? {} : { created_at: now }) },
+    { onConflict: "clinic_id" },
+  );
 
-  const { error: insertError } = await table.insert({
-    ...payload,
-    created_at: now,
-  });
-
-  if (insertError) {
-    logger.warn("Failed to create onboarding state", {
+  if (upsertError) {
+    logger.warn("Failed to upsert onboarding state", {
       context: "onboarding/state",
       clinicId,
-      error: insertError.message,
+      error: upsertError.message,
     });
   }
 }

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
+import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
 import { invalidateSubdomainCache } from "@/lib/subdomain-cache";
 import { createClient, createAdminClient } from "@/lib/supabase-server";
 import type { ClinicType, ClinicTier, Json } from "@/lib/types/database";
@@ -111,6 +112,22 @@ export interface CreateUserInput {
   email?: string;
 }
 
+/**
+ * Result of {@link createUser}. Extends the raw DB row with onboarding-relevant
+ * status so the wizard can tell the operator the truth about each account:
+ *   - `authCreated`  — a Supabase Auth login account exists for this staff
+ *   - `inviteSent`   — the set-your-password invitation email was delivered
+ *   - `inviteError`  — why the invite could not be sent (when `inviteSent` is false)
+ *
+ * Staff DO NOT receive a shared/default password — they set their own via the
+ * invitation link. The wizard must therefore never display a password.
+ */
+export interface CreateUserResult extends UserRow {
+  authCreated: boolean;
+  inviteSent: boolean;
+  inviteError?: string;
+}
+
 export interface CreateServiceInput {
   clinic_id: string;
   name: string;
@@ -135,17 +152,26 @@ interface _CreateTimeSlotInput {
 export async function createClinic(input: CreateClinicInput): Promise<ClinicRow> {
   const supabase = await rawClient();
   const cfg = input.config ?? {};
+
+  // Validate the subdomain BEFORE inserting (Audit #5). This mirrors the DB
+  // trigger (migration 00171) but fails early with a clear, operator-facing
+  // message instead of leaking a raw Postgres constraint error to the UI.
+  if (input.subdomain) {
+    assertAllowedSubdomain(input.subdomain);
+  }
+
   const { data, error } = await supabase
     .from("clinics")
     .insert({
       name: input.name,
       type: input.type,
       tier: input.tier,
-      // QA root-cause fix: always persist the caller-supplied status so new
-      // clinics are created as 'active' by default, not the DB column default
-      // which is 'suspended'. Without this, every onboarding-created clinic
-      // immediately appeared suspended in the All Clinics list.
-      status: input.status ?? "active",
+      // Lifecycle (Audit #3): a freshly-created clinic is NOT live until its
+      // onboarding completes. We default to 'inactive' so an abandoned wizard
+      // never leaves a publicly-resolvable but empty tenant. The wizard calls
+      // `activateClinic()` on the final step to flip it to 'active'. Callers
+      // may still pass an explicit status to override (e.g. data imports).
+      status: input.status ?? "inactive",
       config: cfg as Json,
       subdomain: input.subdomain ?? null,
       // Also set direct columns so public branding queries work
@@ -159,7 +185,9 @@ export async function createClinic(input: CreateClinicInput): Promise<ClinicRow>
     .select()
     .single();
 
-  if (error) throw new Error(`Failed to create clinic: ${error.message}`);
+  if (error) {
+    throw new Error(mapClinicWriteError(error, input.subdomain));
+  }
 
   await syncClinicOnboardingState({
     supabase,
@@ -174,6 +202,45 @@ export async function createClinic(input: CreateClinicInput): Promise<ClinicRow>
   });
 
   return data as ClinicRow;
+}
+
+/**
+ * Translate a Postgres error from a clinics INSERT/UPDATE into a clear,
+ * operator-facing message. Avoids the previous misleading "subdomain may
+ * already be in use" catch-all that masked CHECK-constraint (invalid type)
+ * and other failures (Audit #2).
+ */
+function mapClinicWriteError(
+  error: { code?: string; message: string },
+  subdomain?: string | null,
+): string {
+  // 23505 = unique_violation (subdomain already taken)
+  if (error.code === "23505" || /duplicate key|unique constraint/i.test(error.message)) {
+    return subdomain
+      ? `The subdomain "${subdomain}" is already in use. Please choose another.`
+      : "A clinic with these details already exists.";
+  }
+  // 23514 = check_violation (invalid type/tier/status, or reserved subdomain)
+  if (error.code === "23514" || /check constraint|violates check/i.test(error.message)) {
+    return "Invalid clinic details: the clinic type, tier, or subdomain is not allowed.";
+  }
+  return `Failed to create clinic: ${error.message}`;
+}
+
+/**
+ * Flip a clinic to 'active' — used by the onboarding wizard once setup is
+ * complete (Audit #3). Idempotent and restricted to super_admin via rawClient.
+ */
+export async function activateClinic(clinicId: string): Promise<void> {
+  const supabase = await rawClient();
+  const { data, error } = await supabase
+    .from("clinics") // nosemgrep: tenant-scoping — super-admin activates a specific clinic by id
+    .update({ status: "active" })
+    .eq("id", clinicId)
+    .select("subdomain")
+    .single();
+  if (error) throw new Error(`Failed to activate clinic: ${error.message}`);
+  if (data?.subdomain) invalidateSubdomainCache(data.subdomain as string);
 }
 
 export async function fetchClinics(): Promise<ClinicRow[]> {
@@ -580,7 +647,7 @@ export async function updateSubscriptionStatus(
  * inserted into public.users (without auth_id) so onboarding doesn't break.
  * A warning is logged in that case.
  */
-export async function createUser(input: CreateUserInput): Promise<UserRow> {
+export async function createUser(input: CreateUserInput): Promise<CreateUserResult> {
   const supabase = await rawClient();
   let authId: string | null = null;
 
@@ -639,117 +706,164 @@ export async function createUser(input: CreateUserInput): Promise<UserRow> {
   // and no clinic. So whenever we created (or matched) an auth account above,
   // a users row for this auth_id ALREADY EXISTS and already holds this email.
   //
-  // Because users.email has a UNIQUE index (migration 00068 D-03,
-  // `users_email_lower_uq`), inserting a SECOND row with the same email would
-  // fail with a duplicate-key error — which, thrown from this Server Action,
-  // surfaces in the browser as the generic "An error occurred in the Server
-  // Components render" message in production.
+  // Because users.email has a UNIQUE index (migration 00068 D-03), inserting a
+  // SECOND row with the same email fails with a duplicate-key error. So we
+  // UPDATE the trigger-created row in place instead of inserting a duplicate.
   //
-  // The correct behaviour is therefore to UPDATE the trigger-created row in
-  // place with the staff's real role/clinic/name instead of inserting a
-  // duplicate. (A previous revision split this into two blocks, the first of
-  // which mis-classified the trigger row as "already taken by another user"
-  // and nulled authId, turning the update path into dead code and causing the
-  // duplicate INSERT — and the crash.)
+  // All paths below converge on a single `userRow`, after which we send EXACTLY
+  // ONE invitation email. (A previous revision returned early from the update
+  // and duplicate-recovery paths, so in production — where the service role key
+  // is set and the trigger path is taken — staff never received an invite email
+  // and could not log in. Audit #10.)
+  let userRow: UserRow;
+
+  let triggerRowId: string | null = null;
   if (authId) {
+    // nosemgrep: tenant-scoping -- auth_id-keyed lookup of the trigger-created row
     const { data: existingRow } = await supabase
       .from("users")
       .select("id")
       .eq("auth_id", authId)
       .maybeSingle();
+    triggerRowId = existingRow?.id ?? null;
+  }
 
-    if (existingRow) {
-      const { data: updated, error: updateError } = await supabase
-        .from("users")
-        .update({
-          clinic_id: input.clinic_id,
-          role: input.role,
-          name: input.name,
-          phone: input.phone ?? null,
-          email: input.email ?? null,
-        })
-        .eq("auth_id", authId)
-        .select()
-        .single();
+  if (authId && triggerRowId) {
+    // The auth trigger inserts this row with clinic_id = NULL, so it cannot be
+    // filtered by clinic_id; the row is uniquely identified by the just-created
+    // auth_id. We are assigning the clinic here, not querying across tenants.
+    // nosemgrep: tenant-scoping
+    const { data: updated, error: updateError } = await supabase
+      .from("users")
+      .update({
+        clinic_id: input.clinic_id,
+        role: input.role,
+        name: input.name,
+        phone: input.phone ?? null,
+        email: input.email ?? null,
+      })
+      .eq("auth_id", authId)
+      .select()
+      .single();
 
-      if (updateError) throw new Error(`Failed to update user: ${updateError.message}`);
-      return updated as UserRow;
+    if (updateError) throw new Error(`Failed to update user: ${updateError.message}`);
+    userRow = updated as UserRow;
+  } else {
+    const { data, error } = await supabase
+      .from("users")
+      .insert({
+        clinic_id: input.clinic_id,
+        role: input.role,
+        name: input.name,
+        phone: input.phone ?? null,
+        email: input.email ?? null,
+        ...(authId ? { auth_id: authId } : {}),
+      })
+      .select()
+      .single();
+
+    if (error) {
+      // Recover gracefully if a row with this email already exists (e.g. the
+      // auth trigger created it, or the same staff email was onboarded before).
+      // Scoped to this clinic on purpose: we only relink a row that already
+      // belongs to input.clinic_id. If the email belongs to another tenant, the
+      // filter matches nothing and the original error is surfaced — we never
+      // reassign a user across clinics (tenant isolation, AGENTS.md rule #1).
+      const isDuplicate =
+        error.code === "23505" ||
+        /duplicate key|already exists|unique constraint/i.test(error.message);
+      let recovered: UserRow | null = null;
+      if (isDuplicate && input.email) {
+        const { data: updated } = await supabase
+          .from("users")
+          .update({
+            clinic_id: input.clinic_id,
+            role: input.role,
+            name: input.name,
+            phone: input.phone ?? null,
+            ...(authId ? { auth_id: authId } : {}),
+          })
+          .eq("email", input.email)
+          .eq("clinic_id", input.clinic_id)
+          .select()
+          .single();
+        recovered = (updated as UserRow | null) ?? null;
+      }
+      if (!recovered) throw new Error(`Failed to create user: ${error.message}`);
+      userRow = recovered;
+    } else {
+      userRow = data as UserRow;
     }
   }
 
-  const { data, error } = await supabase
-    .from("users")
-    .insert({
-      clinic_id: input.clinic_id,
-      role: input.role,
-      name: input.name,
-      phone: input.phone ?? null,
-      email: input.email ?? null,
-      ...(authId ? { auth_id: authId } : {}),
-    })
-    .select()
-    .single();
+  // ---- Send the set-your-password invitation email (exactly once) ----
+  // Staff set their OWN password via this link — there is no shared/default
+  // password. `inviteSent`/`inviteError` are surfaced to the wizard so the
+  // operator knows the real access state of each account (Audit #1/#10).
+  let inviteSent = false;
+  let inviteError: string | undefined;
 
-  if (error) {
-    // Recover gracefully if a row with this email already exists (e.g. the
-    // auth trigger created it, or the same staff email was onboarded before).
-    // The users.email UNIQUE index rejects the duplicate with code 23505;
-    // instead of crashing, update the existing row so onboarding is idempotent.
-    const isDuplicate =
-      error.code === "23505" ||
-      /duplicate key|already exists|unique constraint/i.test(error.message);
-    if (isDuplicate && input.email) {
-      const { data: updated, error: updateError } = await supabase
-        .from("users")
-        .update({
-          clinic_id: input.clinic_id,
-          role: input.role,
-          name: input.name,
-          phone: input.phone ?? null,
-          ...(authId ? { auth_id: authId } : {}),
-        })
-        .eq("email", input.email)
-        .select()
-        .single();
-
-      if (!updateError && updated) return updated as UserRow;
-    }
-    throw new Error(`Failed to create user: ${error.message}`);
-  }
-
-  // Send welcome/password-reset email so staff can set their own password
   if (input.email) {
     try {
       const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
-      const admin = createAdminClient("super_admin");
-      const { data: resetLink } = await admin.auth.admin.generateLink({
-        type: "recovery",
-        email: input.email,
-        options: {
-          redirectTo: `${siteUrl}/login?reset=true`,
-        },
-      });
 
-      const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
+      // Resolve the real clinic name for the email (Audit #4 — previously the
+      // clinic UUID was passed as the clinic name).
+      const { data: clinicRow } = await supabase
+        .from("clinics") // nosemgrep: tenant-scoping — fetch the staff member's own clinic name by id
+        .select("name")
+        .eq("id", input.clinic_id)
+        .maybeSingle();
+      const clinicName = ((clinicRow?.name as string | undefined) || "").trim() || "your clinic";
 
-      const template = staffWelcomeEmail({
-        staffName: input.name,
-        clinicName: input.clinic_id,
-        email: input.email,
-        loginUrl,
-        role: input.role,
-      });
-      await sendEmail({ to: input.email, ...template });
+      if (!authId || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+        inviteError = "Login is not enabled — set SUPABASE_SERVICE_ROLE_KEY to create accounts.";
+      } else {
+        const admin = createAdminClient("super_admin");
+        const { data: resetLink, error: linkError } = await admin.auth.admin.generateLink({
+          type: "recovery",
+          email: input.email,
+          options: {
+            redirectTo: `${siteUrl}/login?reset=true`,
+          },
+        });
+
+        if (linkError) {
+          inviteError = linkError.message;
+        } else {
+          const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
+          const template = staffWelcomeEmail({
+            staffName: input.name,
+            clinicName,
+            email: input.email,
+            loginUrl,
+            role: input.role,
+          });
+          const result = await sendEmail({ to: input.email, ...template });
+          inviteSent = result.success;
+          if (!result.success) inviteError = result.error;
+        }
+      }
     } catch (emailErr) {
-      logger.warn("Failed to send welcome email to staff", {
+      inviteError =
+        emailErr instanceof Error ? emailErr.message : "Failed to send invitation email";
+    }
+
+    if (!inviteSent) {
+      logger.warn("Staff invitation email not sent", {
         context: "super-admin-actions",
         email: input.email,
-        error: emailErr,
+        error: inviteError,
       });
     }
   }
 
-  return data as UserRow;
+  return {
+    ...userRow,
+    authCreated: Boolean(authId),
+    inviteSent,
+    inviteError,
+  };
 }
 
 // ---------- Service CRUD ----------

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -17,6 +17,7 @@ import {
   clinicSuspendedEmail,
   clinicActivatedEmail,
 } from "@/lib/email-templates";
+import { getSiteUrl } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
 import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
@@ -805,7 +806,7 @@ export async function createUser(input: CreateUserInput): Promise<CreateUserResu
 
   if (input.email) {
     try {
-      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+      const siteUrl = getSiteUrl() || "https://oltigo.com";
 
       // Resolve the real clinic name for the email (Audit #4 — previously the
       // clinic UUID was passed as the clinic name).
@@ -816,9 +817,13 @@ export async function createUser(input: CreateUserInput): Promise<CreateUserResu
         .maybeSingle();
       const clinicName = ((clinicRow?.name as string | undefined) || "").trim() || "your clinic";
 
-      if (!authId || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      if (!authId) {
+        // authId is only set when the auth account was created/matched above
+        // (which requires SUPABASE_SERVICE_ROLE_KEY). A null authId therefore
+        // means a login account could not be enabled for this staff member.
         inviteError = "Login is not enabled — set SUPABASE_SERVICE_ROLE_KEY to create accounts.";
       } else {
+        // nosemgrep: admin-client-guard -- super-admin generates a one-time recovery link for this staff member
         const admin = createAdminClient("super_admin");
         const { data: resetLink, error: linkError } = await admin.auth.admin.generateLink({
           type: "recovery",

--- a/src/lib/validations/super-admin.ts
+++ b/src/lib/validations/super-admin.ts
@@ -13,21 +13,17 @@ const booleanish = z.preprocess((value: unknown) => {
 
 export const clinicProvisionSchema = z.object({
   clinic_name: z.string().min(1).max(200),
-  clinic_type: z.enum([
-    "doctor",
-    "dentist",
-    "pharmacy",
-    "clinic",
-    "hospital",
-    "laboratory",
-    "veterinary",
-    "restaurant",
-  ]),
-  tier: z.enum(["vitrine", "cabinet", "pro", "premium"]),
+  // The clinics.type column (and ClinicType) only supports these three
+  // "system types" — the feature/permission system is keyed off them. Verticals
+  // such as veterinary/laboratory are modelled separately via clinic_types, not
+  // clinics.type, so accepting them here only produced CHECK-constraint crashes
+  // (Audit #2). Keep this enum aligned with ClinicType in types/database.ts.
+  clinic_type: z.enum(["doctor", "dentist", "pharmacy"]),
+  tier: z.enum(["vitrine", "cabinet", "pro", "premium", "saas"]),
   subdomain: z
     .string()
-    .min(1)
-    .max(63)
+    .min(3)
+    .max(40)
     .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/),
   owner_name: z.string().min(1).max(200),
   owner_email: z.string().email().max(254),

--- a/supabase/migrations/00195_clinic_onboarding_uniqueness.sql
+++ b/supabase/migrations/00195_clinic_onboarding_uniqueness.sql
@@ -1,0 +1,30 @@
+-- 00195: Enforce one onboarding row per clinic (Audit #11)
+--
+-- `syncClinicOnboardingState()` previously did a select-then-insert/update with
+-- no unique constraint on clinic_id. Two concurrent calls (e.g. createClinic +
+-- a parallel provisioning request) could both see "no existing row" and each
+-- INSERT, producing duplicate onboarding rows and silently desynced state.
+--
+-- This migration de-duplicates any existing rows (keeping the most recently
+-- updated one per clinic) and adds a UNIQUE index on clinic_id so the helper
+-- can perform a single race-safe upsert (ON CONFLICT (clinic_id)).
+--
+-- NB: NULL clinic_id rows are allowed and remain distinct (the FK is
+-- ON DELETE SET NULL), so a plain unique index — not a partial one — is used,
+-- which also lets PostgreSQL infer it for ON CONFLICT (clinic_id).
+
+-- 1. De-duplicate: keep the freshest row per non-null clinic_id.
+DELETE FROM clinic_onboardings a
+USING clinic_onboardings b
+WHERE a.clinic_id IS NOT NULL
+  AND a.clinic_id = b.clinic_id
+  AND a.id <> b.id
+  AND (
+    a.updated_at < b.updated_at
+    OR (a.updated_at = b.updated_at AND a.created_at < b.created_at)
+    OR (a.updated_at = b.updated_at AND a.created_at = b.created_at AND a.id < b.id)
+  );
+
+-- 2. Enforce uniqueness going forward.
+CREATE UNIQUE INDEX IF NOT EXISTS clinic_onboardings_clinic_id_uq
+  ON clinic_onboardings (clinic_id);


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Rebased, conflict-free replacement for #1123 (please close #1123 in favour of this one). Implements the full add-clinic audit.

> Note: my `createUser` rewrite here **preserves the clinic-scoped duplicate-recovery + `nosemgrep` tenant-scoping** that the squash-merge of #1122 dropped from `main` — so this also restores that tenant-isolation fix.

## Fixes

**Staff access — fake password (#1) + silent invite failures (#10)**
- Removed `STAFF_DEFAULT_PASSWORD` from the success screen — it never matched the real (random) auth password, so staff could never log in with it.
- `createUser` previously returned early from the trigger-update and duplicate-recovery paths, so in production (service-role key set) staff never got an invitation email. Consolidated so the set-your-password invite is sent on **all** success paths.
- `createUser` now returns `authCreated`/`inviteSent`/`inviteError`; the wizard reports the true access state per staff member.

**Welcome email used the clinic UUID as the name (#4)** — now fetches/uses the real clinic name.

**Clinic type/tier mismatch crash (#2) + missing tier (#8)** — restricted the provision schema + UI to the supported system types (doctor/dentist/pharmacy), added the missing `saas` tier, and mapped DB constraint errors to clear messages (no more misleading "subdomain may already be in use").

**Subdomain validation bypassed the shared helper (#5)** — `createClinic` and the provision route now call `assertAllowedSubdomain` before insert; the wizard uses `checkSubdomain` for clear client-side feedback.

**Clinics went live before onboarding finished (#3/#9)** — clinics are created `inactive` and flipped to `active` only on completion (`activateClinic`; provision activates only when all steps succeed).

**Provisioned clinics had no login (#6)** — the auto-provision route now creates the owner's login + invite as a dedicated step.

**Fail-open auth (#7)** — `GET /api/admin/onboarding-provision` no longer uses `failOpen: true`.

**Onboarding-state race (#11)** — migration `00195` de-duplicates `clinic_onboardings` and adds a unique index on `clinic_id`; `syncClinicOnboardingState` now upserts on conflict.

## Testing
- `tsc --noEmit`, full `eslint` (under the warning baseline), `prettier --check` — all pass.
- `semgrep` (`.semgrep/` suite + `p/javascript`/`p/owasp-top-ten`/`p/secrets`) — no findings on changed lines; privileged queries are clinic-scoped or carry documented `nosemgrep` annotations.
- Relevant vitest suites pass (onboarding, clinic-owner, onboarding-flow, reserved-subdomains, admin-actions-persistence).

## Notes
- Enabling staff/owner logins requires `SUPABASE_SERVICE_ROLE_KEY` + an email provider; the UI now states this honestly instead of showing a fake password.
- Behaviour change: new clinics start `inactive` until onboarding completes (intentional, Audit #3). Migration `00195` ships with this PR.