### PR TITLE
fix(deploy): gate R2 incremental cache so wrangler deploy succeeds before bucket exists

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -7,19 +7,46 @@ import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-
  *
  * Audit R-8: `next.config.ts` enables `experimental.useCache`, but without an
  * `incrementalCache` override OpenNext uses a no-op cache — so `"use cache"`
- * segments and ISR produced nothing durable across Worker isolates (cache was
- * effectively dead). We wire the R2-backed incremental cache so cached entries
- * persist in object storage and are shared across all isolates, fronted by the
- * per-isolate regional cache to cut read latency.
+ * segments and ISR produce nothing durable across Worker isolates. The R2-backed
+ * incremental cache (fronted by the per-isolate regional cache) fixes that by
+ * persisting entries in object storage shared across all isolates.
  *
- * The R2 adapter reads the `NEXT_INC_CACHE_R2_BUCKET` binding and degrades
- * gracefully (IgnorableError → behaves as no-op) if that binding is absent, so
- * this change is safe to ship before the bucket is provisioned. Activate real
- * caching by adding the `NEXT_INC_CACHE_R2_BUCKET` R2 binding in wrangler.toml
- * (documented there) and creating the bucket.
+ * DEPLOY-TIME GATE — why this is behind a flag
+ * --------------------------------------------
+ * `r2IncrementalCache` reads the `NEXT_INC_CACHE_R2_BUCKET` binding. Its "degrades
+ * gracefully when the binding is absent" behaviour only applies at REQUEST time
+ * (a missing binding raises an IgnorableError that the runtime treats as a no-op).
+ * At DEPLOY time it is NOT graceful: `opennextjs-cloudflare deploy` runs a
+ * `populate-cache` step that hard-throws
+ *
+ *     Error: No R2 binding "NEXT_INC_CACHE_R2_BUCKET" found!
+ *
+ * whenever the override is configured but the binding / bucket has not been
+ * provisioned. wrangler.toml intentionally ships that binding commented out
+ * (the dedicated bucket must be created first — it must NOT reuse the PHI
+ * UPLOADS_BUCKET), so wiring the override unconditionally made every
+ * `wrangler deploy` fail. That is the deploy failure this gate resolves.
+ *
+ * Default (flag unset): OpenNext's built-in no-op cache — matches the
+ * "safe to ship before the bucket is provisioned" intent documented in
+ * wrangler.toml, and lets `wrangler deploy` succeed.
+ *
+ * To ACTIVATE durable caching (all three must be done together, in one deploy):
+ *   1. wrangler r2 bucket create webs-alots-next-cache   (+ -staging variant)
+ *   2. Uncomment the NEXT_INC_CACHE_R2_BUCKET r2_buckets blocks in wrangler.toml
+ *      (top level AND [env.production] / [env.staging]).
+ *   3. Set ENABLE_R2_INCREMENTAL_CACHE=1 in the deploy workflow env (it must be
+ *      present for BOTH the build and deploy steps so the bundle and the
+ *      populate-cache step agree).
  */
-export default defineCloudflareConfig({
-  incrementalCache: withRegionalCache(r2IncrementalCache, {
-    mode: "long-lived",
-  }),
-});
+const r2IncrementalCacheEnabled = process.env.ENABLE_R2_INCREMENTAL_CACHE === "1";
+
+export default defineCloudflareConfig(
+  r2IncrementalCacheEnabled
+    ? {
+        incrementalCache: withRegionalCache(r2IncrementalCache, {
+          mode: "long-lived",
+        }),
+      }
+    : {},
+);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -175,12 +175,18 @@ bucket_name = "webs-alots-uploads"
 
 # ── Next.js Incremental Cache (audit R-8) ─────────────────────────────
 # open-next.config.ts wires the R2-backed incremental cache so `use cache`
-# / ISR entries persist across Worker isolates (the adapter degrades to a
-# graceful no-op while this binding is absent). To activate durable caching:
+# / ISR entries persist across Worker isolates. NOTE: the adapter is a graceful
+# no-op when this binding is absent only at REQUEST time — at DEPLOY time
+# `opennextjs-cloudflare deploy` runs populate-cache, which HARD-FAILS
+# ("No R2 binding NEXT_INC_CACHE_R2_BUCKET found!") if the override is wired but
+# the binding is missing. open-next.config.ts therefore gates the r2IncrementalCache
+# override behind ENABLE_R2_INCREMENTAL_CACHE so a plain deploy stays green until
+# the bucket exists. To activate durable caching (do all three together):
 #   1. Create a DEDICATED bucket (do NOT reuse UPLOADS_BUCKET — that bucket
 #      holds PHI and must not be co-mingled with rendered cache content):
 #        wrangler r2 bucket create webs-alots-next-cache
 #   2. Uncomment the binding below (top level AND env.production).
+#   3. Set ENABLE_R2_INCREMENTAL_CACHE=1 in the deploy workflow (build + deploy).
 # The adapter reads the binding name `NEXT_INC_CACHE_R2_BUCKET` exactly.
 # [[r2_buckets]]
 # binding = "NEXT_INC_CACHE_R2_BUCKET"


### PR DESCRIPTION
## Problem

The **Deploy → Deploy to Cloudflare Workers** job has been failing on `main` (e.g. [run 28495792312](https://github.com/groupsmix/webs-alots/actions/runs/28495792312), and earlier). Build succeeds; the `wrangler deploy` step dies at OpenNext's `populate-cache`:

```
Error: No R2 binding "NEXT_INC_CACHE_R2_BUCKET" found!
```

## Root cause

- #1211 wired `r2IncrementalCache` into `open-next.config.ts` **unconditionally** (correct fix for Audit R-8 dead cache).
- But `NEXT_INC_CACHE_R2_BUCKET` ships **commented out** in `wrangler.toml` — the dedicated cache bucket must be created first and must not reuse the PHI `UPLOADS_BUCKET`.
- The adapter's *"graceful no-op when the binding is absent"* only holds at **request time** (IgnorableError). At **deploy time**, `opennextjs-cloudflare deploy` runs `populate-cache`, which **hard-throws** when the override is configured but the binding is missing.

So the two files contradicted each other and every deploy has been red since #1211. Durable caching was therefore never actually live.

## Fix

Gate the override behind `ENABLE_R2_INCREMENTAL_CACHE`:

- **Default (unset):** OpenNext's built-in no-op cache → `wrangler deploy` succeeds. Matches the "safe to ship before the bucket is provisioned" intent already documented in `wrangler.toml`.
- **Activation** is now one coherent checklist cross-referenced in both files:
  1. `wrangler r2 bucket create webs-alots-next-cache` (+ `-staging`)
  2. Uncomment the `NEXT_INC_CACHE_R2_BUCKET` blocks (top level + `[env.production]` / `[env.staging]`)
  3. Set `ENABLE_R2_INCREMENTAL_CACHE=1` in the deploy workflow (build **and** deploy steps)

## Risk

None functional: deploys were 100% red, so nothing was shipping and durable caching was never live. This only makes the not-yet-provisioned state deployable and unblocks the pipeline.