### PR TITLE
perf(frontend): lazy-load recharts in admin/super-admin route pages

### DIFF
--- a/src/app/(admin)/admin/patient-acquisition/_acquisition-bar-chart.tsx
+++ b/src/app/(admin)/admin/patient-acquisition/_acquisition-bar-chart.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+
+interface AcquisitionBarChartProps {
+  data: Array<{ channel: string; patients: number; cost: number; fill: string }>;
+}
+
+export default function AcquisitionBarChart({ data }: AcquisitionBarChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="channel" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="patients" fill="var(--primary)" radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/(admin)/admin/patient-acquisition/page.tsx
+++ b/src/app/(admin)/admin/patient-acquisition/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { DollarSign, Users, Target, TrendingUp } from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
+import dynamic from "next/dynamic";
+import { useState, useEffect } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { useTenant } from "@/components/tenant-provider";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
@@ -49,6 +49,11 @@ const CHANNEL_COLORS: Record<string, string> = {
   other: "#607D8B",
 };
 
+const AcquisitionBarChart = dynamic(() => import("./_acquisition-bar-chart"), {
+  ssr: false,
+  loading: () => <div className="h-[300px] animate-pulse rounded-md bg-muted" />,
+});
+
 export default function PatientAcquisitionPage() {
   const [locale] = useLocale();
   const tenant = useTenant();
@@ -58,36 +63,34 @@ export default function PatientAcquisitionPage() {
 
   const intlLocale = LOCALE_MAP[locale ?? "fr"] ?? "fr-FR";
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    try {
-      const res = await fetch("/api/clinic-owner/patient-acquisition");
-      const json = await res.json();
-      if (json.ok) {
-        setChannels(json.data.channels);
-        setSummary(json.data.summary);
-      }
-    } catch (err) {
-      logger.warn("Failed to load acquisition data", { context: "page", error: err });
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-
-    if (tenant?.clinicId)
-      timeouts.push(
-        setTimeout(() => {
-          loadData();
-        }, 0),
-      );
-
-    return () => {
-      timeouts.forEach((t) => clearTimeout(t));
-    };
-  }, [tenant?.clinicId, loadData]);
+    const controller = new AbortController();
+    async function loadData() {
+      if (!tenant?.clinicId) return;
+      setLoading(true);
+      try {
+        const res = await fetch("/api/clinic-owner/patient-acquisition", {
+          signal: controller.signal,
+        });
+        const json = await res.json();
+        if (controller.signal.aborted) return;
+        if (json.ok) {
+          setChannels(json.data.channels);
+          setSummary(json.data.summary);
+        }
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          logger.warn("Failed to load acquisition data", { context: "page", error: err });
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }
+    loadData();
+    return () => controller.abort();
+  }, [tenant?.clinicId]);
 
   const chartData = channels
     .filter((c) => c.patientCount > 0)
@@ -104,7 +107,6 @@ export default function PatientAcquisitionPage() {
       <Breadcrumb
         items={[{ label: "Admin", href: "/admin/dashboard" }, { label: "Acquisition patients" }]}
       />
-      {}
       <h1 className="text-2xl font-bold">Coût d&apos;acquisition patient</h1>
 
       {loading ? (
@@ -117,7 +119,6 @@ export default function PatientAcquisitionPage() {
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Total patients</CardTitle>
                 <Users className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -129,7 +130,6 @@ export default function PatientAcquisitionPage() {
             </Card>
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Patients suivis</CardTitle>
                 <Target className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -138,14 +138,12 @@ export default function PatientAcquisitionPage() {
                   {(summary?.trackedPatients ?? 0).toLocaleString(intlLocale)}
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {}
                   {summary?.untrackedPatients ?? 0} non suivis
                 </p>
               </CardContent>
             </Card>
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Budget marketing</CardTitle>
                 <DollarSign className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -157,7 +155,6 @@ export default function PatientAcquisitionPage() {
             </Card>
             <Card>
               <CardHeader className="flex flex-row items-center justify-between pb-2">
-                {}
                 <CardTitle className="text-sm font-medium">Coût / patient</CardTitle>
                 <TrendingUp className="h-4 w-4 text-muted-foreground" />
               </CardHeader>
@@ -173,19 +170,10 @@ export default function PatientAcquisitionPage() {
           {chartData.length > 0 && (
             <Card>
               <CardHeader>
-                {}
                 <CardTitle>Patients par canal</CardTitle>
               </CardHeader>
               <CardContent>
-                <ResponsiveContainer width="100%" height={300}>
-                  <BarChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="channel" />
-                    <YAxis />
-                    <Tooltip />
-                    <Bar dataKey="patients" fill="var(--primary)" radius={[4, 4, 0, 0]} />
-                  </BarChart>
-                </ResponsiveContainer>
+                <AcquisitionBarChart data={chartData} />
               </CardContent>
             </Card>
           )}
@@ -193,22 +181,17 @@ export default function PatientAcquisitionPage() {
           {/* Channel Breakdown Table */}
           <Card>
             <CardHeader>
-              {}
               <CardTitle>Détail par canal</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b text-left">
-                      {}
-                      <th className="py-3 pr-4 font-medium">Canal</th>
-                      {}
-                      <th className="py-3 pr-4 font-medium text-right">Patients</th>
-                      {}
-                      <th className="py-3 pr-4 font-medium text-right">Dépenses</th>
-                      {}
-                      <th className="py-3 font-medium text-right">Coût/patient</th>
+                    <tr className="border-b text-start">
+                      <th className="py-3 pe-4 font-medium">Canal</th>
+                      <th className="py-3 pe-4 text-end font-medium">Patients</th>
+                      <th className="py-3 pe-4 text-end font-medium">Dépenses</th>
+                      <th className="py-3 text-end font-medium">Coût/patient</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -217,18 +200,18 @@ export default function PatientAcquisitionPage() {
                       .sort((a, b) => b.patientCount - a.patientCount)
                       .map((c) => (
                         <tr key={c.channel} className="border-b last:border-0">
-                          <td className="py-3 pr-4 flex items-center gap-2">
+                          <td className="py-3 pe-4 flex items-center gap-2">
                             <div
                               className="w-3 h-3 rounded-full"
                               style={{ backgroundColor: CHANNEL_COLORS[c.channel] ?? "#607D8B" }}
                             />
                             {CHANNEL_LABELS[c.channel] ?? c.channel}
                           </td>
-                          <td className="py-3 pr-4 text-right">{c.patientCount}</td>
-                          <td className="py-3 pr-4 text-right">
+                          <td className="py-3 pe-4 text-end">{c.patientCount}</td>
+                          <td className="py-3 pe-4 text-end">
                             {formatCurrency(c.totalSpend / 100, locale ?? "fr")}
                           </td>
-                          <td className="py-3 text-right font-medium">
+                          <td className="py-3 text-end font-medium">
                             {c.costPerPatient > 0
                               ? formatCurrency(c.costPerPatient / 100, locale ?? "fr")
                               : "—"}
@@ -238,7 +221,6 @@ export default function PatientAcquisitionPage() {
                     {channels.filter((c) => c.patientCount > 0 || c.totalSpend > 0).length ===
                       0 && (
                       <tr>
-                        {}
                         <td colSpan={4} className="py-8 text-center text-muted-foreground">
                           Aucune donnée d&apos;acquisition disponible
                         </td>

--- a/src/app/(super-admin)/super-admin/billing/_billing-trend-chart.tsx
+++ b/src/app/(super-admin)/super-admin/billing/_billing-trend-chart.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
+
+interface BillingTrendChartProps {
+  data: Array<{ label: string; amount: number }>;
+  formatter: (value: number) => string;
+}
+
+export default function BillingTrendChart({ data, formatter }: BillingTrendChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={140}>
+      <BarChart data={data} margin={{ top: 4, right: 4, left: 0, bottom: 0 }} barCategoryGap="30%">
+        <XAxis dataKey="label" tick={{ fontSize: 10 }} tickLine={false} axisLine={false} />
+        <YAxis
+          tick={{ fontSize: 10 }}
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          tickFormatter={(v: number) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v))}
+        />
+        <Tooltip
+          formatter={
+            ((value: number) => [formatter(value), "Encaissé"]) as unknown as React.ComponentProps<
+              typeof Tooltip
+            >["formatter"]
+          }
+          labelStyle={{ fontSize: 11 }}
+          contentStyle={{ fontSize: 11 }}
+          cursor={{ fill: "var(--muted)" }}
+        />
+        <Bar dataKey="amount" radius={[3, 3, 0, 0]}>
+          {data.map((entry, index) => (
+            <Cell
+              key={`cell-${index}`}
+              fill="var(--primary)"
+              fillOpacity={index === data.length - 1 ? 1 : 0.45}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/(super-admin)/super-admin/billing/page.tsx
+++ b/src/app/(super-admin)/super-admin/billing/page.tsx
@@ -20,8 +20,8 @@ import {
   FileSpreadsheet,
   FileText,
 } from "lucide-react";
-import { useState, useEffect, useCallback, useMemo, type ComponentProps } from "react";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
+import dynamic from "next/dynamic";
+import { useState, useEffect, useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
@@ -49,6 +49,11 @@ import { logger } from "@/lib/logger";
 import { fetchBillingRecords, type BillingRecord } from "@/lib/super-admin-actions";
 import { formatCurrency, formatNumber, getLocalDateStr } from "@/lib/utils";
 
+const BillingTrendChart = dynamic(() => import("./_billing-trend-chart"), {
+  ssr: false,
+  loading: () => <div className="h-[140px] animate-pulse rounded-md bg-muted" />,
+});
+
 type StatusFilter = "all" | "paid" | "pending" | "overdue" | "cancelled";
 
 export default function BillingPage() {
@@ -66,35 +71,28 @@ export default function BillingPage() {
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
 
-  const loadRecords = useCallback(async () => {
-    try {
-      const data = await fetchBillingRecords();
-      setRecords(data);
-    } catch (err) {
-      logger.warn("Failed to load super-admin billing", { context: "page", error: err });
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-    const controller = new AbortController();
-
-    timeouts.push(
-      setTimeout(() => {
-        loadRecords();
-      }, 0),
-    );
-
+    let active = true;
+    async function loadRecords() {
+      try {
+        const data = await fetchBillingRecords();
+        if (!active) return;
+        setRecords(data);
+      } catch (err) {
+        if (active) {
+          logger.warn("Failed to load super-admin billing", { context: "page", error: err });
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+    loadRecords();
     return () => {
-      timeouts.forEach((t) => clearTimeout(t));
-
-      (() => {
-        controller.abort();
-      })();
+      active = false;
     };
-  }, [loadRecords]);
+  }, []);
 
   // Derive a human-readable invoice number from the payment UUID + invoice date.
   // The raw UUID stays available via tooltip/detail for support lookups.
@@ -414,49 +412,10 @@ export default function BillingPage() {
                 </span>
               </CardHeader>
               <CardContent className="px-4 pb-4 pt-0">
-                <ResponsiveContainer width="100%" height={140}>
-                  <BarChart
-                    data={chartData}
-                    margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
-                    barCategoryGap="30%"
-                  >
-                    <XAxis
-                      dataKey="label"
-                      tick={{ fontSize: 10 }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
-                    <YAxis
-                      tick={{ fontSize: 10 }}
-                      tickLine={false}
-                      axisLine={false}
-                      width={44}
-                      tickFormatter={(v: number) =>
-                        v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)
-                      }
-                    />
-                    <Tooltip
-                      formatter={
-                        ((value: number) => [
-                          formatCurrency(value, "fr", "MAD"),
-                          "Encaissé",
-                        ]) as unknown as ComponentProps<typeof Tooltip>["formatter"]
-                      }
-                      labelStyle={{ fontSize: 11 }}
-                      contentStyle={{ fontSize: 11 }}
-                      cursor={{ fill: "var(--muted)" }}
-                    />
-                    <Bar dataKey="amount" radius={[3, 3, 0, 0]}>
-                      {chartData.map((entry, index) => (
-                        <Cell
-                          key={`cell-${index}`}
-                          fill="var(--primary)"
-                          fillOpacity={index === chartData.length - 1 ? 1 : 0.45}
-                        />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
+                <BillingTrendChart
+                  data={chartData}
+                  formatter={(value) => formatCurrency(value, "fr", "MAD")}
+                />
               </CardContent>
             </Card>
           )}

--- a/src/app/(super-admin)/super-admin/billing/revenue/_revenue-line-chart.tsx
+++ b/src/app/(super-admin)/super-admin/billing/revenue/_revenue-line-chart.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type React from "react";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+interface RevenueLineChartProps {
+  data: Array<{ month: string; revenue: number }>;
+  formatter: (value: number) => string;
+}
+
+export default function RevenueLineChart({ data, formatter }: RevenueLineChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <LineChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
+        <XAxis dataKey="month" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+        <YAxis
+          tick={{ fontSize: 11 }}
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(v: number) => `${(v / 1000).toFixed(0)}k`}
+          width={40}
+        />
+        <Tooltip
+          formatter={
+            ((value: number) => [formatter(value), "Revenus"]) as unknown as React.ComponentProps<
+              typeof Tooltip
+            >["formatter"]
+          }
+          labelStyle={{ fontSize: 12 }}
+          contentStyle={{ fontSize: 12 }}
+        />
+        <Line
+          type="monotone"
+          dataKey="revenue"
+          stroke="var(--primary)"
+          strokeWidth={2}
+          dot={{ r: 3 }}
+          activeDot={{ r: 5 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/(super-admin)/super-admin/billing/revenue/page.tsx
+++ b/src/app/(super-admin)/super-admin/billing/revenue/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { TrendingUp, DollarSign, Users, AlertTriangle, BarChart3, Loader2 } from "lucide-react";
-import type React from "react";
-import { useState, useEffect, useCallback } from "react";
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import dynamic from "next/dynamic";
+import { useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -21,34 +20,37 @@ import {
 } from "@/lib/super-admin-actions";
 import { formatCurrency } from "@/lib/utils";
 
+const RevenueLineChart = dynamic(() => import("./_revenue-line-chart"), {
+  ssr: false,
+  loading: () => <div className="h-[240px] animate-pulse rounded-md bg-muted" />,
+});
+
 export default function RevenueDashboardPage() {
   const [stats, setStats] = useState<RevenueStats | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const loadData = useCallback(async () => {
-    try {
-      const data = await fetchRevenueStatsAction();
-      setStats(data);
-    } catch (err) {
-      logger.warn("Failed to load revenue stats", { context: "revenue-page", error: err });
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-
-    timeouts.push(
-      setTimeout(() => {
-        loadData();
-      }, 0),
-    );
-
+    let active = true;
+    async function loadData() {
+      try {
+        const data = await fetchRevenueStatsAction();
+        if (!active) return;
+        setStats(data);
+      } catch (err) {
+        if (active) {
+          logger.warn("Failed to load revenue stats", { context: "revenue-page", error: err });
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+    loadData();
     return () => {
-      timeouts.forEach((t) => clearTimeout(t));
+      active = false;
     };
-  }, [loadData]);
+  }, []);
 
   return (
     <div>
@@ -175,44 +177,10 @@ export default function RevenueDashboardPage() {
             </CardHeader>
             <CardContent>
               {stats.revenueByMonth.length > 0 ? (
-                <ResponsiveContainer width="100%" height={240}>
-                  <LineChart
-                    data={stats.revenueByMonth}
-                    margin={{ top: 4, right: 8, left: 0, bottom: 4 }}
-                  >
-                    <XAxis
-                      dataKey="month"
-                      tick={{ fontSize: 11 }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
-                    <YAxis
-                      tick={{ fontSize: 11 }}
-                      tickLine={false}
-                      axisLine={false}
-                      tickFormatter={(v: number) => `${(v / 1000).toFixed(0)}k`}
-                      width={40}
-                    />
-                    <Tooltip
-                      formatter={
-                        ((value: number) => [
-                          formatCurrency(value),
-                          "Revenus",
-                        ]) as unknown as React.ComponentProps<typeof Tooltip>["formatter"]
-                      }
-                      labelStyle={{ fontSize: 12 }}
-                      contentStyle={{ fontSize: 12 }}
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="revenue"
-                      stroke="var(--primary)"
-                      strokeWidth={2}
-                      dot={{ r: 3 }}
-                      activeDot={{ r: 5 }}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
+                <RevenueLineChart
+                  data={stats.revenueByMonth}
+                  formatter={(value: number) => formatCurrency(value)}
+                />
               ) : (
                 <div className="text-center py-8">
                   <Loader2 className="h-6 w-6 text-muted-foreground mx-auto mb-2 opacity-50" />

--- a/src/app/(super-admin)/super-admin/pricing/_pricing-comparison-chart.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/_pricing-comparison-chart.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import * as React from "react";
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
+import type { SystemType } from "@/lib/config/pricing";
+import type { PricingTierRow } from "@/lib/super-admin-actions";
+import { formatCurrency } from "@/lib/utils";
+
+interface PricingComparisonChartProps {
+  tiers: PricingTierRow[];
+  selectedSystem: SystemType;
+  billingCycle: "monthly" | "yearly";
+  systemTypeLabels: Record<SystemType, string>;
+}
+
+export default function PricingComparisonChart({
+  tiers,
+  selectedSystem,
+  billingCycle,
+  systemTypeLabels,
+}: PricingComparisonChartProps) {
+  const chartData = tiers
+    .filter((t) => (t.pricing[selectedSystem]?.[billingCycle] ?? 0) >= 0)
+    .map((t) => ({
+      name: t.name,
+      price: t.pricing[selectedSystem]?.[billingCycle] ?? 0,
+      popular: t.popular,
+      slug: t.slug,
+    }));
+
+  if (chartData.every((d) => d.price === 0)) return null;
+
+  return (
+    <div className="rounded-xl border bg-card p-4 mb-6">
+      <p className="text-xs font-medium text-muted-foreground mb-3">
+        Comparaison des prix — {systemTypeLabels[selectedSystem]} ·{" "}
+        {billingCycle === "monthly" ? "Mensuel" : "Annuel"}
+      </p>
+      <ResponsiveContainer width="100%" height={130}>
+        <BarChart
+          data={chartData}
+          margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
+          barCategoryGap="28%"
+        >
+          <XAxis dataKey="name" tick={{ fontSize: 10 }} tickLine={false} axisLine={false} />
+          <YAxis
+            tick={{ fontSize: 10 }}
+            tickLine={false}
+            axisLine={false}
+            width={46}
+            tickFormatter={(v: number) => (v === 0 ? "Gratuit" : `${(v / 1000).toFixed(0)}k`)}
+          />
+          <Tooltip
+            formatter={
+              ((value: number) => [
+                value === 0 ? "Gratuit" : formatCurrency(value, "fr", "MAD"),
+                "Prix",
+              ]) as unknown as React.ComponentProps<typeof Tooltip>["formatter"]
+            }
+            labelStyle={{ fontSize: 11 }}
+            contentStyle={{ fontSize: 11 }}
+            cursor={{ fill: "var(--muted)" }}
+          />
+          <Bar dataKey="price" radius={[3, 3, 0, 0]}>
+            {chartData.map((entry, i) => (
+              <Cell
+                key={`cell-${i}`}
+                fill="var(--primary)"
+                fillOpacity={entry.popular ? 1 : 0.45}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+      <p className="text-[10px] text-muted-foreground mt-1 text-end">
+        La barre en couleur pleine = tier <span className="font-medium">Populaire</span>
+      </p>
+    </div>
+  );
+}

--- a/src/app/(super-admin)/super-admin/pricing/page.tsx
+++ b/src/app/(super-admin)/super-admin/pricing/page.tsx
@@ -26,8 +26,8 @@ import {
   Percent,
   AlertTriangle,
 } from "lucide-react";
-import { useState, useEffect, useCallback, type ComponentProps } from "react";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from "recharts";
+import dynamic from "next/dynamic";
+import { useState, useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
@@ -69,6 +69,11 @@ import {
   type FeatureToggleRow,
 } from "@/lib/super-admin-actions";
 import { formatCurrency, formatNumber } from "@/lib/utils";
+
+const PricingComparisonChart = dynamic(() => import("./_pricing-comparison-chart"), {
+  ssr: false,
+  loading: () => <div className="h-[130px] animate-pulse rounded-md bg-muted mb-6" />,
+});
 
 type TabView = "tiers" | "features" | "promotions";
 type SystemFilter = "all" | SystemType;
@@ -133,57 +138,53 @@ export default function PricingPage() {
   const [deletePromoOpen, setDeletePromoOpen] = useState(false);
   const [deletePromoItem, setDeletePromoItem] = useState<Promotion | null>(null);
 
-  const loadData = useCallback(async (isActive: () => boolean) => {
-    // Each section loads independently: a single slow or failing action must not
-    // blank the whole page or flash a misleading "Failed to load" — we render
-    // whatever resolved and only warn on the parts that didn't. isActive() guards
-    // against applying results after the component has unmounted.
-    const [subsRes, tiersRes, togglesRes, promosRes, historyRes] = await Promise.allSettled([
-      fetchClientSubscriptions(),
-      fetchPricingTiers(),
-      fetchFeatureToggles(),
-      fetchPromotions(),
-      fetchPriceHistory(),
-    ]);
-    if (!isActive()) return;
-
-    if (subsRes.status === "fulfilled") setSubscriptions(subsRes.value);
-    else logger.warn("Failed to load subscriptions", { context: "page", error: subsRes.reason });
-
-    if (tiersRes.status === "fulfilled") setTiers(tiersRes.value);
-    else logger.warn("Failed to load pricing tiers", { context: "page", error: tiersRes.reason });
-
-    if (togglesRes.status === "fulfilled") setToggles(togglesRes.value);
-    else
-      logger.warn("Failed to load feature toggles", { context: "page", error: togglesRes.reason });
-
-    if (promosRes.status === "fulfilled") setPromotions(promosRes.value);
-    else logger.warn("Failed to load promotions", { context: "page", error: promosRes.reason });
-
-    if (historyRes.status === "fulfilled") setPriceHistory(historyRes.value);
-    else logger.warn("Failed to load price history", { context: "page", error: historyRes.reason });
-
-    setLoading(false);
-  }, []);
-
   useEffect(() => {
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
     let active = true;
+    const isActive = () => active;
 
-    timeouts.push(
-      setTimeout(() => {
-        loadData(() => active);
-      }, 0),
-    );
+    async function loadData() {
+      // Each section loads independently: a single slow or failing action must not
+      // blank the whole page or flash a misleading "Failed to load" — we render
+      // whatever resolved and only warn on the parts that didn't. isActive() guards
+      // against applying results after the component has unmounted.
+      const [subsRes, tiersRes, togglesRes, promosRes, historyRes] = await Promise.allSettled([
+        fetchClientSubscriptions(),
+        fetchPricingTiers(),
+        fetchFeatureToggles(),
+        fetchPromotions(),
+        fetchPriceHistory(),
+      ]);
+      if (!isActive()) return;
+
+      if (subsRes.status === "fulfilled") setSubscriptions(subsRes.value);
+      else logger.warn("Failed to load subscriptions", { context: "page", error: subsRes.reason });
+
+      if (tiersRes.status === "fulfilled") setTiers(tiersRes.value);
+      else logger.warn("Failed to load pricing tiers", { context: "page", error: tiersRes.reason });
+
+      if (togglesRes.status === "fulfilled") setToggles(togglesRes.value);
+      else
+        logger.warn("Failed to load feature toggles", {
+          context: "page",
+          error: togglesRes.reason,
+        });
+
+      if (promosRes.status === "fulfilled") setPromotions(promosRes.value);
+      else logger.warn("Failed to load promotions", { context: "page", error: promosRes.reason });
+
+      if (historyRes.status === "fulfilled") setPriceHistory(historyRes.value);
+      else
+        logger.warn("Failed to load price history", { context: "page", error: historyRes.reason });
+
+      setLoading(false);
+    }
+
+    loadData();
 
     return () => {
-      timeouts.forEach((t) => clearTimeout(t));
-
-      (() => {
-        active = false;
-      })();
+      active = false;
     };
-  }, [loadData]);
+  }, []);
 
   const stats = {
     active: subscriptions.filter((s) => s.status === "active").length,
@@ -600,71 +601,12 @@ export default function PricingPage() {
           {/* S7: Price comparison bar chart — shows tier prices side-by-side for
               the active system type + billing cycle. Helps admins instantly spot
               tier positioning gaps and pricing outliers (e.g. SaaS < Premium). */}
-          {(() => {
-            const chartData = tiers
-              .filter((t) => (t.pricing[selectedSystem]?.[billingCycle] ?? 0) >= 0)
-              .map((t) => ({
-                name: t.name,
-                price: t.pricing[selectedSystem]?.[billingCycle] ?? 0,
-                popular: t.popular,
-                slug: t.slug,
-              }));
-            if (chartData.every((d) => d.price === 0)) return null;
-            return (
-              <div className="rounded-xl border bg-card p-4 mb-6">
-                <p className="text-xs font-medium text-muted-foreground mb-3">
-                  Comparaison des prix — {systemTypeLabels[selectedSystem]} ·{" "}
-                  {billingCycle === "monthly" ? "Mensuel" : "Annuel"}
-                </p>
-                <ResponsiveContainer width="100%" height={130}>
-                  <BarChart
-                    data={chartData}
-                    margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
-                    barCategoryGap="28%"
-                  >
-                    <XAxis
-                      dataKey="name"
-                      tick={{ fontSize: 10 }}
-                      tickLine={false}
-                      axisLine={false}
-                    />
-                    <YAxis
-                      tick={{ fontSize: 10 }}
-                      tickLine={false}
-                      axisLine={false}
-                      width={46}
-                      tickFormatter={(v: number) =>
-                        v === 0 ? "Gratuit" : `${(v / 1000).toFixed(0)}k`
-                      }
-                    />
-                    <Tooltip
-                      formatter={
-                        ((value: number) => [
-                          value === 0 ? "Gratuit" : formatCurrency(value, "fr", "MAD"),
-                          "Prix",
-                        ]) as unknown as ComponentProps<typeof Tooltip>["formatter"]
-                      }
-                      labelStyle={{ fontSize: 11 }}
-                      contentStyle={{ fontSize: 11 }}
-                      cursor={{ fill: "var(--muted)" }}
-                    />
-                    <Bar dataKey="price" radius={[3, 3, 0, 0]}>
-                      {chartData.map((entry, i) => (
-                        <Cell
-                          key={`cell-${i}`}
-                          fill="var(--primary)"
-                          fillOpacity={entry.popular ? 1 : 0.45}
-                        />
-                      ))}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
-                <p className="text-[10px] text-muted-foreground mt-1 text-right">
-                  La barre en couleur pleine = tier <span className="font-medium">Populaire</span>
-                </p>
-              </div>
-            );
-          })()}
+          <PricingComparisonChart
+            tiers={tiers}
+            selectedSystem={selectedSystem}
+            billingCycle={billingCycle}
+            systemTypeLabels={systemTypeLabels}
+          />
 
           {/* Pricing Cards */}
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">


### PR DESCRIPTION
## Summary

Lazy-loads `recharts` in the remaining admin and super-admin route pages to reduce the initial shared JS bundle:

- `admin/patient-acquisition`: extracted `_acquisition-bar-chart.tsx` and imported with `next/dynamic`.
- `super-admin/billing`: extracted `_billing-trend-chart.tsx` and imported with `next/dynamic`.
- `super-admin/billing/revenue`: extracted `_revenue-line-chart.tsx` and imported with `next/dynamic`.
- `super-admin/pricing`: extracted `_pricing-comparison-chart.tsx` and imported with `next/dynamic`.

Also removes the `setTimeout(..., 0)` data-fetch anti-pattern in those pages, replacing it with plain `useEffect` logic. For `fetch`-based routes, an `AbortController` cancels in-flight requests on unmount or filter change; for server-action-based routes, an `active` flag prevents state updates after unmount.

## Type of change

- [x] Performance / refactor

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- Minor logical-property substitutions (`pr-4` → `pe-4`, `text-right` → `text-end`, `text-left` → `text-start`) in the files touched.
- Removed stray empty JSX `{}` expressions.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes