### PR TITLE
test: improve coverage for data/client, validations, and pure libraries

### DIFF
--- a/src/lib/__tests__/data-client-coverage.test.ts
+++ b/src/lib/__tests__/data-client-coverage.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  clearLookupCache,
+  fetchAppointments,
+  fetchDoctorAppointments,
+  fetchPatientAppointments,
+  fetchGeneratedSlots,
+  fetchSlotBookingCounts,
+  fetchAvailableSlots,
+  fetchConsultationNotes,
+  fetchTimeSlots,
+  fetchNotifications,
+  fetchDashboardStats,
+  fetchMedicalCertificates,
+  fetchOdontogram,
+  fetchTreatmentPlans,
+  fetchSterilizationLog,
+  fetchBeforeAfterPhotos,
+  fetchInstallmentPlans,
+  fetchHolidays,
+} from "@/lib/data/client";
+import { createClient, createTenantClient } from "@/lib/supabase-client";
+import { createMockSupabaseClient } from "./test-utils";
+
+vi.mock("@/lib/supabase-client", () => ({
+  createClient: vi.fn(),
+  createTenantClient: vi.fn(),
+}));
+
+function setupMock(rows: Record<string, unknown[]>) {
+  const mockSupabase = createMockSupabaseClient(rows);
+  vi.mocked(createClient).mockReturnValue(mockSupabase as never);
+  vi.mocked(createTenantClient).mockReturnValue(mockSupabase as never);
+  return mockSupabase;
+}
+
+beforeEach(() => {
+  clearLookupCache();
+});
+
+// ── Appointments ──────────────────────────────────────────────────────
+
+describe("appointments", () => {
+  const rows = {
+    users: [
+      {
+        id: "p1",
+        name: "Patient One",
+        phone: "+212600000001",
+        email: "p1@test.ma",
+        clinic_id: "clinic-1",
+      },
+      {
+        id: "d1",
+        name: "Dr. Amina",
+        phone: null,
+        email: null,
+        clinic_id: "clinic-1",
+      },
+    ],
+    services: [{ id: "s1", name: "Consultation", price: 200, clinic_id: "clinic-1" }],
+    appointments: [
+      {
+        id: "a1",
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        doctor_id: "d1",
+        service_id: "s1",
+        slot_start: "2026-08-01T10:00:00Z",
+        slot_end: "2026-08-01T10:30:00Z",
+        appointment_date: "2026-08-01",
+        start_time: "10:00:00",
+        end_time: "10:30:00",
+        status: "confirmed",
+        is_first_visit: true,
+        is_walk_in: false,
+        insurance_flag: true,
+        booking_source: "online",
+        notes: null,
+        cancelled_at: null,
+        cancellation_reason: null,
+        rescheduled_from: null,
+        is_emergency: false,
+        recurrence_group_id: null,
+        recurrence_pattern: null,
+        recurrence_index: null,
+        created_at: "2026-07-11T09:00:00Z",
+        updated_at: "2026-07-11T09:00:00Z",
+      },
+    ],
+  };
+
+  it("fetchAppointments returns mapped appointments", async () => {
+    setupMock(rows);
+    const appointments = await fetchAppointments("clinic-1");
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0].patientName).toBe("Patient One");
+    expect(appointments[0].serviceName).toBe("Consultation");
+    expect(appointments[0].hasInsurance).toBe(true);
+    expect(appointments[0].isFirstVisit).toBe(true);
+  });
+
+  it("fetchAppointments filters by sinceDate", async () => {
+    setupMock(rows);
+    const appointments = await fetchAppointments("clinic-1", { sinceDate: "2026-08-01" });
+    expect(appointments).toHaveLength(1);
+  });
+
+  it("fetchDoctorAppointments filters by doctor", async () => {
+    setupMock(rows);
+    const appointments = await fetchDoctorAppointments("clinic-1", "d1");
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0].doctorName).toBe("Dr. Amina");
+  });
+
+  it("fetchPatientAppointments filters by patient", async () => {
+    setupMock(rows);
+    const appointments = await fetchPatientAppointments("clinic-1", "p1");
+    expect(appointments).toHaveLength(1);
+    expect(appointments[0].patientName).toBe("Patient One");
+  });
+});
+
+// ── Booking ───────────────────────────────────────────────────────────
+
+describe("booking", () => {
+  const rows = {
+    users: [
+      {
+        id: "d1",
+        name: "Dr. Amina",
+        phone: null,
+        email: null,
+        clinic_id: "clinic-1",
+      },
+    ],
+    services: [{ id: "s1", name: "Consultation", price: 200, clinic_id: "clinic-1" }],
+    time_slots: [
+      {
+        id: "ts1",
+        clinic_id: "clinic-1",
+        doctor_id: "d1",
+        day_of_week: 6, // Saturday for 2026-08-01
+        start_time: "09:00",
+        end_time: "10:00",
+        max_capacity: 2,
+        buffer_minutes: 0,
+        buffer_min: 0,
+        is_available: true,
+        is_active: true,
+      },
+    ],
+    appointments: [
+      {
+        id: "a1",
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        doctor_id: "d1",
+        appointment_date: "2026-08-01",
+        start_time: "09:00:00",
+        status: "confirmed",
+      },
+      {
+        id: "a2",
+        clinic_id: "clinic-1",
+        patient_id: "p2",
+        doctor_id: "d1",
+        appointment_date: "2026-08-01",
+        start_time: "09:00:00",
+        status: "cancelled",
+      },
+      {
+        id: "a3",
+        clinic_id: "clinic-1",
+        patient_id: "p3",
+        doctor_id: "d1",
+        appointment_date: "2026-08-01",
+        start_time: "09:00:00",
+        status: "confirmed",
+      },
+    ],
+  };
+
+  it("fetchGeneratedSlots returns time slots for a doctor and date", async () => {
+    setupMock(rows);
+    const slots = await fetchGeneratedSlots("clinic-1", "2026-08-01", "d1", {
+      slotDuration: 30,
+      bufferTime: 0,
+      maxPerSlot: 2,
+    });
+    expect(slots).toContain("09:00");
+    expect(slots).toContain("09:30");
+  });
+
+  it("fetchSlotBookingCounts excludes cancelled and no_show", async () => {
+    setupMock(rows);
+    const counts = await fetchSlotBookingCounts("clinic-1", "2026-08-01", "d1");
+    expect(counts["09:00"]).toBe(2);
+    expect(counts["09:30"]).toBeUndefined();
+    expect(counts["cancelled"]).toBeUndefined();
+  });
+
+  it("fetchAvailableSlots removes fully booked slots", async () => {
+    setupMock(rows);
+    const slots = await fetchAvailableSlots("clinic-1", "2026-08-01", "d1", {
+      slotDuration: 30,
+      bufferTime: 0,
+      maxPerSlot: 2,
+    });
+    expect(slots).not.toContain("09:00");
+    expect(slots).toContain("09:30");
+  });
+});
+
+// ── Clinical ──────────────────────────────────────────────────────────
+
+describe("clinical", () => {
+  const rows = {
+    users: [
+      {
+        id: "p1",
+        name: "Patient One",
+        phone: "+212600000001",
+        email: "p1@test.ma",
+        clinic_id: "clinic-1",
+      },
+      {
+        id: "d1",
+        name: "Dr. Amina",
+        phone: null,
+        email: null,
+        clinic_id: "clinic-1",
+      },
+    ],
+    services: [{ id: "s1", name: "Consultation", price: 200, clinic_id: "clinic-1" }],
+    consultation_notes: [
+      {
+        id: "cn1",
+        clinic_id: "clinic-1",
+        appointment_id: "a1",
+        doctor_id: "d1",
+        patient_id: "p1",
+        notes: "Bilan",
+        diagnosis: "Grippe",
+        content: { reason: "fever" },
+        created_at: "2026-07-11T09:00:00Z",
+        updated_at: "2026-07-11T09:00:00Z",
+      },
+    ],
+    time_slots: [
+      {
+        id: "ts1",
+        clinic_id: "clinic-1",
+        doctor_id: "d1",
+        day_of_week: 6,
+        start_time: "09:00",
+        end_time: "10:00",
+        max_capacity: 2,
+        buffer_minutes: 5,
+        buffer_min: 5,
+        is_available: true,
+        is_active: true,
+      },
+    ],
+    notifications: [
+      {
+        id: "n1",
+        clinic_id: "clinic-1",
+        user_id: "p1",
+        type: "appointment",
+        channel: "in_app",
+        title: "Rappel",
+        body: "Rendez-vous demain",
+        is_read: false,
+        sent_at: "2026-07-11T09:00:00Z",
+      },
+    ],
+  };
+
+  it("fetchConsultationNotes maps notes with patient and doctor names", async () => {
+    setupMock(rows);
+    const notes = await fetchConsultationNotes("clinic-1");
+    expect(notes).toHaveLength(1);
+    expect(notes[0].patientName).toBe("Patient One");
+    expect(notes[0].doctorName).toBe("Dr. Amina");
+    expect(notes[0].diagnosis).toBe("Grippe");
+  });
+
+  it("fetchTimeSlots maps active slots", async () => {
+    setupMock(rows);
+    const slots = await fetchTimeSlots("clinic-1", "d1");
+    expect(slots).toHaveLength(1);
+    expect(slots[0].startTime).toBe("09:00");
+    expect(slots[0].isAvailable).toBe(true);
+  });
+
+  it("fetchNotifications maps notifications", async () => {
+    setupMock(rows);
+    const notifications = await fetchNotifications("p1");
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].title).toBe("Rappel");
+    expect(notifications[0].read).toBe(false);
+    expect(notifications[0].status).toBe("delivered");
+  });
+});
+
+describe("clinical dashboard stats", () => {
+  const rows = {
+    users: [
+      {
+        id: "p1",
+        clinic_id: "clinic-1",
+        role: "patient",
+        metadata: { insurance: true },
+      },
+      {
+        id: "p2",
+        clinic_id: "clinic-1",
+        role: "patient",
+        metadata: null,
+      },
+      {
+        id: "d1",
+        clinic_id: "clinic-1",
+        role: "doctor",
+        metadata: null,
+      },
+    ],
+    appointments: [
+      { id: "a1", clinic_id: "clinic-1", status: "completed" },
+      { id: "a2", clinic_id: "clinic-1", status: "no_show" },
+      { id: "a3", clinic_id: "clinic-1", status: "confirmed" },
+    ],
+    payments: [
+      { id: "pay1", clinic_id: "clinic-1", status: "completed", amount: 200 },
+      { id: "pay2", clinic_id: "clinic-1", status: "completed", amount: 300 },
+    ],
+    reviews: [
+      { id: "r1", clinic_id: "clinic-1", stars: 5 },
+      { id: "r2", clinic_id: "clinic-1", stars: 3 },
+    ],
+  };
+
+  it("fetchDashboardStats aggregates counts", async () => {
+    setupMock(rows);
+    const stats = await fetchDashboardStats("clinic-1");
+    expect(stats.totalPatients).toBe(2);
+    expect(stats.totalAppointments).toBe(3);
+    expect(stats.completedAppointments).toBe(1);
+    expect(stats.noShowCount).toBe(1);
+    expect(stats.totalRevenue).toBe(500);
+    expect(stats.averageRating).toBe(4);
+    expect(stats.doctorCount).toBe(1);
+    expect(stats.insurancePatients).toBe(1);
+  });
+});
+
+// ── Dental ────────────────────────────────────────────────────────────
+
+describe("dental", () => {
+  const rows = {
+    users: [
+      {
+        id: "p1",
+        name: "Patient One",
+        phone: "+212600000001",
+        email: "p1@test.ma",
+        clinic_id: "clinic-1",
+      },
+      {
+        id: "d1",
+        name: "Dr. Amina",
+        phone: null,
+        email: null,
+        clinic_id: "clinic-1",
+      },
+    ],
+    services: [{ id: "s1", name: "Consultation", price: 200, clinic_id: "clinic-1" }],
+    medical_certificates: [
+      {
+        id: "mc1",
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        doctor_id: "d1",
+        appointment_id: null,
+        type: "sick_leave",
+        content: { reason: "grippe" },
+        pdf_url: null,
+        issued_date: "2026-07-10",
+        created_at: "2026-07-10T09:00:00Z",
+      },
+    ],
+    odontogram: [
+      {
+        tooth_number: 11,
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        status: "healthy",
+        notes: null,
+      },
+    ],
+    treatment_plans: [
+      {
+        id: "tp1",
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        doctor_id: "d1",
+        title: "Traitement carie",
+        steps: [
+          { step: 1, description: "Nettoyage", status: "completed", date: "2026-07-10", cost: 100 },
+        ],
+        total_cost: 100,
+        status: "in_progress",
+        created_at: "2026-07-10T09:00:00Z",
+        updated_at: "2026-07-10T09:00:00Z",
+      },
+    ],
+    sterilization_log: [
+      {
+        id: "sl1",
+        clinic_id: "clinic-1",
+        tool_name: "Pince",
+        sterilized_by: "Assistant",
+        sterilized_at: "2026-07-11T08:00:00Z",
+        next_due: "2026-07-18T08:00:00Z",
+        method: "autoclave",
+        notes: null,
+        batch_number: "B001",
+        cycle_number: 1,
+      },
+    ],
+    before_after_photos: [
+      {
+        id: "bap1",
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        treatment_plan_id: "tp1",
+        description: "Avant/après",
+        before_date: "2026-07-01",
+        after_date: "2026-07-10",
+        category: "smile",
+      },
+    ],
+  };
+
+  it("fetchMedicalCertificates maps certificates", async () => {
+    setupMock(rows);
+    const certs = await fetchMedicalCertificates("clinic-1");
+    expect(certs).toHaveLength(1);
+    expect(certs[0].patientName).toBe("Patient One");
+    expect(certs[0].type).toBe("sick_leave");
+  });
+
+  it("fetchOdontogram maps teeth", async () => {
+    setupMock(rows);
+    const teeth = await fetchOdontogram("clinic-1", "p1");
+    expect(teeth).toHaveLength(1);
+    expect(teeth[0].toothNumber).toBe(11);
+  });
+
+  it("fetchTreatmentPlans maps plans and steps", async () => {
+    setupMock(rows);
+    const plans = await fetchTreatmentPlans("clinic-1");
+    expect(plans).toHaveLength(1);
+    expect(plans[0].steps).toHaveLength(1);
+    expect(plans[0].steps[0].cost).toBe(100);
+  });
+
+  it("fetchSterilizationLog maps log entries", async () => {
+    setupMock(rows);
+    const log = await fetchSterilizationLog("clinic-1");
+    expect(log).toHaveLength(1);
+    expect(log[0].toolName).toBe("Pince");
+    expect(log[0].method).toBe("autoclave");
+  });
+
+  it("fetchBeforeAfterPhotos maps photos", async () => {
+    setupMock(rows);
+    const photos = await fetchBeforeAfterPhotos("clinic-1");
+    expect(photos).toHaveLength(1);
+    expect(photos[0].category).toBe("smile");
+  });
+});
+
+// ── Clinic ────────────────────────────────────────────────────────────
+
+describe("clinic", () => {
+  const rows = {
+    users: [
+      {
+        id: "p1",
+        name: "Patient One",
+        phone: "+212600000001",
+        email: "p1@test.ma",
+        clinic_id: "clinic-1",
+      },
+    ],
+    services: [{ id: "s1", name: "Consultation", price: 200, clinic_id: "clinic-1" }],
+    installment_plans: [
+      {
+        id: "ip1",
+        clinic_id: "clinic-1",
+        patient_id: "p1",
+        treatment_plan_id: "tp1",
+        total_amount: 1000,
+        currency: "MAD",
+        down_payment: 200,
+        status: "active",
+        whatsapp_reminder: true,
+        created_at: "2026-07-10T09:00:00Z",
+      },
+    ],
+    installments: [
+      {
+        id: "i1",
+        plan_id: "ip1",
+        amount: 200,
+        due_date: "2026-08-10",
+        paid_date: null,
+        status: "pending",
+        receipt_id: null,
+      },
+      {
+        id: "i2",
+        plan_id: "ip1",
+        amount: 200,
+        due_date: "2026-09-10",
+        paid_date: "2026-08-15",
+        status: "paid",
+        receipt_id: "r1",
+      },
+    ],
+    treatment_plans: [{ id: "tp1", title: "Plan A", clinic_id: "clinic-1" }],
+    clinic_holidays: [
+      {
+        id: "h1",
+        clinic_id: "clinic-1",
+        title: "Aid El Kebir",
+        start_date: "2026-07-17",
+        type: "national",
+        recurring: false,
+      },
+    ],
+  };
+
+  it("fetchInstallmentPlans groups installments and maps plan data", async () => {
+    setupMock(rows);
+    const plans = await fetchInstallmentPlans("clinic-1");
+    expect(plans).toHaveLength(1);
+    expect(plans[0].installments).toHaveLength(2);
+    expect(plans[0].treatmentTitle).toBe("Plan A");
+    expect(plans[0].whatsappReminderEnabled).toBe(true);
+  });
+
+  it("fetchHolidays maps holiday rows", async () => {
+    setupMock(rows);
+    const holidays = await fetchHolidays("clinic-1");
+    expect(holidays).toHaveLength(1);
+    expect(holidays[0].name).toBe("Aid El Kebir");
+    expect(holidays[0].type).toBe("national");
+  });
+});

