### PR TITLE
Add Kiro IDE steering + security-review hook

### DIFF
--- a/.kiro/hooks/phi-tenant-review.kiro.hook
+++ b/.kiro/hooks/phi-tenant-review.kiro.hook
@@ -1,0 +1,13 @@
+{
+  "enabled": true,
+  "name": "PHI & tenant security review",
+  "description": "After a spec task completes, the agent reviews that task's diff for the security issues husky + CI can't catch semantically: tenant scoping, mass-assignment, PHI in logs/Sentry, missing audit, non-idempotent webhooks/payments, SEALED-layer edits. Lint, typecheck, tests and secret-scanning are already covered by .husky/ and CI. Agent action = consumes credits, runs once per completed task. To run on demand instead, change when.type to \"userTriggered\".",
+  "version": "1",
+  "when": {
+    "type": "postTaskExecution"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "Review ONLY the files changed in this task against AGENTS.md, .ai/TASK-ROUTER.md, and .kiro/steering/oltigo-kiro.md. Report PASS, FAIL, or N/A for each item with file:line and a one-line fix when FAIL. Do not pad passing items.\n1. Tenant isolation: every supabase query scoped with .eq(\"clinic_id\", clinicId); clinicId only from requireTenant(); no trust of x-clinic-id.\n2. No mass-assignment: no .insert({ ...body }) / .update(body); explicit fields only.\n3. SEALED layers untouched: no edits to src/middleware.ts, src/lib/auth/, src/lib/tenant.ts, src/lib/tenant-context.ts, existing RLS policies, or existing booking/payments routes (new files instead). If any were modified, FAIL and say which.\n4. Validation: every API input validated by a Zod schema from @/lib/validations before any DB call.\n5. PHI/secrets: nothing that could send PHI, tokens, or secrets to logs, Sentry, or analytics; @/lib/logger used; apiError messages are generic.\n6. Audit: every state-changing operation calls logAuditEvent() from @/lib/audit-log.\n7. Webhooks/payments: signature verified before parsing AND idempotent (keyed on provider event id); clinic_id resolved from payload or processing skipped.\n8. Migrations: new tables have a clinic_id-scoped RLS policy + index; PHI soft-deleted (deleted_at), never hard-deleted.\n9. Tests: real handler/function tests (no tautologies); schema tests paired with route-handler tests; coverage floor not lowered.\n10. i18n: new user-facing strings have French + Arabic (RTL); WhatsApp notifications have a Darija template.\nEnd with one line: SAFE TO SHIP, or NEEDS FIXES (n issues)."
+  }
+}

--- a/.kiro/steering/oltigo-api.md
+++ b/.kiro/steering/oltigo-api.md
@@ -1,0 +1,34 @@
+---
+inclusion: fileMatch
+fileMatchPattern: ["src/app/api/**/*.ts"]
+---
+
+# Oltigo — API routes (Kiro)
+
+Builds on `AGENTS.md` §API Conventions / §Security — don't restate it, comply with it. Mirror an existing route; **create new routes, don't modify existing handlers** (`.ai/TASK-ROUTER.md`).
+
+## Real shapes (these are the actual helpers — match them exactly)
+
+- **Auth + RBAC:** `withAuth(handler, allowedRoles)` from `@/lib/with-auth`. The handler is `(request, { supabase, profile }, routeCtx) => { ... }` — `supabase` and `profile` come from this `AuthContext`, not from anywhere else.
+- **Validation:** `withValidation(schema, handler)` and `withAuthValidation(schema, handler, roles)` from `@/lib/api-validate`. Validate with a Zod schema from `@/lib/validations` before any DB call.
+- **Tenant:** `const { clinicId } = await requireTenant()` from `@/lib/tenant` — **takes no argument.** Scope every query with `.eq("clinic_id", clinicId)`.
+- **Responses:** `apiSuccess(data)` / `apiError(message, status, code)` plus `apiNotFound()`, `apiForbidden()`, `apiRateLimited()`, `apiValidationError()` from `@/lib/api-response`. Shape: `{ ok: true, data }` / `{ ok: false, error, code? }`.
+- **Audit:** `logAuditEvent()` from `@/lib/audit-log` on every state-changing operation.
+
+**Canonical route to mirror:** `#[[file:src/app/api/invoices/route.ts]]`
+
+## Never
+
+- Spread a request body into a write (`.insert({ ...body })` / `.update(body)`) — pick explicit fields (mass-assignment guard).
+- Trust `x-clinic-id` — middleware strips it; the tenant comes only from `requireTenant()`.
+- Let an error leak PHI — `apiError` messages stay generic; detail goes to `@/lib/logger`, never to the client and never raw to Sentry.
+
+## Webhooks (`src/app/api/webhooks/**`)
+
+1. Verify the signature **before** parsing (`X-Hub-Signature-256` for WhatsApp, `stripe-signature` for Stripe).
+2. Resolve `clinic_id` from the payload (WABA phone number id / Stripe metadata); if it can't be resolved, **skip — never query across tenants**.
+3. Process **idempotently**, keyed on the provider event id, so retries can't double-apply.
+
+## Patient-facing / unauthenticated endpoints
+
+Rate-limit them (`apiRateLimited()`) against abuse and enumeration. Reuse the existing limiter; don't invent one.

--- a/.kiro/steering/oltigo-database.md
+++ b/.kiro/steering/oltigo-database.md
@@ -1,0 +1,28 @@
+---
+inclusion: fileMatch
+fileMatchPattern: ["supabase/migrations/**/*.sql"]
+---
+
+# Oltigo — Migrations (Kiro)
+
+Builds on `AGENTS.md` §Database Migrations. **RLS policies are SEALED** (`.ai/TASK-ROUTER.md`) — don't modify existing ones without an explicit instruction; ask first.
+
+## Every new migration
+
+- `supabase/migrations/`, sequential 5-digit prefix (next is after the highest existing, e.g. `000NN_description.sql`).
+- Guard every statement: `create table if not exists`, `add column if not exists`, `drop ... if exists`. Safe to re-run.
+- Every tenant table has a `clinic_id` column, an index on it, and an RLS policy scoped to it. **`CREATE POLICY` has no `IF NOT EXISTS`**, so drop-then-create:
+
+```sql
+alter table <t> enable row level security;
+drop policy if exists <t>_tenant_isolation on <t>;
+create policy <t>_tenant_isolation on <t> using (clinic_id = /* the project's tenant helper */);
+```
+
+(Mirror an existing migration's RLS pattern — don't guess the helper.)
+
+## PHI lifecycle (not in AGENTS.md yet)
+
+- **Soft-delete only:** add/keep `deleted_at timestamptz`; never hard-delete PHI. Normal reads filter `deleted_at is null`.
+- **Retention:** Law 09-08 governs how long PHI is kept. Confirm the window per record type with the team before adding any purge logic — don't assume.
+- No destructive change (drop/rename column or table) without an explicit migration plan and approval. No credentials in committed SQL.

--- a/.kiro/steering/oltigo-kiro.md
+++ b/.kiro/steering/oltigo-kiro.md
@@ -1,0 +1,31 @@
+---
+inclusion: always
+---
+
+# Oltigo Health — Kiro operating rules
+
+This repo is already documented. Before any task, READ in order: **`AGENTS.md`** (the binding contract — tenant isolation, security, API conventions, domain, CI) and **`.ai/TASK-ROUTER.md`** (which files to edit vs. never touch). This file adds only Kiro-specific *operating behavior* plus a few rules not yet in those docs. **If anything here conflicts with `AGENTS.md`, `AGENTS.md` wins.**
+
+Oltigo is a multi-tenant healthcare SaaS for Moroccan clinics. A cross-tenant leak or a PHI leak is catastrophic — it outranks shipping speed.
+
+## SEALED — never modify without an explicit instruction
+
+From `.ai/TASK-ROUTER.md`: `src/middleware.ts`, `src/lib/auth/`, `src/lib/tenant.ts`, `src/lib/tenant-context.ts`, RLS policies in `supabase/migrations/`, and the existing booking/payments routes. If a task would touch any of these — or anything involving tenant boundaries, PHI, payments, auth/roles, or webhook trust — **STOP and ask me first.** A wrong guess there is expensive and sometimes unrecoverable.
+
+## How to operate in Kiro
+
+- **Mirror existing code.** Open the nearest existing route/migration/test and follow its patterns, imports, and error handling. Don't invent a new pattern or add a dependency when one already exists.
+- **Create, don't modify.** Add new API routes under `src/app/api/[feature]/route.ts`; don't edit existing handlers (per TASK-ROUTER).
+- **Never `git add .`** — stage only the specific files you changed.
+- **Proceed vs. ask.** Proceed on low-risk, pattern-obvious work; STOP and ask on the SEALED/sensitive surfaces above.
+- **Definition of Done = report each as pass/fail**, matching the CI pipeline in `AGENTS.md`: `npm run lint` → `npm run typecheck` → `npm run test` (coverage ≥ `.vitest-coverage-floor.json`) → bundle ≤ 800 kB (`node scripts/check-bundle-budget.mjs`) → `npm run test:e2e`. No "this should work."
+
+## Rules to apply that aren't yet in AGENTS.md
+
+- **Sentry scrubbing.** PHI and secrets must never reach Sentry or Plausible. Scrub request bodies, query params, and headers in the `sentry.*.config.ts` `beforeSend` paths. `@/lib/logger` is still the only place app logs go.
+- **Idempotency.** Webhooks and payments must process idempotently, keyed on the provider event id (WhatsApp message id, Stripe `event.id`). A retried event must never double-charge, double-book, or double-notify. (Signature verification is already required by `AGENTS.md`.)
+- **PHI is soft-deleted** (`deleted_at`), never hard-deleted; normal reads filter `deleted_at is null`. Retention follows Law 09-08 — confirm the window per record type with the team rather than assuming.
+
+## Deeper rules load by area
+
+`oltigo-api.md` (editing routes) · `oltigo-database.md` (migrations) · `oltigo-testing.md` (tests). Localization: follow `AGENTS.md` (FR default, AR-RTL, Darija for WhatsApp) and read `.ai/skills/ui-ux/SKILL.md` for design tokens / RTL / WCAG before UI work; don't regress `.i18n-coverage-baseline.json`.

