### PR TITLE
fix(security): scope clinic_deleted audit log to clinic_id

### DIFF
--- a/src/lib/super-admin/clinic-lifecycle-actions.ts
+++ b/src/lib/super-admin/clinic-lifecycle-actions.ts
@@ -228,6 +228,7 @@ export async function deleteClinicImpl(
 
   try {
     await supabase.from("activity_logs").insert({
+      clinic_id: clinicId,
       action: "clinic_deleted",
       description:
         `Clinic "${clinic.name}" (id ${clinic.id}, subdomain ${clinic.subdomain ?? "—"}) ` +


### PR DESCRIPTION
## Summary

Resolves the Semgrep `tenant-scoping` finding left open after #1231 merged.

The `activity_logs` insert in `deleteClinicImpl` was missing `clinic_id`. The log is inherently about one clinic and `clinicId` is already in scope, so this sets it directly.

## Why

- Satisfies application-level tenant isolation (`AGENTS.md`): every tenant-scoped query must filter by `clinic_id`.
- Matches the existing `(clinic_id, timestamp)` index on `activity_logs`.
- `clinicId` cannot be imported via `getCronSecret`-style accessor here (no circular-import concern; this is a direct insert), so the field is set inline.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic (tenant scoping on audit log)
- [ ] This PR changes RLS policies

No new env vars, no schema migration (column already exists and is indexed).