### PR TITLE
fix(types): remove remaining explicit any casts in data client modules

### DIFF
--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -803,9 +803,6 @@ async function getAvailableSlots(input: ToolInput, ctx: AgentToolContext): Promi
 
 // ── C2: Agent-to-agent handoff ──
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type UntypedClient = { from(table: string): any };
-
 async function handoffToAgent(input: ToolInput, ctx: AgentToolContext): Promise<ToolResult> {
   if (!ctx.clinicId) return { ok: false, error: "Clinic context is required", code: "NO_CLINIC" };
 
@@ -855,9 +852,7 @@ async function handoffToAgent(input: ToolInput, ctx: AgentToolContext): Promise<
     };
   }
 
-  const untypedSupa = ctx.supabase as unknown as UntypedClient;
-
-  const result = await createTeamTask(untypedSupa, ctx.clinicId, {
+  const result = await createTeamTask(ctx.supabase, ctx.clinicId, {
     title: taskSummary.slice(0, 255),
     description: context?.slice(0, 2000),
     agentType: targetType,
@@ -876,7 +871,7 @@ async function handoffToAgent(input: ToolInput, ctx: AgentToolContext): Promise<
   });
 
   try {
-    await untypedSupa
+    await ctx.supabase
       .from("ai_team_tasks")
       .update({
         history_events: [event],

--- a/src/lib/data/client/clinic.ts
+++ b/src/lib/data/client/clinic.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   fetchRows,
   ensureLookups,
@@ -154,9 +155,8 @@ export async function fetchInstallmentPlans(clinicId: string): Promise<Installme
 }
 
 // clinic_holidays.{type,recurring} columns (migration 00192) are not yet in the
-// generated DB types. Cast through this minimal shape — matches whatsapp.ts.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SupabaseUntyped = { from(table: string): any };
+// generated DB types. Cast through the generic client shape.
+type SupabaseUntyped = SupabaseClient;
 
 // ============================================================
 // HOLIDAYS (clinic_holidays)

--- a/src/lib/data/client/reviews.ts
+++ b/src/lib/data/client/reviews.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { fetchRows, ensureLookups, _activeUserMap, createClient } from "./_core";
 
 // ─────────────────────────────────────────────
@@ -56,9 +57,8 @@ export async function fetchReviews(clinicId: string): Promise<ReviewView[]> {
 // ─────────────────────────────────────────────
 
 // notification_preferences (migration 00161) is not yet in the generated DB
-// types. Cast through this minimal shape — matches src/lib/whatsapp.ts.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type SupabaseUntyped = { from(table: string): any };
+// types. Cast through the generic client shape.
+type SupabaseUntyped = SupabaseClient;
 
 export async function createReview(data: {
   clinicId: string;


### PR DESCRIPTION
## Summary

Removes explicit `any` casts from the remaining non-SEALED data-client modules (L-4 audit follow-up). The `SupabaseUntyped` helper is now an alias for the generic `SupabaseClient` shape instead of `{ from(table: string): any }`.

- `src/lib/data/client/reviews.ts`: `SupabaseUntyped = SupabaseClient`; casts for `notification_preferences` queries use the generic client.
- `src/lib/data/client/clinic.ts`: `SupabaseUntyped = SupabaseClient`; casts for `clinic_holidays` queries use the generic client.

## Type of change

- [x] Refactor (no functional change)

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes