### PR TITLE
Audit end-to-end: build warnings, R2 incremental cache, Storybook cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,11 @@ jobs:
           # Both production and staging use "partial" (matches wrangler.toml
           # [env.*.vars] and .env.example).
           NEXT_PUBLIC_DATA_MASKING: partial
+          # R2-01: Persist Next.js 16 `use cache` / ISR entries across Worker
+          # isolates. The bucket binding is declared in wrangler.toml and
+          # auto-created on first deploy; the build override is gated in
+          # open-next.config.ts so local builds stay green without it.
+          ENABLE_R2_INCREMENTAL_CACHE: 1
           # BG2 / Ops dashboard "Last Deployment": pin a deterministic build
           # timestamp instead of letting next.config.ts fall back to
           # `new Date()` (which makes every build non-reproducible and churns

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from "@storybook/nextjs-vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
     "@chromatic-com/storybook",
     "@storybook/addon-vitest",
@@ -11,5 +11,13 @@ const config: StorybookConfig = {
   ],
   framework: "@storybook/nextjs-vite",
   staticDirs: ["../public"],
+  viteFinal: (config) => {
+    if (config.build) {
+      config.build.chunkSizeWarningLimit = 1536;
+    } else {
+      config.build = { chunkSizeWarningLimit: 1536 };
+    }
+    return config;
+  },
 };
 export default config;

--- a/next.config.ts
+++ b/next.config.ts
@@ -101,18 +101,12 @@ const nextConfig: NextConfig = {
           },
         ],
       },
-      {
-        // CDN-02: Next.js hashed JS/CSS bundles under _next/static are
-        // safe to cache indefinitely. Cloudflare edge caches these via
-        // s-maxage and serves them without hitting the Worker.
-        source: "/_next/static/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: "public, max-age=31536000, s-maxage=31536000, immutable",
-          },
-        ],
-      },
+      // CDN-02: _next/static files are content-hashed and cached by
+      // public/_headers and Cloudflare Static Assets. The Next.js custom
+      // headers() rule for this route is redundant and triggers the
+      // "Custom Cache-Control headers for /_next/static" warning, so it is
+      // removed. Cloudflare serves these assets directly via the [assets]
+      // binding without hitting the Worker.
       {
         // Default: prevent caching of API responses (authentication, patient
         // data, mutations, etc.).  Individual routes that serve truly public

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "seed": "tsx scripts/seed.ts",
     "demo:seed": "tsx scripts/seed.ts",
     "purge:junk": "tsx scripts/purge-junk-clinics.ts",
+    "prestorybook": "node scripts/patch-storybook.mjs",
     "storybook": "storybook dev -p 6006",
+    "prebuild-storybook": "node scripts/patch-storybook.mjs",
     "build-storybook": "storybook build",
     "test-storybook": "vitest run --config vitest.storybook.config.ts",
     "eval:ai": "tsx evals/run-all.ts"

--- a/scripts/check-bindings.ts
+++ b/scripts/check-bindings.ts
@@ -79,7 +79,9 @@ const allSource = sourceFiles.map((f) => readFileSync(f, "utf8")).join("\n");
 // ASSETS is consumed by the Workers runtime, not by user code.
 // UPLOADS_BUCKET is declared for future direct R2 binding usage; currently
 // the app uses the S3-compatible API via R2_ACCESS_KEY_ID env vars.
-const RUNTIME_BINDINGS = new Set(["ASSETS", "UPLOADS_BUCKET"]);
+// NEXT_INC_CACHE_R2_BUCKET is consumed by the OpenNext R2 incremental-cache
+// override (open-next.config.ts) and does not appear in application source.
+const RUNTIME_BINDINGS = new Set(["ASSETS", "UPLOADS_BUCKET", "NEXT_INC_CACHE_R2_BUCKET"]);
 
 const unreferenced = declaredBindings.filter((b) => {
   if (RUNTIME_BINDINGS.has(b)) return false;

--- a/scripts/patch-storybook.mjs
+++ b/scripts/patch-storybook.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/**
+ * Patches node_modules package.json files so that Storybook's auto-ref
+ * discovery can resolve their package.json. Storybook's `getAutoRefs` does
+ * `require.resolve('<pkg>/package.json')` for every dependency; packages that
+ * use `exports` but do not explicitly expose `./package.json` cause:
+ *
+ *   "unable to find package.json for <pkg>"
+ *
+ * This is a non-functional warning but it fails CI in strict mode.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const packages = ["@opennextjs/cloudflare"];
+
+for (const pkg of packages) {
+  const pkgJsonPath = path.join(__dirname, "..", "node_modules", pkg, "package.json");
+  if (!fs.existsSync(pkgJsonPath)) {
+    console.log(`· ${pkg} not installed, skipping`);
+    continue;
+  }
+
+  const raw = fs.readFileSync(pkgJsonPath, "utf-8");
+  const json = JSON.parse(raw);
+
+  if (!json.exports) {
+    console.log(`· ${pkg} has no exports field, skipping`);
+    continue;
+  }
+
+  if (json.exports["./package.json"] || json.exports["package.json"]) {
+    console.log(`· ${pkg}/package.json already exposed, skipping`);
+    continue;
+  }
+
+  json.exports = {
+    "./package.json": "./package.json",
+    ...json.exports,
+  };
+
+  fs.writeFileSync(pkgJsonPath, `${JSON.stringify(json, null, 2)}\n`, "utf-8");
+  console.log(`✓ Exposed package.json in ${pkg}`);
+}

--- a/scripts/post-build-patch.mjs
+++ b/scripts/post-build-patch.mjs
@@ -66,26 +66,43 @@ let mutated = false;
 
 // ── Patch 2: @vercel/og bundle exclusion (CF-BUNDLE-01) ──────────────
 {
-  // Turbopack emits (exact form, repeated per chunk):
+  // Turbopack emits either:
   //   case"next/dist/compiled/@vercel/og/index.node.js":raw=await import("next/dist/compiled/@vercel/og/index.edge.js");break;
-  // We replace the await import(...) with a throw. Wrangler's static
-  // analysis then no longer resolves the @vercel/og edge bundle, and
-  // resvg.wasm + yoga.wasm are not uploaded with the worker.
-  const OG_PATTERN =
+  // or (since opennextjs-cloudflare 1.18+) the case already resolves to
+  // an OpenNext shim that throws "OpenNext shim". In that case the bundle
+  // is already neutralized and no further patch is needed.
+  const OG_LEGACY_PATTERN =
     'case"next/dist/compiled/@vercel/og/index.node.js":raw=await import("next/dist/compiled/@vercel/og/index.edge.js");break;';
-  const OG_REPLACEMENT =
-    'case"next/dist/compiled/@vercel/og/index.node.js":throw new Error("ImageResponse/@vercel/og is not bundled in this Worker build (CF-BUNDLE-01). Re-enable in scripts/post-build-patch.mjs if needed.");';
+  const OG_LEGACY_REPLACEMENT =
+    'case"next/dist/compiled/@vercel/og/index.node.js":throw new Error("ImageResponse/@vercel/og is not bundled in this Worker build (CF-BUNDLE-01). Re-enable in scripts/post-build-patch.mjs if needed.");break;';
+  const OG_SHIM_PATTERN =
+    'case"next/dist/compiled/@vercel/og/index.node.js":raw=await Promise.resolve().then(()=>(init_throw(),throw_exports));break;';
+  const OG_SHIM_REPLACEMENT =
+    'case"next/dist/compiled/@vercel/og/index.node.js":throw new Error("ImageResponse/@vercel/og is not bundled in this Worker build (CF-BUNDLE-01). Re-enable in scripts/post-build-patch.mjs if needed.");break;';
   const OG_MARKER = "ImageResponse/@vercel/og is not bundled in this Worker build";
+  const OG_SHIM_MARKER = "OpenNext shim";
 
-  const ogOccurrences = content.split(OG_PATTERN).length - 1;
-  if (ogOccurrences > 0 && !content.includes(OG_MARKER)) {
-    content = content.replaceAll(OG_PATTERN, OG_REPLACEMENT);
+  const legacyOccurrences = content.split(OG_LEGACY_PATTERN).length - 1;
+  const shimOccurrences = content.split(OG_SHIM_PATTERN).length - 1;
+  if (legacyOccurrences > 0 && !content.includes(OG_MARKER)) {
+    content = content.replaceAll(OG_LEGACY_PATTERN, OG_LEGACY_REPLACEMENT);
     mutated = true;
     console.log(
-      `✓ Patched handler.mjs — @vercel/og static import neutralized (${ogOccurrences} site(s))`,
+      `✓ Patched handler.mjs — @vercel/og legacy import neutralized (${legacyOccurrences} site(s))`,
     );
+  } else if (shimOccurrences > 0 && !content.includes(OG_MARKER)) {
+    content = content.replaceAll(OG_SHIM_PATTERN, OG_SHIM_REPLACEMENT);
+    mutated = true;
+    console.log(`✓ Patched handler.mjs — @vercel/og shim neutralized (${shimOccurrences} site(s))`);
   } else if (content.includes(OG_MARKER)) {
     console.log("· @vercel/og patch already applied");
+  } else if (
+    content.includes('case"next/dist/compiled/@vercel/og/index.node.js"') &&
+    content.includes(OG_SHIM_MARKER)
+  ) {
+    console.log("· @vercel/og is already neutralized by the OpenNext shim");
+  } else if (!content.includes('"next/dist/compiled/@vercel/og/index.node.js"')) {
+    console.log("· No @vercel/og import found in handler.mjs");
   } else {
     console.log(
       "⚠ Could not find @vercel/og externalImport pattern — Turbopack output may have changed",

--- a/src/app/(super-admin)/super-admin/dashboard/page.test.tsx
+++ b/src/app/(super-admin)/super-admin/dashboard/page.test.tsx
@@ -108,12 +108,14 @@ describe("SuperAdminDashboardPage", () => {
       expect(screen.queryByText("Loading...")).toBeNull();
     });
 
-    expect(screen.getByText("2 000,00 MAD")).toBeTruthy();
-    expect(screen.getByText("800,00 MAD")).toBeTruthy();
-    expect(screen.getByText("12")).toBeTruthy();
-    expect(screen.getByText("3")).toBeTruthy();
-    expect(screen.getByText("+2 ce mois")).toBeTruthy();
-    expect(screen.queryByText("Active Pilot Clinics")).toBeNull();
-    expect(screen.queryByText("100%")).toBeNull();
+    await waitFor(() => {
+      screen.getByText("2 000,00 MAD");
+      screen.getByText("800,00 MAD");
+      screen.getByText("12");
+      screen.getByText("3");
+      screen.getByText("+2 ce mois");
+      expect(screen.queryByText("Active Pilot Clinics")).toBeNull();
+      expect(screen.queryByText("100%")).toBeNull();
+    });
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -188,9 +188,11 @@ bucket_name = "webs-alots-uploads"
 #   2. Uncomment the binding below (top level AND env.production).
 #   3. Set ENABLE_R2_INCREMENTAL_CACHE=1 in the deploy workflow (build + deploy).
 # The adapter reads the binding name `NEXT_INC_CACHE_R2_BUCKET` exactly.
-# [[r2_buckets]]
-# binding = "NEXT_INC_CACHE_R2_BUCKET"
-# bucket_name = "webs-alots-next-cache"
+# The bucket is auto-created on first deploy if it does not exist; if that
+# fails, create it manually with `wrangler r2 bucket create webs-alots-next-cache`.
+[[r2_buckets]]
+binding = "NEXT_INC_CACHE_R2_BUCKET"
+bucket_name = "webs-alots-next-cache"
 
 # ── Environment Variables (non-secret) ────────────────────────────────
 # Secrets (API keys, encryption keys) are set via `wrangler secret put`
@@ -297,11 +299,13 @@ dead_letter_queue = "notification-queue-dlq"
 binding = "UPLOADS_BUCKET"
 bucket_name = "webs-alots-uploads"
 
-# Next.js incremental cache (audit R-8) — uncomment after creating the
-# dedicated bucket (see top-level note). Do NOT reuse UPLOADS_BUCKET (PHI).
-# [[env.production.r2_buckets]]
-# binding = "NEXT_INC_CACHE_R2_BUCKET"
-# bucket_name = "webs-alots-next-cache"
+# Next.js incremental cache (audit R-8) — dedicated bucket, do NOT reuse
+# UPLOADS_BUCKET (PHI). The bucket is auto-created on first deploy if it
+# does not exist; if that fails, create it manually with
+# `wrangler r2 bucket create webs-alots-next-cache`.
+[[env.production.r2_buckets]]
+binding = "NEXT_INC_CACHE_R2_BUCKET"
+bucket_name = "webs-alots-next-cache"
 
 # W8-A31-01: KV namespace binding (was missing — rate limiter fell open)
 [[env.production.kv_namespaces]]
@@ -415,6 +419,12 @@ dead_letter_queue = "notification-queue-staging-dlq"
 [[env.staging.r2_buckets]]
 binding = "UPLOADS_BUCKET"
 bucket_name = "webs-alots-uploads-staging"
+
+# Next.js incremental cache (audit R-8) — dedicated staging bucket, do NOT
+# reuse UPLOADS_BUCKET (PHI). Auto-created on first deploy if it does not exist.
+[[env.staging.r2_buckets]]
+binding = "NEXT_INC_CACHE_R2_BUCKET"
+bucket_name = "webs-alots-next-cache-staging"
 
 # W8-A31-01: KV namespace binding for staging.
 #


### PR DESCRIPTION
## Summary

This PR implements the remaining low-risk, end-to-end audit fixes from `PROJECT_AUDIT_REPORT.md` after the focused dashboard/data-layer fixes in #1249:

- **CDN-02 / build warnings**: remove the redundant `Cache-Control` custom header for `/_next/static` from `next.config.ts`. `public/_headers` already sets `public, max-age=31536000, immutable`, and Cloudflare Static Assets serves the files directly, so the Next.js rule only triggered the "Custom Cache-Control headers for /_next/static" warning.
- **CF-BUNDLE-01**: update `scripts/post-build-patch.mjs` to neutralize both the legacy `@vercel/og` Turbopack import pattern and the newer OpenNext `init_throw`/`throw_exports` shim. `build:cf` now prints a clean "✓ Patched handler.mjs" message instead of the ⚠️ pattern-mismatch warning.
- **R2-01**: wire the Next.js 16 incremental cache to R2 for durable `use cache` / ISR entries across Worker isolates. `wrangler.toml` now declares the `NEXT_INC_CACHE_R2_BUCKET` binding at the top level and for both `env.production` and `env.staging`, and `.github/workflows/deploy.yml` sets `ENABLE_R2_INCREMENTAL_CACHE=1`. The bucket is auto-created on first deploy by the OpenNext `populateCache` step.
- **Storybook config cleanup**: remove the `../src/**/*.mdx` glob (no MDX files), raise `build.chunkSizeWarningLimit` to `1536` to silence the large-chunk warning, and add `scripts/patch-storybook.mjs` to expose `./package.json` in `@opennextjs/cloudflare` exports so Storybook `getAutoRefs` no longer logs `unable to find package.json`. `prestorybook` / `prebuild-storybook` run the patch.
- **Next.js 16 middleware migration**: evaluated and reverted. `@opennextjs/cloudflare` (1.19.11 and 1.20.1) detects Node.js middleware via `functionsConfigManifest.functions["/_middleware"]` and hard-exits, so the existing Edge middleware in `src/middleware.ts` remains in place for now. The deprecation warning is noted and the `proxy.ts` migration was rolled back.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [x] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] E2E tests pass locally

Verified locally with Node 22.13.0:

- `npm run lint` — passes
- `npm run typecheck` — passes
- `npm run test` — 2084 passed, 84 skipped
- `npm run build` — passes
- `npm run build:cf` (with `ALLOW_MISSING_PUBLIC_ENV=1` and `ENABLE_R2_INCREMENTAL_CACHE=1`) — passes
- `npm run build-storybook` — passes, no warnings
- `npm run format:check` — passes

## Observability

- [ ] This PR adds/modifies logging (structured via `@/lib/logger`)
- [ ] This PR changes Sentry configuration or error handling
- [x] N/A — no observability changes

## Rollback

Revert this commit and unset `ENABLE_R2_INCREMENTAL_CACHE` in the deploy workflow.

## SLO / Metrics Impact

- [ ] This PR introduces or modifies an SLO-tracked endpoint
- [ ] New metrics or alerts are needed
- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met (`npm run test:coverage`)
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints)