### PR TITLE
refactor(components): deduplicate ChangeIndicator into shared UI component

### DIFF
--- a/src/components/admin/analytics-dashboard.tsx
+++ b/src/components/admin/analytics-dashboard.tsx
@@ -7,8 +7,6 @@ import {
   Clock,
   TrendingUp,
   TrendingDown,
-  ArrowUpRight,
-  ArrowDownRight,
   BarChart3,
   Activity,
 } from "lucide-react";
@@ -28,6 +26,7 @@ import {
 import { useLocale } from "@/components/locale-switcher";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChangeIndicator } from "@/components/ui/change-indicator";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { formatCurrency, LOCALE_MAP } from "@/lib/utils";
 
@@ -121,20 +120,6 @@ const HEATMAP_COLORS = [
 ];
 
 // ── Sub-components (declared outside render to satisfy react-hooks/static-components) ──
-
-function ChangeIndicator({ value }: { value: number }) {
-  if (value === 0) return <span className="text-xs text-muted-foreground">0%</span>;
-  const positive = value > 0;
-  return (
-    <span
-      className={`inline-flex items-center gap-0.5 text-xs font-medium ${positive ? "text-[var(--signal-green)]" : "text-[var(--signal-red)]"}`}
-    >
-      {positive ? <ArrowUpRight className="h-3 w-3" /> : <ArrowDownRight className="h-3 w-3" />}
-      {positive ? "+" : ""}
-      {value}%
-    </span>
-  );
-}
 
 function StatCard({
   icon: Icon,
@@ -930,23 +915,7 @@ function ComparisonItem({
           <p className="text-lg font-bold">{current}</p>
           <p className="text-xs text-muted-foreground">vs {previous}</p>
         </div>
-        <span
-          className={`inline-flex items-center gap-0.5 text-sm font-medium ${
-            change > 0
-              ? "text-[var(--signal-green)]"
-              : change < 0
-                ? "text-[var(--signal-red)]"
-                : "text-muted-foreground"
-          }`}
-        >
-          {change > 0 ? (
-            <ArrowUpRight className="h-3.5 w-3.5" />
-          ) : change < 0 ? (
-            <ArrowDownRight className="h-3.5 w-3.5" />
-          ) : null}
-          {change > 0 ? "+" : ""}
-          {change}%
-        </span>
+        <ChangeIndicator value={change} className="text-sm" />
       </div>
     </div>
   );

--- a/src/components/analytics/analytics-dashboard.tsx
+++ b/src/components/analytics/analytics-dashboard.tsx
@@ -41,6 +41,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChangeIndicator } from "@/components/ui/change-indicator";
 import { PageLoader } from "@/components/ui/page-loader";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
@@ -70,26 +71,6 @@ const PERIOD_LABELS: Record<AnalyticsPeriod, string> = {
   quarter: "This Quarter",
   year: "This Year",
 };
-
-function ChangeIndicator({ value, inverted = false }: { value: number; inverted?: boolean }) {
-  const isPositive = inverted ? value < 0 : value > 0;
-  const isNegative = inverted ? value > 0 : value < 0;
-  return (
-    <Badge
-      variant="outline"
-      className={`text-xs ${
-        isPositive
-          ? "text-green-600 border-green-200"
-          : isNegative
-            ? "text-red-600 border-red-200"
-            : ""
-      }`}
-    >
-      {value > 0 ? "+" : ""}
-      {value}%
-    </Badge>
-  );
-}
 
 export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "doctor" }) {
   const [revenuePeriod, setRevenuePeriod] = useState<"daily" | "weekly" | "monthly">("daily");
@@ -259,7 +240,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-2">
               <Users className="h-5 w-5 text-blue-600" />
-              <ChangeIndicator value={periodComparison.patientChange} />
+              <ChangeIndicator value={periodComparison.patientChange} variant="badge" />
             </div>
             <p className="text-2xl font-bold">{periodComparison.currentPatients}</p>
             <p className="text-xs text-muted-foreground">Patients ({PERIOD_LABELS[timePeriod]})</p>
@@ -272,7 +253,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-2">
               <TrendingUp className="h-5 w-5 text-green-600" />
-              <ChangeIndicator value={periodComparison.revenueChange} />
+              <ChangeIndicator value={periodComparison.revenueChange} variant="badge" />
             </div>
             <p className="text-2xl font-bold">{formatCurrency(periodComparison.currentRevenue)}</p>
             <p className="text-xs text-muted-foreground">Revenue ({PERIOD_LABELS[timePeriod]})</p>
@@ -285,7 +266,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-2">
               <XCircle className="h-5 w-5 text-red-500" />
-              <ChangeIndicator value={periodComparison.noShowChange} inverted />
+              <ChangeIndicator value={periodComparison.noShowChange} inverted variant="badge" />
             </div>
             <p className="text-2xl font-bold">{noShowRate}%</p>
             <p className="text-xs text-muted-foreground">No-show Rate</p>
@@ -298,7 +279,7 @@ export function AnalyticsDashboard({ role = "admin" }: { role?: "admin" | "docto
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-2">
               <Footprints className="h-5 w-5 text-purple-600" />
-              <ChangeIndicator value={periodComparison.appointmentChange} />
+              <ChangeIndicator value={periodComparison.appointmentChange} variant="badge" />
             </div>
             <p className="text-2xl font-bold">{periodComparison.currentAppointments}</p>
             <p className="text-xs text-muted-foreground">

--- a/src/components/ui/change-indicator.tsx
+++ b/src/components/ui/change-indicator.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface ChangeIndicatorProps {
+  value: number;
+  inverted?: boolean;
+  variant?: "inline" | "badge";
+  className?: string;
+}
+
+/**
+ * Displays a percentage change value. Use `variant="badge"` for the dashboard
+ * metric-card style, or `variant="inline"` for a compact inline arrow label.
+ */
+export function ChangeIndicator({
+  value,
+  inverted = false,
+  variant = "inline",
+  className,
+}: ChangeIndicatorProps) {
+  const isPositive = inverted ? value < 0 : value > 0;
+  const isNegative = inverted ? value > 0 : value < 0;
+  const formatted = `${value > 0 ? "+" : ""}${value}%`;
+
+  if (variant === "badge") {
+    return (
+      <Badge
+        variant="outline"
+        className={cn(
+          "text-xs",
+          isPositive && "text-green-600 border-green-200",
+          isNegative && "text-red-600 border-red-200",
+          className,
+        )}
+      >
+        {formatted}
+      </Badge>
+    );
+  }
+
+  if (value === 0) {
+    return <span className={cn("text-xs text-muted-foreground", className)}>0%</span>;
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-0.5 text-xs font-medium",
+        isPositive ? "text-[var(--signal-green)]" : "text-[var(--signal-red)]",
+        className,
+      )}
+    >
+      {isPositive ? <ArrowUpRight className="h-3 w-3" /> : <ArrowDownRight className="h-3 w-3" />}
+      {formatted}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

De-duplicates the near-identical `ChangeIndicator` helper that existed in both `components/admin/analytics-dashboard.tsx` and `components/analytics/analytics-dashboard.tsx` (M-4).

- Creates a shared `src/components/ui/change-indicator.tsx`.
- Supports two variants:
  - `variant="inline"` — arrow + colored percentage text (used in the admin dashboard).
  - `variant="badge"` — outlined badge style (used in analytics dashboard).
- Both variants support the `inverted` prop (positive values can be colored red for metrics like no-show rate).
- Replaces the two local `ChangeIndicator` definitions and updates all call sites to use the shared component.

## Type of change

- [x] Refactor

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None beyond the de-duplication.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes