### PR TITLE
fix(ui): prevent dashboard horizontal overflow on all viewport sizes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -146,9 +146,14 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* Prevent horizontal overflow at the document level. Content that
+       legitimately needs to scroll horizontally (e.g. data tables) must
+       use overflow-x: auto on its own scroll container. */
+    overflow-x: hidden;
   }
   html {
     @apply font-sans;
+    overflow-x: hidden;
   }
 }
 

--- a/src/components/layouts/admin-layout-shell.tsx
+++ b/src/components/layouts/admin-layout-shell.tsx
@@ -230,7 +230,7 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
 
   return (
     <OnboardingProvider>
-      <div className="flex min-h-screen">
+      <div className="flex min-h-screen overflow-x-hidden">
         {/* Skip to content link for keyboard accessibility */}
         <a
           href="#main-content"
@@ -281,7 +281,7 @@ export default function AdminLayoutShell({ children }: { children: React.ReactNo
         </aside>
 
         <AdminHeaderBar />
-        <main id="main-content" className="flex-1 p-4 pt-16 pb-20 md:p-6 md:pb-6 md:pt-18">
+        <main id="main-content" className="flex-1 min-w-0 p-4 pt-16 pb-20 md:p-6 md:pb-6 md:pt-18">
           <AutoBreadcrumb />
           {children}
         </main>

--- a/src/components/layouts/clinic-dashboard-layout.tsx
+++ b/src/components/layouts/clinic-dashboard-layout.tsx
@@ -103,7 +103,7 @@ export function ClinicDashboardLayout({
   );
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen overflow-x-hidden">
       {/* Mobile header bar */}
       <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 border-b bg-card px-4 py-3 md:hidden">
         <button
@@ -158,7 +158,7 @@ export function ClinicDashboardLayout({
 
       <main
         id="main-content"
-        className={`flex-1 ${config.mobileTabs ? "p-4 pt-16 pb-20 md:p-6 md:pb-6" : "p-6 pt-16 md:pt-6"}`}
+        className={`flex-1 min-w-0 ${config.mobileTabs ? "p-4 pt-16 pb-20 md:p-6 md:pb-6" : "p-6 pt-16 md:pt-6"}`}
       >
         {content}
       </main>

--- a/src/components/layouts/patient-layout-shell.tsx
+++ b/src/components/layouts/patient-layout-shell.tsx
@@ -78,7 +78,7 @@ export default function PatientLayoutShell({ children }: { children: React.React
   ];
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen overflow-x-hidden">
       {/* Desktop Sidebar */}
       <aside className="hidden w-64 border-r bg-card p-4 md:flex md:flex-col">
         <div className="flex items-center gap-2 mb-6">
@@ -111,7 +111,7 @@ export default function PatientLayoutShell({ children }: { children: React.React
       </aside>
 
       {/* Mobile Header */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col min-w-0">
         <header className="flex items-center justify-between border-b p-3 md:hidden">
           <div className="flex items-center gap-2">
             <OltigoMonogram size="sm" />
@@ -171,7 +171,7 @@ export default function PatientLayoutShell({ children }: { children: React.React
           </MobileMenuOverlay>
         )}
 
-        <main id="main-content" className="flex-1 p-4 pb-20 md:p-6 md:pb-6">
+        <main id="main-content" className="flex-1 min-w-0 p-4 pb-20 md:p-6 md:pb-6">
           <AutoBreadcrumb />
           {children}
         </main>

--- a/src/components/layouts/receptionist-layout-shell.tsx
+++ b/src/components/layouts/receptionist-layout-shell.tsx
@@ -71,7 +71,7 @@ export default function ReceptionistLayoutShell({ children }: { children: React.
   ];
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen overflow-x-hidden">
       {/* Desktop sidebar */}
       <aside className="hidden w-64 border-r bg-card p-4 md:block">
         <div className="flex items-center gap-2 mb-6">
@@ -84,7 +84,7 @@ export default function ReceptionistLayoutShell({ children }: { children: React.
         </div>
       </aside>
 
-      <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 flex-col min-w-0">
         {/* Mobile Header */}
         <header className="flex items-center justify-between border-b p-3 md:hidden">
           <div className="flex items-center gap-2">
@@ -132,7 +132,7 @@ export default function ReceptionistLayoutShell({ children }: { children: React.
           </div>
         )}
 
-        <main id="main-content" className="flex-1 p-4 pb-20 md:p-6 md:pb-6">
+        <main id="main-content" className="flex-1 min-w-0 p-4 pb-20 md:p-6 md:pb-6">
           <AutoBreadcrumb />
           {children}
         </main>

--- a/src/components/layouts/super-admin-layout-shell.tsx
+++ b/src/components/layouts/super-admin-layout-shell.tsx
@@ -566,7 +566,7 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
   const unreadCount = notifications.filter((n) => n.unread).length;
 
   return (
-    <div className="flex flex-col min-h-screen">
+    <div className="flex flex-col min-h-screen overflow-x-hidden">
       {/* Impersonation Banner */}
       <ImpersonationBanner />
 
@@ -589,7 +589,7 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
         </aside>
 
         {/* Main Content */}
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col min-w-0">
           {/* Top Bar */}
           <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 md:px-6">
             <Button
@@ -726,7 +726,7 @@ export default function SuperAdminLayoutShell({ children }: { children: React.Re
             </DropdownMenu>
           </header>
 
-          <main id="main-content" className="flex-1 p-4 pb-20 md:p-6 md:pb-6">
+          <main id="main-content" className="flex-1 min-w-0 p-4 pb-20 md:p-6 md:pb-6">
             {children}
           </main>
         </div>


### PR DESCRIPTION
## Problem

The dashboard produces horizontal overflow (page wider than viewport) on laptops, tablets, and mobile. Users must scroll left/right to see content.

## Root Cause

Every dashboard shell wraps its main content area in `flex-1` without `min-w-0`. Per the CSS Flexbox spec, a flex child without `min-w-0` is allowed to grow wider than its allocated share of the flex container when its content overflows - pushing the viewport wider and triggering the horizontal scrollbar.

No global `overflow-x: hidden` existed anywhere in the app shell, so any overflowing child could break the layout from any dashboard page.

## Fix

6 files changed - layout/CSS only, no logic or functionality changed.

### Shell components - 5 files

Applied to **every** authenticated dashboard shell:
- `clinic-dashboard-layout.tsx` (Pharmacist, Specialist, all role shells that delegate to it)
- `admin-layout-shell.tsx` (Clinic Admin, Doctor routes)
- `receptionist-layout-shell.tsx`
- `patient-layout-shell.tsx`
- `super-admin-layout-shell.tsx`

Per shell:
1. Outer `div.flex.min-h-screen` ? added `overflow-x-hidden`
2. Intermediate `div.flex-1.flex-col` wrappers ? added `min-w-0`
3. `<main>` ? added `min-w-0`

### Global CSS - `globals.css`

Added `overflow-x: hidden` to both `html` and `body` as a document-level catch-all. Content that legitimately scrolls horizontally (tables, code blocks) must use `overflow-x: auto` on its own scroll container - which the existing `.table-mobile-scroll` utility already does correctly.

## Verification

- TypeScript diagnostics: no errors on all 6 changed files
- Cloudflare Workers Build: passes
- The fix follows the standard pattern documented in [Tailwind's flex sizing docs](https://tailwindcss.com/docs/flex#growing-and-shrinking)