### PR TITLE
fix(ui): make DialogTrigger support asChild and replace span-onClick triggers

### DIFF
--- a/src/components/__tests__/patient-registration.test.tsx
+++ b/src/components/__tests__/patient-registration.test.tsx
@@ -73,6 +73,9 @@ vi.mock("@/components/ui/dialog", () => ({
     onOpenChange: (open: boolean) => void;
     children: React.ReactNode;
   }) => <div data-open={open}>{children}</div>,
+  DialogTrigger: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
   DialogContent: ({
     children,
     onClose: _onClose,

--- a/src/components/receptionist/end-of-day-report-button.tsx
+++ b/src/components/receptionist/end-of-day-report-button.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
+  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -34,58 +35,41 @@ export function EndOfDayReportButton({ trigger }: EndOfDayReportButtonProps) {
     firstVisits: number;
   } | null>(null);
 
-  const generateReport = async () => {
-    setLoading(true);
-    try {
-      const user = await getCurrentUser();
-      if (!user?.clinic_id) {
-        setLoading(false);
-        return;
-      }
-
-      const today = getLocalDateStr();
-      const [appts, invoices] = await Promise.all([
-        fetchTodayAppointments(user.clinic_id),
-        fetchInvoices(user.clinic_id),
-      ]);
-
-      const todayInvoices = invoices.filter((inv) => inv.date === today);
-
-      setReport({
-        totalAppointments: appts.length,
-        completed: appts.filter((a) => a.status === "completed").length,
-        noShows: appts.filter((a) => a.status === "no-show").length,
-        cancelled: appts.filter((a) => a.status === "cancelled").length,
-        pending: appts.filter((a) => a.status === "scheduled" || a.status === "confirmed").length,
-        totalRevenue: todayInvoices.reduce((sum, inv) => sum + inv.amount, 0),
-        paidCount: todayInvoices.filter((inv) => inv.status === "paid").length,
-        pendingPayments: todayInvoices.filter((inv) => inv.status === "pending").length,
-        uniquePatients: new Set(appts.map((a) => a.patientId)).size,
-        firstVisits: appts.filter((a) => a.isFirstVisit).length,
-      });
-    } catch {
-      // Report generation failed silently
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    if (!open) return;
+    async function loadReport() {
+      setLoading(true);
+      try {
+        const user = await getCurrentUser();
+        if (!user?.clinic_id) return;
 
-    if (open && !report) {
-      timeouts.push(
-        setTimeout(() => {
-          generateReport();
-        }, 0),
-      );
+        const today = getLocalDateStr();
+        const [appts, invoices] = await Promise.all([
+          fetchTodayAppointments(user.clinic_id),
+          fetchInvoices(user.clinic_id),
+        ]);
+
+        const todayInvoices = invoices.filter((inv) => inv.date === today);
+
+        setReport({
+          totalAppointments: appts.length,
+          completed: appts.filter((a) => a.status === "completed").length,
+          noShows: appts.filter((a) => a.status === "no-show").length,
+          cancelled: appts.filter((a) => a.status === "cancelled").length,
+          pending: appts.filter((a) => a.status === "scheduled" || a.status === "confirmed").length,
+          totalRevenue: todayInvoices.reduce((sum, inv) => sum + inv.amount, 0),
+          paidCount: todayInvoices.filter((inv) => inv.status === "paid").length,
+          pendingPayments: todayInvoices.filter((inv) => inv.status === "pending").length,
+          uniquePatients: new Set(appts.map((a) => a.patientId)).size,
+          firstVisits: appts.filter((a) => a.isFirstVisit).length,
+        });
+      } catch {
+        // Report generation failed silently
+      } finally {
+        setLoading(false);
+      }
     }
-
-    return () => {
-      timeouts.forEach((t) => clearTimeout(t));
-    };
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    loadReport();
   }, [open]);
 
   const handlePrint = () => {
@@ -94,15 +78,14 @@ export function EndOfDayReportButton({ trigger }: EndOfDayReportButtonProps) {
 
   return (
     <>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard interaction handled by parent or child interactive element */}
-      <span onClick={() => setOpen(true)}>
+      <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger ?? (
           <Button variant="outline" size="sm">
-            <FileText className="h-4 w-4 mr-1" />
+            <FileText className="h-4 w-4 me-1" />
             End of Day Report
           </Button>
         )}
-      </span>
+      </DialogTrigger>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[600px]" onClose={() => setOpen(false)}>
           <DialogHeader>
@@ -240,12 +223,12 @@ export function EndOfDayReportButton({ trigger }: EndOfDayReportButtonProps) {
             </Button>
             <a href="/receptionist/daily-report">
               <Button variant="outline">
-                <FileText className="h-4 w-4 mr-1" />
+                <FileText className="h-4 w-4 me-1" />
                 Full Report
               </Button>
             </a>
             <Button onClick={handlePrint}>
-              <Printer className="h-4 w-4 mr-1" />
+              <Printer className="h-4 w-4 me-1" />
               Print
             </Button>
           </DialogFooter>

--- a/src/components/receptionist/manual-booking-dialog.tsx
+++ b/src/components/receptionist/manual-booking-dialog.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -118,15 +119,14 @@ export function ManualBookingDialog({ trigger, onBook }: ManualBookingDialogProp
 
   return (
     <>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard interaction handled by parent or child interactive element */}
-      <span onClick={() => setOpen(true)}>
+      <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger ?? (
           <Button variant="outline" size="sm">
-            <Phone className="h-4 w-4 mr-1" />
+            <Phone className="h-4 w-4 me-1" />
             Manual Booking
           </Button>
         )}
-      </span>
+      </DialogTrigger>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[500px]" onClose={() => setOpen(false)}>
           <DialogHeader>

--- a/src/components/receptionist/patient-registration-dialog.tsx
+++ b/src/components/receptionist/patient-registration-dialog.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -81,15 +82,14 @@ export function PatientRegistrationDialog({ trigger, onRegister }: PatientRegist
 
   return (
     <>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard interaction handled by parent or child interactive element */}
-      <span onClick={() => setOpen(true)}>
+      <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger ?? (
           <Button>
-            <UserPlus className="h-4 w-4 mr-1" />
+            <UserPlus className="h-4 w-4 me-1" />
             Register New Patient
           </Button>
         )}
-      </span>
+      </DialogTrigger>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
           className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto"

--- a/src/components/receptionist/payment-dialog.tsx
+++ b/src/components/receptionist/payment-dialog.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -64,15 +65,14 @@ export function PaymentDialog({
 
   return (
     <>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard interaction handled by parent or child interactive element */}
-      <span onClick={() => setOpen(true)}>
+      <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger ?? (
           <Button variant="outline" size="sm">
-            <CreditCard className="h-4 w-4 mr-1" />
+            <CreditCard className="h-4 w-4 me-1" />
             Collect Payment
           </Button>
         )}
-      </span>
+      </DialogTrigger>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[420px]" onClose={() => setOpen(false)}>
           <DialogHeader>

--- a/src/components/receptionist/walk-in-dialog.tsx
+++ b/src/components/receptionist/walk-in-dialog.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
+  DialogTrigger,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -112,15 +113,14 @@ export function WalkInDialog({ trigger, onRegister }: WalkInDialogProps) {
 
   return (
     <>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- keyboard interaction handled by parent or child interactive element */}
-      <span onClick={() => setOpen(true)}>
+      <DialogTrigger asChild onClick={() => setOpen(true)}>
         {trigger ?? (
           <Button size="sm">
-            <UserPlus className="h-4 w-4 mr-1" />
+            <UserPlus className="h-4 w-4 me-1" />
             Walk-in Registration
           </Button>
         )}
-      </span>
+      </DialogTrigger>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent className="sm:max-w-[500px]" onClose={() => setOpen(false)}>
           <DialogHeader>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -16,13 +16,27 @@ function Dialog({ open, children }: DialogProps) {
   return <>{open ? children : null}</>;
 }
 
-function DialogTrigger({
-  children,
-  onClick,
-  ...props
-}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+interface DialogTriggerProps extends Omit<React.ComponentProps<"button">, "onClick"> {
+  asChild?: boolean;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+}
+
+function DialogTrigger({ children, asChild, onClick, ...props }: DialogTriggerProps) {
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+      ...props,
+      onClick: (e: React.MouseEvent<HTMLElement>) => {
+        (children.props as { onClick?: React.MouseEventHandler<HTMLElement> }).onClick?.(e);
+        onClick?.(e);
+      },
+    });
+  }
   return (
-    <button type="button" onClick={onClick} {...props}>
+    <button
+      type="button"
+      onClick={onClick as React.MouseEventHandler<HTMLButtonElement> | undefined}
+      {...props}
+    >
       {children}
     </button>
   );


### PR DESCRIPTION
## Summary

Makes the existing `DialogTrigger` prop `asChild` work and uses it to replace inaccessible `<span onClick>` dialog triggers in receptionist components.

- `src/components/ui/dialog.tsx`: `DialogTrigger` now actually supports `asChild`, cloning the child element and composing `onClick` with any existing child `onClick`.
- Receptionist dialogs updated:
  - `walk-in-dialog`
  - `manual-booking-dialog`
  - `payment-dialog`
  - `patient-registration-dialog`
  - `end-of-day-report-button`
- Removed the `setTimeout(..., 0)` report-load pattern in `end-of-day-report-button` in favor of a direct effect.
- Switched icon margins from `mr-1` to `me-1` in the files touched.
- Updated the `patient-registration.test.tsx` mock to export `DialogTrigger`.

## Type of change

- [x] Bug fix / accessibility

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- Logical property `me-1` in touched icons.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes