### PR TITLE
fix(frontend): revenue page quick wins + public header nav labels

### DIFF
--- a/src/app/(admin)/admin/revenue-per-doctor/_revenue-bar-chart.tsx
+++ b/src/app/(admin)/admin/revenue-per-doctor/_revenue-bar-chart.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+
+interface RevenueBarChartProps {
+  data: Array<{ name: string; revenue: number; appointments: number }>;
+  intlLocale: string;
+}
+
+export default function RevenueBarChart({ data, intlLocale }: RevenueBarChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip
+          formatter={(value) =>
+            new Intl.NumberFormat(intlLocale, {
+              style: "currency",
+              currency: "MAD",
+            }).format(Number(value))
+          }
+        />
+        <Bar dataKey="revenue" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/(admin)/admin/revenue-per-doctor/page.tsx
+++ b/src/app/(admin)/admin/revenue-per-doctor/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { DollarSign, Users, TrendingDown, BarChart3 } from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import dynamic from "next/dynamic";
+import { useState, useEffect } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { useTenant } from "@/components/tenant-provider";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -35,6 +35,11 @@ interface RevenueSummary {
   doctorCount: number;
 }
 
+const RevenueBarChart = dynamic(() => import("./_revenue-bar-chart"), {
+  ssr: false,
+  loading: () => <div className="h-[300px] animate-pulse rounded-md bg-muted" />,
+});
+
 export default function RevenuePerDoctorPage() {
   const [locale] = useLocale();
   const tenant = useTenant();
@@ -43,36 +48,34 @@ export default function RevenuePerDoctorPage() {
   const [period, setPeriod] = useState("30d");
   const [loading, setLoading] = useState(true);
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await fetch(`/api/clinic-owner/revenue-per-doctor?period=${period}`);
-      const json = await res.json();
-      if (json.ok) {
-        setDoctors(json.data.doctors);
-        setSummary(json.data.summary);
-      }
-    } catch (err) {
-      logger.warn("Failed to load revenue data", { context: "page", error: err });
-    } finally {
-      setLoading(false);
-    }
-  }, [period]);
-
   useEffect(() => {
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-
-    if (tenant?.clinicId)
-      timeouts.push(
-        setTimeout(() => {
-          loadData();
-        }, 0),
-      );
-
-    return () => {
-      timeouts.forEach((t) => clearTimeout(t));
-    };
-  }, [tenant?.clinicId, loadData]);
+    const controller = new AbortController();
+    async function loadData() {
+      if (!tenant?.clinicId) return;
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/clinic-owner/revenue-per-doctor?period=${period}`, {
+          signal: controller.signal,
+        });
+        const json = await res.json();
+        if (controller.signal.aborted) return;
+        if (json.ok) {
+          setDoctors(json.data.doctors);
+          setSummary(json.data.summary);
+        }
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          logger.warn("Failed to load revenue data", { context: "page", error: err });
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+    loadData();
+    return () => controller.abort();
+  }, [tenant?.clinicId, period]);
 
   const intlLocale = LOCALE_MAP[locale ?? "fr"] ?? "fr-FR";
 
@@ -87,21 +90,16 @@ export default function RevenuePerDoctorPage() {
       <Breadcrumb
         items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Revenu par médecin" }]}
       />
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        {}
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
         <h1 className="text-2xl font-bold">Revenu par médecin</h1>
         <Select value={period} onValueChange={setPeriod}>
           <SelectTrigger className="w-[180px]">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {}
             <SelectItem value="7d">7 jours</SelectItem>
-            {}
             <SelectItem value="30d">30 jours</SelectItem>
-            {}
             <SelectItem value="90d">90 jours</SelectItem>
-            {}
             <SelectItem value="12m">12 mois</SelectItem>
           </SelectContent>
         </Select>
@@ -117,7 +115,6 @@ export default function RevenuePerDoctorPage() {
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Revenu total</CardTitle>
                 <DollarSign className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -129,7 +126,6 @@ export default function RevenuePerDoctorPage() {
             </Card>
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Rendez-vous</CardTitle>
                 <Users className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -141,7 +137,6 @@ export default function RevenuePerDoctorPage() {
             </Card>
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Taux d&apos;annulation</CardTitle>
                 <TrendingDown className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -151,7 +146,6 @@ export default function RevenuePerDoctorPage() {
             </Card>
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Médecins</CardTitle>
                 <BarChart3 className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -165,26 +159,10 @@ export default function RevenuePerDoctorPage() {
           {chartData.length > 0 && (
             <Card>
               <CardHeader>
-                {}
                 <CardTitle>Revenu par médecin (MAD)</CardTitle>
               </CardHeader>
               <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="name" />
-                    <YAxis />
-                    <Tooltip
-                      formatter={(value) =>
-                        new Intl.NumberFormat(intlLocale, {
-                          style: "currency",
-                          currency: "MAD",
-                        }).format(Number(value))
-                      }
-                    />
-                    <Bar dataKey="revenue" fill="var(--primary)" radius={[4, 4, 0, 0]} />
-                  </BarChart>
-                </ResponsiveContainer>
+                <RevenueBarChart data={chartData} intlLocale={intlLocale} />
               </CardContent>
             </Card>
           )}
@@ -192,48 +170,40 @@ export default function RevenuePerDoctorPage() {
           {/* Table */}
           <Card>
             <CardHeader>
-              {}
               <CardTitle>Détail par médecin</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b text-left">
-                      {}
-                      <th className="py-3 pr-4 font-medium">Médecin</th>
-                      {}
-                      <th className="py-3 pr-4 font-medium text-right">Revenu</th>
-                      <th className="py-3 pr-4 font-medium text-right">RDV</th>
-                      {}
-                      <th className="py-3 pr-4 font-medium text-right">Complétés</th>
-                      {}
-                      <th className="py-3 pr-4 font-medium text-right">Annulés</th>
-                      {}
-                      <th className="py-3 pr-4 font-medium text-right">Taux ann.</th>
-                      {}
-                      <th className="py-3 font-medium text-right">Moy./RDV</th>
+                    <tr className="border-b text-start">
+                      <th className="py-3 pe-4 font-medium">Médecin</th>
+                      <th className="py-3 pe-4 text-end font-medium">Revenu</th>
+                      <th className="py-3 pe-4 text-end font-medium">RDV</th>
+                      <th className="py-3 pe-4 text-end font-medium">Complétés</th>
+                      <th className="py-3 pe-4 text-end font-medium">Annulés</th>
+                      <th className="py-3 pe-4 text-end font-medium">Taux ann.</th>
+                      <th className="py-3 text-end font-medium">Moy./RDV</th>
                     </tr>
                   </thead>
                   <tbody>
                     {doctors.map((d) => (
                       <tr key={d.doctorId} className="border-b last:border-0">
-                        <td className="py-3 pr-4">{d.doctorName}</td>
-                        <td className="py-3 pr-4 text-right">
+                        <td className="py-3 pe-4">{d.doctorName}</td>
+                        <td className="py-3 pe-4 text-end">
                           {formatCurrency(d.totalRevenue / 100, locale ?? "fr")}
                         </td>
-                        <td className="py-3 pr-4 text-right">{d.totalAppointments}</td>
-                        <td className="py-3 pr-4 text-right">{d.completedAppointments}</td>
-                        <td className="py-3 pr-4 text-right">{d.cancelledAppointments}</td>
-                        <td className="py-3 pr-4 text-right">{d.cancellationRate}%</td>
-                        <td className="py-3 text-right">
+                        <td className="py-3 pe-4 text-end">{d.totalAppointments}</td>
+                        <td className="py-3 pe-4 text-end">{d.completedAppointments}</td>
+                        <td className="py-3 pe-4 text-end">{d.cancelledAppointments}</td>
+                        <td className="py-3 pe-4 text-end">{d.cancellationRate}%</td>
+                        <td className="py-3 text-end">
                           {formatCurrency(d.avgRevenuePerAppointment / 100, locale ?? "fr")}
                         </td>
                       </tr>
                     ))}
                     {doctors.length === 0 && (
                       <tr>
-                        {}
                         <td colSpan={7} className="py-8 text-center text-muted-foreground">
                           Aucune donnée disponible
                         </td>

--- a/src/components/public/header.tsx
+++ b/src/components/public/header.tsx
@@ -75,7 +75,7 @@ export function PublicHeader({ logoUrl, clinicName, sectionVisibility }: PublicH
         </Link>
 
         {/* Desktop navigation */}
-        <nav aria-label="Navigation principale" className="hidden items-center gap-6 md:flex">
+        <nav aria-label={t(locale, "public.navMain")} className="hidden items-center gap-6 md:flex">
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -107,7 +107,7 @@ export function PublicHeader({ logoUrl, clinicName, sectionVisibility }: PublicH
       {mobileMenuOpen && (
         <nav
           id="clinic-mobile-nav"
-          aria-label="Navigation mobile"
+          aria-label={t(locale, "public.navMobile")}
           className="border-t px-4 py-4 md:hidden"
         >
           <div className="flex flex-col gap-3">

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -990,6 +990,8 @@
   "public.meta.description": "أنشئ موقع عيادتك، أدر المواعيد وطور نشاطك بسهولة. منصة SaaS للأطباء والعيادات في المغرب.",
   "public.meta.ogDescription": "أنشئ موقع عيادتك، أدر المواعيد وطور نشاطك بسهولة.",
   "public.meta.title": "المنصة المتكاملة لإدارة عيادتك الطبية",
+  "public.navMain": "التنقل الرئيسي",
+  "public.navMobile": "التنقل المتنقل",
   "public.openMenu": "فتح القائمة",
   "public.privacy": "الخصوصية",
   "public.quickLinks": "روابط سريعة",

--- a/src/locales/ary.json
+++ b/src/locales/ary.json
@@ -990,6 +990,8 @@
   "public.meta.description": "أنشئ موقع عيادتك، أدر المواعيد وطور نشاطك بسهولة. منصة SaaS للأطباء والعيادات في المغرب.",
   "public.meta.ogDescription": "أنشئ موقع عيادتك، أدر المواعيد وطور نشاطك بسهولة.",
   "public.meta.title": "المنصة المتكاملة لإدارة عيادتك الطبية",
+  "public.navMain": "التنقل الرئيسي",
+  "public.navMobile": "التنقل المتنقل",
   "public.openMenu": "فتح القائمة",
   "public.privacy": "الخصوصية",
   "public.quickLinks": "روابط سريعة",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -990,6 +990,8 @@
   "public.meta.description": "Create your practice website, manage appointments and grow your business easily. SaaS platform for doctors and clinics in Morocco.",
   "public.meta.ogDescription": "Create your practice website, manage appointments and grow your business easily.",
   "public.meta.title": "The complete platform for managing your medical practice",
+  "public.navMain": "Main navigation",
+  "public.navMobile": "Mobile navigation",
   "public.openMenu": "Open menu",
   "public.privacy": "Privacy",
   "public.quickLinks": "Quick Links",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -990,6 +990,8 @@
   "public.meta.description": "Créez le site de votre cabinet, gérez les rendez-vous et développez votre activité facilement. Plateforme SaaS pour médecins et cabinets au Maroc.",
   "public.meta.ogDescription": "Créez le site de votre cabinet, gérez les rendez-vous et développez votre activité facilement.",
   "public.meta.title": "La plateforme complète pour gérer votre cabinet médical",
+  "public.navMain": "Navigation principale",
+  "public.navMobile": "Navigation mobile",
   "public.openMenu": "Ouvrir le menu",
   "public.privacy": "Confidentialité",
   "public.quickLinks": "Liens rapides",


### PR DESCRIPTION
## Summary

Frontend quick wins from the UX/performance and accessibility audits:

- `admin/revenue-per-doctor/page.tsx` now lazy-loads `recharts` through a dynamic `_revenue-bar-chart` component, removing the heavy charting library from the initial route bundle.
- Replaced the `setTimeout(..., 0)` data-fetch anti-pattern with a plain `useEffect` + `AbortController`, so in-flight requests are cancelled when `period` or `tenant.clinicId` changes.
- Removed stray empty JSX expressions and converted physical spacing/alignment classes (`pr-4`, `text-right`, `text-left`) to logical properties (`pe-4`, `text-end`, `text-start`) for correct RTL rendering.
- Localized the two hardcoded-French ARIA labels in `public/header.tsx` by adding `public.navMain` and `public.navMobile` keys to all four locale files and wiring them through `t(locale, key)`.

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes