### PR TITLE
fix(auth): stop 503-ing every clinic dashboard API (tenant-context fail-closed regression)

### DIFF
--- a/src/lib/__tests__/with-auth.test.ts
+++ b/src/lib/__tests__/with-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createClient } from "@/lib/supabase-server";
+import { TenantContextPermissionError } from "@/lib/tenant-context";
 import { withAuth, withAuthAnyRole, type AuthContext } from "../with-auth";
 
 vi.mock("@/lib/supabase-server", () => ({
@@ -23,10 +24,16 @@ vi.mock("@/lib/tenant", () => ({
 // new fail-closed 503 behavior. Individual tests that need to exercise the
 // fail-closed path override `setTenantContext` per-call.
 const setTenantContextMock = vi.fn().mockResolvedValue(undefined);
-vi.mock("@/lib/tenant-context", () => ({
-  setTenantContext: (...args: unknown[]) => setTenantContextMock(...args),
-  logTenantContext: vi.fn(),
-}));
+vi.mock("@/lib/tenant-context", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/tenant-context")>();
+  return {
+    setTenantContext: (...args: unknown[]) => setTenantContextMock(...args),
+    logTenantContext: vi.fn(),
+    // Re-export the real error class so withAuth's `instanceof` check resolves
+    // against the same type the production code throws.
+    TenantContextPermissionError: actual.TenantContextPermissionError,
+  };
+});
 
 // Per-user rate limiter is backed by the shared distributed limiter. Mock it
 // so tests can drive the allow/deny decision deterministically and assert the
@@ -309,6 +316,34 @@ describe("withAuth", () => {
       expect(handler).not.toHaveBeenCalled();
     });
 
+    it("does NOT 503 when setTenantContext is permission-denied — RLS still enforces isolation", async () => {
+      // Regression guard: set_tenant_context is service_role-only, so the
+      // authenticated user client can never set the app.current_clinic_id GUC.
+      // That permission-denied is EXPECTED and must not fail the request
+      // closed — isolation is enforced by RLS (get_user_clinic_id + the
+      // x-clinic-id tenant client). The handler must still run.
+      const mockSupabase = createMockSupabase(
+        { id: "user-1" },
+        { id: "profile-1", role: "clinic_admin", clinic_id: "clinic-1" },
+      );
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+      setTenantContextMock.mockRejectedValueOnce(
+        new TenantContextPermissionError(
+          "Tenant context error: failed to set app.current_clinic_id: permission denied for function set_tenant_context",
+        ),
+      );
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      const wrappedHandler = withAuth(handler, ["clinic_admin"]);
+
+      const response = await wrappedHandler(createMockRequest() as never);
+
+      expect(handler).toHaveBeenCalled();
+      expect(response.status).toBe(200);
+    });
+
     it("returns 503 from withAuthAnyRole when setTenantContext throws (fail-closed default)", async () => {
       const mockSupabase = createMockSupabase(
         { id: "user-1" },
@@ -326,6 +361,29 @@ describe("withAuth", () => {
       expect(response.status).toBe(503);
       expect(body.error).toBe("Tenant context unavailable");
       expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does NOT 503 from withAuthAnyRole when setTenantContext is permission-denied", async () => {
+      const mockSupabase = createMockSupabase(
+        { id: "user-1" },
+        { id: "profile-1", role: "patient", clinic_id: "clinic-1" },
+      );
+      vi.mocked(createClient).mockResolvedValue(mockSupabase as never);
+      setTenantContextMock.mockRejectedValueOnce(
+        new TenantContextPermissionError(
+          "Tenant context error: failed to set app.current_clinic_id: permission denied for function set_tenant_context",
+        ),
+      );
+
+      const handler = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+      const wrappedHandler = withAuthAnyRole(handler);
+
+      const response = await wrappedHandler(createMockRequest() as never);
+
+      expect(handler).toHaveBeenCalled();
+      expect(response.status).toBe(200);
     });
 
     it("invokes the handler when failOpen=true even if setTenantContext throws", async () => {

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -30,6 +30,26 @@ export function isValidClinicId(clinicId: string): boolean {
 }
 
 /**
+ * Thrown when `set_tenant_context` is rejected because the current Postgres
+ * role lacks EXECUTE on it (the function is restricted to `service_role`).
+ *
+ * This is the EXPECTED outcome for the anon/authenticated user client: the
+ * `app.current_clinic_id` GUC is best-effort defense-in-depth only, and real
+ * tenant isolation is enforced by RLS (`get_user_clinic_id()` and the
+ * `x-clinic-id` header on the tenant client). Callers that have already
+ * authenticated the user and scope data through RLS may treat this as benign
+ * and continue, instead of failing the request closed. It is surfaced as a
+ * distinct type so callers can tell it apart from genuine, fail-closed-worthy
+ * failures (e.g. the RPC being unreachable).
+ */
+export class TenantContextPermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TenantContextPermissionError";
+  }
+}
+
+/**
  * Set the tenant context on a Supabase client by setting the PostgreSQL
  * session variable `app.current_clinic_id`.
  *
@@ -74,7 +94,15 @@ export async function setTenantContext(
       clinicId,
       error,
     });
-    throw new Error(`Tenant context error: failed to set app.current_clinic_id: ${message}`);
+    const detail = `Tenant context error: failed to set app.current_clinic_id: ${message}`;
+    // Permission denied is the EXPECTED result for the anon/authenticated
+    // role (set_tenant_context is service_role-only). Surface it as a typed
+    // error so wrappers like withAuth can continue safely — RLS still enforces
+    // isolation — instead of failing the whole request closed with a 503.
+    if (isPermissionDenied) {
+      throw new TenantContextPermissionError(detail);
+    }
+    throw new Error(detail);
   }
 }
 

--- a/src/lib/with-auth.ts
+++ b/src/lib/with-auth.ts
@@ -26,6 +26,16 @@ import { setTenantContext, logTenantContext } from "@/lib/tenant-context";
 import type { UserRole } from "@/lib/types/database";
 import type { Database } from "@/lib/types/database";
 
+/**
+ * True when `setTenantContext` failed because the current Postgres role lacks
+ * EXECUTE on the service_role-only `set_tenant_context` function — the EXPECTED
+ * outcome for the authenticated user client. Detected by error name (not
+ * `instanceof`) so it stays correct under module mocking and minification.
+ */
+function isTenantContextPermissionError(err: unknown): boolean {
+  return (err as { name?: string } | null | undefined)?.name === "TenantContextPermissionError";
+}
+
 interface AuthenticatedUser {
   id: string;
   email?: string | null;
@@ -192,16 +202,31 @@ export function withAuth<RouteCtx = unknown>(
         try {
           await setTenantContext(supabase, profile.clinic_id);
         } catch (tenantErr) {
-          logger.error("Failed to set tenant context in withAuth", {
-            context: "with-auth",
-            clinicId: profile.clinic_id,
-            failOpen,
-            error: tenantErr,
-          });
-          if (!failOpen) {
-            return finalize(
-              NextResponse.json({ error: "Tenant context unavailable" }, { status: 503 }),
+          if (isTenantContextPermissionError(tenantErr)) {
+            // Expected: the authenticated user role cannot set the
+            // app.current_clinic_id GUC (set_tenant_context is service_role-only).
+            // This is NOT a reason to fail closed — tenant isolation is enforced
+            // by RLS (get_user_clinic_id + the x-clinic-id tenant client), not by
+            // this best-effort session variable. Log at debug and continue.
+            logger.debug(
+              "Tenant GUC not set (expected for authenticated role); RLS enforces isolation",
+              {
+                context: "with-auth",
+                clinicId: profile.clinic_id,
+              },
             );
+          } else {
+            logger.error("Failed to set tenant context in withAuth", {
+              context: "with-auth",
+              clinicId: profile.clinic_id,
+              failOpen,
+              error: tenantErr,
+            });
+            if (!failOpen) {
+              return finalize(
+                NextResponse.json({ error: "Tenant context unavailable" }, { status: 503 }),
+              );
+            }
           }
         }
       }
@@ -383,16 +408,29 @@ export function withAuthAnyRole<RouteCtx = unknown>(
         try {
           await setTenantContext(supabase, profile.clinic_id);
         } catch (tenantErr) {
-          logger.error("Failed to set tenant context in withAuthAnyRole", {
-            context: "with-auth",
-            clinicId: profile.clinic_id,
-            failOpen,
-            error: tenantErr,
-          });
-          if (!failOpen) {
-            return finalize(
-              NextResponse.json({ error: "Tenant context unavailable" }, { status: 503 }),
+          if (isTenantContextPermissionError(tenantErr)) {
+            // Expected for the authenticated user role (set_tenant_context is
+            // service_role-only). RLS — not this GUC — enforces isolation, so
+            // continue instead of failing the request closed.
+            logger.debug(
+              "Tenant GUC not set (expected for authenticated role); RLS enforces isolation",
+              {
+                context: "with-auth-any-role",
+                clinicId: profile.clinic_id,
+              },
             );
+          } else {
+            logger.error("Failed to set tenant context in withAuthAnyRole", {
+              context: "with-auth",
+              clinicId: profile.clinic_id,
+              failOpen,
+              error: tenantErr,
+            });
+            if (!failOpen) {
+              return finalize(
+                NextResponse.json({ error: "Tenant context unavailable" }, { status: 503 }),
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
## What this fixes

Every authenticated, tenant-scoped API route (134 of 136 `withAuth`/`withAuthAnyRole` handlers) currently returns **HTTP 503 `Tenant context unavailable`** before the handler runs. This breaks the entire clinic dashboard in production.

### Root cause
`withAuth` calls `setTenantContext()` with the **authenticated user's** Supabase client. `set_tenant_context()` is `SECURITY DEFINER` **restricted to `service_role`** (confirmed on both staging and production), so the RPC always fails `permission denied` for normal users. `withAuth` is **fail-closed by default** (only 2 of 136 routes pass `failOpen: true`), so that expected failure becomes a hard 503.

The `app.current_clinic_id` GUC is best-effort defense-in-depth and is **not** the isolation mechanism. Real tenant isolation is enforced by RLS (`get_user_clinic_id()` and the `x-clinic-id` header used by `createTenantClient`). It is also architecturally ineffective over PostgREST (each call is a separate connection), so the 503 was pure breakage with no security benefit — most likely introduced during audit-hardening.

### The change
- `tenant-context.ts`: throw a typed `TenantContextPermissionError` specifically on `permission denied`.
- `with-auth.ts`: in both wrappers, treat that typed error as benign (log at debug, continue). **Genuine** failures still fail closed with 503. Detection is by error `name` so it survives module mocking + minification.
- `with-auth.test.ts`: regression test asserting permission-denied does **not** 503 (and the existing fail-closed tests still pass).

### Verification
- `tsc --noEmit`, ESLint, Prettier: clean on changed files.
- Unit: `with-auth` (20, incl. new test) + `healthcare-routes` (28) + `rbac-access-control` (17) = **65 passing**.
- Isolation re-proven against a real DB: the full live RLS/cross-tenant suite passes (100 tests); a clinic admin sees only their own data; a clinic session used on another tenant's subdomain → `403`; anonymous → `401`.

### Risk
Low. No isolation property is weakened (RLS unchanged). The only behavior change is that an *expected* permission-denied no longer fails the request closed.