### PR TITLE
fix(audit): repair audit-trail durability, rebooking table, and DSAR rate limiting

### DIFF
--- a/src/app/api/compliance/dsar/route.ts
+++ b/src/app/api/compliance/dsar/route.ts
@@ -1,7 +1,8 @@
 import { type NextRequest } from "next/server";
 import { z } from "zod";
-import { apiError, apiSuccess } from "@/lib/api-response";
+import { apiError, apiRateLimited, apiSuccess } from "@/lib/api-response";
 import { insertInAppNotification } from "@/lib/notification-persist";
+import { extractClientIp, createRateLimiter } from "@/lib/rate-limit";
 import { createServiceClient, createUntypedAdminClient } from "@/lib/supabase-server";
 
 const dsarSchema = z.object({
@@ -13,7 +14,19 @@ const dsarSchema = z.object({
   description: z.string().min(20).max(2000),
 });
 
+// F5: cap public DSAR submissions per IP to prevent notification spam and bot abuse.
+const dsarLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  failClosed: true,
+});
+
 export async function POST(request: NextRequest) {
+  const clientIp = extractClientIp(request);
+  if (!(await dsarLimiter.check(clientIp))) {
+    return apiRateLimited("Too many DSAR requests from this IP. Please try again later.");
+  }
+
   let payload: unknown;
   try {
     payload = await request.json();

--- a/src/app/api/cron/audit-log-flush/route.ts
+++ b/src/app/api/cron/audit-log-flush/route.ts
@@ -10,15 +10,124 @@
  * Protected by CRON_SECRET via Authorization: Bearer header.
  */
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { NextRequest } from "next/server";
 import { apiSuccess } from "@/lib/api-response";
 import { verifyCronSecret } from "@/lib/cron-auth";
 import { logger } from "@/lib/logger";
 import { withSentryCron } from "@/lib/sentry-cron";
 import { createAdminClient } from "@/lib/supabase-server";
+import { isValidClinicId } from "@/lib/tenant-context";
+import type { Database, Json } from "@/lib/types/database";
 
 const BATCH_SIZE = 1000;
 const MAX_RETRIES = 5;
+
+type PendingAuditLog = Database["public"]["Tables"]["pending_audit_logs"]["Row"];
+
+interface AuditPayload {
+  action?: unknown;
+  type?: unknown;
+  actor?: unknown;
+  clinic_id?: unknown;
+  clinic_name?: unknown;
+  description?: unknown;
+  ip_address?: unknown;
+  user_agent?: unknown;
+  metadata?: unknown;
+  timestamp?: unknown;
+}
+
+const ACTIVITY_LOG_TYPES = new Set([
+  "admin",
+  "announcement",
+  "auth",
+  "billing",
+  "booking",
+  "clinic",
+  "config",
+  "feature",
+  "patient",
+  "payment",
+  "security",
+  "template",
+]);
+
+function parsePayload(payload: Json | null): AuditPayload | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  return payload as AuditPayload;
+}
+
+function toString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  return null;
+}
+
+function toJson(value: unknown): Json | null {
+  if (value === null || value === undefined) return null;
+  return value as Json;
+}
+
+function sanitizeClinicId(value: unknown): string | null {
+  const str = toString(value);
+  if (!str) return null;
+  return isValidClinicId(str) ? str : null;
+}
+
+function sanitizeType(value: unknown): string | null {
+  const str = toString(value);
+  if (!str) return null;
+  return ACTIVITY_LOG_TYPES.has(str) ? str : null;
+}
+
+async function flushRow(
+  admin: SupabaseClient<Database>,
+  row: PendingAuditLog,
+): Promise<{ flushed: boolean; errorMessage?: string }> {
+  const payload = parsePayload(row.payload);
+
+  if (!payload) {
+    return { flushed: false, errorMessage: "pending_audit_logs payload is not an object" };
+  }
+
+  const type = sanitizeType(payload.type);
+  const clinicId = sanitizeClinicId(payload.clinic_id);
+  const timestamp = toString(payload.timestamp) ?? row.created_at;
+
+  if (!type) {
+    return {
+      flushed: false,
+      errorMessage: `invalid audit type in payload: ${String(payload.type)}`,
+    };
+  }
+
+  const { error: insertErr } = await admin.from("activity_logs").insert({
+    action: toString(payload.action) ?? "",
+    type,
+    actor: toString(payload.actor),
+    clinic_id: clinicId,
+    clinic_name: toString(payload.clinic_name),
+    description: toString(payload.description),
+    ip_address: toString(payload.ip_address),
+    user_agent: toString(payload.user_agent),
+    metadata: toJson(payload.metadata),
+    timestamp,
+  });
+
+  if (insertErr) {
+    return { flushed: false, errorMessage: insertErr.message };
+  }
+
+  const { error: deleteErr } = await admin.from("pending_audit_logs").delete().eq("id", row.id);
+  if (deleteErr) {
+    return { flushed: false, errorMessage: deleteErr.message };
+  }
+
+  return { flushed: true };
+}
 
 async function handler(request: NextRequest) {
   const authError = verifyCronSecret(request);
@@ -28,35 +137,7 @@ async function handler(request: NextRequest) {
   let flushed = 0;
   let failed = 0;
 
-  const { data: pending, error: fetchErr } = await (
-    admin as never as {
-      from(t: string): {
-        select(cols: string): {
-          order(
-            col: string,
-            opts: { ascending: boolean },
-          ): {
-            limit(n: number): Promise<{
-              data: Array<{
-                id: string;
-                event_type: string;
-                actor_id: string | null;
-                clinic_id: string | null;
-                entity_type: string | null;
-                entity_id: string | null;
-                metadata: Record<string, unknown> | null;
-                ip_address: string | null;
-                user_agent: string | null;
-                retry_count: number;
-                created_at: string;
-              }> | null;
-              error: { message: string } | null;
-            }>;
-          };
-        };
-      };
-    }
-  )
+  const { data: pending, error: fetchErr } = await admin
     .from("pending_audit_logs")
     .select("*")
     .order("created_at", { ascending: true })
@@ -73,64 +154,48 @@ async function handler(request: NextRequest) {
   }
 
   for (const row of pending) {
-    const untypedAdmin = admin as never as {
-      from(t: string): {
-        insert(r: Record<string, unknown>): Promise<{ error: { message: string } | null }>;
-        delete(): {
-          eq(col: string, val: string): Promise<{ error: { message: string } | null }>;
-        };
-        update(r: Record<string, unknown>): {
-          eq(col: string, val: string): Promise<{ error: { message: string } | null }>;
-        };
-      };
-    };
-
-    const { error: insertErr } = await untypedAdmin.from("activity_logs").insert({
-      event_type: row.event_type,
-      actor_id: row.actor_id,
-      clinic_id: row.clinic_id,
-      entity_type: row.entity_type,
-      entity_id: row.entity_id,
-      metadata: row.metadata,
-      ip_address: row.ip_address,
-      user_agent: row.user_agent,
-      created_at: row.created_at,
-    });
-
-    if (!insertErr) {
-      await untypedAdmin.from("pending_audit_logs").delete().eq("id", row.id);
+    const result = await flushRow(admin, row);
+    if (result.flushed) {
       flushed++;
-    } else {
-      const newRetryCount = (row.retry_count ?? 0) + 1;
-      await untypedAdmin
-        .from("pending_audit_logs")
-        .update({
-          retry_count: newRetryCount,
-          last_error: insertErr.message,
-        })
-        .eq("id", row.id);
+      continue;
+    }
 
-      failed++;
+    const newRetryCount = (row.retry_count ?? 0) + 1;
+    const lastError = result.errorMessage ?? "unknown flush error";
 
-      if (newRetryCount > MAX_RETRIES) {
-        logger.error("Pending audit log exceeded max retries", {
-          context: "cron/audit-log-flush",
-          pendingId: row.id,
-          retryCount: newRetryCount,
-          lastError: insertErr.message,
-        });
-        try {
-          const Sentry = await import("@sentry/nextjs");
-          Sentry.captureException(
-            new Error(`Pending audit log ${row.id} exceeded ${MAX_RETRIES} retries`),
-            {
-              tags: { compliance: "audit_log_durability" },
-              extra: { pendingId: row.id, retryCount: newRetryCount, lastError: insertErr.message },
-            },
-          );
-        } catch {
-          // Sentry unavailable
-        }
+    const { error: updateErr } = await admin
+      .from("pending_audit_logs")
+      .update({ retry_count: newRetryCount, last_error: lastError })
+      .eq("id", row.id);
+
+    if (updateErr) {
+      logger.error("Failed to update pending audit log retry count", {
+        context: "cron/audit-log-flush",
+        pendingId: row.id,
+        error: updateErr.message,
+      });
+    }
+
+    failed++;
+
+    if (newRetryCount > MAX_RETRIES) {
+      logger.error("Pending audit log exceeded max retries", {
+        context: "cron/audit-log-flush",
+        pendingId: row.id,
+        retryCount: newRetryCount,
+        lastError,
+      });
+      try {
+        const Sentry = await import("@sentry/nextjs");
+        Sentry.captureException(
+          new Error(`Pending audit log ${row.id} exceeded ${MAX_RETRIES} retries`),
+          {
+            tags: { compliance: "audit_log_durability" },
+            extra: { pendingId: row.id, retryCount: newRetryCount, lastError },
+          },
+        );
+      } catch {
+        // Sentry unavailable
       }
     }
   }

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -483,7 +483,10 @@ export async function POST(request: NextRequest) {
                 };
               };
             };
-            const rbClient = supabase as unknown as RebookClient;
+            // F4: rebooking_requests now has a typed migration (00210).  Webhooks
+            // are unauthenticated, so we use the service-role admin client that
+            // has already resolved the clinic and verified the Meta signature.
+            const rbClient = admin as unknown as RebookClient;
 
             // Find the rebooking request
             const { data: rebookReq } = await rbClient
@@ -509,7 +512,7 @@ export async function POST(request: NextRequest) {
 
               if (chosen && patientId) {
                 // Create new appointment with the chosen slot
-                await supabase.from("appointments").insert({
+                await admin.from("appointments").insert({
                   patient_id: patientId,
                   doctor_id: rebookReq.doctor_id,
                   clinic_id: clinicId,
@@ -522,7 +525,7 @@ export async function POST(request: NextRequest) {
                 });
 
                 // Cancel the original appointment
-                await supabase
+                await admin
                   .from("appointments")
                   .update({
                     status: "cancelled",

--- a/src/lib/__tests__/audit-log-enhanced.test.ts
+++ b/src/lib/__tests__/audit-log-enhanced.test.ts
@@ -80,8 +80,8 @@ describe("logAuditEvent — enhanced fields", () => {
     );
   });
 
-  it("supports all new event types", async () => {
-    const types = ["auth", "config", "security"] as const;
+  it("supports all emitted audit event types", async () => {
+    const types = ["admin", "auth", "booking", "config", "patient", "payment", "security"] as const;
     for (const type of types) {
       const mock = createMockSupabase();
       await logAuditEvent({
@@ -136,7 +136,7 @@ describe("logAuthEvent", () => {
     );
   });
 
-  it("defaults clinicId to 'system' when not provided", async () => {
+  it("defaults clinicId to null when not provided", async () => {
     const mock = createMockSupabase();
     await logAuthEvent({
       supabase: mock as never,
@@ -147,7 +147,7 @@ describe("logAuthEvent", () => {
 
     expect(mock._insert).toHaveBeenCalledWith(
       expect.objectContaining({
-        clinic_id: "system",
+        clinic_id: null,
         metadata: { success: false },
       }),
     );
@@ -219,7 +219,7 @@ describe("logSecurityEvent", () => {
       supabase: mock as never,
       action: "impersonate.end",
       actor: "admin@test.com",
-      clinicId: "system",
+      clinicId: "00000000-0000-0000-0000-000000000000",
     });
 
     expect(mock._insert).toHaveBeenCalledWith(
@@ -227,7 +227,7 @@ describe("logSecurityEvent", () => {
         type: "security",
         action: "impersonate.end",
         actor: "admin@test.com",
-        clinic_id: "system",
+        clinic_id: "00000000-0000-0000-0000-000000000000",
         ip_address: null,
         user_agent: null,
         metadata: null,

--- a/src/lib/audit-log.ts
+++ b/src/lib/audit-log.ts
@@ -11,15 +11,33 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
 import type { Database, Json } from "@/lib/types/database";
 
-/** Audit event categories for structured filtering. */
-type AuditEventType = "booking" | "patient" | "payment" | "admin" | "auth" | "config" | "security";
+/** Audit event categories for structured filtering.
+ *
+ * Must stay in sync with the `activity_logs.type` CHECK constraint
+ * (widened in migration 00209 to include every value the app writes).
+ */
+type AuditEventType =
+  | "admin"
+  | "announcement"
+  | "auth"
+  | "billing"
+  | "booking"
+  | "clinic"
+  | "config"
+  | "feature"
+  | "patient"
+  | "payment"
+  | "security"
+  | "template";
 
 interface AuditLogParams {
   supabase: SupabaseClient<Database>;
   action: string;
   type: AuditEventType;
-  /** clinic_id is required for healthcare compliance — every audit entry must be scoped to a tenant */
-  clinicId: string;
+  /** clinic_id is required for healthcare compliance where a tenant exists.
+   *  Auth/security events that occur before a clinic is resolved (e.g. failed
+   *  logins) must pass `null` instead of a sentinel like "system". */
+  clinicId?: string | null;
   actor?: string | null;
   clinicName?: string | null;
   description?: string | null;
@@ -156,7 +174,7 @@ export async function logAuthEvent(params: {
     action: params.action,
     type: "auth",
     actor: params.actor,
-    clinicId: params.clinicId ?? "system",
+    clinicId: params.clinicId ?? null,
     description: params.description,
     ipAddress: params.ipAddress,
     userAgent: params.userAgent,

--- a/supabase/migrations/00209_widen_activity_logs_type_check.sql
+++ b/supabase/migrations/00209_widen_activity_logs_type_check.sql
@@ -1,0 +1,53 @@
+-- Migration 00209: Widen the activity_logs.type CHECK constraint
+--
+-- Audit findings F1 / F2 / C4:
+--   The previous CHECK in migration 00005 only permitted
+--   ('clinic', 'billing', 'feature', 'announcement', 'template', 'auth').
+--   The application writes ('booking', 'patient', 'payment', 'admin',
+--   'auth', 'config', 'security'), so most audit inserts were rejected.
+--
+-- This migration drops the old narrow constraint and replaces it with one
+-- that covers every value the application emits, preserving the legacy
+-- values for backward compatibility.
+
+BEGIN;
+
+-- Drop the existing CHECK constraint on activity_logs.type.  The constraint
+-- was created unnamed, so its auto-generated name may vary.  We locate it by
+-- inspecting pg_constraint for a check constraint whose definition references
+-- the "type" column.
+DO $$
+DECLARE
+  con_name text;
+BEGIN
+  SELECT conname INTO con_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.activity_logs'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) ILIKE '%type%';
+
+  IF con_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE public.activity_logs DROP CONSTRAINT %I', con_name);
+  END IF;
+END $$;
+
+-- New constraint covers every AuditEventType used by src/lib/audit-log.ts,
+-- plus the legacy values already allowed by the previous CHECK.
+ALTER TABLE public.activity_logs
+  ADD CONSTRAINT activity_logs_type_check
+  CHECK (type IN (
+    'admin',
+    'announcement',
+    'auth',
+    'billing',
+    'booking',
+    'clinic',
+    'config',
+    'feature',
+    'patient',
+    'payment',
+    'security',
+    'template'
+  ));
+
+COMMIT;

--- a/supabase/migrations/00210_create_rebooking_requests.sql
+++ b/supabase/migrations/00210_create_rebooking_requests.sql
@@ -37,7 +37,8 @@ ALTER TABLE public.rebooking_requests ENABLE ROW LEVEL SECURITY;
 
 -- Service role (cron, webhooks) is fully privileged once it has resolved the
 -- clinic; it always filters by clinic_id in application code.
-CREATE POLICY IF NOT EXISTS rebooking_requests_service_all
+DROP POLICY IF EXISTS rebooking_requests_service_all ON public.rebooking_requests;
+CREATE POLICY rebooking_requests_service_all
   ON public.rebooking_requests
   FOR ALL
   TO service_role
@@ -45,7 +46,8 @@ CREATE POLICY IF NOT EXISTS rebooking_requests_service_all
   WITH CHECK (true);
 
 -- Authenticated clinic staff may only access rows belonging to their clinic.
-CREATE POLICY IF NOT EXISTS rebooking_requests_staff_all
+DROP POLICY IF EXISTS rebooking_requests_staff_all ON public.rebooking_requests;
+CREATE POLICY rebooking_requests_staff_all
   ON public.rebooking_requests
   FOR ALL
   USING (
@@ -58,7 +60,8 @@ CREATE POLICY IF NOT EXISTS rebooking_requests_staff_all
   );
 
 -- Super-admins can read/modify rebooking requests for support.
-CREATE POLICY IF NOT EXISTS rebooking_requests_super_admin_all
+DROP POLICY IF EXISTS rebooking_requests_super_admin_all ON public.rebooking_requests;
+CREATE POLICY rebooking_requests_super_admin_all
   ON public.rebooking_requests
   FOR ALL
   USING (is_super_admin())

--- a/supabase/migrations/00210_create_rebooking_requests.sql
+++ b/supabase/migrations/00210_create_rebooking_requests.sql
@@ -1,0 +1,70 @@
+-- Migration 00210: Create rebooking_requests table with tenant-scoped RLS
+--
+-- Audit finding F4: the application references `rebooking_requests` in
+-- src/app/api/webhooks/route.ts, src/app/api/doctor-unavailability/route.ts,
+-- and src/app/api/cron/rebooking-reminders/route.ts, but no migration or
+-- versioned RLS policy existed for the table.  It stores PHI-referencing
+-- appointment/patient/doctor IDs, so it must be created with clinic_id
+-- tenant isolation.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.rebooking_requests (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  appointment_id    UUID REFERENCES public.appointments(id) ON DELETE SET NULL,
+  unavailability_id UUID,
+  clinic_id         UUID NOT NULL REFERENCES public.clinics(id) ON DELETE CASCADE,
+  doctor_id         UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  patient_id        UUID REFERENCES public.users(id) ON DELETE SET NULL,
+  status            TEXT NOT NULL DEFAULT 'pending',
+  alternatives      JSONB,
+  selected_option   INTEGER,
+  sent_at           TIMESTAMPTZ,
+  reminded_at       TIMESTAMPTZ,
+  rebooked_at       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rebooking_requests_clinic_id     ON public.rebooking_requests(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_rebooking_requests_appointment_id ON public.rebooking_requests(appointment_id);
+CREATE INDEX IF NOT EXISTS idx_rebooking_requests_doctor_id     ON public.rebooking_requests(doctor_id);
+CREATE INDEX IF NOT EXISTS idx_rebooking_requests_patient_id    ON public.rebooking_requests(patient_id);
+CREATE INDEX IF NOT EXISTS idx_rebooking_requests_status        ON public.rebooking_requests(status);
+CREATE INDEX IF NOT EXISTS idx_rebooking_requests_created_at    ON public.rebooking_requests(created_at DESC);
+
+ALTER TABLE public.rebooking_requests ENABLE ROW LEVEL SECURITY;
+
+-- Service role (cron, webhooks) is fully privileged once it has resolved the
+-- clinic; it always filters by clinic_id in application code.
+CREATE POLICY IF NOT EXISTS rebooking_requests_service_all
+  ON public.rebooking_requests
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Authenticated clinic staff may only access rows belonging to their clinic.
+CREATE POLICY IF NOT EXISTS rebooking_requests_staff_all
+  ON public.rebooking_requests
+  FOR ALL
+  USING (
+    clinic_id = get_user_clinic_id()
+    AND is_clinic_staff()
+  )
+  WITH CHECK (
+    clinic_id = get_user_clinic_id()
+    AND is_clinic_staff()
+  );
+
+-- Super-admins can read/modify rebooking requests for support.
+CREATE POLICY IF NOT EXISTS rebooking_requests_super_admin_all
+  ON public.rebooking_requests
+  FOR ALL
+  USING (is_super_admin())
+  WITH CHECK (is_super_admin());
+
+COMMENT ON TABLE public.rebooking_requests IS
+  'Tracks alternative slots offered to patients when a doctor becomes unavailable, and their rebooking responses.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes the audit-trail integrity cluster identified in the latest security/compliance review (F1–F5):

- **F1/F2:** `activity_logs.type` now accepts every value the application emits (`admin`, `auth`, `booking`, `config`, `patient`, `payment`, `security`, plus the previous `clinic/billing/feature/announcement/template` values), and the `pending_audit_logs` flush cron now reads the nested `payload` JSONB and inserts valid `activity_logs` rows.
- **F3:** `logAuthEvent` defaults `clinic_id` to `null` instead of the invalid sentinel string `"system"`.
- **F4:** Adds the missing `rebooking_requests` migration with `clinic_id` tenant scoping and switches the WhatsApp webhook rebooking path to the scoped `admin` service client so unauthenticated writes remain tenant-isolated.
- **F5:** Adds per-IP rate limiting to the public `/api/compliance/dsar` endpoint.

The unit-test suite was updated to assert the new `clinic_id` default and the full set of emitted audit types.

## Type of change

- [x] Bug fix

## Security Impact

- [x] This PR changes RLS policies or database migrations
- [x] This PR modifies encryption, audit logging, or PII handling
- [x] This PR changes tenant isolation or multi-tenant scoping

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [x] New tables have RLS policies with `clinic_id` scoping

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` all pass (2263 tests, 117 skipped).

## Observability

- [x] This PR adds/modifies logging (structured via `@/lib/logger`)

## Rollback

- Revert this commit.
- Run a future undo migration to restore the previous `activity_logs` CHECK if needed; no data is mutated by the new constraint.