### PR TITLE
test(e2e): harden cron auth coverage and tighten 404 assertions

### DIFF
--- a/e2e/admissions-adt.spec.ts
+++ b/e2e/admissions-adt.spec.ts
@@ -42,12 +42,15 @@ test.describe("ADT — Page smoke tests", () => {
   test("admin admissions page requires authentication", async ({ page }) => {
     const response = await page.goto("/admin/admissions");
     const url = page.url();
+    // /admin/* is a PROTECTED_PREFIXES route, so middleware redirects an
+    // anonymous caller to /login before Next.js can return a 404. Do NOT
+    // accept 404 — that would mask the page being unguarded if the prefix
+    // protection ever regressed.
     const isProtected =
       url.includes("/login") ||
       url.includes("/auth") ||
       response?.status() === 401 ||
-      response?.status() === 403 ||
-      response?.status() === 404;
+      response?.status() === 403;
     expect(isProtected).toBeTruthy();
   });
 });

--- a/e2e/cron-auth-security.spec.ts
+++ b/e2e/cron-auth-security.spec.ts
@@ -1,3 +1,5 @@
+import { existsSync, readdirSync, readFileSync } from "fs";
+import { join } from "path";
 import { test, expect } from "@playwright/test";
 
 /**
@@ -21,63 +23,149 @@ import { test, expect } from "@playwright/test";
  * (billing charges, GDPR deletions, etc.) in a staging environment.
  * Success paths are covered by the cron route unit tests in
  * src/app/api/__tests__/cron-*.test.ts and src/lib/__tests__/cron-auth.test.ts.
+ *
+ * ── Route discovery (TC-03 hardening) ──────────────────────────────────────
+ * The cron route list is NO LONGER hardcoded. A hardcoded list silently
+ * drifts: new cron routes (e.g. ai-embed-faqs, ai-memory-consolidate,
+ * trial-lifecycle, usage-snapshots, support-sla-check, onboarding-nudges)
+ * were added under src/app/api/cron/ without being added to the test, leaving
+ * destructive/PHI-touching endpoints unverified for auth. We now discover
+ * every cron route from the filesystem and detect each route's REAL exported
+ * HTTP method, so:
+ *   - every cron route is auth-tested automatically, forever, and
+ *   - we exercise the route's actual entrypoint (e.g. payment-reminders is
+ *     POST-only — a GET would return 405 and prove nothing about auth).
  */
 
-// All cron routes that must be auth-protected (matches CRON_ROUTES in worker-cron-handler.ts)
-const CRON_ROUTES = [
-  "/api/cron/uptime-monitor",
-  "/api/cron/notifications",
-  "/api/cron/audit-log-flush",
-  "/api/cron/reminders",
-  "/api/cron/r2-cleanup",
-  "/api/cron/feedback",
-  "/api/cron/rebooking-reminders",
-  "/api/cron/billing",
-  "/api/cron/gdpr-purge",
-  "/api/cron/dedup-purge",
-  "/api/cron/stripe-reconcile",
-  "/api/cron/data-retention",
-  "/api/cron/daily-briefing",
-  "/api/cron/nps-survey",
-  "/api/cron/payment-reminders",
-  "/api/cron/retry-webhooks",
-];
+// Playwright runs with cwd = project root (testDir: "./e2e"), so resolve the
+// cron directory relative to the working directory.
+const CRON_DIR = join(process.cwd(), "src", "app", "api", "cron");
 
-// ── Unauthenticated requests ────────────────────────────────────────────────
+type HttpMethod = "GET" | "POST";
 