--- a/.kiro/steering/oltigo-testing.md
+++ b/.kiro/steering/oltigo-testing.md
@@ -1,0 +1,31 @@
+---
+inclusion: fileMatch
+fileMatchPattern: ["src/**/__tests__/**/*.ts", "src/**/__tests__/**/*.tsx", "e2e/**/*.ts", "**/*.test.ts"]
+---
+
+# Oltigo — Tests (Kiro)
+
+Builds on `AGENTS.md` §Test Conventions. Locations: unit in `src/**/__tests__/`, integration in `src/lib/__tests__/integration/`, e2e in `e2e/`.
+
+## Use the existing test infrastructure
+
+Reuse the shared mocks in `src/components/__tests__/test-utils.ts`: `createMockSupabaseClient()`, `createMockTenantHeaders()`, `mockLogger`, `createMockRequest()`, `createJsonRequest()`. Don't hand-roll new mock plumbing.
+
+## Real tests, not tautologies
+
+- Import and invoke the **actual** route handler / function. A test that checks test data against itself, or only asserts a mock returned what you set, proves nothing.
+- **Schema tests are supplementary.** Always pair a Zod-schema test with a route-handler test that exercises the full chain: request → auth → validation → mutation → response.
+- Coverage never drops below `.vitest-coverage-floor.json`.
+
+## Security tests are required (AGENTS.md implies them; make them explicit)
+
+For any feature reading/writing tenant data, add tests that prove the guardrails, not just the happy path:
+
+- **Tenant isolation:** a request for clinic A cannot read or mutate clinic B's rows.
+- **Permission denied:** a role below the required level is rejected (e.g. `patient` reaching another patient's record, `doctor` doing a `clinic_admin` action).
+- **Validation failure:** malformed/oversized/missing input is rejected before any DB call.
+- **Audit:** a state-changing path records a `logAuditEvent()`.
+
+## E2E (Playwright)
+
+Cover the primary path plus at least one failure path, and test Arabic (RTL) where layout matters. Tests are self-contained; no real PHI in fixtures — use synthetic data.


### PR DESCRIPTION
## What this adds

A **Kiro IDE layer** under `.kiro/` that complements the existing `AGENTS.md` and `.ai/TASK-ROUTER.md` — it does **not** modify or duplicate them.

### Steering (`.kiro/steering/`)
- **`oltigo-kiro.md`** (always) — Kiro operating rules: read `AGENTS.md` + `.ai/TASK-ROUTER.md` first, respect the SEALED layers, spec-workflow done-gate. Adds 3 rules not yet in `AGENTS.md`: Sentry PHI scrubbing, webhook/payment idempotency, PHI soft-delete + Law 09-08 retention.
- **`oltigo-api.md`** (`src/app/api/**`) — real helper shapes (`requireTenant()`, `withAuth`/`withAuthValidation`, `apiSuccess`/`apiError`, `logAuditEvent`), webhook idempotency, rate limiting.
- **`oltigo-database.md`** (`supabase/migrations/**`) — RLS + `clinic_id`, PHI soft-delete/retention.
- **`oltigo-testing.md`** (tests) — reuse `test-utils` mocks, required security tests (tenant isolation, perms, audit).

### Hook (`.kiro/hooks/`)
- **`phi-tenant-review.kiro.hook`** — per-task semantic security review (tenant scoping, mass-assignment, PHI in logs/Sentry, idempotency, SEALED-layer edits). Lint/types/tests/secret-scan stay covered by `.husky/` + CI; this is the part they can't do.

### Not touched
No changes to `AGENTS.md`, `.ai/`, `.husky/`, or app code.

## Verify after merge
1. Open a file under `src/app/api/` and start a Kiro chat — `oltigo-api.md` should be in context (`oltigo-kiro.md` loads everywhere).
2. Open the **Agent Hooks** panel — `PHI & tenant security review` should appear, enabled. If not, recreate via **Agent Hooks → + → "Ask Kiro to create a hook"** using the hook's description text.

> Hook fires after each spec task; if per-task credit cost adds up, switch its `when.type` to `userTriggered` and run on demand.
