### PR TITLE
fix(dashboard): 8 focused dashboard bugs (local dates, KPIs, MRR, overdue, patient scoping)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "fast-check": "4.8.0",
         "husky": "^9.1.7",
         "jest-axe": "^10.0.0",
-        "jsdom": "^27.0.0",
+        "jsdom": "26.0.0",
         "knip": "^6.18.0",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
@@ -547,59 +547,25 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
-      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.0.0",
-        "@csstools/css-color-parser": "^4.0.1",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.5"
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
+      "license": "ISC"
     },
     "node_modules/@ast-grep/napi": {
       "version": "0.40.5",
@@ -2622,9 +2588,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
-      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -2638,13 +2604,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -2658,17 +2624,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
-      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -2682,21 +2648,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.1.0",
-        "@csstools/css-calc": "^3.2.1"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -2710,41 +2676,16 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
-      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -2758,7 +2699,7 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -12419,20 +12360,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -12454,29 +12381,17 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
-      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^4.1.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.4"
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+        "node": ">=18"
       }
     },
     "node_modules/csstype": {
@@ -12644,27 +12559,17 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
-      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^15.1.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/data-urls/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -17230,35 +17135,36 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
-      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.0.0.tgz",
+      "integrity": "sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/dom-selector": "^6.5.4",
-        "cssstyle": "^5.3.0",
-        "data-urls": "^6.0.0",
-        "decimal.js": "^10.5.0",
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.1",
         "html-encoding-sniffer": "^4.0.0",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^7.3.0",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
         "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
+        "tough-cookie": "^5.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.0",
+        "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^3.1.1",
         "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^15.0.0",
-        "ws": "^8.18.2",
+        "whatwg-url": "^14.1.0",
+        "ws": "^8.18.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -18438,13 +18344,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -19490,6 +19389,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -23655,22 +23561,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.2"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -23722,29 +23628,29 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^7.0.5"
+        "tldts": "^6.1.32"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -25045,13 +24951,13 @@
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       }
     },
     "node_modules/webpack-bundle-analyzer": {
@@ -25152,17 +25058,17 @@
       }
     },
     "node_modules/whatwg-url": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.0"
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "fast-check": "4.8.0",
         "husky": "^9.1.7",
         "jest-axe": "^10.0.0",
-        "jsdom": "^29.1.0",
+        "jsdom": "^27.0.0",
         "knip": "^6.18.0",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
@@ -547,47 +547,51 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      },
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
       }
     },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -2308,19 +2312,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
     "node_modules/@chromatic-com/storybook": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.2.1.tgz",
@@ -2631,9 +2622,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
       "dev": true,
       "funding": [
         {
@@ -2675,9 +2666,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
-      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
       "dev": true,
       "funding": [
         {
@@ -2691,7 +2682,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/color-helpers": "^6.1.0",
         "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
@@ -2726,9 +2717,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
-      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
       "dev": true,
       "funding": [
         {
@@ -3438,24 +3429,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
-      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -12480,6 +12453,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -12645,17 +12644,27 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-url": "^15.1.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/data-view-buffer": {
@@ -15333,30 +15342,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-from-html/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/hast-util-from-html/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
@@ -15486,30 +15471,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-raw/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/hast-util-raw/node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/hast-util-sanitize": {
@@ -15664,16 +15625,16 @@
       "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.6.0"
+        "whatwg-encoding": "^3.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -15741,6 +15702,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -17245,36 +17230,35 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
-        "parse5": "^8.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -17285,14 +17269,28 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
+      "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/jsesc": {
@@ -20005,26 +20003,24 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
-      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^8.0.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parse5/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=0.12"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -21519,6 +21515,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -25111,29 +25114,55 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "iconv-lite": "0.6.3"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "fast-check": "4.8.0",
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",
-    "jsdom": "27.0.0",
+    "jsdom": "26.0.0",
     "knip": "^6.18.0",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "fast-check": "4.8.0",
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",
-    "jsdom": "^29.1.0",
+    "jsdom": "27.0.0",
     "knip": "^6.18.0",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",

--- a/src/app/(receptionist)/receptionist/dashboard/page.test.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getCurrentUser, fetchAppointments, fetchInvoices, fetchPatients } from "@/lib/data/client";
+import Page from "./page";
+
+type AppointmentView = {
+  id: string;
+  patientId: string;
+  patientName: string;
+  doctorId: string;
+  doctorName: string;
+  serviceId: string;
+  serviceName: string;
+  date: string;
+  time: string;
+  status: string;
+  isFirstVisit: boolean;
+  hasInsurance: boolean;
+};
+
+type InvoiceView = {
+  id: string;
+  patientName: string;
+  amount: number;
+  currency: string;
+  method: string;
+  status: string;
+  date: string;
+};
+
+vi.mock("@/lib/data/client", () => ({
+  getCurrentUser: vi.fn(),
+  fetchAppointments: vi.fn(),
+  fetchInvoices: vi.fn(),
+  fetchPatients: vi.fn(),
+}));
+
+vi.mock("@/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/utils")>();
+  return {
+    ...actual,
+    getLocalDateStr: vi.fn((date?: Date) => {
+      if (date == null) return "2026-07-11";
+      const day = date.getDate();
+      if (day === 12) return "2026-07-12";
+      if (day === 11) return "2026-06-11";
+      return "2026-07-11";
+    }),
+  };
+});
+
+vi.mock("@/components/patient/reschedule-dialog", () => ({
+  RescheduleDialog: () => null,
+}));
+
+vi.mock("@/components/receptionist/appointment-card", () => ({
+  AppointmentCard: ({ appointment }: { appointment: { id: string } }) => (
+    <div data-testid="appointment-card">{appointment.id}</div>
+  ),
+}));
+vi.mock("@/components/receptionist/cash-register", () => ({
+  CashRegister: () => null,
+}));
+vi.mock("@/components/receptionist/end-of-day-report-button", () => ({
+  EndOfDayReportButton: () => null,
+}));
+vi.mock("@/components/receptionist/manual-booking-dialog", () => ({
+  ManualBookingDialog: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+vi.mock("@/components/receptionist/payment-dialog", () => ({
+  PaymentDialog: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+vi.mock("@/components/receptionist/quick-patient-registration", () => ({
+  QuickPatientRegistration: () => null,
+}));
+vi.mock("@/components/receptionist/realtime-waiting-room", () => ({
+  RealtimeWaitingRoom: () => null,
+}));
+vi.mock("@/components/receptionist/receptionist-ai-widget", () => ({
+  ReceptionistAIWidget: () => null,
+}));
+vi.mock("@/components/receptionist/walk-in-dialog", () => ({
+  WalkInDialog: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}));
+
+const OriginalDate = global.Date;
+
+describe("ReceptionistDashboardPage", () => {
+  beforeEach(() => {
+    global.Date = class extends OriginalDate {
+      constructor(...args: [string | number] | [number, number, ...number[]] | []) {
+        if (args.length === 0) {
+          super("2026-07-11T00:30:00Z");
+        } else if (args.length === 1) {
+          super(args[0]);
+        } else {
+          const [year, monthIndex, ...rest] = args as unknown as [number, number, ...number[]];
+          super(
+            year,
+            monthIndex,
+            rest[0] ?? 1,
+            rest[1] ?? 0,
+            rest[2] ?? 0,
+            rest[3] ?? 0,
+            rest[4] ?? 0,
+          );
+        }
+      }
+      static override now() {
+        return new OriginalDate("2026-07-11T00:30:00Z").getTime();
+      }
+    } as unknown as DateConstructor;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.Date = OriginalDate;
+  });
+
+  it("uses clinic-local dates and does not double-count checked-in patients", async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ clinic_id: "clinic-1" } as never);
+    vi.mocked(fetchPatients).mockResolvedValue([]);
+    vi.mocked(fetchAppointments).mockResolvedValue([
+      {
+        id: "a1",
+        patientId: "p1",
+        patientName: "Patient One",
+        doctorId: "d1",
+        doctorName: "Dr. Amine",
+        serviceId: "s1",
+        serviceName: "Consultation",
+        date: "2026-07-11",
+        time: "09:00",
+        status: "confirmed",
+        isFirstVisit: false,
+        hasInsurance: false,
+      },
+      {
+        id: "a2",
+        patientId: "p1",
+        patientName: "Patient One",
+        doctorId: "d1",
+        doctorName: "Dr. Amine",
+        serviceId: "s1",
+        serviceName: "Consultation",
+        date: "2026-07-11",
+        time: "10:00",
+        status: "in-progress",
+        isFirstVisit: false,
+        hasInsurance: false,
+      },
+      {
+        id: "a3",
+        patientId: "p1",
+        patientName: "Patient One",
+        doctorId: "d1",
+        doctorName: "Dr. Amine",
+        serviceId: "s1",
+        serviceName: "Consultation",
+        date: "2026-07-12",
+        time: "09:00",
+        status: "confirmed",
+        isFirstVisit: false,
+        hasInsurance: false,
+      },
+      {
+        id: "a4",
+        patientId: "p1",
+        patientName: "Patient One",
+        doctorId: "d1",
+        doctorName: "Dr. Amine",
+        serviceId: "s1",
+        serviceName: "Consultation",
+        date: "2026-07-10",
+        time: "09:00",
+        status: "completed",
+        isFirstVisit: false,
+        hasInsurance: false,
+      },
+    ] as AppointmentView[]);
+    vi.mocked(fetchInvoices).mockResolvedValue([
+      {
+        id: "i1",
+        patientName: "Patient One",
+        amount: 100,
+        currency: "MAD",
+        method: "cash",
+        status: "paid",
+        date: "2026-07-11",
+      },
+      {
+        id: "i2",
+        patientName: "Patient One",
+        amount: 50,
+        currency: "MAD",
+        method: "cash",
+        status: "paid",
+        date: "2026-06-01",
+      },
+    ] as InvoiceView[]);
+
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading...")).toBeNull();
+    });
+
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("0")).toBeTruthy();
+    expect(screen.getByText("100,00 MAD")).toBeTruthy();
+
+    expect(fetchAppointments).toHaveBeenCalledWith("clinic-1", {
+      sinceDate: "2026-06-11",
+    });
+  });
+});

--- a/src/app/(receptionist)/receptionist/dashboard/page.tsx
+++ b/src/app/(receptionist)/receptionist/dashboard/page.tsx
@@ -25,12 +25,12 @@ import {
   type AppointmentView,
   type PatientView,
 } from "@/lib/data/client";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, getLocalDateStr } from "@/lib/utils";
 
 export default function ReceptionistDashboardPage() {
   const [todayAppts, setTodayAppts] = useState<AppointmentView[]>([]);
   const [patientMap, setPatientMap] = useState<Map<string, PatientView>>(new Map());
-  const [totalRevenue, setTotalRevenue] = useState(0);
+  const [monthRevenue, setMonthRevenue] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [checkedInIds, setCheckedInIds] = useState<Set<string>>(new Set());
@@ -57,7 +57,7 @@ export default function ReceptionistDashboardPage() {
       lookback.setDate(lookback.getDate() - 30);
       const [appts, invoices, patients] = await Promise.all([
         fetchAppointments(user.clinic_id, {
-          sinceDate: lookback.toISOString().split("T")[0],
+          sinceDate: getLocalDateStr(lookback),
         }),
         fetchInvoices(user.clinic_id, { sinceDate: lookback.toISOString() }),
         fetchPatients(user.clinic_id),
@@ -65,10 +65,11 @@ export default function ReceptionistDashboardPage() {
       if (controller.signal.aborted) return;
       setTodayAppts(appts);
       setPatientMap(new Map(patients.map((p) => [p.id, p])));
+      const monthPrefix = getLocalDateStr().slice(0, 7);
       const revenue = invoices
-        .filter((inv) => inv.status === "paid")
+        .filter((inv) => inv.status === "paid" && inv.date.startsWith(monthPrefix))
         .reduce((sum, inv) => sum + inv.amount, 0);
-      setTotalRevenue(revenue);
+      setMonthRevenue(revenue);
       setLoading(false);
     }
     load().catch((err) => {
@@ -82,14 +83,14 @@ export default function ReceptionistDashboardPage() {
     };
   }, [refreshKey]);
 
-  const todayDateStr = new Date().toISOString().split("T")[0];
+  const todayDateStr = getLocalDateStr();
   const tomorrowDate = new Date();
   tomorrowDate.setDate(tomorrowDate.getDate() + 1);
-  const tomorrowDateStr = tomorrowDate.toISOString().split("T")[0];
+  const tomorrowDateStr = getLocalDateStr(tomorrowDate);
 
   const todayApptsFiltered = todayAppts.filter((a) => a.date === todayDateStr);
   const tomorrowAppts = todayAppts.filter((a) => a.date === tomorrowDateStr);
-  const checkedInAppts = todayAppts.filter(
+  const checkedInAppts = todayApptsFiltered.filter(
     (a) => checkedInIds.has(a.id) || a.status === "in-progress",
   );
   const waitingAppts = todayApptsFiltered.filter(
@@ -98,10 +99,6 @@ export default function ReceptionistDashboardPage() {
   const completedAppts = todayAppts.filter((a) => a.status === "completed");
   const cancelledAppts = todayAppts.filter((a) => a.status === "cancelled");
   const noShowAppts = todayAppts.filter((a) => a.status === "no-show");
-
-  const checkedInCount = todayApptsFiltered.filter(
-    (a) => a.status === "confirmed" || a.status === "in-progress",
-  ).length;
 
   const stats = [
     {
@@ -113,14 +110,14 @@ export default function ReceptionistDashboardPage() {
     {
       icon: Users,
       label: "Checked In",
-      value: (checkedInCount + checkedInIds.size).toString(),
+      value: checkedInAppts.length.toString(),
       color: "text-green-600",
     },
     { icon: UserPlus, label: "Walk-ins Today", value: "0", color: "text-purple-600" },
     {
       icon: CreditCard,
       label: "Revenue (Month)",
-      value: `${formatCurrency(totalRevenue)}`,
+      value: `${formatCurrency(monthRevenue)}`,
       color: "text-orange-600",
     },
   ];

--- a/src/app/(super-admin)/super-admin/dashboard/page.test.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  fetchDashboardStats,
+  fetchAnnouncements,
+  fetchActivityLogs,
+} from "@/lib/super-admin-actions";
+import Page from "./page";
+
+vi.mock("@/lib/super-admin-actions", () => ({
+  fetchDashboardStats: vi.fn(),
+  fetchAnnouncements: vi.fn(),
+  fetchActivityLogs: vi.fn(),
+}));
+
+vi.mock("@/components/admin/clinic-briefing-widget", () => ({
+  ClinicBriefingWidget: () => null,
+}));
+vi.mock("@/components/admin/ops-summary-strip", () => ({
+  OpsSummaryStrip: () => null,
+}));
+vi.mock("@/components/compliance/compliance-widget", () => ({
+  ComplianceWidget: () => null,
+}));
+
+vi.mock("@/components/locale-switcher", () => ({
+  useLocale: () => ["fr", vi.fn()],
+  LocaleSwitcher: () => null,
+}));
+
+vi.mock("@/components/ui/toast", () => ({
+  useToast: () => ({ addToast: vi.fn(), removeToast: vi.fn() }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("@/lib/export-utils", () => ({
+  exportToPDF: vi.fn(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const OriginalDate = global.Date;
+
+describe("SuperAdminDashboardPage", () => {
+  beforeEach(() => {
+    global.Date = class extends OriginalDate {
+      constructor(...args: [string | number] | [number, number, ...number[]] | []) {
+        if (args.length === 0) {
+          super("2026-07-11T00:00:00Z");
+        } else if (args.length === 1) {
+          super(args[0]);
+        } else {
+          const [year, monthIndex, ...rest] = args as unknown as [number, number, ...number[]];
+          super(
+            year,
+            monthIndex,
+            rest[0] ?? 1,
+            rest[1] ?? 0,
+            rest[2] ?? 0,
+            rest[3] ?? 0,
+            rest[4] ?? 0,
+          );
+        }
+      }
+      static override now() {
+        return new OriginalDate("2026-07-11T00:00:00Z").getTime();
+      }
+    } as unknown as DateConstructor;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.Date = OriginalDate;
+  });
+
+  it("renders real monthly MRR, revenue, overdue and paid-this-month stats", async () => {
+    vi.mocked(fetchDashboardStats).mockResolvedValue({
+      clinics: [
+        {
+          id: "c1",
+          name: "Clinic A",
+          type: "doctor",
+          tier: "starter",
+          status: "active",
+          config: { city: "Casablanca" },
+          created_at: "2026-07-02T00:00:00Z",
+        },
+      ],
+      totalClinics: 5,
+      activeClinics: 4,
+      totalPatients: 120,
+      totalAppointments: 250,
+      totalRevenue: 5000,
+      mrr: 2000,
+      monthlyRevenue: 800,
+      paidInvoicesThisMonth: 12,
+      overdueInvoices: 3,
+      newClinicsThisMonth: 2,
+    } as never);
+    vi.mocked(fetchAnnouncements).mockResolvedValue([]);
+    vi.mocked(fetchActivityLogs).mockResolvedValue([]);
+
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading...")).toBeNull();
+    });
+
+    expect(screen.getByText("2 000,00 MAD")).toBeTruthy();
+    expect(screen.getByText("800,00 MAD")).toBeTruthy();
+    expect(screen.getByText("12")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("+2 ce mois")).toBeTruthy();
+    expect(screen.queryByText("Active Pilot Clinics")).toBeNull();
+    expect(screen.queryByText("100%")).toBeNull();
+  });
+});

--- a/src/app/(super-admin)/super-admin/dashboard/page.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.tsx
@@ -54,7 +54,6 @@ interface ClinicDetail {
   type: "doctor" | "dentist" | "pharmacy";
   plan: string;
   city: string;
-  monthlyRevenue: number;
   status: "active" | "suspended" | "trial";
 }
 
@@ -82,6 +81,9 @@ export default function SuperAdminDashboardPage() {
   const [totalRevenue, setTotalRevenue] = useState(0);
   const [mrr, setMrr] = useState(0);
   const [overdue, setOverdue] = useState(0);
+  const [monthlyRevenue, setMonthlyRevenue] = useState(0);
+  const [paidInvoicesThisMonth, setPaidInvoicesThisMonth] = useState(0);
+  const [newClinicsThisMonth, setNewClinicsThisMonth] = useState(0);
   const [announcementList, setAnnouncementList] = useState<Announcement[]>([]);
   const [activityLogList, setActivityLogList] = useState<ActivityLog[]>([]);
   const mountedRef = useRef(true);
@@ -89,7 +91,7 @@ export default function SuperAdminDashboardPage() {
   const loadStats = useCallback(async (isRefresh = false) => {
     if (isRefresh) setRefreshing(true);
     try {
-      const [stats, announcements, logs] = await Promise.all([
+      const [dashboardStats, announcements, logs] = await Promise.all([
         fetchDashboardStats(),
         fetchAnnouncements(),
         fetchActivityLogs(),
@@ -97,14 +99,17 @@ export default function SuperAdminDashboardPage() {
 
       if (!mountedRef.current) return;
 
-      setTotalClinics(stats.totalClinics);
-      setActiveClinics(stats.activeClinics);
-      setTotalPatients(stats.totalPatients);
-      setTotalRevenue(stats.totalRevenue);
-      setMrr(stats.totalRevenue);
-      setOverdue(0);
+      setTotalClinics(dashboardStats.totalClinics);
+      setActiveClinics(dashboardStats.activeClinics);
+      setTotalPatients(dashboardStats.totalPatients);
+      setTotalRevenue(dashboardStats.totalRevenue);
+      setMrr(dashboardStats.mrr);
+      setOverdue(dashboardStats.overdueInvoices);
+      setMonthlyRevenue(dashboardStats.monthlyRevenue);
+      setPaidInvoicesThisMonth(dashboardStats.paidInvoicesThisMonth);
+      setNewClinicsThisMonth(dashboardStats.newClinicsThisMonth);
 
-      const mapped: ClinicDetail[] = stats.clinics.map((c) => {
+      const mapped: ClinicDetail[] = dashboardStats.clinics.map((c) => {
         const config = (c.config ?? {}) as ClinicConfigJson;
         return {
           id: c.id,
@@ -112,7 +117,6 @@ export default function SuperAdminDashboardPage() {
           type: c.type as "doctor" | "dentist" | "pharmacy",
           plan: (c.tier as string) ?? "pro",
           city: config.city ?? "",
-          monthlyRevenue: 0,
           status: (c.status === "inactive" ? "suspended" : (c.status ?? "active")) as
             | "active"
             | "suspended"
@@ -191,8 +195,8 @@ export default function SuperAdminDashboardPage() {
       change: `${activeClinics} ${t(locale, "superAdmin.active")}`,
       color: "text-blue-600 dark:text-blue-400",
       bg: "bg-blue-50 dark:bg-blue-900/30",
-      trend: t(locale, "superAdmin.trendNewThisMonth", { count: 2 }),
-      trendDirection: "up" as const,
+      trend: t(locale, "superAdmin.trendNewThisMonth", { count: newClinicsThisMonth }),
+      trendDirection: newClinicsThisMonth > 0 ? ("up" as const) : ("neutral" as const),
     },
     {
       icon: Building2,
@@ -217,15 +221,15 @@ export default function SuperAdminDashboardPage() {
     {
       icon: TrendingUp,
       label: t(locale, "superAdmin.monthlyRevenue"),
-      value: `${formatCurrency(totalRevenue)}`,
+      value: `${formatCurrency(monthlyRevenue)}`,
       change: t(locale, "superAdmin.fromPayments"),
       color: "text-orange-600 dark:text-orange-400",
       bg: "bg-orange-50 dark:bg-orange-900/30",
       trend:
-        totalRevenue > 0
+        monthlyRevenue > 0
           ? t(locale, "superAdmin.revenueTrendingUp")
           : t(locale, "superAdmin.noRevenueYet"),
-      trendDirection: totalRevenue > 0 ? ("up" as const) : ("neutral" as const),
+      trendDirection: monthlyRevenue > 0 ? ("up" as const) : ("neutral" as const),
     },
   ];
 
@@ -244,7 +248,7 @@ export default function SuperAdminDashboardPage() {
     },
     {
       label: t(locale, "superAdmin.paidThisMonth"),
-      value: `${activeClinics}`,
+      value: paidInvoicesThisMonth.toString(),
       icon: TrendingUp,
       color: "text-blue-600 dark:text-blue-400",
     },
@@ -414,37 +418,6 @@ export default function SuperAdminDashboardPage() {
                 </CardContent>
               </Card>
             ))}
-          </div>
-
-          {/* Pilot Metrics */}
-          <div className="grid gap-4 md:grid-cols-3 mb-6">
-            <Card className="border-blue-200 dark:border-blue-800 bg-blue-50/50 dark:bg-blue-900/10">
-              <CardContent className="flex items-center gap-3 p-4">
-                <Users className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                <div>
-                  <p className="text-lg font-bold">3</p>
-                  <p className="text-xs text-muted-foreground">Active Pilot Clinics</p>
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="border-green-200 dark:border-green-800 bg-green-50/50 dark:bg-green-900/10">
-              <CardContent className="flex items-center gap-3 p-4">
-                <Activity className="h-5 w-5 text-green-600 dark:text-green-400" />
-                <div>
-                  <p className="text-lg font-bold">42</p>
-                  <p className="text-xs text-muted-foreground">Pilot Appointments Today</p>
-                </div>
-              </CardContent>
-            </Card>
-            <Card className="border-purple-200 dark:border-purple-800 bg-purple-50/50 dark:bg-purple-900/10">
-              <CardContent className="flex items-center gap-3 p-4">
-                <Megaphone className="h-5 w-5 text-purple-600 dark:text-purple-400" />
-                <div>
-                  <p className="text-lg font-bold">100%</p>
-                  <p className="text-xs text-muted-foreground">WhatsApp Delivery Rate</p>
-                </div>
-              </CardContent>
-            </Card>
           </div>
 
           {/* Compliance + System snapshot */}

--- a/src/lib/__tests__/dashboard-patient.test.ts
+++ b/src/lib/__tests__/dashboard-patient.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getPatientDashboardData } from "@/lib/data/dashboard";
+import { createClient, createTenantClient } from "@/lib/supabase-server";
+import { createMockSupabaseClient } from "./test-utils";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: vi.fn(),
+  createTenantClient: vi.fn(),
+}));
+
+describe("getPatientDashboardData", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("scopes appointments to a 90-day lookback and all future rows", async () => {
+    const supabase = createMockSupabaseClient({
+      appointments: [
+        {
+          id: "a1",
+          doctor_id: "d1",
+          service_id: "s1",
+          appointment_date: "2026-07-11",
+          start_time: "09:00:00",
+          status: "confirmed",
+          clinic_id: "clinic-1",
+          patient_id: "patient-1",
+        },
+        {
+          id: "a2",
+          doctor_id: "d1",
+          service_id: "s1",
+          appointment_date: "2026-04-12",
+          start_time: "10:00:00",
+          status: "completed",
+          clinic_id: "clinic-1",
+          patient_id: "patient-1",
+        },
+        {
+          id: "a3",
+          doctor_id: "d1",
+          service_id: "s1",
+          appointment_date: "2026-04-11",
+          start_time: "10:00:00",
+          status: "completed",
+          clinic_id: "clinic-1",
+          patient_id: "patient-1",
+        },
+      ],
+      prescriptions: [],
+      payments: [],
+      notifications: [],
+      users: [{ id: "d1", name: "Dr. Amine", clinic_id: "clinic-1" }],
+      services: [{ id: "s1", name: "Consultation", clinic_id: "clinic-1" }],
+      clinics: [{ id: "clinic-1", config: { currency: "MAD" } }],
+    });
+
+    vi.mocked(createClient).mockResolvedValue(supabase as never);
+    vi.mocked(createTenantClient).mockResolvedValue(supabase as never);
+
+    const data = await getPatientDashboardData("clinic-1", "patient-1", "Patient");
+
+    // The a3 appointment (before the lookback) must be excluded by the gte filter.
+    expect(data.appointments.map((a) => a.id)).toEqual(["a2", "a1"]);
+    expect(data.appointments[0].date).toBe("2026-04-12");
+    expect(data.appointments[1].date).toBe("2026-07-11");
+
+    const apptBuilder = vi.mocked(supabase.from).mock.results[0].value;
+    expect(apptBuilder.gte).toHaveBeenCalledWith("appointment_date", "2026-04-12");
+    expect(apptBuilder.order).toHaveBeenCalledWith("appointment_date", { ascending: true });
+  });
+});

--- a/src/lib/__tests__/data-client-invoices.test.ts
+++ b/src/lib/__tests__/data-client-invoices.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { clearLookupCache, fetchInvoices } from "@/lib/data/client";
+import { createClient } from "@/lib/supabase-client";
+import { createMockSupabaseClient } from "./test-utils";
+
+vi.mock("@/lib/supabase-client", () => ({
+  createClient: vi.fn(),
+  createTenantClient: vi.fn(),
+}));
+
+describe("fetchInvoices", () => {
+  beforeEach(() => {
+    clearLookupCache();
+  });
+
+  it("returns payment dates in the clinic-local timezone", async () => {
+    const supabase = createMockSupabaseClient({
+      users: [{ id: "p1", name: "Patient One", phone: null, email: null, clinic_id: "clinic-1" }],
+      services: [{ id: "s1", name: "Consultation", price: 200, clinic_id: "clinic-1" }],
+      payments: [
+        {
+          id: "pay-1",
+          clinic_id: "clinic-1",
+          appointment_id: null,
+          patient_id: "p1",
+          amount: 200,
+          method: "cash",
+          status: "completed",
+          reference: null,
+          payment_type: "appointment",
+          gateway_session_id: null,
+          refunded_amount: 0,
+          created_at: "2026-07-10T23:05:00Z",
+        },
+      ],
+    });
+
+    vi.mocked(createClient).mockReturnValue(supabase as never);
+
+    const invoices = await fetchInvoices("clinic-1");
+
+    expect(invoices).toHaveLength(1);
+    expect(invoices[0].status).toBe("paid");
+    expect(invoices[0].date).toBe("2026-07-11");
+  });
+});

--- a/src/lib/__tests__/super-admin-dashboard-actions.test.ts
+++ b/src/lib/__tests__/super-admin-dashboard-actions.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchDashboardStatsImpl } from "@/lib/super-admin/dashboard-actions";
+import { createMockSupabaseClient } from "./test-utils";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: vi.fn(),
+  createTenantClient: vi.fn(),
+}));
+
+describe("fetchDashboardStatsImpl", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("computes total/all-time revenue from completed payments", async () => {
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+    const supabase = createMockSupabaseClient({
+      clinics: [],
+      users: [],
+      appointments: [],
+      payments: [
+        { amount: 100, created_at: "2026-07-10T10:00:00Z", status: "completed" },
+        { amount: 250, created_at: "2026-06-01T10:00:00Z", status: "completed" },
+      ],
+      invoices: [],
+    });
+
+    const stats = await fetchDashboardStatsImpl(supabase as never);
+
+    expect(stats.totalRevenue).toBe(350);
+    expect(stats.monthlyRevenue).toBe(100);
+    expect(stats.paidInvoicesThisMonth).toBe(1);
+  });
+
+  it("computes MRR from clinic subscription plans, not from total revenue", async () => {
+    const supabase = createMockSupabaseClient({
+      clinics: [
+        {
+          id: "c1",
+          name: "A",
+          type: "doctor",
+          tier: "starter",
+          status: "active",
+          config: {},
+          created_at: "2026-01-01T00:00:00Z",
+        },
+        {
+          id: "c2",
+          name: "B",
+          type: "dentist",
+          tier: "professional",
+          status: "active",
+          config: {},
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      users: [],
+      appointments: [],
+      payments: [],
+      invoices: [],
+    });
+
+    const stats = await fetchDashboardStatsImpl(supabase as never);
+
+    expect(stats.totalRevenue).toBe(0);
+    expect(stats.mrr).toBeGreaterThan(0);
+    expect(stats.mrr).toBe(798); // 199 + 599 from getPlanConfig defaults
+  });
+
+  it("counts overdue invoices and active/new clinics this month", async () => {
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+    const supabase = createMockSupabaseClient({
+      clinics: [
+        {
+          id: "c1",
+          name: "A",
+          type: "doctor",
+          tier: "starter",
+          status: "active",
+          config: {},
+          created_at: "2026-07-05T00:00:00Z",
+        },
+        {
+          id: "c2",
+          name: "B",
+          type: "dentist",
+          tier: "professional",
+          status: "active",
+          config: {},
+          created_at: "2026-06-01T00:00:00Z",
+        },
+      ],
+      users: [],
+      appointments: [],
+      payments: [],
+      invoices: [
+        { status: "overdue", due_date: "2026-07-01" },
+        { status: "sent", due_date: "2026-07-09" },
+        { status: "sent", due_date: "2026-07-12" },
+        { status: "paid", due_date: "2026-07-01" },
+      ],
+    });
+
+    const stats = await fetchDashboardStatsImpl(supabase as never);
+
+    expect(stats.overdueInvoices).toBe(2);
+    expect(stats.newClinicsThisMonth).toBe(1);
+  });
+});

--- a/src/lib/__tests__/test-utils.ts
+++ b/src/lib/__tests__/test-utils.ts
@@ -1,0 +1,109 @@
+import { vi } from "vitest";
+
+interface MockQueryState {
+  table: string;
+  rows: unknown[];
+  head: boolean;
+  filters: Array<{ op: string; column: string; value: unknown }>;
+  orderBy: string | null;
+  ascending: boolean;
+  limit: number;
+}
+
+function createMockQueryBuilder(table: string, rows: unknown[]) {
+  const state: MockQueryState = {
+    table,
+    rows,
+    head: false,
+    filters: [],
+    orderBy: null,
+    ascending: true,
+    limit: Number.MAX_SAFE_INTEGER,
+  };
+
+  const builder = {
+    select: vi.fn((columns?: string, options?: { count?: "exact"; head?: boolean }) => {
+      if (options?.head) state.head = true;
+      return builder;
+    }),
+    eq: vi.fn((column: string, value: unknown) => {
+      state.filters.push({ op: "eq", column, value });
+      return builder;
+    }),
+    in: vi.fn((column: string, value: unknown[]) => {
+      state.filters.push({ op: "in", column, value });
+      return builder;
+    }),
+    gte: vi.fn((column: string, value: unknown) => {
+      state.filters.push({ op: "gte", column, value });
+      return builder;
+    }),
+    lte: vi.fn((column: string, value: unknown) => {
+      state.filters.push({ op: "lte", column, value });
+      return builder;
+    }),
+    order: vi.fn((column: string, options?: { ascending?: boolean }) => {
+      state.orderBy = column;
+      state.ascending = options?.ascending ?? true;
+      return builder;
+    }),
+    limit: vi.fn((n: number) => {
+      state.limit = n;
+      return builder;
+    }),
+    single: vi.fn(() => builder),
+    then: vi.fn((onfulfilled?: (value: unknown) => unknown) => {
+      let result = [...state.rows];
+
+      for (const filter of state.filters) {
+        result = result.filter((row) => {
+          const value = (row as Record<string, unknown>)[filter.column];
+          switch (filter.op) {
+            case "eq":
+              return value === filter.value;
+            case "in":
+              return (filter.value as unknown[]).includes(value);
+            case "gte":
+              return typeof value === "string" && value >= (filter.value as string);
+            case "lte":
+              return typeof value === "string" && value <= (filter.value as string);
+            default:
+              return true;
+          }
+        });
+      }
+
+      if (state.orderBy) {
+        result.sort((a, b) => {
+          const aVal = (a as Record<string, unknown>)[state.orderBy as string];
+          const bVal = (b as Record<string, unknown>)[state.orderBy as string];
+          if (aVal === bVal) return 0;
+          if (aVal == null) return 1;
+          if (bVal == null) return -1;
+          const cmp = aVal < bVal ? -1 : 1;
+          return state.ascending ? cmp : -cmp;
+        });
+      }
+
+      result = result.slice(0, state.limit);
+
+      if (state.head) {
+        return onfulfilled?.({ count: result.length, data: null });
+      }
+
+      return onfulfilled?.({ data: result });
+    }),
+    _state: state,
+  };
+
+  return builder;
+}
+
+export function createMockSupabaseClient(rows: Record<string, unknown[]> = {}) {
+  const supabase = {
+    from: vi.fn((table: string) => createMockQueryBuilder(table, rows[table] ?? [])),
+  };
+  return supabase as unknown as {
+    from: (table: string) => ReturnType<typeof createMockQueryBuilder>;
+  };
+}

--- a/src/lib/__tests__/utils-date.test.ts
+++ b/src/lib/__tests__/utils-date.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getLocalDateStr } from "@/lib/utils";
+
+describe("getLocalDateStr", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats a UTC timestamp to the Casablanca calendar date", () => {
+    vi.setSystemTime(new Date("2026-07-11T00:30:00Z"));
+    expect(getLocalDateStr()).toBe("2026-07-11");
+    expect(getLocalDateStr(new Date("2026-07-10T23:05:00Z"))).toBe("2026-07-11");
+  });
+
+  it("returns tomorrow's local date when passed a date +1 day", () => {
+    vi.setSystemTime(new Date("2026-07-11T12:00:00Z"));
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    expect(getLocalDateStr(tomorrow)).toBe("2026-07-12");
+  });
+
+  it("returns an empty string for invalid dates", () => {
+    expect(getLocalDateStr(new Date("invalid"))).toBe("");
+  });
+});

--- a/src/lib/data/client/index.ts
+++ b/src/lib/data/client/index.ts
@@ -8,7 +8,7 @@
  */
 
 // Core infrastructure
-export { createClient, type ClinicUser, getCurrentUser } from "./_core";
+export { createClient, type ClinicUser, getCurrentUser, clearLookupCache } from "./_core";
 
 export * from "./appointments";
 export * from "./users";

--- a/src/lib/data/client/invoices.ts
+++ b/src/lib/data/client/invoices.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { getLocalDateStr } from "@/lib/utils";
 import { fetchRows, ensureLookups, _activeUserMap } from "./_core";
 
 // ─────────────────────────────────────────────
@@ -53,6 +54,6 @@ export async function fetchInvoices(
     currency: "MAD",
     method: r.method ?? "cash",
     status: r.status === "completed" ? "paid" : r.status,
-    date: r.created_at?.split("T")[0] ?? "",
+    date: r.created_at ? getLocalDateStr(new Date(r.created_at)) : "",
   }));
 }

--- a/src/lib/data/dashboard.ts
+++ b/src/lib/data/dashboard.ts
@@ -468,12 +468,20 @@ export async function getPatientDashboardData(
   const { getClinicConfig } = await import("@/lib/tenant");
   const clinicCfgPromise = getClinicConfig(clinicId);
 
+  // PERF-LAT-03: The patient dashboard only renders current/upcoming appointments
+  // and recent-history. A 90-day lookback plus all future appointments bounds the
+  // payload and prevents the 1000-row ascending cap from dropping recent rows.
+  const lookbackDate = new Date();
+  lookbackDate.setDate(lookbackDate.getDate() - 90);
+  const recentCutoff = getLocalDateStr(lookbackDate);
+
   const [apptsRes, rxRes, invoicesRes, notifsRes] = await Promise.all([
     supabase
       .from("appointments")
       .select("id, doctor_id, service_id, appointment_date, start_time, status")
       .eq("clinic_id", clinicId)
       .eq("patient_id", userId)
+      .gte("appointment_date", recentCutoff)
       .order("appointment_date", { ascending: true })
       .limit(DEFAULT_QUERY_LIMIT),
     supabase

--- a/src/lib/super-admin/dashboard-actions.ts
+++ b/src/lib/super-admin/dashboard-actions.ts
@@ -1,7 +1,10 @@
 import { logger } from "@/lib/logger";
+import { getPlanConfig } from "@/lib/subscription-billing";
 import { createClient } from "@/lib/supabase-server";
 import { mapActivityLog } from "@/lib/super-admin/helpers";
+import { resolveClinicSubscriptionPlan } from "@/lib/super-admin/subscription-helpers";
 import type { ActivityLog, Announcement, AnnouncementInput } from "@/lib/super-admin/types";
+import { getLocalDateStr } from "@/lib/utils";
 
 type SuperAdminClient = Awaited<ReturnType<typeof createClient>>;
 
@@ -20,6 +23,11 @@ export interface DashboardStats {
   totalPatients: number;
   totalAppointments: number;
   totalRevenue: number;
+  mrr: number;
+  monthlyRevenue: number;
+  paidInvoicesThisMonth: number;
+  overdueInvoices: number;
+  newClinicsThisMonth: number;
 }
 
 type AnnouncementRow = {
@@ -74,15 +82,56 @@ async function logAnnouncementActivity(
 }
 
 export async function fetchDashboardStatsImpl(supabase: SuperAdminClient): Promise<DashboardStats> {
-  const [clinicsRes, patientCountRes, appointmentCountRes, revenueRes] = await Promise.all([
-    supabase.from("clinics").select("id, name, type, tier, status, config, created_at"),
-    supabase.from("users").select("id", { count: "exact", head: true }).in("role", ["patient"]),
-    supabase.from("appointments").select("id", { count: "exact", head: true }),
-    supabase.from("payments").select("amount").eq("status", "completed"),
-  ]);
+  const [clinicsRes, patientCountRes, appointmentCountRes, revenueRes, invoicesRes] =
+    await Promise.all([
+      supabase.from("clinics").select("id, name, type, tier, status, config, created_at"),
+      supabase.from("users").select("id", { count: "exact", head: true }).in("role", ["patient"]),
+      supabase.from("appointments").select("id", { count: "exact", head: true }),
+      supabase.from("payments").select("amount, created_at").eq("status", "completed"),
+      supabase.from("invoices").select("status, due_date"),
+    ]);
 
   const clinics = (clinicsRes.data ?? []) as DashboardStats["clinics"];
-  const completedPayments = (revenueRes.data ?? []) as { amount: number }[];
+  const completedPayments = (revenueRes.data ?? []) as { amount: number; created_at: string }[];
+  const invoices = (invoicesRes.data ?? []) as { status: string; due_date: string | null }[];
+
+  const now = new Date();
+  const monthStart = getLocalDateStr(new Date(now.getFullYear(), now.getMonth(), 1));
+  const monthEnd = getLocalDateStr(new Date(now.getFullYear(), now.getMonth() + 1, 0));
+  const todayStr = getLocalDateStr();
+
+  const isInCurrentMonth = (timestamp: string | null): boolean => {
+    if (!timestamp) return false;
+    const date = getLocalDateStr(new Date(timestamp));
+    return date >= monthStart && date <= monthEnd;
+  };
+
+  const totalRevenue = completedPayments.reduce((sum, payment) => sum + (payment.amount ?? 0), 0);
+  const monthlyRevenue = completedPayments
+    .filter((payment) => isInCurrentMonth(payment.created_at))
+    .reduce((sum, payment) => sum + (payment.amount ?? 0), 0);
+  const paidInvoicesThisMonth = completedPayments.filter((payment) =>
+    isInCurrentMonth(payment.created_at),
+  ).length;
+
+  const overdueInvoices = invoices.filter((invoice) => {
+    if (invoice.status === "overdue") return true;
+    if (invoice.status === "sent" || invoice.status === "partially_paid") {
+      return !!invoice.due_date && invoice.due_date < todayStr;
+    }
+    return false;
+  }).length;
+
+  const newClinicsThisMonth = clinics.filter((clinic) => {
+    if (!clinic.created_at) return false;
+    const created = getLocalDateStr(new Date(clinic.created_at));
+    return created >= monthStart && created <= monthEnd;
+  }).length;
+
+  const mrr = clinics.reduce((sum, clinic) => {
+    const plan = resolveClinicSubscriptionPlan(clinic);
+    return sum + getPlanConfig(plan).priceMonthly;
+  }, 0);
 
   return {
     clinics,
@@ -90,7 +139,12 @@ export async function fetchDashboardStatsImpl(supabase: SuperAdminClient): Promi
     activeClinics: clinics.filter((clinic) => clinic.status === "active").length,
     totalPatients: patientCountRes.count ?? 0,
     totalAppointments: appointmentCountRes.count ?? 0,
-    totalRevenue: completedPayments.reduce((sum, payment) => sum + (payment.amount ?? 0), 0),
+    totalRevenue,
+    mrr,
+    monthlyRevenue,
+    paidInvoicesThisMonth,
+    overdueInvoices,
+    newClinicsThisMonth,
   };
 }
 

--- a/src/lib/super-admin/dashboard-actions.ts
+++ b/src/lib/super-admin/dashboard-actions.ts
@@ -85,10 +85,10 @@ export async function fetchDashboardStatsImpl(supabase: SuperAdminClient): Promi
   const [clinicsRes, patientCountRes, appointmentCountRes, revenueRes, invoicesRes] =
     await Promise.all([
       supabase.from("clinics").select("id, name, type, tier, status, config, created_at"),
-      supabase.from("users").select("id", { count: "exact", head: true }).in("role", ["patient"]),
-      supabase.from("appointments").select("id", { count: "exact", head: true }),
-      supabase.from("payments").select("amount, created_at").eq("status", "completed"),
-      supabase.from("invoices").select("status, due_date"),
+      supabase.from("users").select("id", { count: "exact", head: true }).in("role", ["patient"]), // nosemgrep: semgrep.tenant-scoping — global super-admin aggregate across all clinics
+      supabase.from("appointments").select("id", { count: "exact", head: true }), // nosemgrep: semgrep.tenant-scoping — global super-admin aggregate across all clinics
+      supabase.from("payments").select("amount, created_at").eq("status", "completed"), // nosemgrep: semgrep.tenant-scoping — global super-admin aggregate across all clinics
+      supabase.from("invoices").select("status, due_date"), // nosemgrep: semgrep.tenant-scoping — global super-admin aggregate across all clinics
     ]);
 
   const clinics = (clinicsRes.data ?? []) as DashboardStats["clinics"];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,6 +15,7 @@ export function cn(...inputs: ClassValue[]) {
  * instead of the runtime's local timezone or raw UTC boundaries.
  */
 export function getLocalDateStr(date: Date = new Date(), timezone = DEFAULT_TIMEZONE): string {
+  if (Number.isNaN(date.getTime())) return "";
   const formatter = new Intl.DateTimeFormat("en-CA", {
     timeZone: timezone,
     year: "numeric",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,23 +1,15 @@
 import fs from "fs";
+import { fileURLToPath } from "node:url";
 import path from "path";
 import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // FE-006: Read coverage thresholds from a ratchet file so they can be
 // mechanically bumped upward per merged PR. Long-term targets:
 // statements: 80, branches: 70, lines: 70, functions: 60.
 const floorPath = path.resolve(__dirname, ".vitest-coverage-floor.json");
-const floorFile = JSON.parse(fs.readFileSync(floorPath, "utf-8")) as {
-  statements: number;
-  branches: number;
-  lines: number;
-  functions: number;
-  // The ratchet file also carries a `target` object documenting the
-  // long-term goals. It must NOT be forwarded to Vitest: any non-metric key
-  // in `coverage.thresholds` is interpreted as a per-glob threshold, so
-  // `target` would become a glob that matches no files (ignored at best,
-  // a "no files for threshold glob" error at worst). Pick only the metrics.
-  target?: unknown;
-};
+const floorFile = JSON.parse(fs.readFileSync(floorPath, "utf-8"));
 const floor = {
   statements: floorFile.statements,
   branches: floorFile.branches,


### PR DESCRIPTION
## Summary

Fixes 8 focused dashboard/data-layer bugs identified in the focused audit, plus a dev-dependency pin to keep `vitest`/`jsdom` green.

### 1. Receptionist local-date bug
`src/app/(receptionist)/receptionist/dashboard/page.tsx` now uses `getLocalDateStr` from `@/lib/utils` for today and tomorrow, and passes a local-date `sinceDate` to `fetchAppointments`. This prevents off-by-one errors in Morocco (UTC+1 / DST) near midnight.

### 2. Receptionist "Checked In" KPI
Removed the double-count (`checkedInCount + checkedInIds.size`). The KPI now uses the already-deduplicated `checkedInAppts.length` and only counts `in-progress` or explicitly checked-in appointments.

### 3. Receptionist "Revenue (Month)"
Renamed state to `monthRevenue`, filtered paid `InvoiceView.date` to the current calendar month, and updated the card label to `Revenue (Month)`.

### 4. Super-admin "Paid This Month"
Replaced the `activeClinics` value with a real `paidInvoicesThisMonth` count from `fetchDashboardStats` / `src/lib/super-admin/dashboard-actions.ts`.

### 5. Super-admin MRR / Monthly Revenue / overdue
`fetchDashboardStatsImpl` now computes:
- `mrr` from `resolveClinicSubscriptionPlan` + `getPlanConfig(...).priceMonthly`
- `monthlyRevenue` from paid invoices in the current calendar month
- `overdueInvoices` from unpaid invoices with `due_date < today`
The dashboard no longer aliases `setMrr(stats.totalRevenue)`.

### 6. Super-admin hardcoded pilot metrics and trend
Removed the hardcoded "Active Pilot Clinics", "Pilot Appointments Today", and "WhatsApp Delivery Rate" cards. `trendNewThisMonth` now uses the real `newClinicsThisMonth` count.

### 7. Super-admin dead `monthlyRevenue` field
Removed the always-zero `monthlyRevenue` property from `ClinicDetail`.

### 8. Patient dashboard scoping
`getPatientDashboardData` in `src/lib/data/dashboard.ts` now applies a 90-day `gte` lookback for appointments so recent/upcoming rows are not dropped by the 1000-row ascending limit.

### Test / tooling
- Added/updated tests for every fix:
  - `receptionist/dashboard/page.test.tsx`
  - `super-admin/dashboard/page.test.tsx`
  - `dashboard-patient.test.ts`
  - `data-client-invoices.test.ts`
  - `super-admin-dashboard-actions.test.ts`
  - `utils-date.test.ts`
  - `src/lib/__tests__/test-utils.ts` (shared `createMockSupabaseClient`)
- Renamed `vitest.config.ts` -> `vitest.config.mjs` and pinned `jsdom` to `26.0.0` to avoid `cssstyle` 5.x/`@csstools/css-calc` ESM require errors.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR changes tenant isolation or multi-tenant scoping
  - Patient dashboard query now scopes to `clinic_id` + `patient_id` with a date lookback (no change to isolation logic).

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

## Observability

- [x] N/A — no observability changes

## Rollback

Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refrafts

- `src/lib/data/client/index.ts` re-exports `clearLookupCache` for tests.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (2084 passed, 84 skipped)
- [x] `npm run build` passes
- [x] No new API endpoints introduced