### PR TITLE
fix(infra): set ROOT_DOMAIN so clinic subdomains resolve in production

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -208,6 +208,18 @@ RATE_LIMIT_BACKEND = "kv"
 # PHI masking must be "partial" in production per SECURITY.md.
 NEXT_PUBLIC_DATA_MASKING = "partial"
 NEXT_PUBLIC_PLAUSIBLE_HOST = "plausible.io"
+# Tenant routing + cron self-invocation. Without ROOT_DOMAIN, extractSubdomain()
+# returns null for every *.oltigo.com host, so clinic subdomains (e.g.
+# demo.oltigo.com) collapse to the marketing site instead of resolving to a
+# tenant, and unknown subdomains never 404. The cron handler also derives its
+# self-base-URL from ROOT_DOMAIN, so without it scheduled jobs refuse to fire.
+ROOT_DOMAIN = "oltigo.com"
+# Seed-account safety. Verified 2026-06: zero seed users in production
+# auth.users / public.users (9 blocklist entries present). These flags only
+# silence the startup seed-guard warnings; the runtime block is the DB
+# seed_user_blocklist, unaffected by them.
+SEED_PASSWORDS_ROTATED = "true"
+SEED_USERS_DELETED = "true"
 
 [[env.production.queues.producers]]
 binding = "NOTIFICATION_QUEUE"
@@ -308,6 +320,8 @@ RATE_LIMIT_BACKEND = "kv"
 # PHI masking must be "partial" in staging as well.
 NEXT_PUBLIC_DATA_MASKING = "partial"
 NEXT_PUBLIC_PLAUSIBLE_HOST = "plausible.io"
+# Tenant routing on the staging host: clinic.staging.oltigo.com -> "clinic".
+ROOT_DOMAIN = "staging.oltigo.com"
 
 # INF-003: Staging uses a separate R2 bucket to prevent cross-environment
 # PHI contamination. Create with: wrangler r2 bucket create webs-alots-uploads-staging


### PR DESCRIPTION
## What this fixes

`ROOT_DOMAIN` is unset on the deployed workers, and `extractRawSubdomain()` returns `null` for any non-localhost host when `rootDomain` is undefined. As a result **every `*.oltigo.com` subdomain collapses to the marketing site** instead of resolving to a tenant clinic, and unknown subdomains never return the intended hard 404.

**Verified live (before this change):**

| Host | Result |
|---|---|
| `oltigo.com` | marketing homepage (200, 125,621 B) |
| `demo.oltigo.com` | **same** marketing homepage (200, 125,622 B) |
| `nonexistent-clinic-xyz.oltigo.com` | **same** marketing homepage (should 404) |

The cron handler (`worker-cron-handler.ts`) also derives its self-invocation base URL from `ROOT_DOMAIN` (`https://${ROOT_DOMAIN}`), so scheduled jobs were refusing to fire without it.

### Change
- `[env.production.vars]` → `ROOT_DOMAIN = "oltigo.com"`
- `[env.staging.vars]` → `ROOT_DOMAIN = "staging.oltigo.com"`
- `[env.production.vars]` → `SEED_PASSWORDS_ROTATED` / `SEED_USERS_DELETED = "true"` (verified zero seed users in prod; only silences the startup seed-guard warnings — the real block is the DB `seed_user_blocklist`).

### Effect after deploy
- Clinic subdomains resolve to their tenant; unknown subdomains 404 as intended.
- Crons can fire.
- No change to the root domain / marketing site.