### PR TITLE
fix(payments): persist pending payment records for Stripe and CMI checkout initiation

### DIFF
--- a/src/app/api/payments/cmi/route.ts
+++ b/src/app/api/payments/cmi/route.ts
@@ -3,6 +3,7 @@ import { withAuthValidation } from "@/lib/api-validate";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { createCmiPayment, isCmiConfigured } from "@/lib/cmi";
 import { logger } from "@/lib/logger";
+import { PAYMENT_STATUS } from "@/lib/types/database";
 import { cmiPaymentSchema } from "@/lib/validations";
 
 /**
@@ -68,7 +69,7 @@ function validateRedirectUrl(
  */
 export const POST = withAuthValidation(
   cmiPaymentSchema,
-  async (body, request, { user, profile }) => {
+  async (body, request, { user, profile, supabase }) => {
     const traceId = request.headers.get("x-trace-id") ?? undefined;
     const clinicId = profile.clinic_id;
 
@@ -97,6 +98,55 @@ export const POST = withAuthValidation(
 
     const origin = request.nextUrl.origin;
     const orderId = `ord_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
+
+    // P2-2: Persist a pending payment record before redirecting to the
+    // gateway. The CMI server-to-server callback looks up payments by
+    // gateway_session_id; if the initiating request succeeded but the
+    // callback arrives before we could create a row, the completed payment
+    // would be lost.
+    let effectivePatientId = patientId;
+    if (!effectivePatientId && appointmentId && clinicId) {
+      const { data: appt } = await supabase
+        .from("appointments")
+        .select("patient_id")
+        .eq("id", appointmentId)
+        .eq("clinic_id", clinicId)
+        .single();
+      if (appt?.patient_id) {
+        effectivePatientId = appt.patient_id;
+      }
+    }
+
+    if (clinicId && effectivePatientId) {
+      const { error: pendingError } = await supabase.from("payments").insert({
+        clinic_id: clinicId,
+        patient_id: effectivePatientId,
+        appointment_id: appointmentId || null,
+        amount,
+        method: "online",
+        status: PAYMENT_STATUS.PENDING,
+        payment_type: appointmentId ? "appointment" : "full",
+        reference: orderId,
+        gateway_session_id: orderId,
+        refunded_amount: 0,
+      });
+
+      if (pendingError) {
+        logger.error("Failed to persist pending CMI payment", {
+          context: "payments/cmi/initiate",
+          alert: "payment_persistence_failure",
+          traceId,
+          clinicId,
+          userId: user.id,
+          orderId,
+          amount,
+          appointmentId,
+          patientId: effectivePatientId,
+          error: pendingError,
+        });
+        return apiInternalError("Failed to initiate payment");
+      }
+    }
 
     logger.info("CMI payment initiated", {
       context: "payments/cmi/initiate",

--- a/src/app/api/payments/create-checkout/route.ts
+++ b/src/app/api/payments/create-checkout/route.ts
@@ -1,8 +1,9 @@
-import { apiError, apiSuccess } from "@/lib/api-response";
+import { apiError, apiInternalError, apiSuccess } from "@/lib/api-response";
 import { withAuthValidation } from "@/lib/api-validate";
 import { STAFF_ROLES } from "@/lib/auth-roles";
 import { safeFetch } from "@/lib/fetch-wrapper";
 import { logger } from "@/lib/logger";
+import { PAYMENT_STATUS } from "@/lib/types/database";
 import { stripeCheckoutSchema } from "@/lib/validations";
 
 /**
@@ -45,7 +46,7 @@ function validateRedirectUrl(
  */
 export const POST = withAuthValidation(
   stripeCheckoutSchema,
-  async (body, request, { user, profile }) => {
+  async (body, request, { user, profile, supabase }) => {
     const traceId = request.headers.get("x-trace-id") ?? undefined;
     const clinicId = profile.clinic_id;
     const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
@@ -198,6 +199,53 @@ export const POST = withAuthValidation(
         error: session,
       });
       return apiError("Failed to create checkout session");
+    }
+
+    // P2-2: Persist a pending payment record as soon as Stripe confirms the
+    // session. The webhook will upsert by reference (session.id) when the
+    // checkout completes, but having a pending row ensures the payment is
+    // visible and traceable even if the webhook is delayed or fails.
+    let effectivePatientId = patientId;
+    if (!effectivePatientId && appointmentId && clinicId) {
+      const { data: appt } = await supabase
+        .from("appointments")
+        .select("patient_id")
+        .eq("id", appointmentId)
+        .eq("clinic_id", clinicId)
+        .single();
+      if (appt?.patient_id) {
+        effectivePatientId = appt.patient_id;
+      }
+    }
+
+    if (clinicId && effectivePatientId && session.id) {
+      const { error: pendingError } = await supabase.from("payments").insert({
+        clinic_id: clinicId,
+        patient_id: effectivePatientId,
+        appointment_id: appointmentId || null,
+        amount: Math.round(amount) / 100,
+        method: "online",
+        status: PAYMENT_STATUS.PENDING,
+        payment_type: appointmentId ? "appointment" : "full",
+        reference: session.id,
+        gateway_session_id: session.id,
+        refunded_amount: 0,
+      });
+
+      if (pendingError) {
+        logger.error("Failed to persist pending Stripe payment", {
+          context: "payments/create-checkout",
+          alert: "payment_persistence_failure",
+          traceId,
+          clinicId,
+          userId: user.id,
+          sessionId: session.id,
+          appointmentId,
+          patientId: effectivePatientId,
+          error: pendingError,
+        });
+        return apiInternalError("Failed to create checkout session");
+      }
     }
 
     logger.info("Stripe checkout session created", {

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -13,6 +13,7 @@
     "lineWidth": 100
   },
   "imports": {
-    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.107.0"
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.107.0",
+    "https://esm.sh/aws4fetch@1.0.19": "npm:aws4fetch@1.0.19"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the Stripe/CMI payment persistence gap identified in the production-readiness review: checkout initiation did not create a `payments` row, so a CMI callback (or delayed Stripe webhook) could complete a payment that had no trace in the clinic ledger.

- `src/app/api/payments/cmi/route.ts`: before returning the CMI form, insert a `payments` row with `status: pending`, `reference`/`gateway_session_id` set to the generated `orderId`, and `clinic_id`/`patient_id` scoped to the request. If `patientId` is omitted but `appointmentId` is provided, the patient is resolved from the appointment row.
- `src/app/api/payments/create-checkout/route.ts`: after Stripe confirms the Checkout Session, insert a `payments` row with `status: pending`, `reference`/`gateway_session_id` set to `session.id`, and amount converted from centimes to MAD. Patient resolution falls back to the appointment row when `patientId` is omitted.
- Both routes now return an internal error if the pending row cannot be persisted, preventing a redirect/form URL from being issued without a corresponding ledger record.
- `supabase/functions/deno.json`: maps the `aws4fetch` esm.sh URL to `npm:aws4fetch@1.0.19` so the Edge Functions type-check job no longer depends on the flaky esm.sh CDN.

## Type of change

- [x] Bug fix
- [x] Build/CI fix

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed

`npm run lint`, `npm run typecheck`, and `npm run test` pass locally.

## Observability

- [x] N/A — no observability changes

## Rollback

- Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes