### PR TITLE
refactor(rsc): convert optician frame catalog and lens inventory to server components

### DIFF
--- a/src/app/(specialist)/optician/frame-catalog/page.tsx
+++ b/src/app/(specialist)/optician/frame-catalog/page.tsx
@@ -1,55 +1,11 @@
-"use client";
-
 import { Glasses } from "lucide-react";
-import { useState, useEffect } from "react";
 import { FrameCatalog } from "@/components/para-medical/frame-catalog";
-import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser, fetchFrameCatalog } from "@/lib/data/client";
-import { logger } from "@/lib/logger";
-import type { FrameCatalogItem } from "@/lib/types/para-medical";
+import { fetchFrameCatalog } from "@/lib/data/optician";
+import { requireTenant } from "@/lib/tenant";
 
-export default function FrameCatalogPage() {
-  const [frames, setFrames] = useState<FrameCatalogItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    async function load() {
-      const user = await getCurrentUser();
-      if (controller.signal.aborted) return;
-      if (!user?.clinic_id) {
-        setLoading(false);
-        return;
-      }
-      const data = await fetchFrameCatalog(user.clinic_id);
-      if (controller.signal.aborted) return;
-      setFrames(data);
-      setLoading(false);
-    }
-    load().catch((err) => {
-      if (!controller.signal.aborted) {
-        logger.warn("Failed to load frame catalog", {
-          context: "optician/frame-catalog",
-          error: err,
-        });
-        setError(err instanceof Error ? err : new Error(String(err)));
-        setLoading(false);
-      }
-    });
-    return () => controller.abort();
-  }, []);
-
-  if (loading) return <PageLoader message="Loading frame catalog..." />;
-
-  if (error) {
-    return (
-      <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">Failed to load frame catalog.</p>
-        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
-      </div>
-    );
-  }
+export default async function FrameCatalogPage() {
+  const tenant = await requireTenant();
+  const frames = await fetchFrameCatalog(tenant.clinicId);
 
   return (
     <div>

--- a/src/app/(specialist)/optician/lens-inventory/page.tsx
+++ b/src/app/(specialist)/optician/lens-inventory/page.tsx
@@ -1,55 +1,11 @@
-"use client";
-
 import { Package } from "lucide-react";
-import { useState, useEffect } from "react";
 import { LensInventoryManager } from "@/components/para-medical/lens-inventory-manager";
-import { PageLoader } from "@/components/ui/page-loader";
-import { getCurrentUser, fetchLensInventory } from "@/lib/data/client";
-import { logger } from "@/lib/logger";
-import type { LensInventoryItem } from "@/lib/types/para-medical";
+import { fetchLensInventory } from "@/lib/data/optician";
+import { requireTenant } from "@/lib/tenant";
 
-export default function LensInventoryPage() {
-  const [items, setItems] = useState<LensInventoryItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    async function load() {
-      const user = await getCurrentUser();
-      if (controller.signal.aborted) return;
-      if (!user?.clinic_id) {
-        setLoading(false);
-        return;
-      }
-      const data = await fetchLensInventory(user.clinic_id);
-      if (controller.signal.aborted) return;
-      setItems(data);
-      setLoading(false);
-    }
-    load().catch((err) => {
-      if (!controller.signal.aborted) {
-        logger.warn("Failed to load lens inventory", {
-          context: "optician/lens-inventory",
-          error: err,
-        });
-        setError(err instanceof Error ? err : new Error(String(err)));
-        setLoading(false);
-      }
-    });
-    return () => controller.abort();
-  }, []);
-
-  if (loading) return <PageLoader message="Loading lens inventory..." />;
-
-  if (error) {
-    return (
-      <div className="p-8 text-center">
-        <p className="text-red-600 font-medium">Failed to load lens inventory.</p>
-        {error.message && <p className="text-sm text-muted-foreground mt-2">{error.message}</p>}
-      </div>
-    );
-  }
+export default async function LensInventoryPage() {
+  const tenant = await requireTenant();
+  const items = await fetchLensInventory(tenant.clinicId);
 
   return (
     <div>

--- a/src/lib/data/optician.ts
+++ b/src/lib/data/optician.ts
@@ -1,0 +1,70 @@
+import { createClient } from "@/lib/supabase-server";
+import type { Tables } from "@/lib/types/database";
+import type { FrameCatalogItem, LensInventoryItem } from "@/lib/types/para-medical";
+
+export async function fetchFrameCatalog(clinicId: string): Promise<FrameCatalogItem[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("frame_catalog")
+    .select("*")
+    .eq("clinic_id", clinicId)
+    .order("brand", { ascending: true })
+    .limit(1000);
+
+  if (error) {
+    throw new Error(`Failed to load frame catalog: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as Tables<"frame_catalog">[];
+
+  return rows.map((r) => ({
+    id: r.id,
+    clinic_id: r.clinic_id,
+    brand: r.brand,
+    model: r.model,
+    color: r.color,
+    size: r.size,
+    material: r.material,
+    frame_type: r.frame_type as FrameCatalogItem["frame_type"],
+    gender: r.gender as FrameCatalogItem["gender"],
+    price: r.price,
+    cost_price: r.cost_price,
+    stock_quantity: r.stock_quantity,
+    photo_url: r.photo_url,
+    is_active: r.is_active,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }));
+}
+
+export async function fetchLensInventory(clinicId: string): Promise<LensInventoryItem[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("lens_inventory")
+    .select("*")
+    .eq("clinic_id", clinicId)
+    .order("type", { ascending: true })
+    .limit(1000);
+
+  if (error) {
+    throw new Error(`Failed to load lens inventory: ${error.message}`);
+  }
+
+  const rows = (data ?? []) as Tables<"lens_inventory">[];
+
+  return rows.map((r) => ({
+    id: r.id,
+    clinic_id: r.clinic_id,
+    type: r.type as LensInventoryItem["type"],
+    material: r.material,
+    coating: r.coating,
+    power_range: r.power_range,
+    stock_quantity: r.stock_quantity,
+    min_threshold: r.min_threshold,
+    unit_cost: r.unit_cost,
+    selling_price: r.selling_price,
+    supplier: r.supplier,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }));
+}


### PR DESCRIPTION
## Summary

Converts two optician read-only pages from client-side `useEffect` fetchers into React Server Components (RSCs), continuing the H-4 dashboard RSC remediation.

- Adds `src/lib/data/optician.ts` with server-side fetchers:
  - `fetchFrameCatalog` — queries `frame_catalog` scoped by `clinic_id`.
  - `fetchLensInventory` — queries `lens_inventory` scoped by `clinic_id`.
- Rewrites `src/app/(specialist)/optician/frame-catalog/page.tsx` as an async server component that calls `requireTenant()` and `fetchFrameCatalog()` before rendering.
- Rewrites `src/app/(specialist)/optician/lens-inventory/page.tsx` as an async server component that calls `requireTenant()` and `fetchLensInventory()` before rendering.
- Removes `PageLoader`, `useState`, `useEffect`, and client `getCurrentUser`/`fetch*` calls from both pages.

## Type of change

- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes