### PR TITLE
fix(security): scope clinic_deleted audit log to clinic_id

### DIFF
--- a/src/lib/super-admin/clinic-lifecycle-actions.ts
+++ b/src/lib/super-admin/clinic-lifecycle-actions.ts
@@ -228,6 +228,7 @@ export async function deleteClinicImpl(
 
   try {
     await supabase.from("activity_logs").insert({
+      clinic_id: clinicId,
       action: "clinic_deleted",
       description:
         `Clinic "${clinic.name}" (id ${clinic.id}, subdomain ${clinic.subdomain ?? "—"}) ` +


### PR DESCRIPTION
## Summary

Semgrep tenant-scoping flagged the `activity_logs` insert in `deleteClinicImpl` for a missing `clinic_id`. Every tenant-scoped write must carry `clinic_id` for application-level isolation (per AGENTS.md).

The audit log is inherently about one clinic and `clinicId` is already in scope, so we set it directly. This also matches the existing `(clinic_id, timestamp)` compound index on `activity_logs`.

## Context

This finding was raised on #1231, which merged to `main` before it could be addressed. This is the follow-up.

## Type of change

- [x] Bug fix

## Security Impact

- [x] Restores tenant isolation on an audit-log write path