### PR TITLE
fix: harden the add-clinic onboarding flow end-to-end

### DIFF
--- a/.ai/prompts/BLOCKER-AUDIT-PROMPT.md
+++ b/.ai/prompts/BLOCKER-AUDIT-PROMPT.md
@@ -39,6 +39,7 @@ severity using the project's existing scale (`P0` = launch blocker, `P1` = must-
 GA). Anything `P2`/`P3` is NOT a blocker — leave it out.
 
 **P0 — hard launch blockers**
+
 1. **Cross-tenant data leak**: any DB query (`.from(...).select/insert/update/delete`) that
    is not scoped by `clinic_id`, trusts a client-supplied `clinic_id`/`x-clinic-id` header,
    or bypasses `requireTenant()` / `requireTenantWithConfig()`. (See AGENTS.md "Tenant Isolation".)
@@ -56,6 +57,7 @@ GA). Anything `P2`/`P3` is NOT a blocker — leave it out.
    mis-attribute payments across tenants.
 
 **P1 — must-fix-before-GA blockers**
+
 8. **Mass-assignment**: `.insert({...body})` / `.insert(body)` instead of explicit fields.
 9. **Missing input validation** on mutation routes (no Zod schema via `@/lib/validations`).
 10. **Failing/flaky required CI gates**: `lint`, `typecheck`, `test`, bundle-budget, E2E.
@@ -109,20 +111,23 @@ Use this exact structure:
 - **Commit:** <git rev-parse --short HEAD>
 - **Auditor:** <model/agent name>
 - **Verdict:** READY ✅ | NOT READY — CONDITIONAL ⚠️ | NOT READY ❌
-- **Blocker count:** P0: <n>  |  P1: <n>
+- **Blocker count:** P0: <n> | P1: <n>
 
 ## Gate results
-| Gate | Command | Result | Notes |
-| --- | --- | --- | --- |
-| Typecheck | `npm run typecheck` | pass/fail | ... |
-| Lint | `npm run lint` | pass/fail | ... |
-| Unit tests | `npm run test` | pass/fail | ... |
-| Build | `npm run build` | pass/fail | ... |
+
+| Gate       | Command             | Result    | Notes |
+| ---------- | ------------------- | --------- | ----- |
+| Typecheck  | `npm run typecheck` | pass/fail | ...   |
+| Lint       | `npm run lint`      | pass/fail | ...   |
+| Unit tests | `npm run test`      | pass/fail | ...   |
+| Build      | `npm run build`     | pass/fail | ...   |
 
 ## Blockers
+
 > One entry per finding, ordered P0 first. No non-blockers.
 
-### [BLK-01] <short title>  — P0
+### [BLK-01] <short title> — P0
+
 - **Category:** Tenant leak | PHI | AuthZ | Webhook | Build | Migration | Payment | Mass-assignment | Validation | CI | Audit-log
 - **Location:** `path/to/file.ts:LINE` (+ related files)
 - **Evidence:** exact code snippet or command output proving the issue
@@ -135,9 +140,11 @@ Use this exact structure:
 ### [BLK-02] ...
 
 ## Explicitly checked & NOT blocking
+
 > Short list of high-risk areas you verified are fine, so reviewers know coverage.
 
 ## Out of scope / deferred
+
 > Anything you noticed that is real but NOT a blocker (P2/P3, experimental flagged
 > features). One line each. Do not expand these into fixes.
 ```
@@ -169,6 +176,7 @@ Use this exact structure:
    reviewable PRs — never `git add .`, never touch SEALED files without sign-off).
 
 ### Optional tweaks
-- **Faster scope:** add a line restricting it to a path, e.g. *"Only audit `src/app/api/booking/**`."*
+
+- **Faster scope:** add a line restricting it to a path, e.g. _"Only audit `src/app/api/booking/**`."_
 - **Pre-PR gate:** ask the AI to also run the audit against the current branch diff only.
 - **CI integration:** the same prompt works as a manual checklist before tagging a release.

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@ node_modules/
 .open-next/
 coverage/
 dist/
+.kiro/
 supabase/migrations/
 src/lib/types/database.ts
 pnpm-lock.yaml

--- a/src/app/(super-admin)/super-admin/onboarding/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/page.tsx
@@ -41,13 +41,14 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/toast";
-import { STAFF_DEFAULT_PASSWORD } from "@/lib/constants";
 import {
   createClinic,
   createUser,
   createService,
   createTimeSlotsForDoctor,
+  activateClinic,
   type CreateUserInput,
+  type CreateUserAccess,
   type CreateServiceInput,
 } from "@/lib/super-admin-actions";
 
@@ -198,7 +199,7 @@ export default function OnboardingPage() {
   // Step 2: Users
   const [users, setUsers] = useState<UserFormData[]>([{ ...DEFAULT_USER }]);
   const [createdUsers, setCreatedUsers] = useState<
-    { id: string; name: string; role: string; email?: string }[]
+    { id: string; name: string; role: string; email?: string; access?: CreateUserAccess }[]
   >([]);
 
   // Step 3: Services
@@ -502,7 +503,13 @@ export default function OnboardingPage() {
     setLoading(true);
     setError(null);
     try {
-      const created: { id: string; name: string; role: string; email?: string }[] = [];
+      const created: {
+        id: string;
+        name: string;
+        role: string;
+        email?: string;
+        access?: CreateUserAccess;
+      }[] = [];
       for (const u of validUsers) {
         const input: CreateUserInput = {
           clinic_id: createdClinicId,
@@ -517,6 +524,7 @@ export default function OnboardingPage() {
           name: user.name,
           role: user.role,
           email: user.email ?? undefined,
+          access: user.access,
         });
       }
       setCreatedUsers(created);
@@ -647,6 +655,21 @@ export default function OnboardingPage() {
     }
   }
 
+  // Audit #3: clinics are created `inactive` and only go live once onboarding
+  // finishes. Activating here (and on skip) flips the clinic to `active`. On
+  // failure the clinic safely stays inactive and can be activated from Admin.
+  async function activateCreatedClinic(): Promise<void> {
+    if (!createdClinicId) return;
+    try {
+      await activateClinic(createdClinicId);
+    } catch {
+      addToast(
+        "Clinic set up but could not be activated automatically — activate it from All Clinics.",
+        "error",
+      );
+    }
+  }
+
   async function handleStep4() {
     if (!createdClinicId) {
       setError("No clinic created yet.");
@@ -673,6 +696,9 @@ export default function OnboardingPage() {
       }
       addToast("Time slots configured successfully", "success");
 
+      // Audit #3: clinic onboarding is complete — make it live.
+      await activateCreatedClinic();
+
       // Save to recently onboarded
       addRecentClinic({
         id: createdClinicId,
@@ -693,8 +719,10 @@ export default function OnboardingPage() {
     }
   }
 
-  function handleSkipTimeSlots() {
+  async function handleSkipTimeSlots() {
     if (createdClinicId) {
+      // Audit #3: clinic onboarding is complete (slots skipped) — make it live.
+      await activateCreatedClinic();
       addRecentClinic({
         id: createdClinicId,
         name: clinicForm.name,
@@ -985,7 +1013,7 @@ export default function OnboardingPage() {
                       <th className="text-left py-2 pr-4 font-medium">Role</th>
                       <th className="text-left py-2 pr-4 font-medium">Name</th>
                       <th className="text-left py-2 pr-4 font-medium">Email (Login)</th>
-                      <th className="text-left py-2 font-medium">Password</th>
+                      <th className="text-left py-2 font-medium">Access</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -1000,11 +1028,25 @@ export default function OnboardingPage() {
                             <span className="text-amber-600 italic">No email — cannot log in</span>
                           )}
                         </td>
-                        <td className="py-2 font-mono text-xs">
-                          {u.email ? (
-                            STAFF_DEFAULT_PASSWORD
+                        <td className="py-2 text-xs">
+                          {!u.email ? (
+                            <span className="text-amber-600 italic">No email — cannot log in</span>
+                          ) : u.access?.inviteSent ? (
+                            <span className="text-green-600">Invitation email sent</span>
+                          ) : u.access?.authCreated ? (
+                            <span
+                              className="text-amber-600"
+                              title={u.access?.inviteError ?? undefined}
+                            >
+                              Account created — email not sent
+                            </span>
                           ) : (
-                            <span className="text-muted-foreground">—</span>
+                            <span
+                              className="text-destructive"
+                              title={u.access?.inviteError ?? undefined}
+                            >
+                              Login not enabled
+                            </span>
                           )}
                         </td>
                       </tr>
@@ -1012,9 +1054,17 @@ export default function OnboardingPage() {
                   </tbody>
                 </table>
               </div>
-              {createdUsers.some((u) => u.email) && (
-                <p className="text-xs text-amber-600 mt-3 font-medium">
-                  Important: Please change the default passwords after first login.
+              {createdUsers.some((u) => u.access?.inviteSent) && (
+                <p className="text-xs text-muted-foreground mt-3">
+                  Staff shown as Invitation email sent will receive a secure link to set their own
+                  password and log in. No password is displayed here because none is shared.
+                </p>
+              )}
+              {createdUsers.some((u) => u.email && !u.access?.inviteSent) && (
+                <p className="text-xs text-amber-600 mt-2 font-medium">
+                  Some staff have a login but did not receive an invitation email (no email provider
+                  configured). They can use the Forgot password link on the login page, or you can
+                  configure an email provider and re-send the invite from Admin.
                 </p>
               )}
               {createdUsers.some((u) => !u.email) && (

--- a/src/app/(super-admin)/super-admin/onboarding/provision/page.tsx
+++ b/src/app/(super-admin)/super-admin/onboarding/provision/page.tsx
@@ -49,15 +49,13 @@ const STEP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = 
   setup_payment: CreditCard,
 };
 
+// Audit #2: only these system types satisfy the `clinics.type` CHECK
+// constraint (migration 00001). Offering unsupported types caused the
+// provisioning INSERT to fail and surface a misleading error.
 const CLINIC_TYPES = [
   { value: "doctor", label: "Médecin" },
   { value: "dentist", label: "Dentiste" },
   { value: "pharmacy", label: "Pharmacie" },
-  { value: "clinic", label: "Clinique" },
-  { value: "hospital", label: "Hôpital" },
-  { value: "laboratory", label: "Laboratoire" },
-  { value: "veterinary", label: "Vétérinaire" },
-  { value: "restaurant", label: "Restaurant" },
 ];
 
 const TIERS = [
@@ -65,6 +63,7 @@ const TIERS = [
   { value: "cabinet", label: "Cabinet" },
   { value: "pro", label: "Pro" },
   { value: "premium", label: "Premium" },
+  { value: "saas", label: "SaaS" },
 ];
 
 const GATEWAYS = [

--- a/src/app/api/admin/onboarding-provision/route.ts
+++ b/src/app/api/admin/onboarding-provision/route.ts
@@ -14,7 +14,9 @@ import { apiSuccess, apiInternalError, apiValidationError } from "@/lib/api-resp
 import { logAuditEvent } from "@/lib/audit-log";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
+import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
 import { createAdminClient, createUntypedAdminClient } from "@/lib/supabase-server";
+import { createUser } from "@/lib/super-admin-actions";
 import type { UserRole } from "@/lib/types/database";
 import { safeParse } from "@/lib/validations/helpers";
 import { clinicProvisionSchema } from "@/lib/validations/super-admin";
@@ -24,6 +26,7 @@ const ALLOWED_ROLES: UserRole[] = ["super_admin"];
 
 const PROVISIONING_STEPS = [
   { key: "create_clinic", label: "Create clinic record" },
+  { key: "create_owner_login", label: "Create owner login" },
   { key: "configure_subdomain", label: "Configure subdomain" },
   { key: "setup_tables", label: "Setup database tables" },
   { key: "assign_whatsapp", label: "Assign WhatsApp number" },
@@ -87,6 +90,14 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       template_id,
     } = result.data;
 
+    // Audit #5: enforce the shared subdomain policy (length, reserved words,
+    // hyphen abuse, punycode) before any INSERT, not just the DB trigger.
+    try {
+      assertAllowedSubdomain(subdomain);
+    } catch (err) {
+      return apiValidationError(err instanceof Error ? err.message : "Invalid subdomain");
+    }
+
     const typedAdmin = createAdminClient("super_admin");
     const untypedAdmin = createUntypedAdminClient("super_admin");
     let clinicId: string | null = null;
@@ -100,7 +111,11 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
           type: clinic_type,
           tier,
           subdomain,
-          status: "active",
+          // Audit #3: provisioned clinics start `inactive` and are only flipped
+          // to `active` once every provisioning step has succeeded (see the
+          // activation block below), so a partially-provisioned clinic is never
+          // publicly resolvable.
+          status: "inactive",
           owner_name,
           owner_email,
           phone: owner_phone ?? null,
@@ -131,7 +146,20 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
           context: "onboarding-provision",
           error: clinicError,
         });
-        return apiInternalError("Clinic creation failed — subdomain may already be in use");
+        // Audit #2: map DB constraint violations to precise, actionable
+        // messages instead of the previous misleading "subdomain may already be
+        // in use" (which was wrong for, e.g., an unsupported clinic type/tier).
+        if (clinicError.code === "23505") {
+          return apiValidationError(
+            "A clinic with this subdomain already exists — please choose another.",
+          );
+        }
+        if (clinicError.code === "23514") {
+          return apiValidationError("Unsupported clinic type or tier for this clinic.");
+        }
+        return apiInternalError(
+          "Clinic creation failed — please review the details and try again.",
+        );
       }
 
       clinicId = clinic.id;
@@ -147,6 +175,36 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
     // Initialize remaining steps as pending
     for (const step of PROVISIONING_STEPS.slice(1)) {
       await updateStep(untypedAdmin, clinicId, step.key, "pending");
+    }
+
+    // Step 2: Create the clinic owner's login + invitation (Audit #6).
+    // Previously the auto-provision route created a clinic with NO way to log
+    // in. We now create the owner as a `clinic_admin` with a real Supabase Auth
+    // login and a "set your password" invite. If a login cannot be created
+    // (e.g. SUPABASE_SERVICE_ROLE_KEY / email provider not configured) the step
+    // is marked failed so the clinic stays inactive until an owner can log in.
+    try {
+      await updateStep(untypedAdmin, clinicId, "create_owner_login", "in_progress");
+      const ownerResult = await createUser({
+        clinic_id: clinicId,
+        role: "clinic_admin",
+        name: owner_name,
+        phone: owner_phone ?? undefined,
+        email: owner_email,
+      });
+      if (ownerResult.access.authCreated) {
+        await updateStep(untypedAdmin, clinicId, "create_owner_login", "completed");
+      } else {
+        await updateStep(
+          untypedAdmin,
+          clinicId,
+          "create_owner_login",
+          "failed",
+          ownerResult.access.inviteError ?? "Owner login could not be created",
+        );
+      }
+    } catch (err) {
+      await updateStep(untypedAdmin, clinicId, "create_owner_login", "failed", String(err));
     }
 
     // Step 2: Configure subdomain
@@ -270,6 +328,22 @@ async function handlePost(request: NextRequest, auth: AuthContext) {
       });
     }
 
+    // Audit #3: only flip the clinic live when EVERY provisioning step
+    // succeeded. A clinic with a failed step (including a missing owner login)
+    // stays `inactive` and is never publicly resolvable until resolved.
+    if (clinicId && !hasFailures) {
+      const { error: activateError } = await typedAdmin
+        .from("clinics")
+        .update({ status: "active" })
+        .eq("id", clinicId);
+      if (activateError) {
+        logger.error("Failed to activate provisioned clinic", {
+          context: "onboarding-provision",
+          error: activateError,
+        });
+      }
+    }
+
     // Audit log
     await logAuditEvent({
       supabase: auth.supabase,
@@ -330,4 +404,4 @@ async function handleGet(request: NextRequest, _auth: AuthContext) {
 }
 
 export const POST = withAuth(handlePost, ALLOWED_ROLES);
-export const GET = withAuth(handleGet, ALLOWED_ROLES, { failOpen: true });
+export const GET = withAuth(handleGet, ALLOWED_ROLES);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,15 +1,4 @@
 /**
- * Default password assigned to staff accounts created during onboarding.
- *
- * Read from the `STAFF_DEFAULT_PASSWORD` environment variable so that the
- * value is never committed to source control. Falls back to a generated
- * random string if the env var is not set, ensuring accounts are never
- * created with a well-known password.
- */
-export const STAFF_DEFAULT_PASSWORD =
-  process.env.STAFF_DEFAULT_PASSWORD || `Staff-${crypto.randomUUID()}`;
-
-/**
  * Default IANA timezone used as a last-resort fallback when tenant config
  * does not provide one. Matches the primary deployment locale (Morocco).
  *

--- a/src/lib/onboarding/state.ts
+++ b/src/lib/onboarding/state.ts
@@ -154,16 +154,23 @@ export async function syncClinicOnboardingState({
     return;
   }
 
-  const { error: insertError } = await table.insert({
-    ...payload,
-    created_at: now,
-  });
+  // Audit #11: no existing row was found, but a concurrent sync for the same
+  // clinic may insert one first. With the UNIQUE index on clinic_id (migration
+  // 00195), upsert on that key so a race resolves to a single row instead of a
+  // duplicate-key error or duplicate onboarding rows.
+  const { error: upsertError } = await table.upsert(
+    {
+      ...payload,
+      created_at: now,
+    },
+    { onConflict: "clinic_id" },
+  );
 
-  if (insertError) {
-    logger.warn("Failed to create onboarding state", {
+  if (upsertError) {
+    logger.warn("Failed to upsert onboarding state", {
       context: "onboarding/state",
       clinicId,
-      error: insertError.message,
+      error: upsertError.message,
     });
   }
 }

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/email-templates";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
+import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
 import { invalidateSubdomainCache } from "@/lib/subdomain-cache";
 import { createClient, createAdminClient } from "@/lib/supabase-server";
 import type { ClinicType, ClinicTier, Json } from "@/lib/types/database";
@@ -111,6 +112,23 @@ export interface CreateUserInput {
   email?: string;
 }
 
+/**
+ * Per-staff access state returned by {@link createUser} so the onboarding
+ * wizard can report the *true* login status (Audit #1/#10) instead of showing
+ * a fake shared password that never matches the real random auth password.
+ */
+export interface CreateUserAccess {
+  /** A Supabase Auth login exists (was created or already existed) for this staff member. */
+  authCreated: boolean;
+  /** The "set your password" invitation email was sent successfully. */
+  inviteSent: boolean;
+  /** Human-readable reason when a login or invite could not be provided. */
+  inviteError?: string;
+}
+
+/** {@link createUser} result: the persisted row plus its real access state. */
+export type CreateUserResult = UserRow & { access: CreateUserAccess };
+
 export interface CreateServiceInput {
   clinic_id: string;
   name: string;
@@ -135,17 +153,28 @@ interface _CreateTimeSlotInput {
 export async function createClinic(input: CreateClinicInput): Promise<ClinicRow> {
   const supabase = await rawClient();
   const cfg = input.config ?? {};
+
+  // Audit #5: validate the subdomain through the shared helper (length,
+  // reserved words, hyphen abuse, punycode) BEFORE the INSERT, instead of
+  // relying solely on the DB trigger. Throws a clear, operator-facing message
+  // that the wizard surfaces to the user.
+  if (input.subdomain) {
+    assertAllowedSubdomain(input.subdomain);
+  }
+
   const { data, error } = await supabase
     .from("clinics")
     .insert({
       name: input.name,
       type: input.type,
       tier: input.tier,
-      // QA root-cause fix: always persist the caller-supplied status so new
-      // clinics are created as 'active' by default, not the DB column default
-      // which is 'suspended'. Without this, every onboarding-created clinic
-      // immediately appeared suspended in the All Clinics list.
-      status: input.status ?? "active",
+      // Audit #3/#9: onboarding-created clinics start `inactive` and are flipped
+      // to `active` only once onboarding completes (see `activateClinic`). This
+      // stops an abandoned or half-finished onboarding from leaving a
+      // publicly-resolvable, empty/broken tenant live. `inactive` satisfies the
+      // earlier QA concern too: it is distinct from the scary `suspended` state
+      // (the DB column default) and the clinic becomes `active` on completion.
+      status: input.status ?? "inactive",
       config: cfg as Json,
       subdomain: input.subdomain ?? null,
       // Also set direct columns so public branding queries work
@@ -174,6 +203,59 @@ export async function createClinic(input: CreateClinicInput): Promise<ClinicRow>
   });
 
   return data as ClinicRow;
+}
+
+/**
+ * Mark a clinic `active` once its onboarding is complete (Audit #3).
+ *
+ * Clinics are created `inactive` (see `createClinic`) so that an abandoned or
+ * half-finished onboarding never leaves a publicly-resolvable, broken tenant
+ * live. The onboarding wizard calls this on its final step (and the
+ * auto-provision route activates only when every provisioning step succeeds).
+ *
+ * Invalidates the subdomain cache so the tenant-resolution middleware picks up
+ * the new status immediately, and writes a non-blocking audit-log entry.
+ */
+export async function activateClinic(clinicId: string): Promise<void> {
+  const supabase = await rawClient();
+
+  const { data: clinic, error: fetchError } = await supabase
+    .from("clinics") // nosemgrep: tenant-scoping — super-admin activates a specific clinic by id
+    .select("id, name, subdomain, status")
+    .eq("id", clinicId)
+    .single();
+
+  if (fetchError) throw new Error(`Failed to load clinic for activation: ${fetchError.message}`);
+
+  const { error } = await supabase
+    .from("clinics") // nosemgrep: tenant-scoping — super-admin activates a specific clinic by id
+    .update({ status: "active" })
+    .eq("id", clinicId);
+
+  if (error) throw new Error(`Failed to activate clinic: ${error.message}`);
+
+  // Invalidate the subdomain cache so middleware serves the now-active tenant.
+  if (clinic?.subdomain) {
+    invalidateSubdomainCache(clinic.subdomain);
+  }
+
+  // Audit log (non-blocking).
+  try {
+    await supabase.from("activity_logs").insert({
+      action: "clinic_activated",
+      description: `Clinic "${clinic?.name ?? clinicId}" activated on onboarding completion`,
+      clinic_id: clinicId,
+      clinic_name: clinic?.name ?? null,
+      type: "clinic",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn("Non-blocking audit log failed", {
+      context: "super-admin-actions",
+      clinicId,
+      error: err,
+    });
+  }
 }
 
 export async function fetchClinics(): Promise<ClinicRow[]> {
@@ -569,98 +651,51 @@ export async function updateSubscriptionStatus(
 // ---------- User CRUD ----------
 
 /**
- * Create a staff user with a real Supabase Auth login account.
+ * Resolve a clinic's display name for staff-facing emails (Audit #4).
  *
- * When a valid email is provided and SUPABASE_SERVICE_ROLE_KEY is configured,
- * this function:
- *   1. Creates a Supabase Auth user (email + default password, auto-confirmed)
- *   2. Inserts a row in public.users linked via auth_id
- *
- * If the service role key is missing or auth creation fails, the user is still
- * inserted into public.users (without auth_id) so onboarding doesn't break.
- * A warning is logged in that case.
+ * The welcome email previously used `clinic_id` (a raw UUID) as the clinic
+ * name. This fetches the real name; if the lookup fails it falls back to a
+ * neutral label rather than leaking the UUID.
  */
-export async function createUser(input: CreateUserInput): Promise<UserRow> {
-  const supabase = await rawClient();
-  let authId: string | null = null;
+async function fetchClinicName(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  clinicId: string,
+): Promise<string> {
+  const { data } = await supabase
+    .from("clinics") // nosemgrep: tenant-scoping — super-admin reads one clinic's name by id for a staff invite
+    .select("name")
+    .eq("id", clinicId)
+    .maybeSingle();
+  const name = data?.name?.trim();
+  return name && name.length > 0 ? name : "your clinic";
+}
 
-  // Attempt to create a Supabase Auth account if email is provided
-  if (input.email && process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    try {
-      const admin = createAdminClient("super_admin");
-      // Audit P1 #12: Generate a secure random one-time password for new staff
-      // so we don't rely on a shared static STAFF_DEFAULT_PASSWORD constant.
-      const secureOneTimePassword = crypto.randomUUID() + crypto.randomUUID().slice(0, 8);
-      const { data: authUser, error: authError } = await admin.auth.admin.createUser({
-        email: input.email,
-        password: secureOneTimePassword,
-        email_confirm: true,
-        user_metadata: {
-          name: input.name,
-          role: input.role,
-          clinic_id: input.clinic_id,
-          must_change_password: true,
-        },
-      });
-
-      if (authError) {
-        // If user already exists, try to look up their auth_id
-        if (authError.message?.includes("already been registered")) {
-          const { data: listData } = await admin.auth.admin.listUsers();
-          const existing = listData?.users?.find((u) => u.email === input.email);
-          if (existing) {
-            authId = existing.id;
-          }
-        } else {
-          logger.warn(
-            "Failed to create auth account for staff — user will be created without login",
-            {
-              context: "super-admin-actions",
-              email: input.email,
-              error: authError.message,
-            },
-          );
-        }
-      } else if (authUser?.user) {
-        authId = authUser.user.id;
-      }
-    } catch (err) {
-      logger.warn("Auth account creation threw — user will be created without login", {
-        context: "super-admin-actions",
-        email: input.email,
-        error: err,
-      });
-    }
-  }
-
-  // The auth trigger (`handle_new_auth_user`, migrations 00028/00068) fires
-  // automatically when an auth account is created and inserts a public.users
-  // row for the new auth_id — as role='patient', with the auth user's email
-  // and no clinic. So whenever we created (or matched) an auth account above,
-  // a users row for this auth_id ALREADY EXISTS and already holds this email.
-  //
-  // Because users.email has a UNIQUE index (migration 00068 D-03,
-  // `users_email_lower_uq`), inserting a SECOND row with the same email would
-  // fail with a duplicate-key error — which, thrown from this Server Action,
-  // surfaces in the browser as the generic "An error occurred in the Server
-  // Components render" message in production.
-  //
-  // The correct behaviour is therefore to UPDATE the trigger-created row in
-  // place with the staff's real role/clinic/name instead of inserting a
-  // duplicate. (A previous revision split this into two blocks, the first of
-  // which mis-classified the trigger row as "already taken by another user"
-  // and nulled authId, turning the update path into dead code and causing the
-  // duplicate INSERT — and the crash.)
+/**
+ * Persist (or reconcile) the public.users row for a staff member.
+ *
+ * The auth trigger (`handle_new_auth_user`, migrations 00028/00068) inserts a
+ * public.users row (role='patient') the moment an auth account is created, and
+ * users.email is UNIQUE (migration 00068 D-03). So when an auth account exists
+ * we UPDATE the trigger-created row in place rather than inserting a duplicate
+ * (which would 23505 and surface as an opaque Server Component crash). The
+ * insert path additionally recovers from a duplicate-email race by updating the
+ * existing row, keeping onboarding idempotent.
+ */
+async function persistStaffUserRow(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  input: CreateUserInput,
+  authId: string | null,
+): Promise<UserRow> {
   if (authId) {
     const { data: existingRow } = await supabase
-      .from("users")
+      .from("users") // nosemgrep: tenant-scoping — super-admin reconciles the staff row by auth_id; clinic_id is written below
       .select("id")
       .eq("auth_id", authId)
       .maybeSingle();
 
     if (existingRow) {
       const { data: updated, error: updateError } = await supabase
-        .from("users")
+        .from("users") // nosemgrep: tenant-scoping — super-admin sets this staff member's clinic_id/role on the trigger-created row
         .update({
           clinic_id: input.clinic_id,
           role: input.role,
@@ -690,66 +725,198 @@ export async function createUser(input: CreateUserInput): Promise<UserRow> {
     .select()
     .single();
 
-  if (error) {
-    // Recover gracefully if a row with this email already exists (e.g. the
-    // auth trigger created it, or the same staff email was onboarded before).
-    // The users.email UNIQUE index rejects the duplicate with code 23505;
-    // instead of crashing, update the existing row so onboarding is idempotent.
-    const isDuplicate =
-      error.code === "23505" ||
-      /duplicate key|already exists|unique constraint/i.test(error.message);
-    if (isDuplicate && input.email) {
-      const { data: updated, error: updateError } = await supabase
-        .from("users")
-        .update({
-          clinic_id: input.clinic_id,
-          role: input.role,
-          name: input.name,
-          phone: input.phone ?? null,
-          ...(authId ? { auth_id: authId } : {}),
-        })
-        .eq("email", input.email)
-        .select()
-        .single();
+  if (!error) return data as UserRow;
 
-      if (!updateError && updated) return updated as UserRow;
-    }
-    throw new Error(`Failed to create user: ${error.message}`);
+  // Recover gracefully from a duplicate-email row (auth trigger or a prior
+  // onboarding of the same email). users.email is UNIQUE (23505) — update the
+  // existing row so onboarding is idempotent instead of crashing.
+  const isDuplicate =
+    error.code === "23505" || /duplicate key|already exists|unique constraint/i.test(error.message);
+  if (isDuplicate && input.email) {
+    const { data: updated, error: updateError } = await supabase
+      .from("users") // nosemgrep: tenant-scoping — super-admin recovers a duplicate-email staff row and sets its clinic_id/role
+      .update({
+        clinic_id: input.clinic_id,
+        role: input.role,
+        name: input.name,
+        phone: input.phone ?? null,
+        ...(authId ? { auth_id: authId } : {}),
+      })
+      .eq("email", input.email)
+      .select()
+      .single();
+
+    if (!updateError && updated) return updated as UserRow;
   }
 
-  // Send welcome/password-reset email so staff can set their own password
-  if (input.email) {
+  throw new Error(`Failed to create user: ${error.message}`);
+}
+
+/**
+ * Send the "set your password" invitation to a staff member who has a login.
+ *
+ * Returns whether the email was actually sent (Audit #10) and never throws, so
+ * the caller can report the true access state to the wizard.
+ */
+async function sendStaffInvite(params: {
+  email: string;
+  name: string;
+  role: string;
+  clinicName: string;
+}): Promise<{ inviteSent: boolean; inviteError?: string }> {
+  try {
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+    const admin = createAdminClient("super_admin");
+    const { data: resetLink, error: linkError } = await admin.auth.admin.generateLink({
+      type: "recovery",
+      email: params.email,
+      options: { redirectTo: `${siteUrl}/login?reset=true` },
+    });
+
+    if (linkError) {
+      logger.warn("Failed to generate staff invite link", {
+        context: "super-admin-actions",
+        email: params.email,
+        error: linkError.message,
+      });
+      return { inviteSent: false, inviteError: linkError.message };
+    }
+
+    const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
+    const template = staffWelcomeEmail({
+      staffName: params.name,
+      clinicName: params.clinicName,
+      email: params.email,
+      loginUrl,
+      role: params.role,
+    });
+    const result = await sendEmail({ to: params.email, ...template });
+
+    if (!result.success) {
+      logger.warn("Staff invite email not sent", {
+        context: "super-admin-actions",
+        email: params.email,
+        error: result.error,
+      });
+    }
+    return { inviteSent: result.success, inviteError: result.success ? undefined : result.error };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "invite send failed";
+    logger.warn("Failed to send welcome email to staff", {
+      context: "super-admin-actions",
+      email: params.email,
+      error: err,
+    });
+    return { inviteSent: false, inviteError: message };
+  }
+}
+
+/**
+ * Create a staff user with a real Supabase Auth login account.
+ *
+ * When a valid email is provided and SUPABASE_SERVICE_ROLE_KEY is configured:
+ *   1. Creates (or matches an existing) Supabase Auth user, auto-confirmed.
+ *   2. Persists the public.users row (reconciling the auth-trigger row).
+ *   3. Sends a "set your password" invitation email so the staff member can
+ *      log in — on EVERY success path (Audit #10), using the real clinic name
+ *      (Audit #4).
+ *
+ * If the service-role key is missing or auth creation fails, the user is still
+ * inserted into public.users (without a login) so onboarding does not break,
+ * and the returned `access` state honestly reflects that no login was enabled
+ * (Audit #1/#10) — the wizard reports this instead of showing a fake password.
+ */
+export async function createUser(input: CreateUserInput): Promise<CreateUserResult> {
+  const supabase = await rawClient();
+  let authId: string | null = null;
+  let authError: string | undefined;
+  const serviceRoleConfigured = Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  // Attempt to create (or match) a Supabase Auth login when possible.
+  if (input.email && serviceRoleConfigured) {
     try {
-      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
       const admin = createAdminClient("super_admin");
-      const { data: resetLink } = await admin.auth.admin.generateLink({
-        type: "recovery",
+      // Audit P1 #12: random one-time password; staff set their own via the
+      // recovery invite below, so this value is never shown to anyone.
+      const secureOneTimePassword = crypto.randomUUID() + crypto.randomUUID().slice(0, 8);
+      const { data: authUser, error: createErr } = await admin.auth.admin.createUser({
         email: input.email,
-        options: {
-          redirectTo: `${siteUrl}/login?reset=true`,
+        password: secureOneTimePassword,
+        email_confirm: true,
+        user_metadata: {
+          name: input.name,
+          role: input.role,
+          clinic_id: input.clinic_id,
+          must_change_password: true,
         },
       });
 
-      const loginUrl = resetLink?.properties?.action_link ?? `${siteUrl}/login`;
-
-      const template = staffWelcomeEmail({
-        staffName: input.name,
-        clinicName: input.clinic_id,
-        email: input.email,
-        loginUrl,
-        role: input.role,
-      });
-      await sendEmail({ to: input.email, ...template });
-    } catch (emailErr) {
-      logger.warn("Failed to send welcome email to staff", {
+      if (createErr) {
+        if (createErr.message?.includes("already been registered")) {
+          const { data: listData } = await admin.auth.admin.listUsers();
+          const existing = listData?.users?.find((u) => u.email === input.email);
+          if (existing) {
+            authId = existing.id;
+          } else {
+            authError = createErr.message;
+          }
+        } else {
+          authError = createErr.message;
+          logger.warn("Failed to create auth account for staff — user created without login", {
+            context: "super-admin-actions",
+            email: input.email,
+            error: createErr.message,
+          });
+        }
+      } else if (authUser?.user) {
+        authId = authUser.user.id;
+      }
+    } catch (err) {
+      authError = err instanceof Error ? err.message : "auth account creation failed";
+      logger.warn("Auth account creation threw — user will be created without login", {
         context: "super-admin-actions",
         email: input.email,
-        error: emailErr,
+        error: err,
       });
     }
   }
 
-  return data as UserRow;
+  // Persist the public.users row regardless of whether a login was created.
+  const userRow = await persistStaffUserRow(supabase, input, authId);
+
+  // Audit #1/#10: compute and return the TRUE access state on every path.
+  let access: CreateUserAccess;
+  if (!input.email) {
+    access = {
+      authCreated: false,
+      inviteSent: false,
+      inviteError: "No email provided — this staff member cannot log in.",
+    };
+  } else if (!authId) {
+    access = {
+      authCreated: false,
+      inviteSent: false,
+      inviteError: serviceRoleConfigured
+        ? (authError ?? "Login could not be enabled for this staff member.")
+        : "Login not enabled — requires SUPABASE_SERVICE_ROLE_KEY and an email provider.",
+    };
+  } else {
+    // Audit #4: use the real clinic name (not the clinic UUID) in the invite.
+    const clinicName = await fetchClinicName(supabase, input.clinic_id);
+    const invite = await sendStaffInvite({
+      email: input.email,
+      name: input.name,
+      role: input.role,
+      clinicName,
+    });
+    access = {
+      authCreated: true,
+      inviteSent: invite.inviteSent,
+      inviteError: invite.inviteError,
+    };
+  }
+
+  return { ...userRow, access };
 }
 
 // ---------- Service CRUD ----------

--- a/src/lib/super-admin-actions.ts
+++ b/src/lib/super-admin-actions.ts
@@ -17,6 +17,7 @@ import {
   clinicSuspendedEmail,
   clinicActivatedEmail,
 } from "@/lib/email-templates";
+import { getSiteUrl, getSupabaseServiceRoleKey } from "@/lib/env";
 import { logger } from "@/lib/logger";
 import { syncClinicOnboardingState } from "@/lib/onboarding/state";
 import { assertAllowedSubdomain } from "@/lib/reserved-subdomains";
@@ -687,15 +688,17 @@ async function persistStaffUserRow(
   authId: string | null,
 ): Promise<UserRow> {
   if (authId) {
+    // nosemgrep: tenant-scoping — super-admin reconciles the staff row by auth_id; clinic_id is written below. Intentionally cross-tenant (see AGENTS.md super-admin exception)
     const { data: existingRow } = await supabase
-      .from("users") // nosemgrep: tenant-scoping — super-admin reconciles the staff row by auth_id; clinic_id is written below
+      .from("users")
       .select("id")
       .eq("auth_id", authId)
       .maybeSingle();
 
     if (existingRow) {
+      // nosemgrep: tenant-scoping — super-admin sets this staff member's clinic_id/role on the trigger-created row. Intentionally cross-tenant (see AGENTS.md super-admin exception)
       const { data: updated, error: updateError } = await supabase
-        .from("users") // nosemgrep: tenant-scoping — super-admin sets this staff member's clinic_id/role on the trigger-created row
+        .from("users")
         .update({
           clinic_id: input.clinic_id,
           role: input.role,
@@ -733,8 +736,9 @@ async function persistStaffUserRow(
   const isDuplicate =
     error.code === "23505" || /duplicate key|already exists|unique constraint/i.test(error.message);
   if (isDuplicate && input.email) {
+    // nosemgrep: tenant-scoping — super-admin recovers a duplicate-email staff row by email and (re)assigns its clinic_id/role; intentionally cross-tenant, so no clinic_id filter (see AGENTS.md super-admin exception)
     const { data: updated, error: updateError } = await supabase
-      .from("users") // nosemgrep: tenant-scoping — super-admin recovers a duplicate-email staff row and sets its clinic_id/role
+      .from("users")
       .update({
         clinic_id: input.clinic_id,
         role: input.role,
@@ -765,7 +769,8 @@ async function sendStaffInvite(params: {
   clinicName: string;
 }): Promise<{ inviteSent: boolean; inviteError?: string }> {
   try {
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://oltigo.com";
+    const siteUrl = getSiteUrl() || "https://oltigo.com";
+    // nosemgrep: admin-client-guard — super-admin GoTrue auth-admin op (generateLink); cross-tenant by design and x-clinic-id scoping is irrelevant to the Auth API
     const admin = createAdminClient("super_admin");
     const { data: resetLink, error: linkError } = await admin.auth.admin.generateLink({
       type: "recovery",
@@ -830,11 +835,12 @@ export async function createUser(input: CreateUserInput): Promise<CreateUserResu
   const supabase = await rawClient();
   let authId: string | null = null;
   let authError: string | undefined;
-  const serviceRoleConfigured = Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const serviceRoleConfigured = Boolean(getSupabaseServiceRoleKey());
 
   // Attempt to create (or match) a Supabase Auth login when possible.
   if (input.email && serviceRoleConfigured) {
     try {
+      // nosemgrep: admin-client-guard — super-admin GoTrue auth-admin op (createUser); cross-tenant by design and x-clinic-id scoping is irrelevant to the Auth API
       const admin = createAdminClient("super_admin");
       // Audit P1 #12: random one-time password; staff set their own via the
       // recovery invite below, so this value is never shown to anyone.

--- a/src/lib/validations/super-admin.ts
+++ b/src/lib/validations/super-admin.ts
@@ -13,17 +13,16 @@ const booleanish = z.preprocess((value: unknown) => {
 
 export const clinicProvisionSchema = z.object({
   clinic_name: z.string().min(1).max(200),
-  clinic_type: z.enum([
-    "doctor",
-    "dentist",
-    "pharmacy",
-    "clinic",
-    "hospital",
-    "laboratory",
-    "veterinary",
-    "restaurant",
-  ]),
-  tier: z.enum(["vitrine", "cabinet", "pro", "premium"]),
+  // Audit #2: `clinics.type` has a CHECK constraint that only allows these
+  // three system types (see migration 00001). Offering more here meant the
+  // INSERT failed the CHECK constraint and the route mislabelled it as a
+  // "subdomain may already be in use" error. Keep this enum in lockstep with
+  // the `ClinicType` union in src/lib/types/database.ts and the DB constraint.
+  clinic_type: z.enum(["doctor", "dentist", "pharmacy"]),
+  // Audit #8: `clinics.tier` allows `saas` (migration 00001) and `ClinicTier`
+  // includes it, but it was missing here so super-admins could not provision a
+  // SaaS-tier clinic.
+  tier: z.enum(["vitrine", "cabinet", "pro", "premium", "saas"]),
   subdomain: z
     .string()
     .min(1)

--- a/supabase/migrations/00195_clinic_onboardings_unique_clinic.sql
+++ b/supabase/migrations/00195_clinic_onboardings_unique_clinic.sql
@@ -1,0 +1,51 @@
+-- 00195_clinic_onboardings_unique_clinic.sql
+--
+-- Audit #11 — onboarding-state race.
+--
+-- `syncClinicOnboardingState()` previously did a read-then-insert/update with no
+-- uniqueness guarantee, so two concurrent syncs for the same clinic could each
+-- find "no existing row" and both INSERT, leaving duplicate onboarding rows.
+-- Those duplicates then made the "load newest row" path non-deterministic.
+--
+-- This migration:
+--   1. De-duplicates existing rows, keeping the most-recently-updated row per
+--      clinic (tie-broken by created_at, then id) and deleting the rest.
+--   2. Replaces the non-unique clinic_id index with a UNIQUE index so a single
+--      onboarding row per clinic is enforced at the database level. The app
+--      layer now upserts on this key (ON CONFLICT (clinic_id)).
+--
+-- Notes:
+--   * `clinic_id` is nullable (REFERENCES clinics(id) ON DELETE SET NULL). A
+--     plain UNIQUE index still permits multiple NULL rows because Postgres
+--     treats NULLs as distinct, so orphaned onboardings (whose clinic was
+--     deleted) never collide. A non-partial index is used deliberately so the
+--     PostgREST/Supabase `ON CONFLICT (clinic_id)` upsert can use it as the
+--     conflict arbiter.
+--   * De-duplication runs BEFORE index creation so the migration is safe to
+--     apply on existing data.
+
+BEGIN;
+
+-- 1) De-duplicate: keep the freshest row per clinic_id, delete older copies.
+WITH ranked AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY clinic_id
+      ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+    ) AS rn
+  FROM clinic_onboardings
+  WHERE clinic_id IS NOT NULL
+)
+DELETE FROM clinic_onboardings co
+USING ranked r
+WHERE co.id = r.id
+  AND r.rn > 1;
+
+-- 2) Swap the non-unique index for a UNIQUE one on clinic_id.
+DROP INDEX IF EXISTS idx_onboardings_clinic;
+
+CREATE UNIQUE INDEX IF NOT EXISTS clinic_onboardings_clinic_id_uq
+  ON clinic_onboardings (clinic_id);
+
+COMMIT;


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @groupsmix :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Reconciles the intent of #1123 / #1124 with **current `main`**, which has diverged from the branches those PRs were built on. `main` already contains the `createUser` secure-random-password rewrite + duplicate-key recovery (Audit P1 #12 / #1122) and an active-by-default QA workaround, so this PR re-verifies every audit item against the real code and fixes only the bugs that genuinely still exist.

> Because `main` moved on, #1123/#1124 are now stale/conflicting. Suggest closing both in favour of this branch.

## Fixes (verified against current `main`)

**Staff access — fake password (#1) + silent invite failures (#10)**
- The success screen showed `STAFF_DEFAULT_PASSWORD`, which never matches the real random auth password — staff could never log in with it. Removed it (and the now-dead constant); the screen reports the true per-staff access state.
- `createUser` now returns `access { authCreated, inviteSent, inviteError }` and sends the set-your-password invite on **all** success paths (trigger-update, duplicate-recovery, and fresh insert) — previously the early-return paths sent no invite.

**Welcome email used the clinic UUID as the name (#4)** — `createUser` now fetches and uses the real clinic name.

**Clinic type/tier mismatch crash (#2) + missing `saas` tier (#8)** — `clinics.type` only allows `doctor`/`dentist`/`pharmacy` (migration 00001), but the provision schema/UI offered 8 types; the unsupported ones hit a CHECK violation surfaced as a misleading "subdomain may already be in use". Restricted the schema + UI to the supported types, added the missing `saas` tier, and mapped DB constraint errors (`23505`/`23514`) to clear messages.

**Subdomain validation bypassed the shared helper (#5)** — `createClinic` and the provision route now call `assertAllowedSubdomain` before insert.

**Clinics went live before onboarding finished (#3) + stale comment (#9)** — clinics are created `inactive` and flipped to `active` only on completion (new `activateClinic`; the wizard activates on finish/skip, and the provision route activates only when every step succeeds).

**Provisioned clinics had no login (#6)** — the auto-provision route now creates the owner's `clinic_admin` login + invite as a tracked provisioning step.

**Fail-open auth (#7)** — `GET /api/admin/onboarding-provision` no longer uses `failOpen: true`.

**Onboarding-state race (#11)** — migration `00195` de-duplicates `clinic_onboardings` and adds a UNIQUE index on `clinic_id`; `syncClinicOnboardingState` now upserts on conflict.

## Testing
- `npx tsc --noEmit` — passes.
- `npx eslint --max-warnings 3457` (the CI ratchet) — passes (3444 warnings, 0 errors; no new warnings).
- `npx prettier --check` on all changed files — passes.
- `npx vitest run` — **1922 passed**, 84 skipped (170 files), including onboarding, onboarding-flow, reserved-subdomains, clinic-owner, and admin-actions-persistence suites.
- knip ratchet unaffected (no new files; the `.sql` migration is outside knip globs).
- semgrep tenant-scoping: `clinics` is whitelisted by the rule; the `users` reconciliation lookups (by `auth_id`/`email`) carry documented `nosemgrep` annotations.

## Notes / behaviour changes
- New clinics start `inactive` until onboarding completes (intentional, Audit #3). Migration `00195` ships with this PR.
- Enabling staff/owner logins still requires `SUPABASE_SERVICE_ROLE_KEY` + an email provider; when missing, the UI now states this honestly ("Login not enabled") instead of showing a fake password, and an auto-provisioned clinic stays `inactive` until an owner login can be created.