-test.describe("TC-03 — Cron routes reject unauthenticated GET requests", () => {
-  for (const route of CRON_ROUTES) {
-    test(`GET ${route} without Authorization header → 401`, async ({ request }) => {
-      const res = await request.get(route);
-      expect(res.status()).toBe(401);
-    });
+interface CronRoute {
+  /** Request path, e.g. "/api/cron/billing". */
+  path: string;
+  /** HTTP methods the route actually exports (GET, POST, or both). */
+  methods: HttpMethod[];
+}
+
+/**
+ * Discover every cron route by scanning src/app/api/cron/<name>/route.ts and
+ * detecting which HTTP method handlers it exports. Supports both
+ * `export const GET = ...` and `export (async) function GET()` forms.
+ */
+function discoverCronRoutes(): CronRoute[] {
+  const entries = readdirSync(CRON_DIR, { withFileTypes: true });
+  const routes: CronRoute[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const routeFile = join(CRON_DIR, entry.name, "route.ts");
+    if (!existsSync(routeFile)) continue;
+
+    const src = readFileSync(routeFile, "utf8");
+    const methods: HttpMethod[] = [];
+    for (const method of ["GET", "POST"] as const) {
+      const constForm = new RegExp(`export\\s+const\\s+${method}\\b`);
+      const fnForm = new RegExp(`export\\s+(?:async\\s+)?function\\s+${method}\\b`);
+      if (constForm.test(src) || fnForm.test(src)) {
+        methods.push(method);
+      }
+    }
+
+    // A cron folder with no HTTP handler is not a routable entrypoint — skip.
+    if (methods.length === 0) continue;
+
+    routes.push({ path: `/api/cron/${entry.name}`, methods });
+  }
+
+  return routes.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+const CRON_ROUTES = discoverCronRoutes();
+
+// ── Discovery sanity guard ──────────────────────────────────────────────────
+// If the cron directory moves or discovery breaks, CRON_ROUTES would be empty
+// and every for-loop below would register ZERO tests — a silent no-op that
+// hides the entire suite. Assert a sane floor so a broken path fails loudly.
+// (There are 20+ cron routes today; 16 is a conservative lower bound.)
+test.describe("TC-03 — Cron route discovery", () => {
+  test("discovers the full set of cron routes from the filesystem", () => {
+    expect(CRON_ROUTES.length).toBeGreaterThanOrEqual(16);
+    // Spot-check that destructive/sensitive routes are present so a future
+    // refactor that drops them from discovery is caught.
+    const paths = CRON_ROUTES.map((r) => r.path);
+    for (const required of [
+      "/api/cron/billing",
+      "/api/cron/gdpr-purge",
+      "/api/cron/trial-lifecycle",
+      "/api/cron/payment-reminders",
+    ]) {
+      expect(paths).toContain(required);
+    }
+  });
+});
+
+/** Issue an unauthenticated request using the given method. */
+async function requestUnauthenticated(
+  request: import("@playwright/test").APIRequestContext,
+  method: HttpMethod,
+  path: string,
+  headers?: Record<string, string>,
+) {
+  return method === "GET"
+    ? request.get(path, { headers })
+    : request.post(path, { data: {}, headers });
+}
+
+// ── Unauthenticated requests (real exported method) ────────────────────────
+
+test.describe("TC-03 — Cron routes reject unauthenticated requests", () => {
+  for (const { path, methods } of CRON_ROUTES) {
+    for (const method of methods) {
+      test(`${method} ${path} without Authorization header → 401`, async ({ request }) => {
+        const res = await requestUnauthenticated(request, method, path);
+        // verifyCronSecret runs before any method/body logic, so the route's
+        // real entrypoint must reject the anonymous caller with 401. A 200
+        // (job ran) or 5xx (crash) is a security failure.
+        expect(res.status()).toBe(401);
+      });
+    }
   }
 });
 
-test.describe("TC-03 — Cron routes reject unauthenticated POST requests", () => {
-  for (const route of CRON_ROUTES) {
-    test(`POST ${route} without Authorization header → 401`, async ({ request }) => {
-      const res = await request.post(route, { data: {} });
-      // Some cron routes only accept GET — 405 is also acceptable (method check after auth check
-      // would return 401 regardless; method-check first returns 405). Either is fine:
-      // what matters is that 200 is never returned.
+// ── Unsupported method must never run the job ───────────────────────────────
+
+test.describe("TC-03 — Cron routes reject the unsupported method", () => {
+  for (const { path, methods } of CRON_ROUTES) {
+    const unsupported: HttpMethod = methods.includes("GET") ? "POST" : "GET";
+    // Only assert when the route genuinely does not export this method.
+    if (methods.includes(unsupported)) continue;
+
+    test(`${unsupported} ${path} (unsupported) is never accepted`, async ({ request }) => {
+      const res = await requestUnauthenticated(request, unsupported, path);
+      // Either 405 (method not allowed) or 401 (auth runs first) — but never
+      // 200 (job executed) or 5xx (crash).
       expect([401, 405]).toContain(res.status());
+      expect(res.status()).not.toBe(200);
     });
   }
 });
 
-// ── Wrong token ─────────────────────────────────────────────────────────────
+// ── Wrong token (real exported method) ──────────────────────────────────────
 
 test.describe("TC-03 — Cron routes reject wrong Bearer token", () => {
-  for (const route of CRON_ROUTES) {
-    test(`GET ${route} with wrong token → 401`, async ({ request }) => {
-      const res = await request.get(route, {
-        headers: {
+  for (const { path, methods } of CRON_ROUTES) {
+    for (const method of methods) {
+      test(`${method} ${path} with wrong token → 401`, async ({ request }) => {
+        const res = await requestUnauthenticated(request, method, path, {
           Authorization: "Bearer wrong-secret-that-is-definitely-incorrect-value-for-ci",
-        },
+        });
+        expect(res.status()).toBe(401);
       });
-      expect(res.status()).toBe(401);
-    });
+    }
   }
 });
 

--- a/e2e/insurance-claims.spec.ts
+++ b/e2e/insurance-claims.spec.ts
@@ -44,12 +44,14 @@ test.describe("Insurance claims — Page smoke tests", () => {
   test("admin insurance claims page requires authentication", async ({ page }) => {
     const response = await page.goto("/admin/insurance-claims");
     const url = page.url();
+    // /admin/* is a PROTECTED_PREFIXES route, so middleware redirects an
+    // anonymous caller to /login before a 404 can be returned. 404 is
+    // rejected so a prefix-protection regression can't pass silently.
     const isProtected =
       url.includes("/login") ||
       url.includes("/auth") ||
       response?.status() === 401 ||
-      response?.status() === 403 ||
-      response?.status() === 404;
+      response?.status() === 403;
     expect(isProtected).toBeTruthy();
   });
 });

--- a/e2e/rbac.spec.ts
+++ b/e2e/rbac.spec.ts
@@ -189,13 +189,13 @@ test.describe("RBAC — specialist role routes require authentication", () => {
       const url = page.url();
       const status = response?.status() ?? 0;
       // A 5xx must NOT count as "protected" — a crashing dashboard is a bug,
-      // not access control. Accept only a login/auth redirect or 401/403/404.
+      // not access control. 404 is also rejected: every specialist prefix is
+      // in PROTECTED_PREFIXES (src/lib/middleware/routes.ts), so middleware
+      // redirects an anonymous caller to /login BEFORE Next.js can resolve a
+      // 404 — even for a route whose page file doesn't exist. Accepting 404
+      // here would let a removed/renamed (and thus unguarded) route pass.
       const isProtected =
-        url.includes("/login") ||
-        url.includes("/auth") ||
-        status === 401 ||
-        status === 403 ||
-        status === 404;
+        url.includes("/login") || url.includes("/auth") || status === 401 || status === 403;
       expect(isProtected).toBe(true);
     });
   }

--- a/e2e/staff-invitations.spec.ts
+++ b/e2e/staff-invitations.spec.ts
@@ -28,12 +28,15 @@ test.describe("Staff invitations — Page smoke tests", () => {
   test("admin staff invitations page requires authentication", async ({ page }) => {
     const response = await page.goto("/admin/staff");
     const url = page.url();
+    // /admin/* is a PROTECTED_PREFIXES route, so middleware redirects an
+    // anonymous caller to /login before Next.js can resolve a 404. Rejecting
+    // 404 keeps this a real access-control assertion rather than a route-
+    // existence check.
     const isProtected =
       url.includes("/login") ||
       url.includes("/auth") ||
       response?.status() === 401 ||
-      response?.status() === 403 ||
-      response?.status() === 404;
+      response?.status() === 403;
     expect(isProtected).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Hardens the E2E security test suite in two areas surfaced during an audit of `e2e/`.

### 1. Cron auth coverage (`cron-auth-security.spec.ts`)
- Replaced the hardcoded 16-route list with **filesystem discovery** of `src/app/api/cron/*/route.ts`, detecting each route's real exported HTTP method.
- Now covers **all 23 cron routes** (was 16). Previously untested: `ai-clinic-briefings`, `ai-embed-faqs`, `ai-memory-consolidate`, `onboarding-nudges`, `support-sla-check`, `trial-lifecycle`, `usage-snapshots`.
- Tests the route's actual entrypoint, fixing a latent bug: `GET /api/cron/payment-reminders` was asserted to 401, but the route is POST-only (returns 405).
- Added a discovery sanity guard (>=16 routes + destructive routes present) so a broken path fails loudly instead of registering zero tests.
- Added an "unsupported method is never accepted" check per route.

### 2. Tighten 404-masking assertions
Removed `404` from the unauthenticated "is protected" assertions in `rbac.spec.ts` (specialist routes), `admissions-adt.spec.ts`, `insurance-claims.spec.ts`, and `staff-invitations.spec.ts`. Every `/admin/*` and specialist prefix is in `PROTECTED_PREFIXES`, so middleware redirects anonymous callers to `/login` before a 404 can be returned. Accepting 404 masked a possible prefix-protection regression.

## Testing
- Verified route discovery against the filesystem: 23 routes found, methods correct (`payment-reminders`=POST).
- All edited files pass TypeScript diagnostics.
- Pre-commit (lint-staged + gitleaks) and pre-push hooks passed.

No malware or runtime-security issues were found in `e2e/` â€” these are test-quality and coverage hardening fixes.
