### PR TITLE
fix(auth): allowlist /api/auth/resolve-clinic so the login funnel works

### DIFF
--- a/src/lib/__tests__/public-api-surface.test.ts
+++ b/src/lib/__tests__/public-api-surface.test.ts
@@ -55,6 +55,10 @@ describe("Public API surface lock", () => {
 // (see audit finding AZ-2 on prefix-match scope).
 const EXPECTED_PUBLIC_ROUTES: string[] = [
   "/api/auth/demo-login",
+  // Root-domain login funnel: email -> clinic subdomain resolver. Reachable
+  // pre-session/pre-tenant; returns only {subdomain, name}, rate-limited and
+  // enumeration-safe in the handler.
+  "/api/auth/resolve-clinic",
   "/api/billing/webhook",
   "/api/booking",
   "/api/booking/cancel",

--- a/src/lib/middleware/routes.ts
+++ b/src/lib/middleware/routes.ts
@@ -151,6 +151,10 @@ const PUBLIC_API_ROUTES = [
   "/api/leads",
   // Demo login (dev/staging only, guarded in handler)
   "/api/auth/demo-login",
+  // Root-domain login funnel — resolves which clinic subdomain an email
+  // belongs to before any session/tenant context exists. Returns only
+  // {subdomain, name}; rate-limited and enumeration-safe in the handler.
+  "/api/auth/resolve-clinic",
   // CSP report endpoint
   "/api/csp-report",
   // Versioned (v1) equivalents of public routes — rewrites in next.config.ts


### PR DESCRIPTION
## Summary

**Follow-up to #1263 (which merged before this fix landed).** The root login-funnel resolver
`POST /api/auth/resolve-clinic` is unreachable in production: the middleware denies-by-default any
`/api/*` route not in `PUBLIC_API_ROUTES`, and the new resolver was never allowlisted — so anonymous
root-domain calls return **401 Unauthorized** and the funnel can never resolve a clinic.

This adds the resolver to the public API allowlist and pins it in the `public-api-surface` lock test.

```diff
 // src/lib/middleware/routes.ts (PUBLIC_API_ROUTES)
   "/api/auth/demo-login",
+  // Root-domain login funnel — resolves which clinic subdomain an email
+  // belongs to before any session/tenant context exists.
+  "/api/auth/resolve-clinic",
```

The route is public **by design**: it runs before any session/tenant context exists (its whole job is
to discover the clinic before the user knows their subdomain). It is safe:
- rate-limited (`loginLimiter`),
- enumeration-safe (unknown email → `{clinics: []}`, same shape as a hit),
- returns only `{subdomain, name}` — never cross-tenant PHI,
- Zod-validated body, no email/PII logged.

Verified end-to-end against a local Supabase with a seeded `demo` clinic (see #1263 test report):
known email → `{subdomain:"demo"}`, unknown → `[]`, invalid → 422, and the browser funnel redirects to
`demo.localhost:3000/login` where the tenant login form renders.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR changes tenant isolation or multi-tenant scoping

Adds one intentionally-public, enumeration-safe pre-auth resolver endpoint to the allowlist; pinned in
the public-API-surface lock test so the exposure is explicit and reviewed.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated (public-api-surface lock updated)
- [x] Manual testing performed (local Supabase E2E)

## Observability

- [x] N/A — no observability changes

## Rollback

Revert this commit; the resolver returns to 401 (funnel non-functional but no security regression).

## SLO / Metrics Impact

- [x] N/A

## Drive-by Refactors

- None

## Checklist

- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints)
