### PR TITLE
fix(logger): wire phi-compliance helpers into log redaction

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -21,6 +21,8 @@
  *   }
  */
 
+import { containsPotentialPHI, sanitizeErrorMessage } from "@/lib/phi-compliance";
+
 type LogLevel = "debug" | "info" | "warn" | "error";
 
 /**
@@ -66,11 +68,12 @@ function formatError(err: unknown): Record<string, unknown> {
   if (err instanceof Error) {
     return {
       name: err.name,
-      message: err.message,
+      message: containsPotentialPHI(err.message) ? sanitizeErrorMessage(err.message) : err.message,
       stack: err.stack,
     };
   }
-  return { raw: String(err) };
+  const raw = String(err);
+  return { raw: containsPotentialPHI(raw) ? sanitizeErrorMessage(raw) : raw };
 }
 
 // F-A93-07: PHI field names that must be auto-redacted from log metadata.
@@ -99,6 +102,8 @@ function redactPhi(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     if (PHI_FIELD_PATTERNS.has(key.toLowerCase())) {
+      result[key] = "[REDACTED]";
+    } else if (typeof value === "string" && containsPotentialPHI(value)) {
       result[key] = "[REDACTED]";
     } else if (Array.isArray(value)) {
       result[key] = value.map((item) =>


### PR DESCRIPTION
## Summary

The production-readiness audit identified `src/lib/phi-compliance.ts` as a dead/test-only helper: it was not connected to the logger it was meant to guard. This change wires the existing PHI/PII pattern checks into `src/lib/logger.ts` so PHI is redacted before any log payload is serialized or forwarded to Sentry.

- Error messages and non-Error `raw` values are sanitized when they contain PHI patterns (dates of birth, national ID/SSN-like numbers).
- Any string value in log `extra` metadata that matches a PHI pattern is now replaced with `[REDACTED]`, closing the case where PHI could leak under an unrecognized key name.

## Type of change

- [x] Bug fix

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [ ] This PR changes RLS policies or database migrations
- [x] This PR modifies encryption, audit logging, or PII handling
- [ ] This PR changes tenant isolation or multi-tenant scoping
- [ ] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] This PR adds/modifies logging (structured via `@/lib/logger`)

## Rollback

- Revert this commit.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes