### PR TITLE
fix: correct misleading geo-block diagnoses on super-admin AI surfaces

### DIFF
--- a/src/app/(admin)/admin/ai-team/page.tsx
+++ b/src/app/(admin)/admin/ai-team/page.tsx
@@ -779,6 +779,11 @@ function AITeamDashboard() {
             <p className="text-xs text-muted-foreground">
               Votre équipe virtuelle d&apos;agents IA pour gérer votre clinique
             </p>
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              Les agents actifs au quotidien de votre clinique (Marketing, Support, Rappels). Le
+              catalogue des capacités IA de la plateforme se trouve dans «&nbsp;AI Agents&nbsp;»
+              côté super-admin.
+            </p>
           </div>
         </div>
         <div className="flex items-center gap-2">

--- a/src/app/(super-admin)/super-admin/agents/page.tsx
+++ b/src/app/(super-admin)/super-admin/agents/page.tsx
@@ -137,6 +137,12 @@ export default function AIAgentsPage() {
           <p className="text-sm text-muted-foreground mt-1">
             Platform AI capabilities available to {clinicCount > 0 ? clinicCount : "all"} clinics
           </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            This is the platform-wide capability catalogue (what AI features exist and their
+            rollout status). For the live per-clinic AI team that runs day to day (Marketing,
+            Support, Reminder), see <span className="font-medium">AI Team</span> in the clinic
+            admin area.
+          </p>
         </div>
       </div>
 

--- a/src/app/(super-admin)/super-admin/agents/page.tsx
+++ b/src/app/(super-admin)/super-admin/agents/page.tsx
@@ -138,10 +138,9 @@ export default function AIAgentsPage() {
             Platform AI capabilities available to {clinicCount > 0 ? clinicCount : "all"} clinics
           </p>
           <p className="text-xs text-muted-foreground mt-1">
-            This is the platform-wide capability catalogue (what AI features exist and their
-            rollout status). For the live per-clinic AI team that runs day to day (Marketing,
-            Support, Reminder), see <span className="font-medium">AI Team</span> in the clinic
-            admin area.
+            This is the platform-wide capability catalogue (what AI features exist and their rollout
+            status). For the live per-clinic AI team that runs day to day (Marketing, Support,
+            Reminder), see <span className="font-medium">AI Team</span> in the clinic admin area.
           </p>
         </div>
       </div>

--- a/src/app/(super-admin)/super-admin/marketplace/page.tsx
+++ b/src/app/(super-admin)/super-admin/marketplace/page.tsx
@@ -36,6 +36,12 @@ const CATEGORY_COLORS: Record<string, string> = {
 export default function MarketplacePage() {
   const [features, setFeatures] = useState<Feature[]>([]);
   const [loading, setLoading] = useState(true);
+  // Distinguishes a geo-restricted 403 (the catalogue *can't be read* from
+  // here) from a genuinely empty catalogue (seed not applied). Without this,
+  // an admin reading from outside Morocco sees "the seed likely hasn't been
+  // applied" — a misdiagnosis, since the same feature_definitions table is
+  // read fine by the (non-geo-fenced) server actions on the Features page.
+  const [accessBlocked, setAccessBlocked] = useState(false);
   const [search, setSearch] = useState("");
   const [catFilter, setCatFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState<"all" | "enabled" | "disabled">("all");
@@ -44,8 +50,17 @@ export default function MarketplacePage() {
   const { addToast } = useToast();
 
   const loadFeatures = useCallback(async () => {
+    setAccessBlocked(false);
     try {
       const res = await fetch("/api/admin/marketplace");
+      // 403 here is the admin geo-restriction, not an empty catalogue.
+      if (res.status === 403) {
+        setAccessBlocked(true);
+        logger.warn("Marketplace catalogue is geo-restricted from this location", {
+          context: "marketplace-page",
+        });
+        return;
+      }
       const json = await res.json();
       if (json.ok) {
         setFeatures(json.data.features);
@@ -291,6 +306,23 @@ export default function MarketplacePage() {
           <Loader2 className="h-6 w-6 animate-spin inline mr-2" />
           Loading features...
         </div>
+      ) : accessBlocked ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <Package className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+            <p className="text-sm font-medium">Catalogue unavailable from this location</p>
+            <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+              Admin endpoints are geo-restricted to Morocco, so the marketplace catalogue
+              couldn&apos;t be read from here. This does <strong>not</strong> mean the catalogue is
+              empty or that the <span className="font-mono">feature_definitions</span> seed is
+              missing — the data is read normally from an allowed location. Retry from Morocco, or
+              use the emergency-access path.
+            </p>
+            <Button variant="outline" size="sm" className="mt-4" onClick={() => loadFeatures()}>
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
       ) : features.length === 0 ? (
         <Card>
           <CardContent className="py-12 text-center">

--- a/src/app/(super-admin)/super-admin/settings/ai/emergency-stop.tsx
+++ b/src/app/(super-admin)/super-admin/settings/ai/emergency-stop.tsx
@@ -23,6 +23,44 @@ interface KillSwitchState {
 }
 
 /**
+ * Last-known kill-switch state, persisted to localStorage. When the live
+ * status check fails, an admin should not be acting fully blind: we surface
+ * the most recent confirmed state (and when it was seen) alongside the
+ * degraded notice, while still making the unknown state loud.
+ */
+const LAST_KNOWN_KEY = "oltigo:ai-kill-switch:last-known";
+
+interface LastKnown {
+  ai_enabled: boolean;
+  at: string; // ISO timestamp of when this state was last confirmed
+}
+
+function readLastKnown(): LastKnown | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(LAST_KNOWN_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<LastKnown>;
+    if (typeof parsed.ai_enabled !== "boolean" || typeof parsed.at !== "string") return null;
+    return { ai_enabled: parsed.ai_enabled, at: parsed.at };
+  } catch {
+    return null;
+  }
+}
+
+function writeLastKnown(ai_enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      LAST_KNOWN_KEY,
+      JSON.stringify({ ai_enabled, at: new Date().toISOString() }),
+    );
+  } catch {
+    // Storage unavailable (private mode / quota) — degrade silently.
+  }
+}
+
+/**
  * Emergency AI kill switch.
  *
  * Stops ALL AI traffic platform-wide by flipping the `ai.enabled` flag in
@@ -34,10 +72,16 @@ export function EmergencyStop() {
   const { addToast } = useToast();
   const [state, setState] = useState<KillSwitchState | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
+  const [lastKnown, setLastKnown] = useState<LastKnown | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [forceStopOpen, setForceStopOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
   const [working, setWorking] = useState(false);
+
+  // Hydrate last-known state on mount so a first-load failure still has context.
+  useEffect(() => {
+    setLastKnown(readLastKnown());
+  }, []);
 
   const fetchState = useCallback(async () => {
     setLoadFailed(false);
@@ -46,6 +90,9 @@ export function EmergencyStop() {
       const json = (await res.json()) as { ok: boolean; data?: KillSwitchState };
       if (res.ok && json.ok && json.data) {
         setState(json.data);
+        // Persist the confirmed state so a later failure isn't fully blind.
+        writeLastKnown(json.data.ai_enabled);
+        setLastKnown({ ai_enabled: json.data.ai_enabled, at: new Date().toISOString() });
       } else {
         // Resolve to a failed state so the section never spins forever.
         setLoadFailed(true);
@@ -73,6 +120,10 @@ export function EmergencyStop() {
           enabled ? "AI re-enabled platform-wide" : "EMERGENCY STOP — all AI is now disabled",
           enabled ? "success" : "error",
         );
+        // The flip itself is a confirmed state transition — record it even if
+        // the follow-up status read later fails.
+        writeLastKnown(enabled);
+        setLastKnown({ ai_enabled: enabled, at: new Date().toISOString() });
         setDialogOpen(false);
         setForceStopOpen(false);
         setConfirmText("");
@@ -104,6 +155,28 @@ export function EmergencyStop() {
                     You can still force a stop below, or set the{" "}
                     <span className="font-mono">AI_DISABLED</span> environment variable.
                   </p>
+                  {lastKnown ? (
+                    <p className="mt-1 text-xs">
+                      <span className="text-muted-foreground">Last confirmed state: </span>
+                      <span
+                        className={
+                          lastKnown.ai_enabled
+                            ? "font-medium text-green-600 dark:text-green-400"
+                            : "font-medium text-destructive"
+                        }
+                      >
+                        {lastKnown.ai_enabled ? "AI was ENABLED" : "AI was STOPPED"}
+                      </span>
+                      <span className="text-muted-foreground">
+                        {" "}
+                        as of {new Date(lastKnown.at).toLocaleString()} (may be stale).
+                      </span>
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      No previously confirmed state is cached on this device.
+                    </p>
+                  )}
                 </div>
               </div>
               <div className="flex items-center gap-2">

--- a/src/app/(super-admin)/super-admin/settings/ai/emergency-stop.tsx
+++ b/src/app/(super-admin)/super-admin/settings/ai/emergency-stop.tsx
@@ -72,16 +72,14 @@ export function EmergencyStop() {
   const { addToast } = useToast();
   const [state, setState] = useState<KillSwitchState | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
-  const [lastKnown, setLastKnown] = useState<LastKnown | null>(null);
+  // Lazy initializer hydrates the last-known state from localStorage on first
+  // render (client-side; readLastKnown returns null under SSR). Doing it here
+  // rather than in an effect avoids a synchronous setState-in-effect.
+  const [lastKnown, setLastKnown] = useState<LastKnown | null>(() => readLastKnown());
   const [dialogOpen, setDialogOpen] = useState(false);
   const [forceStopOpen, setForceStopOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
   const [working, setWorking] = useState(false);
-
-  // Hydrate last-known state on mount so a first-load failure still has context.
-  useEffect(() => {
-    setLastKnown(readLastKnown());
-  }, []);
 
   const fetchState = useCallback(async () => {
     setLoadFailed(false);


### PR DESCRIPTION
## What this fixes

Follow-up to the second (super-admin / AI) review. This PR ships the fixes that are **clean and correct without a product decision**. Crucially, two of the review's findings turned out to be **misdiagnoses caused by the geo-block**, not the bugs they looked like.

> **Note on console noise:** the review's "raw 403s / `Failed to load clinics` dumped at error level" findings are **already addressed** by the logger-level fix in the footer/CSP PR (#1184). That code already calls `logger.warn`; it only *looked* like an error because `logger.emit()` was routing everything to `console.error`. No change needed here.

### 1. 🟠 Marketplace "0 features / seed not applied" was a false alarm
Marketplace and Fonctionnalités read the **same** `feature_definitions` table. They disagreed (0 vs 58) only because:
- **Fonctionnalités** uses a **server action** (`fetchFeatureDefinitions` → `rawClient()`) — runs server-side, **not** geo-fenced.
- **Marketplace** fetches `/api/admin/marketplace`, which the middleware **403-blocks outside Morocco**.

So from outside Morocco the marketplace got a 403 → 0 features → then wrongly told the admin **"the seed likely hasn't been applied."** The 58 from Fonctionnalités proves the seed **is** applied.

**Fix:** the page now detects the 403, shows a *"catalogue is geo-restricted from this location"* message with a **Retry**, and only shows the seed-missing copy on a genuine empty result.

### 2. 🔴 AI kill switch: don't leave an admin acting fully blind
When the live status read fails, the degraded card said only *"status unknown."* It now **persists the last confirmed state + timestamp to localStorage** and surfaces it in the degraded notice — so the admin sees the most recent known state, clearly labelled "may be stale," while the unknown state stays loud.

`Force emergency stop` **stays clickable by design** — a safety stop must work precisely when you *can't* read state. (State is persisted on every successful status read and on every flip.)

### 3. 🟡 AI Agents vs Équipe IA: clarified, not merged
These are two **intentionally different** surfaces:
- Super-admin **AI Agents** = platform capability catalogue (what exists, rollout status).
- Admin **Équipe IA** = the live per-clinic runtime (Marketing / Support / Reminder).

Added a **one-line cross-reference** to each so admins know which is authoritative. Unifying the agent model is a roadmap decision and is **deliberately not done here** — guessing a merge would risk the working `/api/ai/team/*` runtime.

## Deliberately out of scope (own PRs)
- **Trusted-admin geo bypass** so `/api/admin/*` works while travelling / on VPN. This punches a hole in a deliberate **Loi 09-08 compliance control** and must be reviewed in isolation, not bundled into a hygiene PR.
- **Unifying the two agent models** into one canonical source — needs an owner decision on which model is authoritative.

## Testing notes
- All four changed files transpile cleanly.
- No new imports required (`Button` already present in marketplace).
- localStorage access is guarded for SSR and private-mode/quota failures.