--- a/src/lib/__tests__/lib-pure-coverage.test.ts
+++ b/src/lib/__tests__/lib-pure-coverage.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getInsuranceProvider } from "@/lib/env";
+import { checkEligibility, submitClaim } from "@/lib/insurance/client";
+import { logger } from "@/lib/logger";
+import { executeReport, convertToCSV, type ReportDefinition } from "@/lib/reports/builder";
+import {
+  classifyIncidentSeverity,
+  createIncident,
+  getContainmentProcedures,
+  getNotificationDeadlineHours,
+  isNotifiable,
+} from "@/lib/security/incident-response";
+import { detectLanguage, LANGUAGE_LABELS } from "@/lib/support/language-detect";
+import { createMockSupabaseClient } from "./test-utils";
+
+vi.mock("@/lib/env", () => ({
+  getInsuranceProvider: vi.fn(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "550e8400-e29b-41d4-a716-446655440000") });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetAllMocks();
+});
+
+// ── Insurance client ──────────────────────────────────────────────────
+
+describe("insurance client", () => {
+  it("checkEligibility returns sandbox result for valid policy", async () => {
+    vi.mocked(getInsuranceProvider).mockReturnValue("sandbox");
+    const result = await checkEligibility("123456", "AMO");
+    expect(result.eligible).toBe(true);
+    expect(result.coveragePercentage).toBe(70);
+    expect(result.insuranceType).toBe("AMO");
+  });
+
+  it("checkEligibility returns ineligible for short policy", async () => {
+    vi.mocked(getInsuranceProvider).mockReturnValue("sandbox");
+    const result = await checkEligibility("123", "AMO");
+    expect(result.eligible).toBe(false);
+    expect(result.coPayPercentage).toBe(100);
+  });
+
+  it("checkEligibility throws for unsupported provider", async () => {
+    vi.mocked(getInsuranceProvider).mockReturnValue("amo");
+    await expect(checkEligibility("123456", "AMO")).rejects.toThrow(
+      'Insurance provider "amo" integration not yet implemented',
+    );
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("submitClaim returns sandbox claim", async () => {
+    vi.mocked(getInsuranceProvider).mockReturnValue("sandbox");
+    const result = await submitClaim({
+      policyNumber: "123456",
+      insuranceType: "CNOPS",
+      amountCentimes: 1000,
+      appointmentDate: "2026-07-11",
+      doctorName: "Dr. Test",
+      patientName: "Patient Test",
+    });
+    expect(result.success).toBe(true);
+    expect(result.approvedAmountCentimes).toBe(800);
+    expect(result.processingDays).toBe(14);
+    expect(result.claimNumber).toContain("CNOPS-");
+  });
+
+  it("submitClaim throws for unsupported provider", async () => {
+    vi.mocked(getInsuranceProvider).mockReturnValue("cnops");
+    await expect(
+      submitClaim({
+        policyNumber: "123456",
+        insuranceType: "CNOPS",
+        amountCentimes: 1000,
+        appointmentDate: "2026-07-11",
+        doctorName: "Dr. Test",
+        patientName: "Patient Test",
+      }),
+    ).rejects.toThrow('Insurance provider "cnops" integration not yet implemented');
+  });
+});
+
+// ── Language detection ────────────────────────────────────────────────
+
+describe("language detection", () => {
+  it("detects Arabic text", () => {
+    expect(detectLanguage("مرحبا بالعالم")).toBe("ar");
+  });
+
+  it("detects English text", () => {
+    expect(detectLanguage("hello doctor appointment")).toBe("en");
+  });
+
+  it("defaults to French for ambiguous text", () => {
+    expect(detectLanguage("bonjour clinique")).toBe("fr");
+  });
+
+  it("returns fr for empty strings", () => {
+    expect(detectLanguage("")).toBe("fr");
+  });
+
+  it("exposes language labels", () => {
+    expect(LANGUAGE_LABELS.fr).toBe("Français");
+    expect(LANGUAGE_LABELS.ar).toBe("العربية");
+    expect(LANGUAGE_LABELS.en).toBe("English");
+  });
+});
+
+// ── Security incident response ────────────────────────────────────────
+
+describe("security incident response", () => {
+  it("creates an incident", () => {
+    const incident = createIncident({
+      clinicId: "clinic-1",
+      category: "data_breach",
+      severity: "critical",
+      title: "Test incident",
+      description: "Sensitive data exposed",
+      reportedBy: "system",
+      affectedSystems: ["db"],
+      affectedPatientCount: 5,
+    });
+    expect(incident.category).toBe("data_breach");
+    expect(incident.status).toBe("reported");
+    expect(incident.affectedPatientCount).toBe(5);
+    expect(incident.id).toBe("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("classifies severity", () => {
+    expect(
+      classifyIncidentSeverity({
+        dataBreached: true,
+        patientsAffected: 101,
+        systemsAffected: 1,
+        serviceImpacted: false,
+      }),
+    ).toBe("critical");
+    expect(
+      classifyIncidentSeverity({
+        dataBreached: true,
+        patientsAffected: 1,
+        systemsAffected: 1,
+        serviceImpacted: false,
+      }),
+    ).toBe("high");
+    expect(
+      classifyIncidentSeverity({
+        dataBreached: false,
+        patientsAffected: 0,
+        systemsAffected: 3,
+        serviceImpacted: true,
+      }),
+    ).toBe("high");
+    expect(
+      classifyIncidentSeverity({
+        dataBreached: false,
+        patientsAffected: 0,
+        systemsAffected: 2,
+        serviceImpacted: false,
+      }),
+    ).toBe("medium");
+    expect(
+      classifyIncidentSeverity({
+        dataBreached: false,
+        patientsAffected: 0,
+        systemsAffected: 0,
+        serviceImpacted: false,
+      }),
+    ).toBe("low");
+  });
+
+  it("returns containment procedures by category", () => {
+    expect(getContainmentProcedures("data_breach")).toContain(
+      "Notify DPO within 1 hour (Moroccan Law 09-08)",
+    );
+    expect(getContainmentProcedures("phishing")).toContain("Block sender domain/address");
+    expect(getContainmentProcedures("unknown" as never)).toContain("Document the incident details");
+  });
+
+  it("determines if incident is notifiable", () => {
+    const breach = createIncident({
+      clinicId: "clinic-1",
+      category: "data_breach",
+      severity: "high",
+      title: "B",
+      description: "B",
+      reportedBy: "system",
+      affectedSystems: ["db"],
+      affectedPatientCount: 1,
+    });
+    expect(isNotifiable(breach)).toBe(true);
+    const critical = createIncident({
+      clinicId: "clinic-1",
+      category: "service_disruption",
+      severity: "critical",
+      title: "C",
+      description: "C",
+      reportedBy: "system",
+      affectedSystems: ["api"],
+      affectedPatientCount: 0,
+    });
+    expect(isNotifiable(critical)).toBe(true);
+    const low = createIncident({
+      clinicId: "clinic-1",
+      category: "policy_violation",
+      severity: "low",
+      title: "L",
+      description: "L",
+      reportedBy: "system",
+      affectedSystems: ["email"],
+      affectedPatientCount: 0,
+    });
+    expect(isNotifiable(low)).toBe(false);
+  });
+
+  it("returns notification deadline hours", () => {
+    const breach = createIncident({
+      clinicId: "clinic-1",
+      category: "data_breach",
+      severity: "high",
+      title: "B",
+      description: "B",
+      reportedBy: "system",
+      affectedSystems: ["db"],
+      affectedPatientCount: 1,
+    });
+    expect(getNotificationDeadlineHours(breach)).toBe(72);
+    const critical = createIncident({
+      clinicId: "clinic-1",
+      category: "service_disruption",
+      severity: "critical",
+      title: "C",
+      description: "C",
+      reportedBy: "system",
+      affectedSystems: ["api"],
+      affectedPatientCount: 0,
+    });
+    expect(getNotificationDeadlineHours(critical)).toBe(24);
+    const low = createIncident({
+      clinicId: "clinic-1",
+      category: "policy_violation",
+      severity: "low",
+      title: "L",
+      description: "L",
+      reportedBy: "system",
+      affectedSystems: ["email"],
+      affectedPatientCount: 0,
+    });
+    expect(getNotificationDeadlineHours(low)).toBe(168);
+  });
+});
+
+// ── Report builder ────────────────────────────────────────────────────
+
+describe("report builder", () => {
+  const rows = {
+    appointments: [
+      {
+        id: "a1",
+        patient_id: "p1",
+        doctor_id: "d1",
+        status: "confirmed",
+        slot_start: "2026-07-11T10:00:00Z",
+        slot_end: "2026-07-11T10:30:00Z",
+        appointment_type: "consultation",
+        created_at: "2026-07-11T09:00:00Z",
+        clinic_id: "clinic-1",
+      },
+      {
+        id: "a2",
+        patient_id: "p2",
+        doctor_id: "d1",
+        status: "cancelled",
+        slot_start: "2026-07-11T11:00:00Z",
+        slot_end: "2026-07-11T11:30:00Z",
+        appointment_type: "followup",
+        created_at: "2026-07-11T09:00:00Z",
+        clinic_id: "clinic-1",
+      },
+      {
+        id: "a3",
+        patient_id: "p3",
+        doctor_id: "d2",
+        status: "confirmed",
+        slot_start: "2026-07-12T10:00:00Z",
+        slot_end: "2026-07-12T10:30:00Z",
+        appointment_type: "consultation",
+        created_at: "2026-07-12T09:00:00Z",
+        clinic_id: "clinic-1",
+      },
+    ],
+  };
+
+  function makeDefinition(overrides?: Partial<ReportDefinition>): ReportDefinition {
+    return {
+      clinicId: "clinic-1",
+      dataSource: "appointments",
+      fields: ["id", "status", "appointment_type"],
+      filters: [],
+      orderBy: { field: "created_at", direction: "desc" },
+      exportFormat: "json",
+      ...overrides,
+    };
+  }
+
+  it("executeReport returns filtered rows and count", async () => {
+    const supabase = createMockSupabaseClient(rows);
+    const result = await executeReport(supabase as never, makeDefinition());
+    expect(result.columns).toEqual(["id", "status", "appointment_type"]);
+    expect(result.rows).toHaveLength(3);
+    expect(result.totalRows).toBe(3);
+    expect(result.generatedAt).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  it("executeReport applies filters", async () => {
+    const supabase = createMockSupabaseClient(rows);
+    const result = await executeReport(
+      supabase as never,
+      makeDefinition({
+        filters: [
+          { field: "status", operator: "eq", value: "confirmed" },
+          { field: "doctor_id", operator: "neq", value: "d2" },
+        ],
+      }),
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].id).toBe("a1");
+  });
+
+  it("executeReport skips disallowed fields and filters", async () => {
+    const supabase = createMockSupabaseClient(rows);
+    const result = await executeReport(
+      supabase as never,
+      makeDefinition({
+        fields: ["id", "malicious_column"],
+        filters: [{ field: "malicious_column", operator: "eq", value: "x" }],
+      }),
+    );
+    expect(result.columns).toEqual(["id"]);
+    expect(result.rows).toHaveLength(3);
+  });
+
+  it("executeReport rejects invalid data source", async () => {
+    const supabase = createMockSupabaseClient(rows);
+    await expect(
+      executeReport(supabase as never, makeDefinition({ dataSource: "invalid" as never })),
+    ).rejects.toThrow("Invalid data source: invalid");
+  });
+
+  it("executeReport rejects empty field list", async () => {
+    const supabase = createMockSupabaseClient(rows);
+    await expect(executeReport(supabase as never, makeDefinition({ fields: [] }))).rejects.toThrow(
+      "No valid fields selected",
+    );
+  });
+
+  it("convertToCSV formats rows and escapes values", () => {
+    const result = {
+      columns: ["id", "name"],
+      rows: [
+        { id: "a1", name: "Alice" },
+        { id: "a2", name: 'Bob, "the builder"' },
+      ],
+      totalRows: 2,
+      generatedAt: "2026-07-11",
+    };
+    const csv = convertToCSV(result);
+    expect(csv).toContain("id,name");
+    expect(csv).toContain("a1,Alice");
+    expect(csv).toContain('a2,"Bob, ""the builder"""');
+  });
+
+  it("convertToCSV handles empty rows", () => {
+    const result = {
+      columns: ["id"],
+      rows: [],
+      totalRows: 0,
+      generatedAt: "2026-07-11",
+    };
+    expect(convertToCSV(result)).toBe("id\n");
+  });
+});

--- a/src/lib/__tests__/test-utils.ts
+++ b/src/lib/__tests__/test-utils.ts
@@ -4,7 +4,8 @@ interface MockQueryState {
   table: string;
   rows: unknown[];
   head: boolean;
-  filters: Array<{ op: string; column: string; value: unknown }>;
+  count: boolean;
+  filters: Array<{ op: string; column: string; value: unknown; operator?: string }>;
   orderBy: string | null;
   ascending: boolean;
   limit: number;
@@ -15,6 +16,7 @@ function createMockQueryBuilder(table: string, rows: unknown[]) {
     table,
     rows,
     head: false,
+    count: false,
     filters: [],
     orderBy: null,
     ascending: true,
@@ -24,6 +26,7 @@ function createMockQueryBuilder(table: string, rows: unknown[]) {
   const builder = {
     select: vi.fn((columns?: string, options?: { count?: "exact"; head?: boolean }) => {
       if (options?.head) state.head = true;
+      if (options?.count === "exact") state.count = true;
       return builder;
     }),
     eq: vi.fn((column: string, value: unknown) => {
@@ -40,6 +43,22 @@ function createMockQueryBuilder(table: string, rows: unknown[]) {
     }),
     lte: vi.fn((column: string, value: unknown) => {
       state.filters.push({ op: "lte", column, value });
+      return builder;
+    }),
+    not: vi.fn((column: string, operator: string, value: unknown) => {
+      state.filters.push({ op: "not", column, value, operator });
+      return builder;
+    }),
+    neq: vi.fn((column: string, value: unknown) => {
+      state.filters.push({ op: "neq", column, value });
+      return builder;
+    }),
+    gt: vi.fn((column: string, value: unknown) => {
+      state.filters.push({ op: "gt", column, value });
+      return builder;
+    }),
+    lt: vi.fn((column: string, value: unknown) => {
+      state.filters.push({ op: "lt", column, value });
       return builder;
     }),
     order: vi.fn((column: string, options?: { ascending?: boolean }) => {
@@ -67,6 +86,28 @@ function createMockQueryBuilder(table: string, rows: unknown[]) {
               return typeof value === "string" && value >= (filter.value as string);
             case "lte":
               return typeof value === "string" && value <= (filter.value as string);
+            case "not": {
+              const operator = filter.operator ?? "eq";
+              let matches = false;
+              if (operator === "eq") {
+                matches = value === filter.value;
+              } else if (operator === "in") {
+                const raw = String(filter.value);
+                const values = raw
+                  .replace(/[()]/g, "")
+                  .split(",")
+                  .map((s) => s.replace(/"/g, "").trim())
+                  .filter(Boolean);
+                matches = values.includes(String(value));
+              }
+              return !matches;
+            }
+            case "neq":
+              return value !== filter.value;
+            case "gt":
+              return typeof value === "string" && value > (filter.value as string);
+            case "lt":
+              return typeof value === "string" && value < (filter.value as string);
             default:
               return true;
           }
@@ -89,6 +130,10 @@ function createMockQueryBuilder(table: string, rows: unknown[]) {
 
       if (state.head) {
         return onfulfilled?.({ count: result.length, data: null });
+      }
+
+      if (state.count) {
+        return onfulfilled?.({ data: result, count: result.length });
       }
 
       return onfulfilled?.({ data: result });

--- a/src/lib/__tests__/validations-coverage.test.ts
+++ b/src/lib/__tests__/validations-coverage.test.ts
@@ -1,0 +1,491 @@
+import { describe, expect, it } from "vitest";
+// Import from the barrel where the schema is re-exported, and directly when it
+// is intentionally not in the barrel.
+import {
+  aiTeamAlertReadSchema,
+  aiTeamChatSchema,
+  aiTeamGenerateSchema,
+  aiTeamTaskUpdateSchema,
+  oneClickCheckinSchema,
+  phoneHandlerLookupSchema,
+  attestationCreateSchema,
+  attestationSignSchema,
+  familyLinkCreateSchema,
+  doctorDelayUpdateSchema,
+  inventoryItemCreateSchema,
+  inventoryItemUpdateSchema,
+  inventoryTransactionSchema,
+  invoiceCreateSchema,
+  invoiceUpdateSchema,
+  paymentPlanCreateSchema,
+  installmentUpdateSchema,
+  reminderSendSchema,
+  revenueInsightsQuerySchema,
+  timelineQuerySchema,
+  TIMELINE_EVENT_TYPES,
+  passwordPolicySchema,
+  evaluatePasswordStrength,
+  clinicProvisionSchema,
+  churnPredictionQuerySchema,
+  revenueForecastQuerySchema,
+} from "@/lib/validations";
+import { aiTeamTaskCreateSchema, aiTeamTaskTransitionSchema } from "@/lib/validations/ai-team";
+import {
+  attestationListSchema,
+  familyLinkDeleteSchema,
+  familyMembersListSchema,
+  inventoryAlertsSchema,
+  waitTimeEstimateSchema,
+} from "@/lib/validations/batch4c";
+import { financialSummaryQuerySchema } from "@/lib/validations/billing";
+import {
+  noShowAnalyticsQuerySchema,
+  noShowMarkSchema,
+  smartScheduleConfirmSchema,
+  smartScheduleSchema,
+  waitlistAddSchema,
+  waitlistNotifySchema,
+  waitlistPromoteSchema,
+} from "@/lib/validations/receptionist-ai";
+import {
+  clinicAnalyticsQuerySchema,
+  clinicHealthMutationSchema,
+  clinicHealthQuerySchema,
+  clinicNarrativeRequestSchema,
+} from "@/lib/validations/super-admin";
+
+const validUUID = "550e8400-e29b-41d4-a716-446655440000";
+
+// ── AI Team ───────────────────────────────────────────────────────────
+
+describe("ai-team schemas", () => {
+  const baseChat = {
+    agentType: "support" as const,
+    message: "Hello",
+    conversationHistory: [{ role: "user" as const, content: "Hi" }],
+  };
+
+  it("validates aiTeamChatSchema", () => {
+    const result = aiTeamChatSchema.safeParse(baseChat);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown agentType in aiTeamChatSchema", () => {
+    const result = aiTeamChatSchema.safeParse({ ...baseChat, agentType: "unknown" });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates aiTeamTaskUpdateSchema", () => {
+    const result = aiTeamTaskUpdateSchema.safeParse({
+      taskId: validUUID,
+      status: "completed" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates aiTeamAlertReadSchema", () => {
+    const result = aiTeamAlertReadSchema.safeParse({ alertId: validUUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates aiTeamGenerateSchema", () => {
+    const result = aiTeamGenerateSchema.safeParse({ agentType: "marketing" as const });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates aiTeamTaskCreateSchema", () => {
+    const result = aiTeamTaskCreateSchema.safeParse({
+      title: "Write release notes",
+      agentType: "marketing" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates aiTeamTaskTransitionSchema", () => {
+    const result = aiTeamTaskTransitionSchema.safeParse({
+      taskId: validUUID,
+      fromStatus: "backlog" as const,
+      toStatus: "in_progress" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Batch 4C ──────────────────────────────────────────────────────────
+
+describe("batch4c schemas", () => {
+  it("validates oneClickCheckinSchema", () => {
+    const result = oneClickCheckinSchema.safeParse({
+      patientId: validUUID,
+      doctorId: validUUID,
+      appointmentId: validUUID,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates phoneHandlerLookupSchema", () => {
+    const result = phoneHandlerLookupSchema.safeParse({ phone: "+212612345678" });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates attestationCreateSchema", () => {
+    const result = attestationCreateSchema.safeParse({
+      patientId: validUUID,
+      doctorId: validUUID,
+      type: "sick_leave" as const,
+      title: "Arrêt de travail",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates attestationListSchema", () => {
+    const result = attestationListSchema.safeParse({ patientId: validUUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates attestationSignSchema", () => {
+    const result = attestationSignSchema.safeParse({ attestationId: validUUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates familyLinkCreateSchema", () => {
+    const result = familyLinkCreateSchema.safeParse({
+      primaryPatientId: validUUID,
+      linkedPatientId: validUUID,
+      relationship: "spouse" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates familyLinkDeleteSchema", () => {
+    const result = familyLinkDeleteSchema.safeParse({ linkId: validUUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates familyMembersListSchema", () => {
+    const result = familyMembersListSchema.safeParse({ patientId: validUUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates waitTimeEstimateSchema", () => {
+    const result = waitTimeEstimateSchema.safeParse({ doctorId: validUUID });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates doctorDelayUpdateSchema", () => {
+    const result = doctorDelayUpdateSchema.safeParse({
+      doctorId: validUUID,
+      delayMinutes: 30,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates inventoryItemCreateSchema", () => {
+    const result = inventoryItemCreateSchema.safeParse({
+      name: "Gants",
+      category: "consumable" as const,
+      currentStock: 100,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates inventoryItemUpdateSchema", () => {
+    const result = inventoryItemUpdateSchema.safeParse({ itemId: validUUID, name: "Gants XL" });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates inventoryTransactionSchema", () => {
+    const result = inventoryTransactionSchema.safeParse({
+      itemId: validUUID,
+      type: "usage" as const,
+      quantity: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates inventoryAlertsSchema", () => {
+    const result = inventoryAlertsSchema.safeParse({
+      category: "medication" as const,
+      alertType: "low_stock" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Billing ───────────────────────────────────────────────────────────
+
+describe("billing schemas", () => {
+  it("validates invoiceCreateSchema", () => {
+    const result = invoiceCreateSchema.safeParse({
+      patient_id: validUUID,
+      payment_method: "cash" as const,
+      line_items: [
+        {
+          description: "Consultation",
+          quantity: 1,
+          unit_price_centimes: 20000,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invoiceCreateSchema without line items", () => {
+    const result = invoiceCreateSchema.safeParse({ patient_id: validUUID });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates invoiceUpdateSchema", () => {
+    const result = invoiceUpdateSchema.safeParse({ status: "paid" as const });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates paymentPlanCreateSchema", () => {
+    const result = paymentPlanCreateSchema.safeParse({
+      invoice_id: validUUID,
+      num_installments: 3,
+      start_date: "2026-08-01",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates installmentUpdateSchema", () => {
+    const result = installmentUpdateSchema.safeParse({ status: "paid" as const });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates reminderSendSchema", () => {
+    const result = reminderSendSchema.safeParse({
+      invoice_id: validUUID,
+      reminder_type: "overdue_7d" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates revenueInsightsQuerySchema", () => {
+    const result = revenueInsightsQuerySchema.safeParse({ question: "Quel est le revenu ?" });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates financialSummaryQuerySchema", () => {
+    const result = financialSummaryQuerySchema.safeParse({
+      period: "month" as const,
+      start_date: "2026-07-01",
+      end_date: "2026-07-31",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Patient Timeline ──────────────────────────────────────────────────
+
+describe("patient-timeline schema", () => {
+  it("validates timelineQuerySchema", () => {
+    const result = timelineQuerySchema.safeParse({
+      patientId: validUUID,
+      eventType: "prescription" as const,
+      from: "2026-07-01",
+      to: "2026-07-31",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(1);
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("rejects invalid eventType", () => {
+    const result = timelineQuerySchema.safeParse({
+      patientId: validUUID,
+      eventType: "invalid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("exposes TIMELINE_EVENT_TYPES", () => {
+    expect(TIMELINE_EVENT_TYPES).toContain("visit");
+    expect(TIMELINE_EVENT_TYPES).toContain("prescription");
+  });
+});
+
+// ── Receptionist AI ───────────────────────────────────────────────────
+
+describe("receptionist-ai schemas", () => {
+  it("validates smartScheduleSchema", () => {
+    const result = smartScheduleSchema.safeParse({
+      doctorId: validUUID,
+      serviceId: validUUID,
+      patientId: validUUID,
+      preferredDate: "2026-08-01",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates smartScheduleConfirmSchema", () => {
+    const result = smartScheduleConfirmSchema.safeParse({
+      doctorId: validUUID,
+      serviceId: validUUID,
+      patientId: validUUID,
+      patientName: "Ahmed",
+      date: "2026-08-01",
+      time: "10:00",
+      slotDuration: 30,
+      bufferTime: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates waitlistAddSchema", () => {
+    const result = waitlistAddSchema.safeParse({
+      patientId: validUUID,
+      patientName: "Ahmed",
+      doctorId: validUUID,
+      preferredDate: "2026-08-01",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates waitlistNotifySchema", () => {
+    const result = waitlistNotifySchema.safeParse({
+      entryId: "entry-1",
+      availableDate: "2026-08-01",
+      availableTime: "10:00",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates waitlistPromoteSchema", () => {
+    const result = waitlistPromoteSchema.safeParse({
+      entryId: "entry-1",
+      date: "2026-08-01",
+      time: "10:00",
+      slotDuration: 30,
+      bufferTime: 5,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates noShowMarkSchema", () => {
+    const result = noShowMarkSchema.safeParse({
+      appointmentId: "appt-1",
+      reason: "Patient absent",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates noShowAnalyticsQuerySchema", () => {
+    const result = noShowAnalyticsQuerySchema.safeParse({
+      doctorId: validUUID,
+      startDate: "2026-07-01",
+      endDate: "2026-07-31",
+      view: "doctor-stats" as const,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Password Policy ───────────────────────────────────────────────────
+
+describe("password-policy", () => {
+  it("accepts strong passwords", () => {
+    expect(passwordPolicySchema.safeParse("StrongP@ss1").success).toBe(true);
+  });
+
+  it("rejects weak passwords", () => {
+    expect(passwordPolicySchema.safeParse("weak").success).toBe(false);
+  });
+
+  it("evaluates password strength", () => {
+    const result = evaluatePasswordStrength("StrongP@ss1");
+    expect(result.score).toBe(5);
+    expect(result.label).toBe("strong");
+  });
+
+  it("returns weak for short passwords", () => {
+    const result = evaluatePasswordStrength("abc");
+    expect(result.label).toBe("weak");
+  });
+});
+
+// ── Super Admin ───────────────────────────────────────────────────────
+
+describe("super-admin schemas", () => {
+  it("validates clinicProvisionSchema", () => {
+    const result = clinicProvisionSchema.safeParse({
+      clinic_name: "Clinique Test",
+      clinic_type: "doctor" as const,
+      tier: "pro" as const,
+      subdomain: "clinique-test",
+      owner_name: "Dr. Test",
+      owner_email: "test@clinique.ma",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid subdomain in clinicProvisionSchema", () => {
+    const result = clinicProvisionSchema.safeParse({
+      clinic_name: "Clinique Test",
+      clinic_type: "doctor" as const,
+      tier: "pro" as const,
+      subdomain: "_invalid",
+      owner_name: "Dr. Test",
+      owner_email: "test@clinique.ma",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("validates churnPredictionQuerySchema", () => {
+    const result = churnPredictionQuerySchema.safeParse({
+      risk_level: "high" as const,
+      sort_by: "score" as const,
+      sort_order: "desc" as const,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it("validates revenueForecastQuerySchema", () => {
+    const result = revenueForecastQuerySchema.safeParse({ months_ahead: 6 });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates clinicHealthQuerySchema", () => {
+    const result = clinicHealthQuerySchema.safeParse({
+      clinic_id: validUUID,
+      include_alerts: "false",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.include_alerts).toBe(false);
+    }
+  });
+
+  it("validates clinicHealthMutationSchema", () => {
+    const result = clinicHealthMutationSchema.safeParse({
+      clinic_id: validUUID,
+      create_alerts: "yes",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.create_alerts).toBe(true);
+    }
+  });
+
+  it("validates clinicNarrativeRequestSchema", () => {
+    const result = clinicNarrativeRequestSchema.safeParse({
+      clinic_id: validUUID,
+      refresh: "1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates clinicAnalyticsQuerySchema", () => {
+    const result = clinicAnalyticsQuerySchema.safeParse({
+      question: "Revenu ce mois ?",
+      clinic_id: validUUID,
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused unit tests to raise overall coverage from ~20.4% to 21.3% while pushing high-risk but previously uncovered modules into the 70–100% range.

- **Shared test mock** (`src/lib/__tests__/test-utils.ts`): adds `not`, `neq`, `gt`, `lt`, and `count` support to the mock Supabase query builder so data-layer tests can exercise the full filter surface.
- **`src/lib/data/client` coverage**: adds tests for `appointments`, `booking`, `clinical`, `dental`, and `clinic` fetch helpers, plus `fetchDashboardStats`.
- **Validation schemas**: adds tests for `ai-team`, `batch4c`, `billing`, `patient-timeline`, `receptionist-ai`, `super-admin`, and `password-policy` schemas.
- **Pure modules**: adds tests for `insurance/client`, `support/language-detect`, `security/incident-response`, and `reports/builder`.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated

## Observability

- [x] N/A — no observability changes

## Rollback

Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met (`npm run test:coverage`)
