### PR TITLE
chore(environment): pin Devin environment to Node 22.13.0

### DIFF
--- a/.devin/blueprint.yaml
+++ b/.devin/blueprint.yaml
@@ -1,0 +1,27 @@
+# https://docs.devin.ai/onboard-devin/environment-yaml
+initialize:
+  - uses: github.com/actions/setup-node@v4
+    with:
+      node-version: "22.13.0"
+  - run: npm install
+maintenance: |
+  npm install
+knowledge:
+  - name: lint
+    contents: |
+      npm run lint
+  - name: test
+    contents: |
+      npm run test
+  - name: coverage
+    contents: |
+      npm run test:coverage
+  - name: build
+    contents: |
+      npm run build:cf
+  - name: node
+    contents: |
+      node -v
+  - name: husky
+    contents: |
+      npx husky install


### PR DESCRIPTION
## Summary

Add `.devin/blueprint.yaml` so Devin sessions boot with Node 22.13.0, matching `.nvmrc` and `package.json` engines. This is the environment piece of the Node 22 migration; the pre-push hook already uses 22.13.0 and the application build is verified on it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] Infrastructure / CI

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [ ] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [x] No security impact

## Migration Safety

- [ ] This PR includes database migrations
- [ ] Migrations are backward-compatible (no destructive changes)
- [ ] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping
- [x] N/A — no migrations

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] E2E tests pass locally

## Observability

- [ ] This PR adds/modifies logging (structured via `@/lib/logger`)
- [ ] This PR changes Sentry configuration or error handling
- [x] N/A — no observability changes

## Rollback

Revert this commit or delete `.devin/blueprint.yaml`.

## SLO / Metrics Impact

- [ ] This PR introduces or modifies an SLO-tracked endpoint
- [ ] New metrics or alerts are needed
- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met (`npm run test:coverage`)
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints)
