### PR TITLE
fix(db): pin public_clinic_directory to security_invoker=off + Supabase key rotation docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,16 @@
 # =============================================================================
 
 # ---- Supabase [Required] ----
+# NOTE: Supabase's LEGACY API keys (the long "eyJ..." JWT anon/service_role keys)
+# are being phased out and can be disabled per-project. When they are disabled,
+# every anon request fails ("Legacy API keys are disabled") and ALL tenant
+# subdomains 404. Prefer the NEW keys from Project Settings → API Keys:
+#   - NEXT_PUBLIC_SUPABASE_ANON_KEY  -> the "publishable" key (sb_publishable_...)
+#   - SUPABASE_SERVICE_ROLE_KEY      -> the "secret" key (sb_secret_...)
+# The app reads these as opaque strings (no JWT decoding), so either format works.
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-# Service role key — used by rate limiter and cron jobs (bypasses RLS)
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-or-publishable-key
+# Service role / secret key — used by rate limiter and cron jobs (bypasses RLS)
 SUPABASE_SERVICE_ROLE_KEY=
 # ---- Supabase Connection Pooling [Required for Workers deployment] ----
 # CRITICAL for production: Cloudflare Workers have no persistent TCP connections.

--- a/supabase/migrations/00212_pin_public_clinic_directory_security_invoker.sql
+++ b/supabase/migrations/00212_pin_public_clinic_directory_security_invoker.sql
@@ -1,0 +1,44 @@
+-- =============================================================================
+-- Migration 00212: Pin public_clinic_directory to security_invoker = off
+--
+-- INCIDENT: All tenant subdomains returned a hard 404 in production because
+-- `public_clinic_directory` had been switched to `security_invoker = on`
+-- (most likely via Supabase's Security Advisor "fix" for SECURITY DEFINER
+-- views). With security_invoker = on the view executes as the *querying*
+-- role (anon) and therefore enforces the underlying `clinics` RLS, which has
+-- no anonymous SELECT policy. Anon subdomain resolution in the middleware
+-- (src/lib/middleware/subdomain-resolution.ts) then returned zero rows and
+-- every clinic 404'd.
+--
+-- DESIGN INTENT (see migration 00068 S-07): this view is the ONLY clinics
+-- surface exposed to anon callers and it deliberately relies on
+-- `GRANT SELECT ... TO anon` INSTEAD of RLS. It must run with the view
+-- owner's privileges (security_invoker = off) so it bypasses `clinics` RLS
+-- and returns only the safe, non-PHI subset selected below.
+--
+-- This migration recreates the view with security_invoker explicitly OFF so
+-- the setting is captured in source control and cannot silently drift again.
+-- The column list and WHERE clause are unchanged from migration 00095/00096.
+-- =============================================================================
+
+BEGIN;
+
+DROP VIEW IF EXISTS public_clinic_directory;
+
+CREATE VIEW public_clinic_directory
+WITH (security_invoker = off) AS
+SELECT id, name, subdomain, type, tier, status, patient_message_locale
+FROM clinics
+WHERE status = 'active'
+  AND deleted_at IS NULL;
+
+GRANT SELECT ON public_clinic_directory TO anon;
+
+COMMENT ON VIEW public_clinic_directory IS
+  'SEC-10 / S-07: Restricted, non-PHI subset of clinics exposed to anonymous '
+  'callers for subdomain resolution. Runs with security_invoker = off so it '
+  'relies on GRANT SELECT TO anon instead of clinics RLS. Do NOT switch to '
+  'security_invoker = on (see migration 00212) — it takes all tenant '
+  'subdomains offline.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Production hardening after a full tenant outage: **all clinic subdomains were returning a hard 404** because anon subdomain resolution failed.

Two root causes were fixed live in the production Supabase project; this PR captures the durable part in source control and documents the key rotation:

1. **`public_clinic_directory` view had drifted to `security_invoker = on`** (likely applied via Supabase's Security Advisor). With `security_invoker = on` the view runs as the *querying* role (anon) and enforces `clinics` RLS, which has no anonymous SELECT policy — so the middleware's anon lookup (`src/lib/middleware/subdomain-resolution.ts`) returned zero rows and every subdomain 404'd. Migration `00212` recreates the view with `security_invoker = off` explicitly, matching the original design intent from `00068` (S-07): *"relies on GRANT SELECT TO anon instead of RLS."* The column list / WHERE clause are unchanged from `00095`.

2. **Legacy Supabase API keys were disabled** (2026-05-29). The deployed Worker still uses the legacy `anon` key, so every anon request returned `"Legacy API keys are disabled"`. Re-enabled them live to restore service. `.env.example` now documents the new `sb_publishable_*` / `sb_secret_*` keys so the Worker can be moved onto them and legacy keys disabled again.

No app code decodes these keys as JWTs (`getSupabaseAnonKey` / `getSupabaseServiceRoleKey` read them as opaque strings), so switching to the new key format is an env-only change.

## Type of change

- [x] Bug fix
- [x] Infrastructure / CI
- [x] Documentation

## Security Impact

- [ ] This PR modifies authentication or authorization logic
- [x] This PR changes RLS policies or database migrations
- [x] This PR changes tenant isolation or multi-tenant scoping

The view deliberately bypasses `clinics` RLS via `security_invoker = off` and a narrow `GRANT SELECT TO anon`. It exposes only a non-PHI subset (`id, name, subdomain, type, tier, status, patient_message_locale`) of **active, non-deleted** clinics — the minimum needed for anon subdomain resolution. This restores the pre-incident, as-designed behavior.

## Migration Safety

- [x] This PR includes database migrations
- [x] Migrations are backward-compatible (no destructive changes)
- [x] Migrations include `IF NOT EXISTS` / `IF EXISTS` guards
- [ ] New tables have RLS policies with `clinic_id` scoping — N/A (view only)

`00212` is idempotent (`DROP VIEW IF EXISTS` + `CREATE VIEW`) and already matches the current production state (the setting was applied live during incident response).

## Testing

- [x] Manual testing performed

Verified live after the fix: `cabinet-test`, `sara`, `monal` all return 200 on `/` and `/login/`; the publishable key reads the view; a real clinic-admin login returns a token (HTTP 200).

## Rollback

Revert this commit. The view can also be re-pinned manually with
`ALTER VIEW public.public_clinic_directory SET (security_invoker = off);`.
Do **not** set `security_invoker = on` — it takes all tenant subdomains offline.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Follow-up (not in this PR — needs Cloudflare access)

Rotate the deployed Worker secrets to the new keys, then disable legacy keys:
```
wrangler secret put NEXT_PUBLIC_SUPABASE_ANON_KEY --env production   # sb_publishable_...
wrangler secret put SUPABASE_SERVICE_ROLE_KEY --env production        # sb_secret_...
```
Then re-deploy and disable legacy keys in Supabase → Settings → API Keys.
