### PR TITLE
fix(k6): harden smoke test - real endpoints, availability SLO, load/smoke modes, prod guard

### DIFF
--- a/k6/smoke.js
+++ b/k6/smoke.js
@@ -41,13 +41,26 @@ export function setup() {
       "BASE_URL is required. Example: k6 run --env BASE_URL=https://staging.oltigo.com k6/smoke.js",
     );
   }
+
+  // Parse the URL to inspect the hostname directly — substring matching on the
+  // raw string is unsafe (e.g. "https://evil.com/oltigo.com" passes includes()).
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(`BASE_URL is not a valid URL: ${baseUrl}`);
+  }
+  const hostname = parsed.hostname; // e.g. "staging.oltigo.com"
   const isProd =
-    baseUrl.includes("oltigo.com") &&
-    !baseUrl.includes("staging") &&
-    !baseUrl.includes("preview") &&
-    !baseUrl.includes("localhost");
+    (hostname === "oltigo.com" || hostname.endsWith(".oltigo.com")) &&
+    !hostname.startsWith("staging") &&
+    !hostname.startsWith("preview") &&
+    hostname !== "localhost";
+
   if (isProd && __ENV.ALLOW_PROD !== "true") {
-    throw new Error("BASE_URL looks like a production host. Set --env ALLOW_PROD=true to confirm.");
+    throw new Error(
+      `BASE_URL resolves to a production host (${hostname}). Set --env ALLOW_PROD=true to confirm.`,
+    );
   }
   return { baseUrl };
 }

--- a/k6/smoke.js
+++ b/k6/smoke.js
@@ -1,55 +1,161 @@
 /**
- * QA-004: k6 smoke load test for staging deployments.
+ * k6 smoke / load test — Oltigo Health staging.
  *
- * Validates SLO claims (99.9% availability, p95 < 800ms) under light load.
- * Run manually or wire into deploy.yml staging step:
+ * This file is run MANUALLY only. Automated post-deploy checks use
+ * scripts/smoke-post-deploy.mjs (no k6 dependency).
  *
+ * Usage:
+ *   # Install k6: https://k6.io/docs/get-started/installation/
+ *
+ *   # Smoke mode (default — 2 VUs, 30 s, safe for any environment):
  *   k6 run --env BASE_URL=https://staging.oltigo.com k6/smoke.js
  *
- * Thresholds:
- *   - p95 response time < 800ms
- *   - Error rate < 0.1%
- *   - Availability > 99.9%
+ *   # Load mode (100-VU ramp — staging only, explicit opt-in required):
+ *   k6 run --env BASE_URL=https://staging.oltigo.com --env SMOKE_MODE=load k6/smoke.js
+ *
+ *   # Production (requires explicit opt-in to prevent accidents):
+ *   k6 run --env BASE_URL=https://oltigo.com --env ALLOW_PROD=true k6/smoke.js
+ *
+ * Thresholds enforced:
+ *   - availability (custom Rate):  > 99.9 % across user-facing probes
+ *   - http_req_failed:             < 0.1 %  (k6 built-in)
+ *   - per-endpoint p95 durations:  ping < 300ms, status/health < 500ms, landing < 800ms
  */
 
 /* eslint-disable import/no-anonymous-default-export */
 import { check, sleep } from "k6";
 import http from "k6/http";
+import { Rate } from "k6/metrics";
 
-const BASE_URL = __ENV.BASE_URL || "https://staging.oltigo.com";
+// ── Custom metrics ──────────────────────────────────────────────────────────
 
