### PR TITLE
fix(layout): document super-admin notification queries for Semgrep tenant scoping

### DIFF
--- a/src/components/layouts/super-admin-notification-bell.tsx
+++ b/src/components/layouts/super-admin-notification-bell.tsx
@@ -80,6 +80,9 @@ export function SuperAdminNotificationBell() {
         } = await supabase.auth.getUser();
         if (!user || !mountedRef.current) return;
 
+        // nosemgrep: tenant-scoping
+        // User profile lookup pinned to the authenticated auth_id; clinic_id
+        // is not known until the profile is returned, so it cannot be scoped here.
         const { data: profile } = await supabase
           .from("users")
           .select("id, clinic_id")
@@ -92,6 +95,7 @@ export function SuperAdminNotificationBell() {
         // isolation (defense-in-depth alongside RLS). user_id already pins
         // the result to the current user; clinic_id is applied when the
         // profile has one (super_admin has clinic_id = null and is unscoped).
+        // nosemgrep: tenant-scoping
         let notifQuery = supabase
           .from("notifications")
           .select("id, title, body, sent_at, is_read")


### PR DESCRIPTION
## Summary

Addresses the Semgrep review findings on #1288 for `src/components/layouts/super-admin-notification-bell.tsx`.

- Adds documented `// nosemgrep: tenant-scoping` annotations above the two Supabase queries in the super-admin notification bell.
- The `users` query is keyed on `auth_id` from the authenticated session; `clinic_id` is not known until the profile row is returned, so it cannot be scoped at that point.
- The `notifications` query is keyed on `user_id`; `clinic_id` is applied conditionally when the resolved profile has one (clinic users), and deliberately omitted for super-admin users where `clinic_id` is `null`. The annotation documents this as an intentional user-scoped exception.

No runtime behavior changes.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes