### PR TITLE
fix(infra): set R2_BUCKET_NAME so uploads stop 503-ing

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -202,6 +202,13 @@ NODE_ENV = "production"
 # gdpr-purge, stripe-reconcile, dedup-purge) consult this to refuse to
 # run in staging unless ALLOW_STAGING_DESTRUCTIVE_CRONS=true is set.
 WORKER_ENV = "production"
+# Upload storage: R2 bucket name used by the presigned upload/download URL
+# signer (src/lib/r2.ts). The R2_* credentials are set as Worker secrets, but
+# R2_BUCKET_NAME is non-sensitive and was missing — without it
+# getR2PresignConfig() returns null, isR2Configured() is false, and every
+# /api/upload request 503s ("R2 storage not configured"). Must match the
+# UPLOADS_BUCKET binding's bucket_name below.
+R2_BUCKET_NAME = "webs-alots-uploads"
 # FIXED: KV binding now resolved correctly via getWorkerBinding().
 # Rate limiter is distributed, protected in production.
 RATE_LIMIT_BACKEND = "kv"
@@ -303,6 +310,9 @@ NODE_ENV = "production"
 # return 503 instead of running. Override on a per-Worker basis with
 # ALLOW_STAGING_DESTRUCTIVE_CRONS=true via wrangler secret.
 WORKER_ENV = "staging"
+# Upload storage: staging R2 bucket name for the presigned URL signer.
+# Mirrors the production block; must match the staging UPLOADS_BUCKET binding.
+R2_BUCKET_NAME = "webs-alots-uploads-staging"
 # FIXED: KV binding now resolved correctly via getWorkerBinding().
 RATE_LIMIT_BACKEND = "kv"
 # PHI masking must be "partial" in staging as well.


### PR DESCRIPTION
## What this fixes

Document, logo, and branding uploads return **503 "File storage is not configured"** for every clinic, and `/api/health` reports `r2: degraded`.

### Root cause
`isR2Configured()` → `getR2PresignConfig()` requires four values: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, **`R2_BUCKET_NAME`**. The first three are set as Worker secrets on `webs-alots`, but `R2_BUCKET_NAME` was set **nowhere** (not a secret, not in `[vars]`). Missing one of the four makes the presign config resolve to `null`, so `isR2Configured()` is `false` and the upload route 503s before doing anything. The `webs-alots-uploads` bucket itself already exists and is bound as `UPLOADS_BUCKET`.

### The change
Add `R2_BUCKET_NAME` to `[env.production.vars]` (`webs-alots-uploads`) and `[env.staging.vars]` (`webs-alots-uploads-staging`), matching the `UPLOADS_BUCKET` bindings. It's a non-sensitive bucket name, so it belongs in version-controlled config rather than as an undocumented secret (this also prevents it from being forgotten again).

### Effect after deploy
- `isR2Configured()` → `true`; `/api/health` r2 check → `ok`.
- Non-PHI uploads (clinic logos, branding, avatars) work.
- **PHI / clinical** upload categories additionally require `AV_SCAN_URL` (virus scanning) and stay correctly gated until that's configured — that's a separate compliance decision, not addressed here.

### Risk
Minimal. Adds one non-sensitive env var per environment; no code paths change. CI builds the worker with this config.