### PR TITLE
fix(ai): revive CopilotKit endpoint (provider + auth_id bug) + provision FEATURE_FLAGS_KV

### DIFF
--- a/workers/ai/src/handlers/copilotkit.ts
+++ b/workers/ai/src/handlers/copilotkit.ts
@@ -25,28 +25,55 @@ let cachedRuntimeModule: any = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let cachedServiceAdapter: any = null;
 
-async function loadRuntime() {
+async function loadRuntime(env: Env) {
   if (cachedRuntimeModule) {
     return { runtimeModule: cachedRuntimeModule, serviceAdapter: cachedServiceAdapter };
   }
   // Dynamic import — see header comment.
   const runtimeModule = await import("@copilotkit/runtime");
-  const serviceAdapter = new runtimeModule.AnthropicAdapter();
+
+  // Provider selection (handler guard guarantees at least one key is set):
+  //   • OPENAI_API_KEY → OpenAI-compatible adapter. Works with ANY
+  //     OpenAI-compatible endpoint via OPENAI_BASE_URL (e.g. mimo, OpenAI,
+  //     groq). OPENAI_MODEL selects the model id.
+  //   • else ANTHROPIC_API_KEY → original Anthropic adapter.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let serviceAdapter: any;
+  if (env.OPENAI_API_KEY) {
+    const { default: OpenAI } = await import("openai");
+    const openai = new OpenAI({
+      apiKey: env.OPENAI_API_KEY,
+      ...(env.OPENAI_BASE_URL ? { baseURL: env.OPENAI_BASE_URL } : {}),
+    });
+    serviceAdapter = new runtimeModule.OpenAIAdapter({
+      openai,
+      ...(env.OPENAI_MODEL ? { model: env.OPENAI_MODEL } : {}),
+    });
+  } else {
+    serviceAdapter = new runtimeModule.AnthropicAdapter();
+  }
+
   cachedRuntimeModule = runtimeModule;
   cachedServiceAdapter = serviceAdapter;
   return { runtimeModule, serviceAdapter };
 }
 
 export async function handleCopilotKit(request: Request, env: Env): Promise<Response> {
-  if (!env.ANTHROPIC_API_KEY) {
-    return jsonResponse({ error: "ANTHROPIC_API_KEY is not configured on webs-alots-ai" }, 500);
+  if (!env.OPENAI_API_KEY && !env.ANTHROPIC_API_KEY) {
+    return jsonResponse(
+      {
+        error:
+          "No AI provider configured on webs-alots-ai (set OPENAI_API_KEY [+ OPENAI_BASE_URL/OPENAI_MODEL] or ANTHROPIC_API_KEY)",
+      },
+      500,
+    );
   }
 
   const authResult = await requireSuperAdmin(request, env);
   if (!authResult.ok) return authResult.response;
   const { userId, userEmail } = authResult;
 
-  const { runtimeModule, serviceAdapter } = await loadRuntime();
+  const { runtimeModule, serviceAdapter } = await loadRuntime(env);
   const { CopilotRuntime, copilotRuntimeNextJSAppRouterEndpoint } = runtimeModule;
 
   const runtime = new CopilotRuntime({

--- a/workers/ai/src/lib/supabase.ts
+++ b/workers/ai/src/lib/supabase.ts
@@ -117,9 +117,20 @@ export async function requireSuperAdmin(
   }
 
   // super_admin users have no clinic_id; this query fetches the calling
-  // user's own role, scoped by their auth UID. (Mirrors the // nosemgrep
-  // annotation in the original handler.)
-  const { data: profile } = await supabase.from("users").select("role").eq("id", user.id).single();
+  // user's own role, scoped by their auth UID.
+  //
+  // BUGFIX: the auth UID (auth.users.id / user.id) maps to the public.users
+  // `auth_id` column, NOT the `users.id` primary key. Querying `.eq("id",
+  // user.id)` matched zero rows for every account (no row has id == auth_id),
+  // so this returned 403 Forbidden for ALL callers — including valid
+  // super_admins — silently breaking the CopilotKit endpoint even when keys
+  // were configured. The rest of the app (with-auth.ts, AgentWidgetMount)
+  // correctly keys on `auth_id`.
+  const { data: profile } = await supabase
+    .from("users")
+    .select("role")
+    .eq("auth_id", user.id)
+    .single();
 
   if (profile?.role !== "super_admin") {
     return {

--- a/workers/ai/src/lib/supabase.ts
+++ b/workers/ai/src/lib/supabase.ts
@@ -29,6 +29,8 @@ export interface Env {
   ANTHROPIC_API_KEY?: string; // consumed by the CopilotKit runtime
   GOOGLE_GENERATIVE_AI_API_KEY?: string;
   OPENAI_API_KEY?: string;
+  OPENAI_BASE_URL?: string; // OpenAI-compatible endpoint (e.g. mimo)
+  OPENAI_MODEL?: string; // model id for the OpenAI-compatible provider
   DEEPSEEK_API_KEY?: string;
   MISTRAL_API_KEY?: string;
   XAI_API_KEY?: string;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -74,6 +74,14 @@ binding = "RATE_LIMIT_KV"
 id = "7ac37dff0a794542b0c766f38e73f105"
 preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
 
+# FEATURE_FLAGS_KV — backs super-admin feature toggles (e.g. ai.enabled global
+# kill switch). Without this binding, PUT /api/super-admin/feature-flags returns
+# 503 KV_UNAVAILABLE and the toggle silently fails in the UI. Namespace
+# provisioned 2026-06 to fix that.
+[[kv_namespaces]]
+binding = "FEATURE_FLAGS_KV"
+id = "223443c0631c4046b72ca8426f733f3c"
+
 # O4 (DEFERRED — provisioning task, not code): Application cache for clinic
 # configs, feature flags, AI status. features.ts prefers this namespace and
 # falls back to a direct Supabase read when the binding is absent, so leaving
@@ -249,6 +257,12 @@ bucket_name = "webs-alots-uploads"
 binding = "RATE_LIMIT_KV"
 id = "7ac37dff0a794542b0c766f38e73f105"
 preview_id = "854c78ea8c9442ed8706d3ec31fe292e"
+
+# FEATURE_FLAGS_KV (production) — see top-level note. Required so the
+# super-admin global AI kill-switch toggle persists instead of 503-ing.
+[[env.production.kv_namespaces]]
+binding = "FEATURE_FLAGS_KV"
+id = "223443c0631c4046b72ca8426f733f3c"
 
 # Uncomment after provisioning APP_CACHE_KV for production:
 # [[env.production.kv_namespaces]]


### PR DESCRIPTION
## What this fixes

### 1. CopilotKit AI endpoint was returning 500 for everyone (two stacked bugs)
- **No provider key** → handler hard-failed on `ANTHROPIC_API_KEY`. Now supports any **OpenAI-compatible** provider via `OPENAI_API_KEY` + `OPENAI_BASE_URL` + `OPENAI_MODEL` (deployed pointing at mimo / `mimo-v2.5-pro`).
- **Auth bug (the important one):** `requireSuperAdmin` looked the caller up with `.eq("id", user.id)`, but the Supabase auth UID maps to the **`auth_id`** column — **0 of 50 users** have `id == auth_id`. So it returned **403 Forbidden to every caller, including valid super-admins**, even once a key was set. Fixed to `.eq("auth_id", user.id)`, matching `with-auth.ts` / `AgentWidgetMount`.

Verified live on `webs-alots-ai`: endpoint went `500 (no key)` → `401 (unauth)` → authenticates super-admin → reaches the CopilotKit runtime.

### 2. `FEATURE_FLAGS_KV` was never provisioned
The super-admin **Global AI kill-switch** toggle wrote to a KV namespace that didn't exist → `503 KV_UNAVAILABLE` (silent fail in the UI). Created the namespace and bound it in `wrangler.toml` (top-level + production).

## Why merge matters
The Deploy workflow ships `webs-alots-ai` from `main`. The CopilotKit fix above was hot-deployed to keep the endpoint alive, but **will be reverted on the next `main` deploy unless merged.** Merging makes it permanent and ships the KV binding through the normal pipeline. (Provider secrets are already set on the worker and persist across deploys.)

## Notes / not included
- Did **not** touch main-app code paths — only `workers/ai/*` and `wrangler.toml`.
- All 1924 unit tests pass; typecheck + lint clean; pre-commit (eslint/prettier/gitleaks) green.