### PR TITLE
feat(public): render per-clinic brand colors + template header/footer + section order

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,9 +1,13 @@
 import { Chatbot } from "@/components/chatbot";
 import { ConsentGatedAnalytics } from "@/components/consent-gated-analytics";
 import { DemoBanner } from "@/components/demo-banner";
+import { DynamicFooter } from "@/components/public/dynamic-footer";
+import { DynamicHeader } from "@/components/public/dynamic-header";
 import { PublicFooter } from "@/components/public/footer";
 import { PublicHeader } from "@/components/public/header";
 import { getPublicBranding, type ClinicBranding } from "@/lib/data/public";
+import { buildPublicThemeStyle } from "@/lib/public-theme";
+import { getTemplate } from "@/lib/templates";
 import { getTenant } from "@/lib/tenant";
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
@@ -25,24 +29,39 @@ export default async function PublicLayout({ children }: { children: React.React
 
   const isDemo = tenant.subdomain === "demo";
 
+  // Template-aware header/footer: the clinic's chosen template can swap the
+  // header/footer layout. "top-sticky"/"classic-3col" keep the default
+  // components; other variants use the dynamic (template-driven) ones.
+  const template = getTemplate(branding.templateId);
+  const useOriginalHeader = template.headerVariant === "top-sticky";
+  const useOriginalFooter = template.footerVariant === "classic-3col";
+
   return (
-    <div
-      style={
-        {
-          "--brand-primary": branding.primaryColor,
-          "--brand-secondary": branding.secondaryColor,
-          "--brand-heading-font": branding.headingFont,
-          "--brand-body-font": branding.bodyFont,
-        } as React.CSSProperties
-      }
-    >
+    <div style={buildPublicThemeStyle(branding)}>
       {isDemo && <DemoBanner />}
       <ConsentGatedAnalytics gaId={gaId} gtmId={gtmId} />
-      <PublicHeader logoUrl={branding.logoUrl} clinicName={branding.clinicName} />
+      {useOriginalHeader ? (
+        <PublicHeader logoUrl={branding.logoUrl} clinicName={branding.clinicName} />
+      ) : (
+        <DynamicHeader
+          logoUrl={branding.logoUrl}
+          clinicName={branding.clinicName}
+          headerVariant={template.headerVariant}
+          template={template}
+        />
+      )}
       <main id="main-content" className="flex-1">
         {children}
       </main>
-      <PublicFooter clinicName={branding.clinicName} />
+      {useOriginalFooter ? (
+        <PublicFooter clinicName={branding.clinicName} />
+      ) : (
+        <DynamicFooter
+          clinicName={branding.clinicName}
+          footerVariant={template.footerVariant}
+          template={template}
+        />
+      )}
       <Chatbot />
       {/* <CookieConsent /> is mounted globally in src/app/layout.tsx — do not re-mount here */}
     </div>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { Fragment } from "react";
 import { LandingPage } from "@/components/landing/landing-page";
 import { HeroSection } from "@/components/public/hero-section";
 import {
@@ -20,9 +21,54 @@ import { getPublicReviews, getPublicAverageRating, getPublicBranding } from "@/l
 import { t, type Locale } from "@/lib/i18n";
 import { safeJsonLdStringify } from "@/lib/json-ld";
 import { logger } from "@/lib/logger";
-import { mergeSectionVisibility } from "@/lib/section-visibility";
+import { mergeSectionVisibility, type SectionKey } from "@/lib/section-visibility";
 import { getTemplate } from "@/lib/templates";
 import { getTenant } from "@/lib/tenant";
+
+/**
+ * Map a template's `sectionOrder` (which uses loose, historical names like
+ * "about"/"contact") onto the canonical `SectionKey` render vocabulary.
+ * Unknown names are dropped; any visible section missing from the template
+ * order is appended in a stable default order so nothing ever disappears.
+ */
+const SECTION_ALIASES: Record<string, SectionKey> = {
+  contact: "contactForm",
+  contactform: "contactForm",
+  team: "doctors",
+  testimonials: "reviews",
+};
+
+const DEFAULT_SECTION_TAIL: SectionKey[] = [
+  "services",
+  "doctors",
+  "reviews",
+  "blog",
+  "location",
+  "booking",
+  "contactForm",
+  "insurance",
+  "faq",
+];
+
+function resolveSectionOrder(templateOrder: string[], renderable: SectionKey[]): SectionKey[] {
+  const allow = new Set(renderable);
+  const ordered: SectionKey[] = [];
+  const seen = new Set<SectionKey>();
+  const push = (key: SectionKey) => {
+    if (allow.has(key) && !seen.has(key)) {
+      ordered.push(key);
+      seen.add(key);
+    }
+  };
+  // hero is always rendered first when visible
+  push("hero");
+  for (const raw of templateOrder) {
+    const key = (SECTION_ALIASES[raw.toLowerCase()] ?? raw) as SectionKey;
+    push(key);
+  }
+  for (const key of DEFAULT_SECTION_TAIL) push(key);
+  return ordered;
+}
 
 /** Default timeout (ms) for Supabase data-fetching on public pages. */
 const DATA_FETCH_TIMEOUT_MS = 10_000;
@@ -253,6 +299,129 @@ export default async function HomePage() {
     },
   };
 
+  const reviewsSection = (
+    <section className="py-16">
+      <div className="container mx-auto px-4">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl font-bold mb-4">{t(locale, "public.reviews.heading")}</h2>
+          <p className="text-sm text-muted-foreground mb-2">
+            {t(locale, "public.reviews.subtitle")}
+          </p>
+          <div className="flex items-center justify-center gap-2">
+            <span className="text-3xl font-bold">{avgRating}</span>
+            <div className="flex gap-0.5" role="img" aria-label={`${avgRating} out of 5 stars`}>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Star
+                  key={i}
+                  aria-hidden="true"
+                  className={`h-5 w-5 ${
+                    i < Math.round(avgRating)
+                      ? "fill-yellow-400 text-yellow-400"
+                      : "fill-muted text-muted"
+                  }`}
+                />
+              ))}
+            </div>
+            <span className="text-sm text-muted-foreground">
+              {t(locale, "public.reviews.count", { count: reviews.length })}
+            </span>
+          </div>
+        </div>
+        {/* Rating distribution */}
+        {reviews.length > 0 && (
+          <div className="mx-auto mb-10 max-w-xs space-y-1.5">
+            {[5, 4, 3, 2, 1].map((star) => {
+              const count = reviews.filter((r) => r.rating === star).length;
+              const pct = Math.round((count / reviews.length) * 100);
+              return (
+                <div key={star} className="flex items-center gap-2 text-sm">
+                  <span className="w-6 text-end font-medium">
+                    {star}
+                    <span className="text-yellow-400">&#9733;</span>
+                  </span>
+                  <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-yellow-400"
+                      data-width={String(Math.round(pct))}
+                    />
+                  </div>
+                  <span className="w-8 text-xs text-muted-foreground">{count}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
+          {topReviews.map((review) => (
+            <Card key={review.id}>
+              <CardContent className="pt-6">
+                <div
+                  className="flex gap-0.5 mb-3"
+                  role="img"
+                  aria-label={`${review.rating} out of 5 stars`}
+                >
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Star
+                      key={i}
+                      aria-hidden="true"
+                      className={`h-4 w-4 ${
+                        i < review.rating
+                          ? "fill-yellow-400 text-yellow-400"
+                          : "fill-muted text-muted"
+                      }`}
+                    />
+                  ))}
+                </div>
+                <p className="text-sm text-muted-foreground mb-4">&ldquo;{review.comment}&rdquo;</p>
+                <p className="text-sm font-medium">{review.patientName}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <div className="mt-10 text-center">
+          <Link href="/reviews" className={linkBtnOutline}>
+            {t(locale, "public.reviews.viewAll")}
+            <ArrowRight className="ms-2 h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+
+  // Build one renderer per *visible* section, then lay them out in the order
+  // defined by the clinic's chosen template (`template.sectionOrder`).
+  const renderers: Partial<Record<SectionKey, React.ReactNode>> = {};
+  if (sections.hero) {
+    renderers.hero = (
+      <HeroSection
+        overrides={
+          branding.websiteConfig
+            ? {
+                title: (branding.websiteConfig as { hero?: { title?: string } }).hero?.title,
+                subtitle: (branding.websiteConfig as { hero?: { subtitle?: string } }).hero
+                  ?.subtitle,
+              }
+            : undefined
+        }
+      />
+    );
+  }
+  if (sections.services) renderers.services = <ServicesPreview />;
+  if (sections.doctors) renderers.doctors = <DoctorsSection />;
+  if (sections.reviews && topReviews.length > 0) renderers.reviews = reviewsSection;
+  if (sections.blog) renderers.blog = <BlogSection />;
+  if (sections.location) renderers.location = <LocationSection />;
+  if (sections.booking) renderers.booking = <BookingSection />;
+  if (sections.contactForm) renderers.contactForm = <ContactFormSection />;
+  if (sections.insurance) renderers.insurance = <InsuranceSection />;
+  if (sections.faq) renderers.faq = <FaqSection />;
+
+  const orderedSections = resolveSectionOrder(
+    template.sectionOrder,
+    Object.keys(renderers) as SectionKey[],
+  );
+
   return (
     <div className={template.wrapperClass} dir={template.rtl ? "rtl" : "ltr"}>
       <script
@@ -261,137 +430,9 @@ export default async function HomePage() {
         suppressHydrationWarning
         dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(clinicSchema) }}
       />
-      {/* Hero — always visible */}
-      {sections.hero && (
-        <HeroSection
-          overrides={
-            branding.websiteConfig
-              ? {
-                  title: (branding.websiteConfig as { hero?: { title?: string } }).hero?.title,
-                  subtitle: (branding.websiteConfig as { hero?: { subtitle?: string } }).hero
-                    ?.subtitle,
-                }
-              : undefined
-          }
-        />
-      )}
-
-      {/* Services */}
-      {sections.services && <ServicesPreview />}
-
-      {/* Doctors / Team */}
-      {sections.doctors && <DoctorsSection />}
-
-      {/* Reviews */}
-      {sections.reviews && topReviews.length > 0 && (
-        <section className="py-16">
-          <div className="container mx-auto px-4">
-            <div className="text-center mb-12">
-              <h2 className="text-3xl font-bold mb-4">{t(locale, "public.reviews.heading")}</h2>
-              <p className="text-sm text-muted-foreground mb-2">
-                {t(locale, "public.reviews.subtitle")}
-              </p>
-              <div className="flex items-center justify-center gap-2">
-                <span className="text-3xl font-bold">{avgRating}</span>
-                <div className="flex gap-0.5" role="img" aria-label={`${avgRating} out of 5 stars`}>
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <Star
-                      key={i}
-                      aria-hidden="true"
-                      className={`h-5 w-5 ${
-                        i < Math.round(avgRating)
-                          ? "fill-yellow-400 text-yellow-400"
-                          : "fill-muted text-muted"
-                      }`}
-                    />
-                  ))}
-                </div>
-                <span className="text-sm text-muted-foreground">
-                  {t(locale, "public.reviews.count", { count: reviews.length })}
-                </span>
-              </div>
-            </div>
-            {/* Rating distribution */}
-            {reviews.length > 0 && (
-              <div className="mx-auto mb-10 max-w-xs space-y-1.5">
-                {[5, 4, 3, 2, 1].map((star) => {
-                  const count = reviews.filter((r) => r.rating === star).length;
-                  const pct = Math.round((count / reviews.length) * 100);
-                  return (
-                    <div key={star} className="flex items-center gap-2 text-sm">
-                      <span className="w-6 text-end font-medium">
-                        {star}
-                        <span className="text-yellow-400">&#9733;</span>
-                      </span>
-                      <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden">
-                        <div
-                          className="h-full rounded-full bg-yellow-400"
-                          data-width={String(Math.round(pct))}
-                        />
-                      </div>
-                      <span className="w-8 text-xs text-muted-foreground">{count}</span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-
-            <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
-              {topReviews.map((review) => (
-                <Card key={review.id}>
-                  <CardContent className="pt-6">
-                    <div
-                      className="flex gap-0.5 mb-3"
-                      role="img"
-                      aria-label={`${review.rating} out of 5 stars`}
-                    >
-                      {Array.from({ length: 5 }).map((_, i) => (
-                        <Star
-                          key={i}
-                          aria-hidden="true"
-                          className={`h-4 w-4 ${
-                            i < review.rating
-                              ? "fill-yellow-400 text-yellow-400"
-                              : "fill-muted text-muted"
-                          }`}
-                        />
-                      ))}
-                    </div>
-                    <p className="text-sm text-muted-foreground mb-4">
-                      &ldquo;{review.comment}&rdquo;
-                    </p>
-                    <p className="text-sm font-medium">{review.patientName}</p>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-            <div className="mt-10 text-center">
-              <Link href="/reviews" className={linkBtnOutline}>
-                {t(locale, "public.reviews.viewAll")}
-                <ArrowRight className="ms-2 h-4 w-4" />
-              </Link>
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Blog */}
-      {sections.blog && <BlogSection />}
-
-      {/* Location */}
-      {sections.location && <LocationSection />}
-
-      {/* Booking CTA */}
-      {sections.booking && <BookingSection />}
-
-      {/* Contact Form */}
-      {sections.contactForm && <ContactFormSection />}
-
-      {/* Insurance */}
-      {sections.insurance && <InsuranceSection />}
-
-      {/* FAQ */}
-      {sections.faq && <FaqSection />}
+      {orderedSections.map((key) => (
+        <Fragment key={key}>{renderers[key]}</Fragment>
+      ))}
     </div>
   );
 }

--- a/src/components/layouts/clinic-public-layout.tsx
+++ b/src/components/layouts/clinic-public-layout.tsx
@@ -4,6 +4,7 @@ import { DynamicHeader } from "@/components/public/dynamic-header";
 import { PublicFooter } from "@/components/public/footer";
 import { PublicHeader } from "@/components/public/header";
 import { getPublicBranding } from "@/lib/data/public";
+import { buildPublicThemeStyle } from "@/lib/public-theme";
 import { getTemplate } from "@/lib/templates";
 
 /**
@@ -27,16 +28,7 @@ export async function ClinicPublicLayout({ children }: { children: React.ReactNo
   const useOriginalFooter = template.footerVariant === "classic-3col";
 
   return (
-    <div
-      style={
-        {
-          "--brand-primary": branding.primaryColor,
-          "--brand-secondary": branding.secondaryColor,
-          "--brand-heading-font": branding.headingFont,
-          "--brand-body-font": branding.bodyFont,
-        } as React.CSSProperties
-      }
-    >
+    <div style={buildPublicThemeStyle(branding)}>
       {useOriginalHeader ? (
         <PublicHeader logoUrl={branding.logoUrl} clinicName={branding.clinicName} />
       ) : (

--- a/src/lib/__tests__/public-theme.test.ts
+++ b/src/lib/__tests__/public-theme.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { buildPublicThemeStyle, readableForeground } from "@/lib/public-theme";
+
+describe("readableForeground", () => {
+  it("returns light (bone) text on dark brand colors", () => {
+    expect(readableForeground("#005a3b")).toBe("#f4f1ea"); // dark green
+    expect(readableForeground("#1E4DA1")).toBe("#f4f1ea"); // dark blue
+    expect(readableForeground("#000000")).toBe("#f4f1ea");
+  });
+
+  it("returns dark (ink) text on light brand colors", () => {
+    expect(readableForeground("#ffffff")).toBe("#0b0f0e");
+    expect(readableForeground("#ffd54a")).toBe("#0b0f0e"); // bright yellow
+  });
+
+  it("supports 3-digit hex", () => {
+    expect(readableForeground("#fff")).toBe("#0b0f0e");
+    expect(readableForeground("#000")).toBe("#f4f1ea");
+  });
+
+  it("falls back to light text for invalid input", () => {
+    expect(readableForeground("not-a-color")).toBe("#f4f1ea");
+    expect(readableForeground("")).toBe("#f4f1ea");
+  });
+});
+
+describe("buildPublicThemeStyle", () => {
+  const branding = {
+    primaryColor: "#1E4DA1",
+    secondaryColor: "#0F6E56",
+    headingFont: "Geist",
+    bodyFont: "Geist",
+  };
+
+  it("re-maps shadcn theme tokens onto the clinic's brand colors", () => {
+    const style = buildPublicThemeStyle(branding) as Record<string, string>;
+    expect(style["--primary"]).toBe("#1E4DA1");
+    expect(style["--ring"]).toBe("#1E4DA1");
+    expect(style["--sidebar-primary"]).toBe("#1E4DA1");
+    // dark brand → light foreground
+    expect(style["--primary-foreground"]).toBe("#f4f1ea");
+    expect(style["--sidebar-primary-foreground"]).toBe("#f4f1ea");
+  });
+
+  it("keeps raw brand + font custom properties", () => {
+    const style = buildPublicThemeStyle(branding) as Record<string, string>;
+    expect(style["--brand-primary"]).toBe("#1E4DA1");
+    expect(style["--brand-secondary"]).toBe("#0F6E56");
+    expect(style["--brand-heading-font"]).toBe("Geist");
+    expect(style["--brand-body-font"]).toBe("Geist");
+  });
+});

--- a/src/lib/public-theme.ts
+++ b/src/lib/public-theme.ts
@@ -1,0 +1,82 @@
+/**
+ * Public-site theming.
+ *
+ * Maps a clinic's chosen branding colors onto the shadcn theme tokens
+ * (`--primary`, `--ring`, `--secondary`, …) so the *public* clinic site
+ * actually renders in the clinic's colors instead of the shared Oltigo
+ * green. This is applied as an inline style on the public layout wrapper,
+ * so the override is scoped to public pages only — admin, clinical, and
+ * auth surfaces keep the app-wide palette.
+ *
+ * Without this, `--brand-primary` was set but never consumed, and every
+ * clinic rendered with the hardcoded `--primary: var(--oltigo-green)`.
+ */
+
+import type { CSSProperties } from "react";
+
+const INK = "#0b0f0e"; // dark foreground (matches --ink)
+const BONE = "#f4f1ea"; // light foreground (matches --bone)
+
+/** Parse a #rgb / #rrggbb string into [r, g, b] (0–255), or null if invalid. */
+function parseHex(hex: string): [number, number, number] | null {
+  const cleaned = hex.trim().replace(/^#/, "");
+  const full =
+    cleaned.length === 3
+      ? cleaned
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : cleaned;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) return null;
+  const int = parseInt(full, 16);
+  return [(int >> 16) & 255, (int >> 8) & 255, int & 255];
+}
+
+/** Relative luminance (WCAG) of an sRGB color, 0 (black) … 1 (white). */
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const channel = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+/**
+ * Choose a readable foreground (ink or bone) for text/icons placed on top
+ * of `bgHex`. Falls back to bone (light) for unparseable input, matching
+ * the previous green-on-bone default.
+ */
+export function readableForeground(bgHex: string): string {
+  const rgb = parseHex(bgHex);
+  if (!rgb) return BONE;
+  return relativeLuminance(rgb) > 0.5 ? INK : BONE;
+}
+
+export interface PublicThemeBranding {
+  primaryColor: string;
+  secondaryColor: string;
+  headingFont: string;
+  bodyFont: string;
+}
+
+/**
+ * Build the inline style object that re-themes the public site to the
+ * clinic's branding. Spread onto the public layout wrapper `<div>`.
+ */
+export function buildPublicThemeStyle(branding: PublicThemeBranding): CSSProperties {
+  const primaryFg = readableForeground(branding.primaryColor);
+  return {
+    // Raw brand values (kept for any component reading them directly).
+    "--brand-primary": branding.primaryColor,
+    "--brand-secondary": branding.secondaryColor,
+    "--brand-heading-font": branding.headingFont,
+    "--brand-body-font": branding.bodyFont,
+    // Re-map the shadcn theme tokens so bg-primary / text-primary / ring etc.
+    // pick up the clinic's colors across the whole public subtree.
+    "--primary": branding.primaryColor,
+    "--primary-foreground": primaryFg,
+    "--ring": branding.primaryColor,
+    "--sidebar-primary": branding.primaryColor,
+    "--sidebar-primary-foreground": primaryFg,
+  } as CSSProperties;
+}


### PR DESCRIPTION
## Summary

Clinics could pick a template + brand colors, but the public site threw almost all of it away — so **every clinic rendered the same generic green Oltigo look**. This wires the existing template system into what actually renders (Phase 1 of a phased effort).

Three gaps fixed:

1. **Brand colors now actually apply.** `--brand-primary` was set but consumed nowhere; `--primary` was hardcoded to `--oltigo-green`. New `buildPublicThemeStyle()` (in `src/lib/public-theme.ts`) re-maps the shadcn theme tokens (`--primary`, `--ring`, `--sidebar-primary`, …) onto the clinic's chosen colors, scoped to the public layout wrapper only — admin/clinical/auth surfaces are untouched. `--primary-foreground` is computed from WCAG luminance so text stays readable on any brand color.
2. **The main clinic homepage now honors the template's header/footer.** `(public)/layout.tsx` always used the static `PublicHeader`/`PublicFooter`; it now switches to the template-aware `DynamicHeader`/`DynamicFooter` for non-default variants (same pattern the dentist/pharmacy sub-sites already used). Default `modern`/`top-sticky` keeps the existing header, so default clinics only change color.
3. **Sections render in `template.sectionOrder`.** The homepage previously hardcoded section order. `resolveSectionOrder()` maps the template's order (normalizing legacy names like `contact`→`contactForm`, dropping unknowns) onto visible sections and appends any leftovers in a stable order so nothing disappears.

```
buildPublicThemeStyle(branding) -> { "--primary": branding.primaryColor,
                                     "--primary-foreground": readableForeground(...),
                                     "--ring": ..., "--brand-*": ... }
resolveSectionOrder(template.sectionOrder, visibleSections) -> ordered SectionKey[]
```

**Visible effect:** every clinic public site now renders in its own colors (the default branding is blue `#1E4DA1`, so most sites shift from green→their configured color), and different templates lay out differently.

## Type of change

- [x] Bug fix
- [x] New feature

## Security Impact

- [x] No security impact

Public-only presentational change. No auth, RLS, tenant scoping, or data access changed. Branding is read via the existing `getPublicBranding()`.

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

New `src/lib/__tests__/public-theme.test.ts` covers luminance-based foreground selection (incl. 3-digit hex + invalid input) and token mapping. `npm run typecheck` and ESLint pass on all changed files.

## Rollback

Revert this commit. No stateful/schema changes.

## SLO / Metrics Impact

- [x] N/A

## Drive-by Refactors

- Extracted the inline reviews JSX into a local `reviewsSection` const so it can participate in the ordered-section map. No behavior change.

## Follow-up (Phase 2)

Apply `cardStyle` / `borderRadius` / `heroVariant` per template across the section components, and turn the admin template thumbnails into real previews, for stronger visual differentiation between templates.
