### PR TITLE
fix(audit): require env vars, remove leftover helper, and rate-limit /api/super-admin/*

### DIFF
--- a/scripts/oltigo-production-audit.mjs
+++ b/scripts/oltigo-production-audit.mjs
@@ -10,8 +10,8 @@
  * Usage:
  *   export PATH=/home/ubuntu/.n/bin:$PATH
  *   E2E_BASE_URL=https://oltigo.com \
- *   ADMIN_EMAIL=admin@admin.com \
- *   ADMIN_PASSWORD=123456789 \
+ *   ADMIN_EMAIL=your-email@example.com \
+ *   ADMIN_PASSWORD=your-password \
  *   node scripts/oltigo-production-audit.mjs
  */
 
@@ -23,9 +23,17 @@ import { chromium } from "@playwright/test";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
 const BASE_URL = process.env.E2E_BASE_URL || "https://oltigo.com";
-const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "admin@admin.com";
-const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || "123456789";
+const ADMIN_EMAIL = requireEnv("ADMIN_EMAIL");
+const ADMIN_PASSWORD = requireEnv("ADMIN_PASSWORD");
 const OUTPUT_DIR = process.env.OUTPUT_DIR || "/home/ubuntu/oltigo-audit-output";
 const DELAY_MS = Number(process.env.AUDIT_DELAY_MS || 1500);
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -840,6 +840,16 @@ export const perClinicLimiter = createRateLimiter({
   max: 50_000,
 });
 
+/** Super-admin API namespace: 60 req / 60s per IP.
+ *  These endpoints are now reachable under /api/super-admin/* via the
+ *  middleware rewrite; apply a per-IP cap so the dashboard cannot be used to
+ *  exhaust the underlying /api/admin/* handlers. */
+const superAdminApiLimiter = createRateLimiter({
+  windowMs: 60_000,
+  max: 60,
+  failClosed: true,
+});
+
 /** Analytics reads: 100 req / 60s per IP. */
 const analyticsLimiter = createRateLimiter({
   windowMs: 60_000,
@@ -910,6 +920,7 @@ export const rateLimitRules: RateLimitRule[] = [
   { prefix: "/api/branding", limiter: brandingLimiter, windowMs: 60_000, max: 20 },
   { prefix: "/api/notifications", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
   { prefix: "/api/analytics", limiter: analyticsLimiter, windowMs: 60_000, max: 100 },
+  { prefix: "/api/super-admin/", limiter: superAdminApiLimiter, windowMs: 60_000, max: 60 },
   // Catch-all for other API mutations (applied in middleware only to POST/PUT/PATCH/DELETE)
   { prefix: "/api/", limiter: apiMutationLimiter, windowMs: 60_000, max: 30 },
 ];


### PR DESCRIPTION
## Summary

Completes the immediate code-side cleanup items from the "what's still left" list:

- **Audit script hardening**: `scripts/oltigo-production-audit.mjs` no longer defaults `ADMIN_EMAIL` / `ADMIN_PASSWORD` to `admin@admin.com` / `123456789`. Both are now required environment variables, and the usage comment uses placeholders instead of real credentials.
- **Remove leftover helper**: deleted the untracked `scripts/fix-audit-report.mjs` helper.
- **Rate-limit the new super-admin API namespace**: added a dedicated `superAdminApiLimiter` (60 req / 60s per IP) and a `/api/super-admin/` prefix rule in `rateLimitRules`, so the middleware rewrite path is covered by the existing rate-limiting layer.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Infrastructure / CI

## Security Impact

- [x] This PR modifies authentication or authorization logic
  - Adds a per-IP rate limit to `/api/super-admin/*` to prevent abuse of the new namespace.
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [x] N/A — no migrations

## Testing

- `npm run lint` — 0 errors, 3369 pre-existing warnings
- `npm run typecheck` — passes
- `npm run test` — 183 test files / 2074 tests passed
- `npm run build` — succeeds

## Rollback

Revert commit `0997215c` on branch `devin/1783705769-cleanup`.

## SLO / Metrics Impact

- [ ] This PR introduces or modifies an SLO-tracked endpoint
- [ ] New metrics or alerts are needed
- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] Coverage thresholds still met (`npm run test:coverage`)
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints)