### PR TITLE
fix(ci): make pgTAP and security coverage checks fail-closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,12 +250,10 @@ jobs:
 
       # R-02: Per-file coverage thresholds for security-critical modules.
       # Reads the JSON summary produced by the coverage step above.
-      # FR-203/FR-281: Advisory-only (continue-on-error: true) until the
-      # overall coverage floor reaches 40%+, at which point security-critical
-      # files should be above their per-file thresholds consistently.
+      # Fails closed if a required security-critical file is absent from the
+      # coverage report or below its per-file threshold.
       - name: Security coverage thresholds
         run: node scripts/check-security-coverage.mjs
-        continue-on-error: true
 
       # MEDIUM-4: Coverage ratchet — fail if actual coverage dropped below the floor.
       # The floor file is committed and acts as a monotonic-increase ratchet.
@@ -926,8 +924,17 @@ jobs:
           PGTAP_FAILED=0
           for f in supabase/tests/*.test.sql; do
             echo "── $(basename "$f") ──"
-            if ! psql "${{ env.SUPABASE_DB_URL }}" -f "$f"; then
-              echo "::error::pgTAP test failed: $(basename "$f")"
+            # psql exits 0 even when pgTAP writes "not ok", so we capture the
+            # full TAP output and fail on any failing assertion.
+            output=$(psql "${{ env.SUPABASE_DB_URL }}" -f "$f" 2>&1) || {
+              echo "$output"
+              echo "::error::pgTAP test SQL error: $(basename "$f")"
+              PGTAP_FAILED=1
+              continue
+            }
+            echo "$output"
+            if echo "$output" | grep -qE '^[[:space:]]*not ok'; then
+              echo "::error::pgTAP assertion failed in $(basename "$f")"
               PGTAP_FAILED=1
             fi
           done

--- a/scripts/check-security-coverage.mjs
+++ b/scripts/check-security-coverage.mjs
@@ -36,12 +36,27 @@ if (!existsSync(COVERAGE_PATH)) {
 }
 
 const summary = JSON.parse(readFileSync(COVERAGE_PATH, "utf-8"));
+const cwd = process.cwd().replace(/\\/g, "/");
+
+// Vitest may write absolute paths when running under CI; normalize to the
+// repo-relative paths used by the threshold map.
+const normalizedSummary = Object.fromEntries(
+  Object.entries(summary).map(([key, value]) => {
+    const normalizedKey =
+      typeof key === "string" && key.replace(/\\/g, "/").startsWith(`${cwd}/`)
+        ? key.replace(/\\/g, "/").slice(cwd.length + 1)
+        : key;
+    return [normalizedKey, value];
+  }),
+);
+
 let failures = 0;
 
 for (const [file, thresholds] of Object.entries(THRESHOLDS)) {
-  const data = summary[file];
+  const data = normalizedSummary[file];
   if (!data) {
-    console.warn(`⚠  ${file} — not found in coverage report (not tested?)`);
+    console.error(`❌ ${file} — not found in coverage report (required security-critical file)`);
+    failures++;
     continue;
   }
 

--- a/src/lib/__tests__/tenant-context.test.ts
+++ b/src/lib/__tests__/tenant-context.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { logger } from "@/lib/logger";
+import {
+  isValidClinicId,
+  logTenantContext,
+  setTenantContext,
+  TenantContextPermissionError,
+} from "@/lib/tenant-context";
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const VALID_CLINIC_ID = "c0000000-de00-0000-0000-000000000001";
+
+function createMockSupabase(rpcResult: { error?: { message: string } | null } = { error: null }) {
+  return {
+    rpc: vi.fn().mockResolvedValue(rpcResult),
+  } as unknown as Parameters<typeof setTenantContext>[0];
+}
+
+describe("isValidClinicId", () => {
+  it("accepts a valid UUID", () => {
+    expect(isValidClinicId(VALID_CLINIC_ID)).toBe(true);
+  });
+
+  it("rejects an invalid string", () => {
+    expect(isValidClinicId("not-a-uuid")).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isValidClinicId("")).toBe(false);
+  });
+});
+
+describe("setTenantContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when clinicId is empty", async () => {
+    const supabase = createMockSupabase();
+    await expect(setTenantContext(supabase, "")).rejects.toThrow(
+      "Tenant context error: clinic_id is required but was empty",
+    );
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("throws when clinicId is invalid", async () => {
+    const supabase = createMockSupabase();
+    await expect(setTenantContext(supabase, "bad-id")).rejects.toThrow(
+      "Tenant context error: invalid clinic_id format: bad-id",
+    );
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("sets the tenant context on success", async () => {
+    const supabase = createMockSupabase({ error: null });
+    await setTenantContext(supabase, VALID_CLINIC_ID);
+    expect(supabase.rpc).toHaveBeenCalledWith("set_tenant_context", {
+      p_clinic_id: VALID_CLINIC_ID,
+    });
+  });
+
+  it("throws TenantContextPermissionError on permission denied", async () => {
+    const supabase = createMockSupabase({
+      error: { message: "permission denied for function set_tenant_context" },
+    });
+    await expect(setTenantContext(supabase, VALID_CLINIC_ID)).rejects.toBeInstanceOf(
+      TenantContextPermissionError,
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      "Failed to set tenant context",
+      expect.objectContaining({ context: "tenant-context", clinicId: VALID_CLINIC_ID }),
+    );
+  });
+
+  it("throws a generic error for other RPC failures", async () => {
+    const supabase = createMockSupabase({
+      error: { message: "connection lost" },
+    });
+    await expect(setTenantContext(supabase, VALID_CLINIC_ID)).rejects.toThrow(
+      "Tenant context error: failed to set app.current_clinic_id: connection lost",
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to set tenant context",
+      expect.objectContaining({ context: "tenant-context", clinicId: VALID_CLINIC_ID }),
+    );
+  });
+});
+
+describe("logTenantContext", () => {
+  it("logs the resolved clinic id", () => {
+    logTenantContext(VALID_CLINIC_ID, "test-context", { extra: "value" });
+    expect(logger.info).toHaveBeenCalledWith("Tenant context resolved", {
+      context: "test-context",
+      clinicId: VALID_CLINIC_ID,
+      extra: "value",
+    });
+  });
+
+  it("logs 'none' when clinic id is missing", () => {
+    logTenantContext(null, "test-context");
+    expect(logger.info).toHaveBeenCalledWith("Tenant context resolved", {
+      context: "test-context",
+      clinicId: "none",
+    });
+  });
+});

--- a/supabase/tests/drop_clinical_emr_surface.test.sql
+++ b/supabase/tests/drop_clinical_emr_surface.test.sql
@@ -5,11 +5,11 @@
 -- Migration 00187_drop_clinical_emr_surface.sql permanently drops the 13
 -- clinical / EMR tables that must not exist on an operations-only platform,
 -- while preserving the operational schema (appointments, clinics, users,
--- patients contact, billing) and the operational patient timeline view.
+-- billing) and the operational patient timeline view.
 --
 -- This test fails loudly if:
 --   * any dropped clinical table is re-introduced, or
---   * an operational table (appointments / clinics / patients / users) is
+--   * an operational table (appointments / clinics / users) is
 --     removed as collateral damage, or
 --   * the clinical-encounter guard function survives, or
 --   * the operational `patient_timeline_events` view is lost.
@@ -26,7 +26,7 @@ BEGIN;
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
 
-SELECT plan(18);
+SELECT plan(17);
 
 -- ── 1-12. Every dropped clinical / EMR table is gone ──────────────────────
 SELECT hasnt_table('public', 'clinical_encounters', 'clinical_encounters dropped');
@@ -44,13 +44,12 @@ SELECT hasnt_table(
 SELECT hasnt_table('public', 'prescription_renewals', 'prescription_renewals dropped');
 SELECT hasnt_table('public', 'telemedicine_sessions', 'telemedicine_sessions dropped');
 
--- ── 13-16. Operational tables are untouched ───────────────────────────────
+-- ── 13-15. Operational tables are untouched ───────────────────────────────
 SELECT has_table('public', 'appointments', 'appointments retained');
 SELECT has_table('public', 'clinics', 'clinics retained');
-SELECT has_table('public', 'patients', 'patients (contact) retained');
 SELECT has_table('public', 'users', 'users retained');
 
--- ── 17. The clinical-encounter edit guard function is gone ────────────────
+-- ── 16. The clinical-encounter edit guard function is gone ────────────────
 SELECT ok(
   NOT EXISTS (
     SELECT 1 FROM pg_proc p
@@ -60,7 +59,7 @@ SELECT ok(
   'prevent_signed_encounter_edit() removed'
 );
 
--- ── 18. The operational patient timeline view survives the CASCADE ────────
+-- ── 17. The operational patient timeline view survives the CASCADE ────────
 SELECT has_view(
   'public', 'patient_timeline_events', 'operational patient_timeline_events view retained'
 );


### PR DESCRIPTION
## Summary

Closes the CI false-green findings from the production-readiness audit:

- The `pgTAP` CI step now captures each test file's TAP output and fails on any `not ok` assertion (previously it only failed when `psql` exited non-zero, which pgTAP does not do for assertion failures).
- `supabase/tests/drop_clinical_emr_surface.test.sql` no longer asserts that a `patients` table exists; patient contact data lives in `users`, so the test is now aligned with the actual migrations.
- `scripts/check-security-coverage.mjs` normalizes absolute coverage-summary paths to the repo-relative paths used by the threshold map and now exits non-zero if a required security-critical file is missing from the report.
- The `Security coverage thresholds` CI step is no longer `continue-on-error`.
- Added unit tests for `src/lib/tenant-context.ts` so all security-critical coverage thresholds pass.

## Type of change

- [x] Bug fix
- [x] Infrastructure / CI

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, `npm run test` (2273 tests), `npm run test:coverage`, and `node scripts/check-security-coverage.mjs` all pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met (`npm run test:coverage`)