### PR TITLE
Revert "chore(deps): bump actions/attest-build-provenance from 4.1.0 to 4.1.1 in the github-actions-all group"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
       # unsupported-platform error doesn't fail the Security Scans job.
       - name: Attest SBOM build provenance (SLSA)
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: bom.json
         continue-on-error: true


### PR DESCRIPTION
Reverts groupsmix/webs-alots#1222