### PR TITLE
fix: clarify MRR vs billed revenue and harden pricing page load

### DIFF
--- a/src/app/(super-admin)/super-admin/billing/page.tsx
+++ b/src/app/(super-admin)/super-admin/billing/page.tsx
@@ -344,20 +344,26 @@ export default function BillingPage() {
               <CardContent className="p-4">
                 <div className="flex items-center gap-2 mb-2">
                   <TrendingUp className="h-4 w-4 text-green-600" />
-                  <span className="text-xs text-muted-foreground">MRR (facturé)</span>
+                  <span className="text-xs text-muted-foreground">Facturé ce mois</span>
                 </div>
                 <p className="text-2xl font-bold">{formatNumber(mrr)}</p>
-                <p className="text-xs text-muted-foreground">MAD / mois</p>
+                <p className="text-xs text-muted-foreground">
+                  MAD — total facturé, pas le MRR. Voir{" "}
+                  <a href="/super-admin/subscriptions" className="underline hover:text-foreground">
+                    Abonnements
+                  </a>{" "}
+                  pour le MRR récurrent.
+                </p>
               </CardContent>
             </Card>
             <Card>
               <CardContent className="p-4">
                 <div className="flex items-center gap-2 mb-2">
                   <DollarSign className="h-4 w-4 text-blue-600" />
-                  <span className="text-xs text-muted-foreground">ARR</span>
+                  <span className="text-xs text-muted-foreground">Facturé annualisé</span>
                 </div>
                 <p className="text-2xl font-bold">{formatNumber(arr)}</p>
-                <p className="text-xs text-muted-foreground">MAD / an</p>
+                <p className="text-xs text-muted-foreground">MAD / an (facturé × 12)</p>
               </CardContent>
             </Card>
             <Card>

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -160,30 +160,40 @@ export default function PricingPage() {
   const [deletePromoOpen, setDeletePromoOpen] = useState(false);
   const [deletePromoItem, setDeletePromoItem] = useState<Promotion | null>(null);
 
-  const loadData = useCallback(async () => {
-    try {
-      const [subs, tiersData, togglesData, promosData] = await Promise.all([
-        fetchClientSubscriptions(),
-        fetchPricingTiers(),
-        fetchFeatureToggles(),
-        fetchPromotions(),
-      ]);
-      setSubscriptions(subs);
-      setTiers(tiersData);
-      setToggles(togglesData);
-      setPromotions(promosData);
-    } catch (err) {
-      logger.warn("Failed to load pricing page", { context: "page", error: err });
-    } finally {
-      setLoading(false);
-    }
+  const loadData = useCallback(async (isActive: () => boolean) => {
+    // Each section loads independently: a single slow or failing action must not
+    // blank the whole page or flash a misleading "Failed to load" — we render
+    // whatever resolved and only warn on the parts that didn't. isActive() guards
+    // against applying results after the component has unmounted.
+    const [subsRes, tiersRes, togglesRes, promosRes] = await Promise.allSettled([
+      fetchClientSubscriptions(),
+      fetchPricingTiers(),
+      fetchFeatureToggles(),
+      fetchPromotions(),
+    ]);
+    if (!isActive()) return;
+
+    if (subsRes.status === "fulfilled") setSubscriptions(subsRes.value);
+    else logger.warn("Failed to load subscriptions", { context: "page", error: subsRes.reason });
+
+    if (tiersRes.status === "fulfilled") setTiers(tiersRes.value);
+    else logger.warn("Failed to load pricing tiers", { context: "page", error: tiersRes.reason });
+
+    if (togglesRes.status === "fulfilled") setToggles(togglesRes.value);
+    else
+      logger.warn("Failed to load feature toggles", { context: "page", error: togglesRes.reason });
+
+    if (promosRes.status === "fulfilled") setPromotions(promosRes.value);
+    else logger.warn("Failed to load promotions", { context: "page", error: promosRes.reason });
+
+    setLoading(false);
   }, []);
 
   useEffect(() => {
-    const controller = new AbortController();
-    loadData();
+    let active = true;
+    loadData(() => active);
     return () => {
-      controller.abort();
+      active = false;
     };
   }, [loadData]);
 
@@ -496,10 +506,10 @@ export default function PricingPage() {
           <CardContent className="p-4">
             <div className="flex items-center gap-2 mb-2">
               <DollarSign className="h-4 w-4 text-green-600" />
-              <span className="text-xs text-muted-foreground">MRR (abonnements actifs)</span>
+              <span className="text-xs text-muted-foreground">MRR</span>
             </div>
             <p className="text-2xl font-bold">{formatNumber(mrr)}</p>
-            <p className="text-xs text-muted-foreground">MAD / mois</p>
+            <p className="text-xs text-muted-foreground">MAD / mois — abonnements actifs</p>
           </CardContent>
         </Card>
         <Card>

--- a/src/app/(super-admin)/super-admin/subscriptions/page.tsx
+++ b/src/app/(super-admin)/super-admin/subscriptions/page.tsx
@@ -513,10 +513,12 @@ export default function SubscriptionsPage() {
           <CardContent className="p-4">
             <div className="flex items-center gap-2 mb-2">
               <CreditCard className="h-4 w-4 text-green-600" />
-              <span className="text-xs text-muted-foreground">MRR (abonnements actifs)</span>
+              <span className="text-xs text-muted-foreground">MRR</span>
             </div>
             <p className="text-2xl font-bold">{formatNumber(mrr)}</p>
-            <p className="text-xs text-muted-foreground">MAD / mois</p>
+            <p className="text-xs text-muted-foreground">
+              MAD / mois — abonnements actifs (réf. revenus récurrents)
+            </p>
           </CardContent>
         </Card>
         <Card>


### PR DESCRIPTION
## What this fixes

Follow-up to the REVENUS / super-admin audit. Two issues, both about **trust in the dashboard** rather than broken functionality.

### 1. 🔴 MRR disagreed across pages (the 17x gap)

Three pages showed different MRR:
- **Facturation** computed it from issued **invoices** (300 MAD — only 1 invoice exists), labelled "MRR (facturé)".
- **Abonnements** and **Tarifs & Offres** compute from **active subscriptions** (5,296 MAD), identical formula.

Both definitions are defensible, but a super-admin glancing across pages sees revenue off by 17x and loses trust in all of it. Since **MRR is a recurring-revenue metric**, subscription MRR is the honest canonical figure; the invoice number is really *cashflow* (what we billed this period), not MRR.

**Change — labels only, no numbers or formulas touched:**
- Facturation: `MRR (facturé)` → **`Facturé ce mois`** with a one-line note + link to Abonnements for the recurring figure. ARR card → **`Facturé annualisé (facturé × 12)`**.
- Abonnements / Tarifs: `MRR (abonnements actifs)` → **`MRR`** with a basis caption, so they read as the authoritative source.

### 2. 🟡 Pricing page slow load + "Failed to load" flash

`loadData` ran four server actions in a single `Promise.all`. If **any one** was slow or rejected, the whole batch failed: the page blanked and flashed "Failed to load pricing page" before recovering. That's the transient error seen in the audit.

**Change:**
- `Promise.all` → **`Promise.allSettled`**: each section (subscriptions, tiers, toggles, promotions) applies independently; only the failing part logs a warning, the rest still render.
- Replaced the **no-op `AbortController`** (the server actions take no `signal`) with an `isActive()` guard that prevents post-unmount state updates.

---

## Notes for the reviewer (no code change in this PR)

**The "74% suspended" subscriptions are quarantined junk, not churn.** The `aagmzzd` / `-Admin--Admin-` style records are exactly the keyboard-mash tenants that migration **`00173_quarantine_known_junk_tenants.sql`** already suspended (reversibly, by setting `status = 'suspended'`). They're correctly **excluded from MRR** (the active/past_due filter skips them), so the 5,296 figure is clean — but they still inflate the *suspended* count and the 74% rate. If you want, a follow-up can visually separate "quarantined" from real suspensions on the Abonnements page so that number stops looking alarming. Left out here to keep this PR focused.

**Geo-403 console noise:** the referrals/usage/usage-dashboard pages already log via `logger.warn` (fixed in the prior PR). The remaining raw red `403`s in the console are emitted by the **browser's own network logging** and cannot be suppressed from JS — the only real fix is the trusted-admin geo-bypass, which deserves its own security-scoped PR.

## Test plan
- [ ] Facturation: card reads "Facturé ce mois" with working link to Abonnements; ARR card reads "Facturé annualisé".
- [ ] Abonnements & Tarifs: card reads "MRR" with basis caption; value unchanged (5,296).
- [ ] Tarifs & Offres: page still renders if one underlying action is slow/fails (no full-page "Failed to load" flash).
