### PR TITLE
fix(types): remove explicit any casts in AI/report/chaos paths

### DIFF
--- a/src/lib/ai/clinic-briefings.ts
+++ b/src/lib/ai/clinic-briefings.ts
@@ -9,6 +9,7 @@
  * OWASP A04: All DB queries scoped to clinic_id.
  */
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { resolveAIConfig } from "@/lib/ai/config";
 import { validateAIOutput } from "@/lib/ai/validate-output";
 import { isAIEnabled } from "@/lib/features";
@@ -497,10 +498,7 @@ Génère le briefing exécutif.`;
 
 // ── Main exported function — called by cron ──
 
-export async function generateDailyClinicBriefings(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  supabase: any,
-): Promise<number> {
+export async function generateDailyClinicBriefings(supabase: SupabaseClient): Promise<number> {
   // F-AI-01: Kill switch
   if (!(await isAIEnabled())) {
     logger.info("AI briefings skipped — AI features disabled", {

--- a/src/lib/ai/feature-toggles.ts
+++ b/src/lib/ai/feature-toggles.ts
@@ -10,6 +10,7 @@
  * provider at or above the feature's required tier is available.
  */
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
 import { getCachedFeatureToggles, setCachedFeatureToggles } from "./config-cache";
 
@@ -32,8 +33,9 @@ export interface FeatureToggleState {
 /**
  * Load feature toggle state from DB (with caching).
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function loadFeatureToggles(supabase: any): Promise<Map<string, FeatureToggleState>> {
+export async function loadFeatureToggles(
+  supabase: SupabaseClient,
+): Promise<Map<string, FeatureToggleState>> {
   const cached = getCachedFeatureToggles();
   if (cached) return cached;
 

--- a/src/lib/ai/router.ts
+++ b/src/lib/ai/router.ts
@@ -16,6 +16,7 @@
  * column (not a quadratic estimate of token counts).
  */
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { getWorkerBinding } from "@/lib/cf-bindings";
 import { logger } from "@/lib/logger";
 import { getCachedConfigs, invalidateConfigCache, setCachedConfigs } from "./config-cache";
@@ -72,8 +73,7 @@ function markRateLimitedInMemory(provider: AIProvider, retryAfterMs: number): vo
 
 /** Persist a rate-limit cooldown across serverless invocations. */
 async function persistRateLimit(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  supabase: any,
+  supabase: SupabaseClient,
   provider: AIProvider,
   retryAfterMs: number,
 ): Promise<void> {
@@ -204,8 +204,7 @@ export async function selectAvailableProvider(
 export async function routeAIRequest(
   request: AIRequest,
   configs: Map<AIProvider, ProviderConfig>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  supabase?: any,
+  supabase?: SupabaseClient,
 ): Promise<AIResponse> {
   // F-AI-14 / AUDIT P1-11: default a reproducibility seed so every routed
   // request is replayable. It is passed to the provider (providers.ts) and
@@ -385,8 +384,7 @@ async function tryProviderWithFallback(
   request: AIRequest,
   provider: AIProvider,
   configs: Map<AIProvider, ProviderConfig>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  supabase?: any,
+  supabase?: SupabaseClient,
 ): Promise<AIResponse> {
   const availability = await checkProviderAvailable(provider, configs);
 
@@ -455,8 +453,7 @@ async function tryProviderWithFallback(
 // ── Load provider configs from DB (cached) ──
 
 export async function loadProviderConfigs(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  supabase: any,
+  supabase: SupabaseClient,
   options: { forceRefresh?: boolean } = {},
 ): Promise<Map<AIProvider, ProviderConfig>> {
   if (!options.forceRefresh) {

--- a/src/lib/ai/task-config.ts
+++ b/src/lib/ai/task-config.ts
@@ -15,6 +15,7 @@
  * (config-cache.ts) — same staleness bound, same multi-instance caveat.
  */
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { logger } from "@/lib/logger";
 import { createUntypedAdminClient } from "@/lib/supabase-server";
 import { ALLOWED_MODELS, resolveModelAlias } from "./models";
@@ -44,8 +45,7 @@ export function invalidateTaskConfigCache(): void {
  * Fails open to an empty map (auto routing for everything) on any error so
  * a missing table or DB hiccup can never take AI down.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function loadTaskConfigs(supabase?: any): Promise<Map<AITaskType, TaskPin>> {
+async function loadTaskConfigs(supabase?: SupabaseClient): Promise<Map<AITaskType, TaskPin>> {
   if (_cached && Date.now() < _cached.expiresAt) return _cached.pins;
 
   const pins = new Map<AITaskType, TaskPin>();
@@ -111,8 +111,10 @@ async function loadTaskConfigs(supabase?: any): Promise<Map<AITaskType, TaskPin>
 }
 
 /** Resolve the pin for a single task. Null = full auto. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function getTaskPin(task: AITaskType, supabase?: any): Promise<TaskPin | null> {
+export async function getTaskPin(
+  task: AITaskType,
+  supabase?: SupabaseClient,
+): Promise<TaskPin | null> {
   const pins = await loadTaskConfigs(supabase);
   return pins.get(task) ?? null;
 }

--- a/src/lib/chaos/chaos-engine.ts
+++ b/src/lib/chaos/chaos-engine.ts
@@ -37,6 +37,11 @@ interface ChaosConfig {
   statusCode?: number;
 }
 
+interface ChaosError extends Error {
+  chaosExperiment?: ChaosExperiment;
+  statusCode?: number;
+}
+
 const CHAOS_CONFIGS: Record<ChaosExperiment, ChaosConfig> = {
   database_timeout: {
     probability: 0.1, // 10% of DB calls
@@ -136,11 +141,9 @@ export async function withChaos<T>(experiment: ChaosExperiment, fn: () => Promis
   }
 
   if (config.errorMessage) {
-    const error = new Error(config.errorMessage);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (error as any).chaosExperiment = experiment;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (error as any).statusCode = config.statusCode;
+    const error = new Error(config.errorMessage) as ChaosError;
+    error.chaosExperiment = experiment;
+    error.statusCode = config.statusCode;
     throw error;
   }
 

--- a/src/lib/data/client/parapharmacy.ts
+++ b/src/lib/data/client/parapharmacy.ts
@@ -2,7 +2,7 @@
 
 import { logger } from "@/lib/logger";
 import { createClient } from "@/lib/supabase-client";
-import type { Database } from "@/lib/types/database";
+import type { Database, TablesInsert } from "@/lib/types/database";
 import { getLocalDateStr } from "@/lib/utils";
 import { fetchRows } from "./_core";
 import type { ProductView, ProductRaw, StockRaw } from "./pharmacy";
@@ -107,8 +107,7 @@ export async function createParapharmacySale(data: {
       time: now.toTimeString().slice(0, 5),
       items: data.items,
       is_parapharmacy: true,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
+    } as unknown as TablesInsert<"sales">)
     .select("id")
     .single();
   if (error) {

--- a/src/lib/reports/builder.ts
+++ b/src/lib/reports/builder.ts
@@ -83,8 +83,7 @@ export async function executeReport(
 
   const selectStr = safeFields.join(", ");
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let query = (supabase as any)
+  let query = (supabase as SupabaseClient)
     .from(dataSource)
     .select(selectStr, { count: "exact" })
     .eq("clinic_id", clinicId);
@@ -137,7 +136,7 @@ export async function executeReport(
 
   return {
     columns: safeFields,
-    rows: (data ?? []) as Record<string, unknown>[],
+    rows: (data ?? []) as unknown as Record<string, unknown>[],
     totalRows: count ?? 0,
     generatedAt: new Date().toISOString(),
   };

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -443,16 +443,14 @@ function wrapChaosBuilder<T extends object>(builder: T): T {
           onRejected?: (reason: unknown) => unknown,
         ) =>
           withChaos("database_timeout", () => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const thenable = target as unknown as PromiseLike<any>;
+            const thenable = target as unknown as PromiseLike<unknown>;
             return Promise.resolve(thenable);
           }).then(onFulfilled, onRejected);
       }
 
       const value = Reflect.get(target, prop, receiver);
       if (typeof value === "function") {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (...args: any[]) => {
+        return (...args: unknown[]) => {
           const result = (value as (...a: unknown[]) => unknown).apply(target, args);
           // Re-wrap chainable builders (objects that are still thenable) so
           // chaos continues to apply no matter how deep the chain goes.


### PR DESCRIPTION
## Summary

Removes explicit `any` casts from the AI routing layer, report builder, parapharmacy data client, and the chaos proxy (L-4 audit follow-up).

- `src/lib/ai/{router,task-config,feature-toggles,clinic-briefings}.ts`: `supabase` parameters are now typed as `SupabaseClient` instead of `any`.
- `src/lib/reports/builder.ts`: uses a typed `SupabaseClient` cast instead of `as any` for dynamic `dataSource` queries.
- `src/lib/data/client/parapharmacy.ts`: replaces `as any` on the `sales` insert payload with `as unknown as TablesInsert<"sales">`.
- `src/lib/chaos/chaos-engine.ts`: introduces a typed `ChaosError` interface instead of mutating a plain `Error` with `as any`.
- `src/lib/supabase-server.ts`: changes the chaos wrapper proxy to use `unknown` instead of `any`.

## Type of change

- [x] Code style update (formatting, renaming)
- [x] Refactor (no functional change)

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes