### PR TITLE
refactor(rsc): convert pharmacist expiry tracker to server component

### DIFF
--- a/src/app/(pharmacist)/pharmacist/expiry/page.tsx
+++ b/src/app/(pharmacist)/pharmacist/expiry/page.tsx
@@ -1,71 +1,37 @@
-"use client";
-
 import { AlertTriangle, Check, Clock, X } from "lucide-react";
-import { useState, useEffect, useMemo } from "react";
-import { useLocale } from "@/components/locale-switcher";
-import { useTenant } from "@/components/tenant-provider";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { PageLoader } from "@/components/ui/page-loader";
-import { fetchProducts, getExpiryStatus } from "@/lib/data/client";
-import type { ProductView } from "@/lib/data/client";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { formatCurrency, formatNumber } from "@/lib/utils";
+import type { ProductView } from "@/lib/data/client/pharmacy";
+import { fetchProducts, getExpiryStatus } from "@/lib/data/pharmacy";
+import type { Locale } from "@/lib/i18n";
+import { getLocaleFromTenant, requireTenant } from "@/lib/tenant";
+import { formatCurrency } from "@/lib/utils";
 
-export default function ExpiryTrackerPage() {
-  const [locale] = useLocale();
+interface ProductWithExpiry extends ProductView {
+  expiryStatus: "red" | "yellow" | "green";
+  daysUntilExpiry: number;
+}
 
-  const tenant = useTenant();
-  const [allProducts, setAllProducts] = useState<ProductView[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+function getDaysUntilExpiry(expiryDate: string): number {
+  if (!expiryDate) return Infinity;
+  const now = new Date();
+  const expiry = new Date(expiryDate);
+  return Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}
 
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchProducts(tenant?.clinicId ?? "")
-      .then((d) => {
-        if (!controller.signal.aborted) setAllProducts(d);
-      })
-      .catch((err) => {
-        if (!controller.signal.aborted) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
-    return () => {
-      controller.abort();
-    };
-  }, [tenant?.clinicId]);
+export default async function ExpiryTrackerPage() {
+  const tenant = await requireTenant();
+  const locale = getLocaleFromTenant(tenant) as Locale;
+  const allProducts = await fetchProducts(tenant.clinicId);
 
-  const products = useMemo(() => {
-    return allProducts
-      .filter((p) => p.active)
-      .map((p) => ({
-        ...p,
-        expiryStatus: getExpiryStatus(p.expiryDate),
-        daysUntilExpiry: Math.ceil(
-          (new Date(p.expiryDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24),
-        ),
-      }))
-      .sort((a, b) => a.daysUntilExpiry - b.daysUntilExpiry);
-  }, [allProducts]);
-
-  if (loading) {
-    return <PageLoader message="Loading expiry data..." />;
-  }
-
-  if (error) {
-    return (
-      <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">
-          Failed to load data. Please try refreshing the page.
-        </p>
-        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
-      </div>
-    );
-  }
+  const products: ProductWithExpiry[] = allProducts
+    .filter((p) => p.active)
+    .map((p) => ({
+      ...p,
+      expiryStatus: getExpiryStatus(p.expiryDate),
+      daysUntilExpiry: getDaysUntilExpiry(p.expiryDate),
+    }))
+    .sort((a, b) => a.daysUntilExpiry - b.daysUntilExpiry);
 
   const expired = products.filter((p) => p.expiryStatus === "red");
   const expiringSoon = products.filter((p) => p.expiryStatus === "yellow");
@@ -170,7 +136,7 @@ export default function ExpiryTrackerPage() {
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead>
-                <tr className="border-b text-left text-sm text-muted-foreground">
+                <tr className="border-b text-start text-sm text-muted-foreground">
                   <th className="py-3 px-2 font-medium">Status</th>
                   <th className="py-3 px-2 font-medium">Product</th>
                   <th className="py-3 px-2 font-medium">Category</th>
@@ -214,11 +180,7 @@ export default function ExpiryTrackerPage() {
                       </td>
                       <td className="py-3 px-2">{product.stockQuantity}</td>
                       <td className="py-3 px-2 font-medium">
-                        {formatCurrency(
-                          product.price * product.stockQuantity,
-                          typeof locale !== "undefined" ? locale : "fr",
-                          "MAD",
-                        )}
+                        {formatCurrency(product.price * product.stockQuantity, locale, "MAD")}
                       </td>
                     </tr>
                   );

--- a/src/lib/data/pharmacy.ts
+++ b/src/lib/data/pharmacy.ts
@@ -1,0 +1,63 @@
+import type { ProductView } from "@/lib/data/client/pharmacy";
+import { createClient } from "@/lib/supabase-server";
+import type { Tables } from "@/lib/types/database";
+
+export async function fetchProducts(clinicId: string): Promise<ProductView[]> {
+  const supabase = await createClient();
+
+  const [productsResult, stockResult] = await Promise.all([
+    supabase.from("products").select("*").eq("clinic_id", clinicId).limit(1000),
+    supabase.from("stock").select("*").eq("clinic_id", clinicId).limit(1000),
+  ]);
+
+  if (productsResult.error) {
+    throw new Error(`Failed to load products: ${productsResult.error.message}`);
+  }
+  if (stockResult.error) {
+    throw new Error(`Failed to load stock: ${stockResult.error.message}`);
+  }
+
+  const stockMap = new Map(
+    (stockResult.data ?? []).map((s) => [s.product_id, s as Tables<"stock">]),
+  );
+
+  const rows = (productsResult.data ?? []) as Tables<"products">[];
+
+  return rows.map((p) => {
+    const s = stockMap.get(p.id);
+
+    return {
+      id: p.id,
+      name: p.name,
+      genericName: p.generic_name ?? undefined,
+      category: p.category ?? "General",
+      description: p.description ?? undefined,
+      price: p.price ?? 0,
+      currency: "MAD",
+      requiresPrescription: p.requires_prescription ?? false,
+      stockQuantity: s?.quantity ?? 0,
+      minimumStock: s?.min_threshold ?? 0,
+      expiryDate: s?.expiry_date ?? "",
+      barcode: s?.batch_number ?? undefined,
+      manufacturer: p.manufacturer ?? undefined,
+      supplierId: s?.supplier_id ?? undefined,
+      dosageForm: p.dosage_form ?? undefined,
+      strength: p.strength ?? undefined,
+      active: p.is_active ?? true,
+    };
+  });
+}
+
+export function getExpiryStatus(expiryDate: string): "red" | "yellow" | "green" {
+  if (!expiryDate) return "green";
+
+  const now = new Date();
+  const expiry = new Date(expiryDate);
+
+  if (expiry < now) return "red";
+
+  const diffDays = Math.ceil((expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays <= 90) return "yellow";
+
+  return "green";
+}


### PR DESCRIPTION
## Summary

Converts the pharmacist expiry tracker from a client-side `useEffect` fetcher into a React Server Component (RSC), continuing the H-4 dashboard RSC remediation.

- Adds `src/lib/data/pharmacy.ts` with:
  - `fetchProducts` — server-side product/stock join scoped by `clinic_id`.
  - `getExpiryStatus` — pure helper that classifies an expiry date as `red` (expired), `yellow` (≤90 days), or `green`.
- Rewrites `src/app/(pharmacist)/pharmacist/expiry/page.tsx` as an async server component: `requireTenant()` → `fetchProducts()` → compute expiry buckets → render.
- Replaces the page-level `useState`/`useEffect`/`useMemo` and `PageLoader` spinner with direct server data.
- Replaces `text-left` with `text-start` for RTL support.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes