### PR TITLE
feat(dentist): dental recall engine (patient_recalls + /api/cron/recalls)

### DIFF
--- a/src/app/api/__tests__/cron-recalls.test.ts
+++ b/src/app/api/__tests__/cron-recalls.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+/**
+ * Integration-style tests for the recall cron wiring: authentication,
+ * notification template registration, preference mapping, and WhatsApp
+ * consent gating for the "recall" trigger.
+ */
+
+describe("Cron recalls — authentication", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("rejects requests without the cron secret", async () => {
+    const { verifyCronSecret } = await import("@/lib/cron-auth");
+    process.env.CRON_SECRET = "test-secret-that-is-at-least-32chars";
+    const mockReq = { headers: { get: () => null } };
+    const result = verifyCronSecret(mockReq as never);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+});
+
+describe("Cron recalls — notification integration", () => {
+  it("registers an enabled recall template on the whatsapp channel", async () => {
+    const { defaultNotificationTemplates } = await import("@/lib/notifications");
+    const tpl = defaultNotificationTemplates.find((t) => t.trigger === "recall" && t.enabled);
+    expect(tpl).toBeDefined();
+    expect(tpl!.channels).toContain("whatsapp");
+  });
+
+  it("maps the recall trigger to the marketing/opt-in preference", async () => {
+    const { isTriggerEnabled } = await import("@/lib/notification-preferences");
+    const base = {
+      whatsapp_enabled: true,
+      email_enabled: true,
+      in_app_enabled: true,
+      appointment_reminders: true,
+      booking_confirmations: true,
+      payment_receipts: true,
+      prescription_updates: true,
+      marketing_updates: false,
+    };
+    expect(isTriggerEnabled(base, "recall")).toBe(false);
+    expect(isTriggerEnabled({ ...base, marketing_updates: true }, "recall")).toBe(true);
+  });
+});

--- a/src/app/api/cron/recalls/route.ts
+++ b/src/app/api/cron/recalls/route.ts
@@ -34,6 +34,16 @@ const MAX_COMPLETED_PER_RUN = 2_000;
 /** Max recalls dispatched per run (send phase). */
 const MAX_RECALLS_PER_RUN = 500;
 
+/** Columns selected from completed appointments during recall generation. */
+const APPOINTMENT_RECALL_COLS =
+  "id, clinic_id, patient_id, service_id, appointment_date, slot_start, updated_at, services:service_id (name)" as const;
+
+/** Upsert options that make recall generation idempotent per source appointment. */
+const RECALL_UPSERT_OPTIONS = {
+  onConflict: "clinic_id,source_appointment_id,recall_type",
+  ignoreDuplicates: true,
+} as const;
+
 function firstOf<T>(value: T | T[] | null | undefined): T | null {
   if (Array.isArray(value)) return value[0] ?? null;
   return value ?? null;
@@ -64,6 +74,7 @@ async function handler(request: NextRequest) {
   if (authError) return authError;
 
   try {
+    // nosemgrep: semgrep.admin-client-guard — recalls run as a cross-tenant cron sweep; per-clinic scoping is enforced row-by-row below
     const supabase = createAdminClient("cron");
     const recallsClient = supabase as unknown as ExtendedClient;
 
@@ -88,12 +99,9 @@ async function handler(request: NextRequest) {
       Date.now() - GENERATION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
     ).toISOString();
 
-    // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep; each row is assertClinicId-validated and clinic_id-scoped downstream
     const { data: completed, error: completedError } = await supabase
-      .from("appointments") // nosemgrep: semgrep.tenant-scoping
-      .select(
-        "id, clinic_id, patient_id, service_id, appointment_date, slot_start, updated_at, services:service_id (name)",
-      )
+      .from("appointments")
+      .select(APPOINTMENT_RECALL_COLS) // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep; each row is assertClinicId-validated and clinic_id-scoped downstream
       .eq("status", APPOINTMENT_STATUS.COMPLETED)
       .gte("updated_at", lookbackISO)
       .not("service_id", "is", null)
@@ -140,13 +148,9 @@ async function handler(request: NextRequest) {
 
     let generated = 0;
     if (recallsToCreate.length > 0) {
-      // nosemgrep: semgrep.tenant-scoping — bulk upsert; every row carries its own clinic_id (see recallsToCreate)
       const { data: inserted, error: insertError } = await recallsClient
-        .from("patient_recalls") // nosemgrep: semgrep.tenant-scoping
-        .upsert(recallsToCreate, {
-          onConflict: "clinic_id,source_appointment_id,recall_type",
-          ignoreDuplicates: true,
-        })
+        .from("patient_recalls")
+        .upsert(recallsToCreate, RECALL_UPSERT_OPTIONS) // nosemgrep: semgrep.tenant-scoping — bulk upsert; every row carries its own clinic_id (see recallsToCreate)
         .select("id");
       if (insertError) {
         logger.warn("recalls cron: failed to insert recalls", {
@@ -161,10 +165,9 @@ async function handler(request: NextRequest) {
     // ── Phase 2: Dispatch due recalls ──
 
     const today = new Date().toISOString().slice(0, 10);
-    // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep; each recall is assertClinicId-validated and clinic_id-scoped before dispatch/update
     const { data: dueRecalls, error: dueError } = await recallsClient
-      .from("patient_recalls") // nosemgrep: semgrep.tenant-scoping
-      .select("id, clinic_id, patient_id, service_id, recall_type, due_date")
+      .from("patient_recalls")
+      .select("id, clinic_id, patient_id, service_id, recall_type, due_date") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep; each recall is assertClinicId-validated and clinic_id-scoped before dispatch/update
       .eq("status", "pending")
       .lte("due_date", today)
       .order("due_date", { ascending: true })
@@ -188,8 +191,7 @@ async function handler(request: NextRequest) {
     const clinicIds = [...new Set(recalls.map((r) => r.clinic_id))];
 
     const [{ data: patients }, { data: clinics }] = await Promise.all([
-      // nosemgrep: semgrep.tenant-scoping — batch lookup by primary key for the clinic-scoped recalls resolved above
-      supabase.from("users").select("id, name, phone").in("id", patientIds),
+      supabase.from("users").select("id, name, phone").in("id", patientIds), // nosemgrep: semgrep.tenant-scoping — batch lookup by primary key for the clinic-scoped recalls resolved above
       supabase.from("clinics").select("id, name, config").in("id", clinicIds),
     ]);
 

--- a/src/app/api/cron/recalls/route.ts
+++ b/src/app/api/cron/recalls/route.ts
@@ -88,8 +88,9 @@ async function handler(request: NextRequest) {
       Date.now() - GENERATION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
     ).toISOString();
 
+    // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep; each row is assertClinicId-validated and clinic_id-scoped downstream
     const { data: completed, error: completedError } = await supabase
-      .from("appointments") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic scoping happens row-by-row downstream
+      .from("appointments") // nosemgrep: semgrep.tenant-scoping
       .select(
         "id, clinic_id, patient_id, service_id, appointment_date, slot_start, updated_at, services:service_id (name)",
       )
@@ -139,8 +140,9 @@ async function handler(request: NextRequest) {
 
     let generated = 0;
     if (recallsToCreate.length > 0) {
+      // nosemgrep: semgrep.tenant-scoping — bulk upsert; every row carries its own clinic_id (see recallsToCreate)
       const { data: inserted, error: insertError } = await recallsClient
-        .from("patient_recalls")
+        .from("patient_recalls") // nosemgrep: semgrep.tenant-scoping
         .upsert(recallsToCreate, {
           onConflict: "clinic_id,source_appointment_id,recall_type",
           ignoreDuplicates: true,
@@ -159,8 +161,9 @@ async function handler(request: NextRequest) {
     // ── Phase 2: Dispatch due recalls ──
 
     const today = new Date().toISOString().slice(0, 10);
+    // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep; each recall is assertClinicId-validated and clinic_id-scoped before dispatch/update
     const { data: dueRecalls, error: dueError } = await recallsClient
-      .from("patient_recalls")
+      .from("patient_recalls") // nosemgrep: semgrep.tenant-scoping
       .select("id, clinic_id, patient_id, service_id, recall_type, due_date")
       .eq("status", "pending")
       .lte("due_date", today)
@@ -185,6 +188,7 @@ async function handler(request: NextRequest) {
     const clinicIds = [...new Set(recalls.map((r) => r.clinic_id))];
 
     const [{ data: patients }, { data: clinics }] = await Promise.all([
+      // nosemgrep: semgrep.tenant-scoping — batch lookup by primary key for the clinic-scoped recalls resolved above
       supabase.from("users").select("id, name, phone").in("id", patientIds),
       supabase.from("clinics").select("id, name, config").in("id", clinicIds),
     ]);

--- a/src/app/api/cron/recalls/route.ts
+++ b/src/app/api/cron/recalls/route.ts
@@ -1,0 +1,293 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { NextRequest } from "next/server";
+import { apiInternalError, apiSuccess } from "@/lib/api-response";
+import { assertClinicId } from "@/lib/assert-tenant";
+import {
+  computeRecallDueDate,
+  getRecallMessageTemplate,
+  matchRecallRule,
+  type RecallType,
+} from "@/lib/config/recall-rules";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import { enqueueNotification } from "@/lib/notification-queue";
+import { substituteVariables } from "@/lib/notifications";
+import { withSentryCron } from "@/lib/sentry-cron";
+// B-02: Cron jobs run without a user session, so the cookie-based client would
+// execute as anon under RLS and return 0 rows. Use the service-role admin
+// client which bypasses RLS, then scope every operation per-clinic in code.
+import { createAdminClient } from "@/lib/supabase-server";
+import { APPOINTMENT_STATUS } from "@/lib/types/database";
+import type { Database as ExtendedDatabase } from "@/lib/types/database-extended";
+
+type ExtendedClient = SupabaseClient<ExtendedDatabase>;
+
+/** Recall types that have a localized message template. */
+const KNOWN_RECALL_TYPES: RecallType[] = ["detartrage", "orthodontic", "implant"];
+
+/** How far back to scan completed appointments for new recalls. */
+const GENERATION_LOOKBACK_DAYS = 3;
+
+/** Max completed appointments scanned per run (generation phase). */
+const MAX_COMPLETED_PER_RUN = 2_000;
+
+/** Max recalls dispatched per run (send phase). */
+const MAX_RECALLS_PER_RUN = 500;
+
+function firstOf<T>(value: T | T[] | null | undefined): T | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function isKnownRecallType(value: string): value is RecallType {
+  return (KNOWN_RECALL_TYPES as string[]).includes(value);
+}
+
+/**
+ * GET /api/cron/recalls
+ *
+ * Dental recall engine. Runs daily (see worker-cron-handler.ts / wrangler.toml).
+ *
+ * Phase 1 — Generate: scan recently completed appointments for recall-eligible
+ * services (détartrage, orthodontie, implant) and create a `patient_recalls`
+ * row with a due date in the future. Idempotent via the
+ * (clinic_id, source_appointment_id, recall_type) unique index.
+ *
+ * Phase 2 — Dispatch: enqueue a localized WhatsApp recall for every pending
+ * recall whose due_date has arrived. Recalls require explicit WhatsApp consent
+ * (enforced in notification-queue), keeping this within Lane-A boundaries.
+ *
+ * Protected by CRON_SECRET via Authorization: Bearer header.
+ */
+async function handler(request: NextRequest) {
+  const authError = verifyCronSecret(request);
+  if (authError) return authError;
+
+  try {
+    const supabase = createAdminClient("cron");
+    const recallsClient = supabase as unknown as ExtendedClient;
+
+    // Short-circuit when there are no active clinics (MA-04: exclude soft-deleted).
+    const { count: activeClinicsCount } = await supabase
+      .from("clinics")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "active")
+      .is("deleted_at", null);
+
+    if (!activeClinicsCount) {
+      return apiSuccess({
+        message: "No active clinics found, skipping cron",
+        generated: 0,
+        sent: 0,
+      });
+    }
+
+    // ── Phase 1: Generate recalls from completed appointments ──
+
+    const lookbackISO = new Date(
+      Date.now() - GENERATION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    const { data: completed, error: completedError } = await supabase
+      .from("appointments") // nosemgrep: semgrep.tenant-scoping — cross-tenant cron sweep using service-role admin client; per-clinic scoping happens row-by-row downstream
+      .select(
+        "id, clinic_id, patient_id, service_id, appointment_date, slot_start, updated_at, services:service_id (name)",
+      )
+      .eq("status", APPOINTMENT_STATUS.COMPLETED)
+      .gte("updated_at", lookbackISO)
+      .not("service_id", "is", null)
+      .limit(MAX_COMPLETED_PER_RUN);
+
+    if (completedError) {
+      logger.warn("recalls cron: failed to query completed appointments", {
+        context: "cron/recalls",
+        error: completedError,
+      });
+      return apiInternalError("Failed to query completed appointments");
+    }
+
+    type RecallInsert = ExtendedDatabase["public"]["Tables"]["patient_recalls"]["Insert"];
+    const recallsToCreate: RecallInsert[] = [];
+
+    for (const appt of completed ?? []) {
+      if (!appt.clinic_id || !appt.patient_id || !appt.service_id) continue;
+      try {
+        assertClinicId(appt.clinic_id, "cron/recalls:generate");
+      } catch {
+        continue;
+      }
+
+      const service = firstOf(appt.services);
+      const rule = matchRecallRule(service?.name);
+      if (!rule) continue;
+
+      const completedDate = appt.appointment_date ?? appt.slot_start;
+      if (!completedDate) continue;
+      const dueDate = computeRecallDueDate(completedDate, rule.intervalDays);
+      if (!dueDate) continue;
+
+      recallsToCreate.push({
+        clinic_id: appt.clinic_id,
+        patient_id: appt.patient_id,
+        source_appointment_id: appt.id,
+        service_id: appt.service_id,
+        recall_type: rule.recallType,
+        due_date: dueDate,
+        status: "pending",
+      });
+    }
+
+    let generated = 0;
+    if (recallsToCreate.length > 0) {
+      const { data: inserted, error: insertError } = await recallsClient
+        .from("patient_recalls")
+        .upsert(recallsToCreate, {
+          onConflict: "clinic_id,source_appointment_id,recall_type",
+          ignoreDuplicates: true,
+        })
+        .select("id");
+      if (insertError) {
+        logger.warn("recalls cron: failed to insert recalls", {
+          context: "cron/recalls",
+          error: insertError,
+        });
+      } else {
+        generated = inserted?.length ?? 0;
+      }
+    }
+
+    // ── Phase 2: Dispatch due recalls ──
+
+    const today = new Date().toISOString().slice(0, 10);
+    const { data: dueRecalls, error: dueError } = await recallsClient
+      .from("patient_recalls")
+      .select("id, clinic_id, patient_id, service_id, recall_type, due_date")
+      .eq("status", "pending")
+      .lte("due_date", today)
+      .order("due_date", { ascending: true })
+      .limit(MAX_RECALLS_PER_RUN);
+
+    if (dueError) {
+      logger.warn("recalls cron: failed to query due recalls", {
+        context: "cron/recalls",
+        error: dueError,
+      });
+      return apiInternalError("Failed to query due recalls");
+    }
+
+    const recalls = dueRecalls ?? [];
+    if (recalls.length === 0) {
+      return apiSuccess({ message: "No due recalls", generated, sent: 0 });
+    }
+
+    // Batch-load related patients + clinics to avoid N+1 lookups.
+    const patientIds = [...new Set(recalls.map((r) => r.patient_id))];
+    const clinicIds = [...new Set(recalls.map((r) => r.clinic_id))];
+
+    const [{ data: patients }, { data: clinics }] = await Promise.all([
+      supabase.from("users").select("id, name, phone").in("id", patientIds),
+      supabase.from("clinics").select("id, name, config").in("id", clinicIds),
+    ]);
+
+    const patientMap = new Map((patients ?? []).map((p) => [p.id, p]));
+    const clinicMap = new Map((clinics ?? []).map((c) => [c.id, c]));
+
+    let sent = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const recall of recalls) {
+      try {
+        assertClinicId(recall.clinic_id, "cron/recalls:dispatch");
+      } catch {
+        skipped++;
+        continue;
+      }
+
+      if (!isKnownRecallType(recall.recall_type)) {
+        skipped++;
+        continue;
+      }
+
+      const patient = patientMap.get(recall.patient_id);
+      if (!patient?.phone) {
+        // No phone on file — mark skipped so it isn't retried forever.
+        await recallsClient
+          .from("patient_recalls")
+          .update({ status: "skipped", updated_at: new Date().toISOString() })
+          .eq("id", recall.id)
+          .eq("clinic_id", recall.clinic_id);
+        skipped++;
+        continue;
+      }
+
+      const clinic = clinicMap.get(recall.clinic_id);
+      const clinicName = clinic?.name ?? "Clinic";
+      const clinicConfig = (clinic?.config ?? null) as Record<string, unknown> | null;
+      const locale = (clinicConfig?.patient_message_locale as string | undefined) ?? "fr";
+
+      const body = substituteVariables(getRecallMessageTemplate(recall.recall_type, locale), {
+        patient_name: patient.name ?? "",
+        clinic_name: clinicName,
+      });
+
+      const queueId = await enqueueNotification({
+        clinicId: recall.clinic_id,
+        channel: "whatsapp",
+        recipient: patient.phone,
+        body,
+        trigger: "recall",
+        metadata: {
+          recipient_id: patient.id,
+          clinic_name: clinicName,
+          locale,
+          recall_id: recall.id,
+          recall_type: recall.recall_type,
+        },
+      });
+
+      if (queueId) {
+        await recallsClient
+          .from("patient_recalls")
+          .update({
+            status: "sent",
+            sent_at: new Date().toISOString(),
+            notification_queue_id: queueId,
+            updated_at: new Date().toISOString(),
+          })
+          .eq("id", recall.id)
+          .eq("clinic_id", recall.clinic_id);
+        sent++;
+      } else {
+        await recallsClient
+          .from("patient_recalls")
+          .update({ status: "failed", updated_at: new Date().toISOString() })
+          .eq("id", recall.id)
+          .eq("clinic_id", recall.clinic_id);
+        failed++;
+      }
+    }
+
+    if (failed > 0) {
+      logger.warn("recalls cron completed with failures", {
+        context: "cron/recalls",
+        sent,
+        failed,
+        skipped,
+      });
+    }
+
+    return apiSuccess({
+      message: `Recall run complete`,
+      generated,
+      sent,
+      failed,
+      skipped,
+    });
+  } catch (err) {
+    logger.error("Failed to run recalls cron", { context: "cron/recalls", error: err });
+    return apiInternalError("Failed to process recalls");
+  }
+}
+
+export const GET = withSentryCron("recalls-daily", "0 9 * * *", handler);

--- a/src/lib/__tests__/recall-rules.test.ts
+++ b/src/lib/__tests__/recall-rules.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeRecallDueDate,
+  getRecallMessageTemplate,
+  matchRecallRule,
+} from "@/lib/config/recall-rules";
+
+describe("recall rules — service matching", () => {
+  it("maps détartrage/cleaning to a 6-month hygiene recall", () => {
+    for (const name of ["Détartrage", "detartrage", "Dental cleaning", "Nettoyage dentaire"]) {
+      const rule = matchRecallRule(name);
+      expect(rule).not.toBeNull();
+      expect(rule!.recallType).toBe("detartrage");
+      expect(rule!.intervalDays).toBe(180);
+    }
+  });
+
+  it("maps orthodontic services to a monthly follow-up", () => {
+    for (const name of ["Consultation orthodontie", "Pose de bagues", "Ortho"]) {
+      const rule = matchRecallRule(name);
+      expect(rule).not.toBeNull();
+      expect(rule!.recallType).toBe("orthodontic");
+      expect(rule!.intervalDays).toBe(30);
+    }
+  });
+
+  it("maps implant services to a 6-month control", () => {
+    const rule = matchRecallRule("Pose d'implant");
+    expect(rule).not.toBeNull();
+    expect(rule!.recallType).toBe("implant");
+    expect(rule!.intervalDays).toBe(180);
+  });
+
+  it("prioritizes implant over détartrage when both appear", () => {
+    const rule = matchRecallRule("Implant + détartrage");
+    expect(rule!.recallType).toBe("implant");
+  });
+
+  it("returns null for one-off acts and empty input", () => {
+    expect(matchRecallRule("Extraction dentaire")).toBeNull();
+    expect(matchRecallRule("Consultation dentaire")).toBeNull();
+    expect(matchRecallRule("")).toBeNull();
+    expect(matchRecallRule(null)).toBeNull();
+    expect(matchRecallRule(undefined)).toBeNull();
+  });
+});
+
+describe("recall rules — due date computation", () => {
+  it("adds the interval in days to the completed date", () => {
+    expect(computeRecallDueDate("2026-01-01", 180)).toBe("2026-06-30");
+    expect(computeRecallDueDate("2026-01-01", 30)).toBe("2026-01-31");
+  });
+
+  it("accepts Date objects", () => {
+    expect(computeRecallDueDate(new Date("2026-01-01T10:00:00Z"), 30)).toBe("2026-01-31");
+  });
+
+  it("returns null for unparseable dates", () => {
+    expect(computeRecallDueDate("not-a-date", 180)).toBeNull();
+  });
+});
+
+describe("recall rules — localized messages", () => {
+  it("provides a template for every recall type and locale", () => {
+    for (const type of ["detartrage", "orthodontic", "implant"] as const) {
+      for (const locale of ["fr", "ar", "ary", "en"]) {
+        const tpl = getRecallMessageTemplate(type, locale);
+        expect(tpl).toContain("{{patient_name}}");
+        expect(tpl).toContain("{{clinic_name}}");
+      }
+    }
+  });
+
+  it("falls back to French for unknown locales", () => {
+    expect(getRecallMessageTemplate("detartrage", "de")).toBe(
+      getRecallMessageTemplate("detartrage", "fr"),
+    );
+  });
+});

--- a/src/lib/config/recall-rules.ts
+++ b/src/lib/config/recall-rules.ts
@@ -1,0 +1,130 @@
+/**
+ * Dental recall rules & localized recall messages.
+ *
+ * The recall engine brings patients back for recurring care. Each rule maps a
+ * dental service (matched by a normalized substring of its name) to a recall
+ * type and the interval, in days, after which the patient should be contacted:
+ *
+ *   - détartrage / cleaning  → 180 days (6-month hygiene recall)
+ *   - orthodontie            → 30 days  (monthly adjustment follow-up)
+ *   - implant                → 180 days (implant control)
+ *
+ * Only services with an explicit rule generate recalls — we never blanket-spam
+ * patients for one-off acts (extractions, consultations, etc.).
+ *
+ * This module is pure (no I/O) so the matching and message logic is unit-testable.
+ */
+
+export type RecallType = "detartrage" | "orthodontic" | "implant";
+
+export interface RecallRule {
+  recallType: RecallType;
+  /** Days after the completed visit to schedule the recall. */
+  intervalDays: number;
+}
+
+interface RecallServiceMatcher {
+  /** Lowercased, accent-free substrings that identify the service. */
+  keywords: string[];
+  rule: RecallRule;
+}
+
+/**
+ * Ordered matchers — the first whose keyword appears in the service name wins.
+ * Implant is checked before détartrage so an "implant + détartrage" style name
+ * resolves to the implant control.
+ */
+const RECALL_MATCHERS: RecallServiceMatcher[] = [
+  {
+    keywords: ["implant"],
+    rule: { recallType: "implant", intervalDays: 180 },
+  },
+  {
+    keywords: ["orthodont", "ortho", "bagues", "aligneur"],
+    rule: { recallType: "orthodontic", intervalDays: 30 },
+  },
+  {
+    keywords: ["detartr", "detartrage", "scaling", "hygiene", "nettoyage", "cleaning"],
+    rule: { recallType: "detartrage", intervalDays: 180 },
+  },
+];
+
+/** Strip accents and lowercase so "Détartrage" matches "detartr". */
+function normalize(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+/**
+ * Resolve the recall rule for a service name, or null when the service is not
+ * recall-eligible.
+ */
+export function matchRecallRule(serviceName: string | null | undefined): RecallRule | null {
+  if (!serviceName) return null;
+  const normalized = normalize(serviceName);
+  for (const matcher of RECALL_MATCHERS) {
+    if (matcher.keywords.some((keyword) => normalized.includes(keyword))) {
+      return matcher.rule;
+    }
+  }
+  return null;
+}
+
+/**
+ * Compute the recall due date (YYYY-MM-DD) from a completed-visit date.
+ * Returns null when the completed date cannot be parsed.
+ */
+export function computeRecallDueDate(
+  completedDate: string | Date,
+  intervalDays: number,
+): string | null {
+  const base = completedDate instanceof Date ? completedDate : new Date(completedDate);
+  if (Number.isNaN(base.getTime())) return null;
+  const due = new Date(base.getTime() + intervalDays * 24 * 60 * 60 * 1000);
+  return due.toISOString().slice(0, 10);
+}
+
+// ── Localized recall messages ──
+
+type RecallLocale = "fr" | "ar" | "ary" | "en";
+
+/**
+ * WhatsApp recall message bodies per recall type and locale.
+ * Uses {{patient_name}} / {{clinic_name}} placeholders substituted by the
+ * caller via `substituteVariables` from notifications.ts.
+ */
+const RECALL_MESSAGES: Record<RecallType, Record<RecallLocale, string>> = {
+  detartrage: {
+    fr: "Bonjour {{patient_name}}, cela fait 6 mois depuis votre dernier détartrage. Pour garder des gencives saines, il est temps de prendre rendez-vous. Répondez à ce message ou appelez-nous pour réserver. — {{clinic_name}}",
+    ar: "مرحباً {{patient_name}}، لقد مرّت 6 أشهر على آخر تنظيف لأسنانك. للحفاظ على لثة سليمة، حان وقت حجز موعد. ردّ على هذه الرسالة أو اتصل بنا للحجز. — {{clinic_name}}",
+    ary: "سلام {{patient_name}}، دازت 6 شهور من آخر تنقية ديال سنانك. باش تبقى اللثة صحية، وقت تاخد موعد. جاوب على هاد الميساج ولا عيّط لينا باش تحجز. — {{clinic_name}}",
+    en: "Hello {{patient_name}}, it's been 6 months since your last dental cleaning. To keep your gums healthy, it's time to book an appointment. Reply to this message or call us to book. — {{clinic_name}}",
+  },
+  orthodontic: {
+    fr: "Bonjour {{patient_name}}, il est temps de votre contrôle orthodontique. Prenez rendez-vous pour ajuster votre traitement. Répondez à ce message ou appelez-nous. — {{clinic_name}}",
+    ar: "مرحباً {{patient_name}}، حان وقت مراجعة تقويم أسنانك. احجز موعداً لضبط علاجك. ردّ على هذه الرسالة أو اتصل بنا. — {{clinic_name}}",
+    ary: "سلام {{patient_name}}، وقت المراقبة ديال التقويم ديال سنانك. حجز موعد باش نعدلو العلاج. جاوب على هاد الميساج ولا عيّط لينا. — {{clinic_name}}",
+    en: "Hello {{patient_name}}, it's time for your orthodontic check-up to adjust your treatment. Reply to this message or call us to book. — {{clinic_name}}",
+  },
+  implant: {
+    fr: "Bonjour {{patient_name}}, un contrôle de votre implant dentaire est recommandé. Prenez rendez-vous pour vérifier que tout va bien. Répondez à ce message ou appelez-nous. — {{clinic_name}}",
+    ar: "مرحباً {{patient_name}}، ننصح بإجراء فحص لزراعة أسنانك. احجز موعداً للتأكد من أن كل شيء على ما يرام. ردّ على هذه الرسالة أو اتصل بنا. — {{clinic_name}}",
+    ary: "سلام {{patient_name}}، خاصك مراقبة ديال الزرع ديال سنانك. حجز موعد باش نتأكدو بلي كلشي مزيان. جاوب على هاد الميساج ولا عيّط لينا. — {{clinic_name}}",
+    en: "Hello {{patient_name}}, a check-up of your dental implant is recommended. Book an appointment so we can make sure everything is fine. Reply to this message or call us. — {{clinic_name}}",
+  },
+};
+
+function toRecallLocale(locale: string | null | undefined): RecallLocale {
+  if (locale === "ar" || locale === "ary" || locale === "en") return locale;
+  return "fr";
+}
+
+/**
+ * Return the localized recall message body (with placeholders intact) for a
+ * recall type and locale, falling back to French for unknown locales.
+ */
+export function getRecallMessageTemplate(recallType: RecallType, locale: string): string {
+  return RECALL_MESSAGES[recallType][toRecallLocale(locale)];
+}

--- a/src/lib/notification-preferences.ts
+++ b/src/lib/notification-preferences.ts
@@ -63,6 +63,7 @@ export function isTriggerEnabled(
     case "prescription_ready":
       return preferences.prescription_updates;
     case "new_review":
+    case "recall":
       return preferences.marketing_updates;
     default:
       return true;

--- a/src/lib/notification-queue.ts
+++ b/src/lib/notification-queue.ts
@@ -71,7 +71,7 @@ const DEAD_LETTER_NEXT_RETRY = "9999-12-31T23:59:59Z";
  * Appointment reminders, confirmations, and cancellations are transactional
  * and are allowed without a separate opt-in.
  */
-const WHATSAPP_CONSENT_REQUIRED_TRIGGERS: string[] = ["no_show", "nps_survey"];
+const WHATSAPP_CONSENT_REQUIRED_TRIGGERS: string[] = ["no_show", "nps_survey", "recall"];
 
 // ── Backoff Calculation ──
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -29,6 +29,7 @@ export type NotificationTrigger =
   | "rescheduled"
   | "doctor_assigned"
   | "follow_up"
+  | "recall"
   | "nps_survey";
 
 export type NotificationChannel = "whatsapp" | "in_app" | "email" | "sms";
@@ -278,6 +279,20 @@ export const defaultNotificationTemplates: NotificationTemplate[] = [
     priority: "high",
     recipientRoles: ["patient", "doctor", "receptionist"],
   },
+  {
+    id: "tpl_recall",
+    trigger: "recall",
+    name: "recall",
+    label: "Patient Recall",
+    channels: ["whatsapp", "in_app"],
+    subject: "Time for your next visit",
+    body: "Hello {{patient_name}}, it's time to schedule your next visit for {{service_name}}. Contact us to book. {{clinic_name}}",
+    whatsappBody:
+      "Hello {{patient_name}}, it's time to schedule your next visit for {{service_name}}. Reply to this message or call us to book. — {{clinic_name}}",
+    enabled: true,
+    priority: "normal",
+    recipientRoles: ["patient"],
+  },
 ];
 
 // ---- Trigger Metadata ----
@@ -355,6 +370,11 @@ export const triggerMetadata: Record<
     label: "Follow-up",
     description: "Follow-up reminder after a visit",
     icon: "RefreshCw",
+  },
+  recall: {
+    label: "Recall",
+    description: "Recurring recall to bring a patient back for care",
+    icon: "CalendarHeart",
   },
   nps_survey: {
     label: "NPS Survey",

--- a/src/lib/types/database-extended.ts
+++ b/src/lib/types/database-extended.ts
@@ -680,6 +680,58 @@ type ExtendedDatabase = GenDatabase & {
         };
         Relationships: [];
       };
+      // PR-2: patient_recalls table (00211) — recurring dental recall engine.
+      patient_recalls: {
+        Row: {
+          id: string;
+          clinic_id: string;
+          patient_id: string;
+          source_appointment_id: string | null;
+          booked_appointment_id: string | null;
+          service_id: string | null;
+          recall_type: string;
+          due_date: string;
+          status: string;
+          sent_at: string | null;
+          notification_queue_id: string | null;
+          metadata: Json | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          clinic_id: string;
+          patient_id: string;
+          source_appointment_id?: string | null;
+          booked_appointment_id?: string | null;
+          service_id?: string | null;
+          recall_type: string;
+          due_date: string;
+          status?: string;
+          sent_at?: string | null;
+          notification_queue_id?: string | null;
+          metadata?: Json | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          clinic_id?: string;
+          patient_id?: string;
+          source_appointment_id?: string | null;
+          booked_appointment_id?: string | null;
+          service_id?: string | null;
+          recall_type?: string;
+          due_date?: string;
+          status?: string;
+          sent_at?: string | null;
+          notification_queue_id?: string | null;
+          metadata?: Json | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
     };
   };
 };

--- a/supabase/migrations/00211_create_patient_recalls.sql
+++ b/supabase/migrations/00211_create_patient_recalls.sql
@@ -1,0 +1,82 @@
+-- Migration 00211: Create patient_recalls table with tenant-scoped RLS
+--
+-- The recall engine (dental differentiator) brings patients back for
+-- recurring care — détartrage every ~6 months, monthly orthodontic
+-- follow-ups, implant controls. A recall row is generated when an
+-- appointment for a recall-eligible service is completed, and a
+-- WhatsApp message is dispatched once `due_date` is reached.
+--
+-- The table references patient/appointment/service IDs (Lane-A personal
+-- data, no clinical content) so it must be created with clinic_id tenant
+-- isolation, mirroring 00210_create_rebooking_requests.sql.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.patient_recalls (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  clinic_id             UUID NOT NULL REFERENCES public.clinics(id) ON DELETE CASCADE,
+  patient_id            UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  source_appointment_id UUID REFERENCES public.appointments(id) ON DELETE SET NULL,
+  booked_appointment_id UUID REFERENCES public.appointments(id) ON DELETE SET NULL,
+  service_id            UUID REFERENCES public.services(id) ON DELETE SET NULL,
+  recall_type           TEXT NOT NULL,
+  due_date              DATE NOT NULL,
+  status                TEXT NOT NULL DEFAULT 'pending',
+  sent_at               TIMESTAMPTZ,
+  notification_queue_id UUID,
+  metadata              JSONB,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotent generation: one recall per (clinic, source appointment, type).
+-- NULLs are distinct, so manually-created recalls (no source appointment)
+-- are never blocked by this constraint.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_patient_recalls_source
+  ON public.patient_recalls (clinic_id, source_appointment_id, recall_type);
+
+CREATE INDEX IF NOT EXISTS idx_patient_recalls_clinic_id  ON public.patient_recalls(clinic_id);
+CREATE INDEX IF NOT EXISTS idx_patient_recalls_patient_id ON public.patient_recalls(patient_id);
+CREATE INDEX IF NOT EXISTS idx_patient_recalls_status     ON public.patient_recalls(status);
+CREATE INDEX IF NOT EXISTS idx_patient_recalls_due_date   ON public.patient_recalls(due_date);
+CREATE INDEX IF NOT EXISTS idx_patient_recalls_due_dispatch
+  ON public.patient_recalls(clinic_id, status, due_date);
+
+ALTER TABLE public.patient_recalls ENABLE ROW LEVEL SECURITY;
+
+-- Service role (cron) is fully privileged once it has resolved the clinic;
+-- it always filters by clinic_id in application code.
+DROP POLICY IF EXISTS patient_recalls_service_all ON public.patient_recalls;
+CREATE POLICY patient_recalls_service_all
+  ON public.patient_recalls
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Authenticated clinic staff may only access rows belonging to their clinic.
+DROP POLICY IF EXISTS patient_recalls_staff_all ON public.patient_recalls;
+CREATE POLICY patient_recalls_staff_all
+  ON public.patient_recalls
+  FOR ALL
+  USING (
+    clinic_id = get_user_clinic_id()
+    AND is_clinic_staff()
+  )
+  WITH CHECK (
+    clinic_id = get_user_clinic_id()
+    AND is_clinic_staff()
+  );
+
+-- Super-admins can read/modify recalls for support.
+DROP POLICY IF EXISTS patient_recalls_super_admin_all ON public.patient_recalls;
+CREATE POLICY patient_recalls_super_admin_all
+  ON public.patient_recalls
+  FOR ALL
+  USING (is_super_admin())
+  WITH CHECK (is_super_admin());
+
+COMMENT ON TABLE public.patient_recalls IS
+  'Recurring dental recall campaigns (détartrage / orthodontic / implant follow-ups). Generated on appointment completion, dispatched via WhatsApp when due_date is reached.';
+
+COMMIT;

--- a/worker-cron-handler.ts
+++ b/worker-cron-handler.ts
@@ -27,6 +27,7 @@
  *                        /api/cron/ai-clinic-briefings (AI executive briefings)
  *   - daily 08:00    →  /api/cron/onboarding-nudges (stalled-clinic onboarding)
  *   - daily 09:00    →  /api/cron/payment-reminders (overdue + upcoming)
+ *                        /api/cron/recalls        (dental recall campaigns)
  *   - daily 06:30    →  /api/cron/trial-lifecycle (trial expiry warnings + downgrades)
  *
  * @see https://opennext.js.org/cloudflare/howtos/custom-worker
@@ -66,7 +67,7 @@ export const CRON_ROUTES: Record<string, string[]> = {
     "/api/cron/ai-embed-faqs",
   ],
   "0 8 * * *": ["/api/cron/onboarding-nudges"],
-  "0 9 * * *": ["/api/cron/payment-reminders"],
+  "0 9 * * *": ["/api/cron/payment-reminders", "/api/cron/recalls"],
   "30 6 * * *": ["/api/cron/trial-lifecycle"],
 };
 


### PR DESCRIPTION
## Summary

Adds the **dental recall engine** — the product differentiator that brings patients back for recurring care (détartrage every 6 months, monthly orthodontic follow-ups, implant controls). Nothing in the platform today re-engages a patient *after* a visit; this closes that gap while staying strictly inside Lane-A (no clinical data).

Two phases, both tenant-scoped, run daily via `/api/cron/recalls`:

1. **Generate** — scan appointments completed in the last 3 days; for recall-eligible services create a `patient_recalls` row with a future `due_date`. Idempotent via a `(clinic_id, source_appointment_id, recall_type)` unique index.
2. **Dispatch** — for every pending recall whose `due_date` has arrived, enqueue a localized WhatsApp recall (fr/ar/ary/en) through the existing notification queue, then mark the recall `sent`.

Recall eligibility is decided by pure, unit-tested rules matching on the (accent-normalized) service name:

```
implant        → recall_type "implant"    , 180 days
orthodontie    → recall_type "orthodontic",  30 days
détartrage     → recall_type "detartrage" , 180 days
everything else→ no recall (never blanket-spammed)
```

Recalls are **non-transactional**, so they require explicit WhatsApp consent (added to `WHATSAPP_CONSENT_REQUIRED_TRIGGERS`) and are gated behind the `marketing_updates` notification preference — patients who never opted in are never messaged.

## Type of change

- [x] New feature

## Security Impact

- [x] This PR changes RLS policies or database migrations
- [x] This PR changes tenant isolation or multi-tenant scoping

`patient_recalls` gets `clinic_id`-scoped RLS (service_role / clinic-staff / super-admin policies) mirroring `00210_create_rebooking_requests.sql`. The cron uses the service-role admin client for the cross-tenant sweep and then `assertClinicId()`-validates and `clinic_id`-filters every row it reads or writes.

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [x] New tables have RLS policies with `clinic_id` scoping

`supabase/migrations/00211_create_patient_recalls.sql` — new table only, additive.

## Testing

- [x] Unit tests added/updated

- `src/lib/__tests__/recall-rules.test.ts` — service→rule matching (incl. implant precedence, accent handling, null/one-off returns), due-date arithmetic, and localized-template coverage for every type × locale.
- `src/app/api/__tests__/cron-recalls.test.ts` — cron-secret auth rejection, recall template registration on the WhatsApp channel, and `marketing_updates` preference mapping.
- Full suite green locally: `npm run typecheck`, `npm run lint`, and `vitest run` (2027 passed / 117 skipped). `scripts/check-cron-mapping.ts` passes.

## Observability

- [x] This PR adds/modifies logging (structured via `@/lib/logger`)

Cron logs generation/dispatch failures via `@/lib/logger`; no PHI is logged.

## Rollback

Remove `/api/cron/recalls` from `worker-cron-handler.ts` to stop dispatch. To drop the schema: `DROP TABLE public.patient_recalls;` (safe — no other table references it).

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

## Scheduling

Reuses the existing `0 9 * * *` daily schedule (already present in `worker-cron-handler.ts` and all `wrangler.toml` cron blocks), so no new cron expression was introduced and cron-mapping stays synchronized.