-export const options = {
+/** Tracks whether each user-facing probe succeeded — drives the availability SLO. */
+const availability = new Rate("availability");
+
+// ── Setup: validate environment ──────────────────────────────────────────────
+
+export function setup() {
+  const baseUrl = __ENV.BASE_URL;
+  if (!baseUrl) {
+    throw new Error(
+      "BASE_URL is required. Example: k6 run --env BASE_URL=https://staging.oltigo.com k6/smoke.js",
+    );
+  }
+  const isProd =
+    baseUrl.includes("oltigo.com") &&
+    !baseUrl.includes("staging") &&
+    !baseUrl.includes("preview") &&
+    !baseUrl.includes("localhost");
+  if (isProd && __ENV.ALLOW_PROD !== "true") {
+    throw new Error("BASE_URL looks like a production host. Set --env ALLOW_PROD=true to confirm.");
+  }
+  return { baseUrl };
+}
+
+// ── Scenario options ─────────────────────────────────────────────────────────
+
+const smokeScenario = {
+  executor: "constant-vus",
+  vus: 2,
+  duration: "30s",
+};
+
+const loadScenario = {
+  executor: "ramping-vus",
   stages: [
     { duration: "30s", target: 20 }, // ramp up
-    { duration: "3m", target: 100 }, // sustain
+    { duration: "3m", target: 100 }, // sustain at 100 VUs
     { duration: "30s", target: 0 }, // ramp down
   ],
+};
+
+const isLoadMode = __ENV.SMOKE_MODE === "load";
+
+export const options = {
+  scenarios: {
+    main: isLoadMode ? loadScenario : smokeScenario,
+  },
   thresholds: {
-    http_req_duration: ["p(95)<800"], // SLO: p95 < 800ms
-    http_req_failed: ["rate<0.001"], // SLO: error rate < 0.1%
+    // Availability SLO: > 99.9% of user-facing probes must succeed.
+    availability: ["rate>0.999"],
+
+    // Overall error rate < 0.1%.
+    http_req_failed: ["rate<0.001"],
+
+    // Per-endpoint p95 latency budgets (tagged thresholds).
+    "http_req_duration{endpoint:ping}": ["p(95)<300"],
+    "http_req_duration{endpoint:status}": ["p(95)<500"],
+    "http_req_duration{endpoint:health}": ["p(95)<500"],
+    "http_req_duration{endpoint:landing}": ["p(95)<800"],
   },
 };
 
-export default function () {
-  // Health check endpoint
-  const health = http.get(`${BASE_URL}/api/health`);
-  check(health, {
-    "health status 200": (r) => r.status === 200,
-    "health p95 < 500ms": (r) => r.timings.duration < 500,
-  });
+// ── Main scenario ─────────────────────────────────────────────────────────────
 
-  // Public availability endpoint (no auth required)
-  const avail = http.get(`${BASE_URL}/api/v1/availability`);
-  check(avail, {
-    "availability responds": (r) => r.status < 500,
-  });
+export default function (data) {
+  const BASE_URL = data.baseUrl;
 
-  // Landing page
-  const landing = http.get(`${BASE_URL}/`);
-  check(landing, {
-    "landing status 200": (r) => r.status === 200,
-    "landing p95 < 800ms": (r) => r.timings.duration < 800,
+  // ── /api/ping — liveness probe ────────────────────────────────────────────
+  // Must be 200. Any other status = hard failure.
+  const ping = http.get(`${BASE_URL}/api/ping`, {
+    tags: { endpoint: "ping" },
   });
+  const pingOk = check(ping, {
+    "ping 200": (r) => r.status === 200,
+  });
+  availability.add(pingOk);
+
+  // ── /api/status — platform status ─────────────────────────────────────────
+  // Accepts 200 (all ok) and 503 (degraded but intentionally reported).
+  // 503 is an expected response when a subsystem is disabled (e.g. AI kill
+  // switch), NOT an infrastructure failure — don't trip http_req_failed.
+  const status = http.get(`${BASE_URL}/api/status`, {
+    tags: { endpoint: "status" },
+    responseCallback: http.expectedStatuses(200, 503),
+  });
+  const statusOk = check(status, {
+    "status 200 or 503": (r) => r.status === 200 || r.status === 503,
+    "status has status field": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return typeof body.status === "string";
+      } catch {
+        return false;
+      }
+    },
+  });
+  availability.add(statusOk);
+
+  // ── /api/health — readiness probe ─────────────────────────────────────────
+  // Same contract as /api/status: 200 = healthy, 503 = degraded but responsive.
+  const health = http.get(`${BASE_URL}/api/health`, {
+    tags: { endpoint: "health" },
+    responseCallback: http.expectedStatuses(200, 503),
+  });
+  const healthOk = check(health, {
+    "health 200 or 503": (r) => r.status === 200 || r.status === 503,
+    "health has status value": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return body.status === "ok" || body.status === "degraded";
+      } catch {
+        return false;
+      }
+    },
+  });
+  availability.add(healthOk);
+
+  // ── / — landing page ──────────────────────────────────────────────────────
+  // Accepts any 2xx or 3xx — the CDN may redirect to a locale-prefixed URL
+  // (e.g. /fr/) which is correct behaviour, not a failure.
+  const landing = http.get(`${BASE_URL}/`, {
+    tags: { endpoint: "landing" },
+    responseCallback: http.expectedStatuses({ min: 200, max: 399 }),
+  });
+  const landingOk = check(landing, {
+    "landing 2xx or 3xx": (r) => r.status >= 200 && r.status <= 399,
+  });
+  availability.add(landingOk);
 
   sleep(1);
 }


### PR DESCRIPTION
## Summary

Rewrites `k6/smoke.js` addressing every finding from the static review. 1 file changed - no production code touched.

---

### Critical - Nonexistent endpoint removed

Dropped `/api/v1/availability` (route does not exist - caused unconditional 404 failures). Replaced with four real endpoints: `/api/ping`, `/api/status`, `/api/health`, and `/`.

### High - True smoke profile by default

Default is now `constant-vus` (2 VUs, 30 s) - a genuine smoke test. The 100-VU ramp is preserved but gated behind `--env SMOKE_MODE=load` so it only runs when explicitly requested.

### High - Availability SLO now measured

Added a custom `Rate("availability")` metric fed by all four user-facing probes. Enforced by a real threshold: `availability: ["rate>0.999"]`.

### Medium - Exact-contract status checks

- `/api/ping`: must be exactly 200
- `/api/status`, `/api/health`: 200 or 503, with JSON body validation (`status` field present and `"ok"`/`"degraded"`)
- `/`: 2xx or 3xx (CDN redirect is correct behaviour)

### Medium - Real tagged percentile thresholds

Removed the misleading per-request `timings.duration < Xms` checks (those are p100, not p95). Replaced with k6 tagged thresholds: `http_req_duration{endpoint:ping|status|health|landing}` with per-endpoint p95 budgets (300/500/500/800 ms).

### Medium - Health 503 no longer a false failure

`responseCallback: http.expectedStatuses(200, 503)` on `/api/health` and `/api/status` - a deliberate 503 (AI kill switch) does not trip `http_req_failed`. Same for the landing redirect.

### Low - BASE_URL required; production host refused

`setup()` throws if `BASE_URL` is missing. A production hostname is refused unless `--env ALLOW_PROD=true` is set.

### Low - Doc header rewritten

Header now documents: manual-only usage, smoke vs. load modes, the prod guard, and that automated checks use `scripts/smoke-post-deploy.mjs`.

---

### Verification

- `node --check k6/smoke.js` ? (syntax OK)
- `eslint k6/smoke.js --max-warnings 0` ?
- `prettier --check k6/smoke.js` ?
- k6 is not installed locally so a live run was not possible; all k6 APIs used (`http.expectedStatuses`, per-request `responseCallback`, `Rate`, `scenarios`/executors, tagged thresholds) are standard documented k6 features