### PR TITLE
fix(login): force-play hero video so it actually loops

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { HeroVideo } from "@/components/hero-video";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { t, type Locale } from "@/lib/i18n";
 
@@ -59,18 +60,10 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
       {/* ── Left hero panel (hidden on mobile) ── */}
       <div className="relative hidden lg:flex lg:w-[480px] xl:w-[520px] flex-col justify-between overflow-hidden bg-gradient-to-br from-[#005a3b] via-[#00795a] to-[#009e74] text-white">
         {/* Looping background video (decorative). The container gradient acts as
-            a fallback while the video loads or if autoplay is blocked. */}
-        <video
-          className="pointer-events-none absolute inset-0 z-0 h-full w-full object-cover motion-reduce:hidden"
-          autoPlay
-          loop
-          muted
-          playsInline
-          preload="metadata"
-          aria-hidden="true"
-        >
-          <source src="/login-bg.mp4" type="video/mp4" />
-        </video>
+            a fallback while the video loads or if autoplay is blocked.
+            HeroVideo is a client component that force-plays the muted loop so
+            it doesn't sit frozen on browsers that block silent autoplay. */}
+        <HeroVideo />
         {/* Brand tint over the video: light enough to let the loop show
             clearly, with a stronger bottom scrim so the white text and
             feature copy stay legible over the brighter video frames. */}

--- a/src/components/hero-video.tsx
+++ b/src/components/hero-video.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Decorative looping background video for the auth hero panel.
+ *
+ * Rendered as a client component so playback can be forced: several desktop
+ * browsers refuse muted autoplay until the page explicitly calls play(),
+ * which otherwise leaves a frozen first frame ("static") on screen. We also
+ * retry on the first user interaction and whenever the tab becomes visible
+ * again.
+ *
+ * The element stays `aria-hidden` + `muted`, so it contributes no audio and
+ * is exempt from the axe `video-caption` rule enforced by
+ * e2e/accessibility.spec.ts. It is intentionally NOT hidden under
+ * prefers-reduced-motion: the looping brand video is the requested effect.
+ */
+export function HeroVideo() {
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = ref.current;
+    if (!video) return;
+
+    video.muted = true;
+
+    const play = () => {
+      void video.play().catch(() => {
+        // Autoplay blocked by the browser; we retry on interaction below.
+      });
+    };
+
+    play();
+
+    const resume = () => play();
+    window.addEventListener("pointerdown", resume, { once: true });
+    document.addEventListener("visibilitychange", play);
+
+    return () => {
+      window.removeEventListener("pointerdown", resume);
+      document.removeEventListener("visibilitychange", play);
+    };
+  }, []);
+
+  return (
+    <video
+      ref={ref}
+      className="pointer-events-none absolute inset-0 z-0 h-full w-full object-cover"
+      autoPlay
+      loop
+      muted
+      playsInline
+      preload="auto"
+      aria-hidden="true"
+    >
+      <source src="/login-bg.mp4" type="video/mp4" />
+    </video>
+  );
+}


### PR DESCRIPTION
Follow-up to #1181/#1182. Users reported the hero video showing as a static frame.

Two causes:
1. **Silent-autoplay block** — some desktop browsers won't start a muted video until play() is called explicitly, leaving a frozen first frame.
2. **prefers-reduced-motion** — the earlier motion-reduce:hidden hid the video entirely, so anyone with Reduce Motion enabled saw only the gradient (i.e. no change at all across deploys).

Fix: extract the video into a small client component (HeroVideo) that force-plays on mount, retries on first interaction and on tab visibility change; drop the reduced-motion hide; preload=auto so playback can start. Stays aria-hidden + muted → no new axe video-caption violations on the login a11y audit.