### PR TITLE
fix(infra): explicit API token, staging protect, DLQ/wildcard docs, fmt

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -95,8 +95,8 @@ root so state and identifiers cannot be accidentally committed
 ## Prerequisites
 
 - Terraform `>= 1.6` (`>= 1.11` recommended for native S3-backend state locking)
-- Cloudflare API token with permissions for Workers KV, R2, Queues, and Workers Routes
-- `CLOUDFLARE_API_TOKEN` exported in your shell or injected by CI
+- Cloudflare API token with permissions for Workers KV, R2, Queues, and Workers Routes — see `providers.tf` for the full permission list
+- Pass the token via `TF_VAR_cloudflare_api_token` (never in `terraform.tfvars` or any committed file)
 - `terraform.tfvars` created from `terraform.tfvars.example`
 - A configured remote backend (see `backend.tf`)
 
@@ -131,6 +131,22 @@ Known namespace IDs already recorded in `wrangler.toml`:
 - staging preview `RATE_LIMIT_KV`: `4965f9300c924de3afc0407679ff775b`
 
 For routes and queues, obtain the existing resource IDs from the Cloudflare dashboard or API, then import them before the first apply.
+
+## DLQ monitoring
+
+The production notification queue is configured with `max_retries = 3`. After three failed delivery attempts a message is forwarded to `notification-queue-dlq`. A growing DLQ means patients are not receiving WhatsApp/SMS/email notifications — it is a patient-safety signal, not just an operational noise.
+
+**Current gap:** There is no Terraform-managed Logpush rule or alerting policy watching DLQ depth. Until one is added:
+
+1. Check the DLQ message count manually via the Cloudflare dashboard → **Queues** → `notification-queue-dlq` → **Messages**.
+2. Alternatively, query the Queues REST API: `GET /accounts/{id}/queues/{id}/messages` with `?visible=true&status=delayed`.
+3. For incidents involving missed patient notifications, treat a non-empty DLQ as a P1.
+
+**Recommended follow-up:** Add a `cloudflare_logpush_job` resource that ships queue metrics to your SIEM/alerting layer, or configure a Cloudflare notification policy on queue message count.
+
+## Wildcard routing
+
+The production route patterns include `*.oltigo.com/*`, which routes all subdomains to the application Worker. This is intentional for the multi-tenant subdomain architecture (ADR-0007). Any new subdomain that should **not** be served by the application Worker must use a separate Cloudflare zone or a different account. Do not create internal/admin subdomains under `*.oltigo.com` without reviewing this routing first.
 
 ## Suggested next iterations
 

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,4 +1,12 @@
 locals {
+  # WILDCARD ROUTING NOTE:
+  # "*.oltigo.com/*" routes all subdomains (clinic subdomains, demo, etc.) to
+  # the application Worker — this is intentional for the multi-tenant subdomain
+  # routing architecture (see ADR-0007). Any new internal/admin subdomain that
+  # should NOT be handled by the application Worker (e.g. an admin panel, an
+  # internal service, or a third-party integration) MUST use a separate
+  # Cloudflare zone or be placed on a different account. Do not create
+  # internal subdomains under *.oltigo.com without first reviewing this routing.
   production_route_patterns = toset([
     "oltigo.com/*",
     "*.oltigo.com/*",
@@ -13,5 +21,8 @@ locals {
     batch_size       = 25
     max_wait_time_ms = 30000
     max_retries      = 3
+    # After max_retries attempts the message is forwarded to the DLQ. Monitor
+    # DLQ depth to detect silent notification failures (WhatsApp/SMS/email).
+    # See the "DLQ monitoring" section of infra/README.md.
   }
 }

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,1 +1,15 @@
-provider "cloudflare" {}
+# The Cloudflare provider reads api_token from this variable.
+#
+# Do NOT set cloudflare_api_token in terraform.tfvars — it would be stored in
+# plaintext on disk and risks accidental commit. Pass it instead via the
+# environment variable TF_VAR_cloudflare_api_token, a secrets manager (e.g.
+# Vault, AWS Secrets Manager), or a CI-injected secret.
+#
+# Required token permissions:
+#   - Account: Workers KV Storage: Edit
+#   - Account: R2 Storage: Edit
+#   - Account: Queues: Edit
+#   - Zone: Workers Routes: Edit (only needed when manage_worker_routes = true)
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/infra/queues.tf
+++ b/infra/queues.tf
@@ -14,6 +14,16 @@ resource "cloudflare_queue" "notification_production_dlq" {
   account_id = var.cloudflare_account_id
   queue_name = var.production_notification_dlq_name
 
+  # Dead-letter queue for the production notification queue. Messages land here
+  # after max_retries (3) failed delivery attempts. DLQ accumulation means
+  # patients are NOT receiving WhatsApp/SMS/email notifications — this must
+  # be monitored.
+  #
+  # Known gap: there is no Terraform-managed Logpush rule or alerting policy
+  # watching DLQ depth today. Until one is added, use the Cloudflare dashboard
+  # or the Queues REST API to check the DLQ message count after incidents.
+  # Adding a Logpush → SIEM / alerting rule is the recommended follow-up.
+  # See infra/README.md — "DLQ monitoring" section.
   lifecycle {
     prevent_destroy = true
   }

--- a/infra/r2.tf
+++ b/infra/r2.tf
@@ -21,4 +21,12 @@ resource "cloudflare_r2_bucket" "uploads_staging" {
   location      = var.r2_bucket_location
   jurisdiction  = var.r2_bucket_jurisdiction
   storage_class = var.r2_storage_class
+
+  # Staging may hold PHI-equivalent test data tied to CI pipelines. Guard it
+  # against accidental `terraform destroy` — reprovisioning during an active
+  # CI run would break pipeline artifact references. Remove deliberately if a
+  # clean staging reprovision is actually needed.
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -5,23 +5,30 @@
 cloudflare_account_id = "replace-with-cloudflare-account-id"
 cloudflare_zone_id    = "replace-with-oltigo-com-zone-id"
 
+# cloudflare_api_token — NEVER set this here. Pass it via the environment
+# variable TF_VAR_cloudflare_api_token so the secret stays out of any file
+# that could be committed or printed in CI logs.
+# See providers.tf and variables.tf for the required token permissions.
+
 # Optional overrides
-# production_worker_name                  = "webs-alots"
-# staging_worker_name                     = "webs-alots-staging"
-# production_rate_limit_namespace_title   = "RATE_LIMIT_KV"
-# staging_rate_limit_namespace_title      = "RATE_LIMIT_KV_STAGING"
-# production_uploads_bucket_name          = "webs-alots-uploads"
-# staging_uploads_bucket_name             = "webs-alots-uploads-staging"
-# production_notification_queue_name      = "notification-queue"
-# production_notification_dlq_name        = "notification-queue-dlq"
+# production_worker_name                 = "webs-alots"
+# staging_worker_name                    = "webs-alots-staging"
+# production_rate_limit_namespace_title  = "RATE_LIMIT_KV"
+# staging_rate_limit_namespace_title     = "RATE_LIMIT_KV_STAGING"
+# production_uploads_bucket_name         = "webs-alots-uploads"
+# staging_uploads_bucket_name            = "webs-alots-uploads-staging"
+# production_notification_queue_name     = "notification-queue"
+# production_notification_dlq_name       = "notification-queue-dlq"
 # staging_notification_queue_name        = "notification-queue-staging"
-# staging_notification_dlq_name           = "notification-queue-staging-dlq"
+# staging_notification_dlq_name          = "notification-queue-staging-dlq"
+
 # Routes and queue consumers are owned by wrangler.toml by default. Only set
 # these to true after removing the matching blocks from wrangler.toml.
-# manage_queue_consumers                  = false
-# manage_worker_routes                    = false
-# r2_bucket_location                      = null
-# r2_bucket_jurisdiction is set to "eu" by default (see ADR-0008).
+# manage_queue_consumers                 = false
+# manage_worker_routes                   = false
+
+# r2_bucket_location                     = null
+# r2_bucket_jurisdiction is set to "eu" by default (see ADR-0012).
 # Only change this before the first apply — it is immutable (ForceNew).
-# r2_bucket_jurisdiction                  = "eu"
-# r2_storage_class                        = null
+# r2_bucket_jurisdiction                 = "eu"
+# r2_storage_class                       = null

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -3,6 +3,24 @@ variable "cloudflare_account_id" {
   type        = string
 }
 
+variable "cloudflare_api_token" {
+  description = <<-EOT
+    Cloudflare API token passed to the provider.
+
+    Required permissions:
+      - Account / Workers KV Storage: Edit
+      - Account / R2 Storage: Edit
+      - Account / Queues: Edit
+      - Zone / Workers Routes: Edit  (only when manage_worker_routes = true)
+
+    IMPORTANT: Never set this in terraform.tfvars or any file committed to git.
+    Inject it via the environment variable TF_VAR_cloudflare_api_token in CI,
+    or use a secrets manager at plan/apply time.
+  EOT
+  type        = string
+  sensitive   = true
+}
+
 variable "cloudflare_zone_id" {
   description = "Cloudflare zone ID for oltigo.com routes."
   type        = string

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -5,6 +5,17 @@ terraform {
     cloudflare = {
       source  = "cloudflare/cloudflare"
       version = "~> 5.19"
+      # ~> 5.19 allows 5.20, 5.21, etc. The .terraform.lock.hcl file pins the
+      # exact version used at last `terraform init`. This is the intended safety
+      # mechanism — the lock file MUST be committed so CI always uses the same
+      # binary that was tested locally.
+      #
+      # NEVER run `terraform init -upgrade` in CI. Only run it deliberately when
+      # intentionally reviewing and accepting a new provider version. After
+      # upgrading, re-review the provider changelog for breaking changes to
+      # cloudflare_r2_bucket, cloudflare_workers_kv_namespace,
+      # cloudflare_queue, and cloudflare_queue_consumer before applying to
+      # production.
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the remaining fixable findings from the infra/ audit. 8 files changed - no application code touched.

> Note: findings #1 (remote backend guard), #3 (R2 jurisdiction ? eu), and the SHA256 CI step were already addressed in PR #1156.

---

### #2 ?? Blocker - Explicit Cloudflare API token

`providers.tf`: replaced the empty `provider "cloudflare" {}` with `api_token = var.cloudflare_api_token`.

`variables.tf`: added `cloudflare_api_token` as `type = string`, `sensitive = true` with the full required permission list documented. Token MUST be passed via `TF_VAR_cloudflare_api_token` - never in `terraform.tfvars` or any committed file. Any misconfigured shell now surfaces a clear Terraform variable error rather than a confusing unauthenticated apply.

### #4 ?? Security - Staging R2 bucket now guarded

`r2.tf`: added `lifecycle { prevent_destroy = true }` to `uploads_staging`. Staging can hold PHI-equivalent test data tied to CI pipelines; an accidental destroy during an active run would break artifact references.

### #5 ?? Lock-file enforcement documented

`versions.tf`: added comment explaining that `.terraform.lock.hcl` is the intended safety mechanism, that `terraform init -upgrade` must never run in CI, and what changelog sections to review when a provider bump is intentional.

### #6 ?? Wildcard routing is now documented as deliberate

`locals.tf`: added inline comment explaining that `*.oltigo.com/*` is intentional for ADR-0007 multi-tenant subdomain routing, and that any new internal subdomain must use a separate zone/account.

### #7 ?? terraform.tfvars.example spacing fixed

Aligned all optional variable comment columns so `terraform fmt -check` passes cleanly. Added explicit API token warning. Updated ADR reference from 0008 ? 0012.

### #8 ?? DLQ monitoring gap documented

`queues.tf`: inline comment on the production DLQ resource explaining the gap and what to check during incidents.

`README.md`: added "DLQ monitoring" section with actionable manual steps until a `cloudflare_logpush_job` resource is added, and "Wildcard routing" section cross-referencing ADR-0007. Updated Prerequisites to use `TF_VAR_cloudflare_api_token` instead of `CLOUDFLARE_API_TOKEN`.

---

### Verification

- `terraform fmt -check -diff -recursive infra` passes (exit 0)
- `terraform validate` still passes (verified via CI Terraform workflow)
- No production resource attributes changed - only variables, lifecycle guards, and documentation