### PR TITLE
fix(ai-agent): repair the assistant widget + move super-admin assistant into the sidebar

### DIFF
--- a/src/app/api/ai/agent/route.ts
+++ b/src/app/api/ai/agent/route.ts
@@ -65,9 +65,22 @@ const messageSchema = z.object({
 
 const agentRequestSchema = z.object({
   agentType: z.enum(SITE_TEAM_AGENT_TYPES as [SiteTeamAgentType, ...SiteTeamAgentType[]]),
-  clinicId: z.string().uuid().optional(),
+  // The widget sends `clinicId: null` / `conversationId: null` from its initial
+  // React state (a super_admin has no clinic, and there is no conversation yet
+  // before the first reply). `JSON.stringify` keeps explicit nulls, so accept
+  // null/undefined here and normalise to `undefined` for the handler — using a
+  // plain `.optional()` rejected null with "expected string, received null".
+  clinicId: z
+    .string()
+    .uuid()
+    .nullish()
+    .transform((value) => value ?? undefined),
   messages: z.array(messageSchema).min(1).max(20),
-  conversationId: z.string().uuid().optional(),
+  conversationId: z
+    .string()
+    .uuid()
+    .nullish()
+    .transform((value) => value ?? undefined),
 });
 
 type AgentMessage = z.infer<typeof messageSchema>;

--- a/src/components/ai/AgentWidget.tsx
+++ b/src/components/ai/AgentWidget.tsx
@@ -101,13 +101,18 @@ export function AgentWidget({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           agentType,
-          clinicId,
-          conversationId,
+          // Only include these when present — sending an explicit `null`
+          // (e.g. a super_admin with no clinic, or no conversation yet) made
+          // the request fail schema validation.
+          ...(clinicId ? { clinicId } : {}),
+          ...(conversationId ? { conversationId } : {}),
           ...apiBodyConfig,
-          messages: nextMessages.map((message) => ({
-            role: message.role,
-            content: message.content,
-          })),
+          messages: nextMessages
+            .filter((message) => message.content.trim().length > 0)
+            .map((message) => ({
+              role: message.role,
+              content: message.content,
+            })),
         }),
         signal: controller.signal,
       });
@@ -170,11 +175,12 @@ export function AgentWidget({
       if (err instanceof DOMException && err.name === "AbortError") return;
       const message = err instanceof Error ? err.message : "Erreur IA";
       setError(message);
+      // Remove the empty assistant placeholder so the error is shown once
+      // (in the styled error line below) instead of twice.
       setMessages((current: ChatMessage[]) =>
-        current.map((chatMessage: ChatMessage) =>
-          chatMessage.id === assistantMessageId && !chatMessage.content
-            ? { ...chatMessage, content: message }
-            : chatMessage,
+        current.filter(
+          (chatMessage: ChatMessage) =>
+            !(chatMessage.id === assistantMessageId && !chatMessage.content),
         ),
       );
     } finally {


### PR DESCRIPTION
## Problem

The in-layout **Assistant Oltigo** widget (`AgentWidget`) never worked: sending any message returned `Invalid input: expected string, received null` (shown twice in the UI - once as the assistant bubble, once as the error line).

### Root cause

The widget posts `clinicId` and `conversationId` straight from its initial React state, which is `null` (a `super_admin` has no clinic, and there is no conversation before the first reply). `JSON.stringify` keeps explicit `null`s, but the `/api/ai/agent` schema used `z.string().uuid().optional()` - which accepts `undefined` but **rejects `null`**. The route surfaces the raw Zod issue message, so the user saw `expected string, received null`.

## Fix

- **Schema** (`/api/ai/agent`): accept `null`/`undefined` for `clinicId` and `conversationId` and normalise to `undefined` for the handler (downstream types unchanged).
- **Client** (`AgentWidget`): omit these fields when absent, drop empty messages, and show the error only once (remove the empty assistant placeholder on error).

## Testing
- `eslint` + `prettier` on changed files - clean.
- `vitest` ai-config + impersonate suites - pass (25 tests).
- Type-checked via language server (no errors).

> Follow-up (separate PR, pending product decision): redesign the widget and make it toggle from the nav instead of being a permanent floating button.