### PR TITLE
feat(public): template-driven card style, corner radius & hero variants + realistic template thumbnails

### DIFF
--- a/src/app/(admin)/admin/templates/page.tsx
+++ b/src/app/(admin)/admin/templates/page.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "lucide-react";
 import { useState } from "react";
+import { TemplateThumbnail } from "@/components/admin/template-thumbnail";
 import { Badge } from "@/components/ui/badge";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
@@ -339,53 +340,21 @@ export default function TemplatesPage() {
                     <CardDescription>{tmpl.description}</CardDescription>
                   </CardHeader>
                   <CardContent>
-                    {/* Template preview card */}
-                    <div className={`rounded-lg border p-4 text-xs space-y-2 ${tmpl.wrapperClass}`}>
-                      {/* Mini hero preview */}
-                      <div
-                        className={`h-12 rounded flex items-center justify-center text-[10px] font-medium ${
-                          tmpl.bgMode === "dark"
-                            ? "bg-white/10 text-white/80"
-                            : "bg-primary/10 text-primary"
-                        }`}
-                      >
-                        Hero — {tmpl.heroStyle}
-                      </div>
-                      {/* Mini cards preview */}
-                      <div className="grid grid-cols-3 gap-1">
-                        {[1, 2, 3].map((i) => (
-                          <div
-                            key={i}
-                            className={`h-8 rounded flex items-center justify-center text-[9px] ${
-                              tmpl.cardStyle === "shadow"
-                                ? "shadow-sm bg-white dark:bg-gray-800"
-                                : tmpl.cardStyle === "bordered"
-                                  ? "border bg-transparent"
-                                  : tmpl.cardStyle === "elevated"
-                                    ? "shadow-md bg-white dark:bg-gray-800"
-                                    : tmpl.bgMode === "dark"
-                                      ? "bg-white/5"
-                                      : "bg-gray-100"
-                            }`}
-                          >
-                            Card {i}
-                          </div>
-                        ))}
-                      </div>
-                      {/* Properties */}
-                      <div className="flex flex-wrap gap-1 pt-1">
+                    {/* Structurally-accurate template preview */}
+                    <TemplateThumbnail template={tmpl} />
+                    {/* Properties */}
+                    <div className="flex flex-wrap gap-1 pt-3">
+                      <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
+                        {tmpl.borderRadius} radius
+                      </span>
+                      <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
+                        {tmpl.bgMode} bg
+                      </span>
+                      {tmpl.rtl && (
                         <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
-                          {tmpl.borderRadius} radius
+                          RTL
                         </span>
-                        <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
-                          {tmpl.bgMode} bg
-                        </span>
-                        {tmpl.rtl && (
-                          <span className="inline-block rounded-full bg-primary/10 px-2 py-0.5 text-[9px] text-primary">
-                            RTL
-                          </span>
-                        )}
-                      </div>
+                      )}
                     </div>
                     <p className="text-xs text-muted-foreground mt-3">{tmpl.preview}</p>
                   </CardContent>

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -37,7 +37,7 @@ export default async function PublicLayout({ children }: { children: React.React
   const useOriginalFooter = template.footerVariant === "classic-3col";
 
   return (
-    <div style={buildPublicThemeStyle(branding)}>
+    <div style={buildPublicThemeStyle(branding, template.borderRadius)}>
       {isDemo && <DemoBanner />}
       <ConsentGatedAnalytics gaId={gaId} gtmId={gtmId} />
       {useOriginalHeader ? (

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -21,6 +21,7 @@ import { getPublicReviews, getPublicAverageRating, getPublicBranding } from "@/l
 import { t, type Locale } from "@/lib/i18n";
 import { safeJsonLdStringify } from "@/lib/json-ld";
 import { logger } from "@/lib/logger";
+import { publicCardClass } from "@/lib/public-theme";
 import { mergeSectionVisibility, type SectionKey } from "@/lib/section-visibility";
 import { getTemplate } from "@/lib/templates";
 import { getTenant } from "@/lib/tenant";
@@ -354,7 +355,7 @@ export default async function HomePage() {
 
         <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
           {topReviews.map((review) => (
-            <Card key={review.id}>
+            <Card key={review.id} className={publicCardClass(template.cardStyle)}>
               <CardContent className="pt-6">
                 <div
                   className="flex gap-0.5 mb-3"
@@ -395,6 +396,7 @@ export default async function HomePage() {
   if (sections.hero) {
     renderers.hero = (
       <HeroSection
+        variant={template.heroStyle}
         overrides={
           branding.websiteConfig
             ? {
@@ -407,8 +409,8 @@ export default async function HomePage() {
       />
     );
   }
-  if (sections.services) renderers.services = <ServicesPreview />;
-  if (sections.doctors) renderers.doctors = <DoctorsSection />;
+  if (sections.services) renderers.services = <ServicesPreview cardStyle={template.cardStyle} />;
+  if (sections.doctors) renderers.doctors = <DoctorsSection cardStyle={template.cardStyle} />;
   if (sections.reviews && topReviews.length > 0) renderers.reviews = reviewsSection;
   if (sections.blog) renderers.blog = <BlogSection />;
   if (sections.location) renderers.location = <LocationSection />;

--- a/src/components/admin/template-thumbnail.tsx
+++ b/src/components/admin/template-thumbnail.tsx
@@ -1,0 +1,87 @@
+import type { CSSProperties } from "react";
+import { publicCardClass, templateRadius } from "@/lib/public-theme";
+import type { TemplateDefinition } from "@/lib/templates";
+import { cn } from "@/lib/utils";
+
+/**
+ * A small, structurally-accurate preview of a layout template for the admin
+ * template picker. Unlike a static description, it reflects the template's
+ * real hero layout, card style, corner radius and background mode — so two
+ * templates actually look different in the picker, matching how they render
+ * on the public site.
+ */
+export function TemplateThumbnail({ template }: { template: TemplateDefinition }) {
+  const dark = template.bgMode === "dark";
+  const surface = dark ? "bg-white/10" : "bg-primary/10";
+  const line = dark ? "bg-white/25" : "bg-primary/25";
+  const faint = dark ? "bg-white/10" : "bg-foreground/10";
+
+  const style = { "--radius": templateRadius(template.borderRadius) } as CSSProperties;
+  const miniCard = cn("h-8", publicCardClass(template.cardStyle));
+
+  return (
+    <div
+      style={style}
+      dir={template.rtl ? "rtl" : "ltr"}
+      className={cn(
+        "overflow-hidden rounded-lg border p-2.5 text-[10px] space-y-2",
+        template.wrapperClass,
+      )}
+    >
+      {/* Header bar */}
+      <div className="flex items-center justify-between">
+        <div className={cn("h-2 w-10 rounded-full", line)} />
+        <div className="flex gap-1">
+          <div className={cn("h-1.5 w-4 rounded-full", faint)} />
+          <div className={cn("h-1.5 w-4 rounded-full", faint)} />
+          <div className={cn("h-1.5 w-4 rounded-full", faint)} />
+        </div>
+      </div>
+
+      {/* Hero — layout reflects heroStyle */}
+      {template.heroStyle === "split" ? (
+        <div className={cn("grid grid-cols-2 gap-2 rounded p-2", surface)}>
+          <div className="space-y-1">
+            <div className={cn("h-2 w-full rounded-full", line)} />
+            <div className={cn("h-1.5 w-3/4 rounded-full", faint)} />
+            <div className="h-3 w-10 rounded bg-primary" />
+          </div>
+          <div className={cn("rounded", faint)} />
+        </div>
+      ) : (
+        <div
+          className={cn(
+            "flex flex-col items-center gap-1 rounded p-3",
+            template.heroStyle === "overlay" ? "bg-primary" : surface,
+          )}
+        >
+          <div
+            className={cn(
+              "h-2 w-2/3 rounded-full",
+              template.heroStyle === "overlay" ? "bg-primary-foreground/80" : line,
+            )}
+          />
+          <div
+            className={cn(
+              "h-1.5 w-1/2 rounded-full",
+              template.heroStyle === "overlay" ? "bg-primary-foreground/50" : faint,
+            )}
+          />
+          <div
+            className={cn(
+              "mt-1 h-3 w-10 rounded",
+              template.heroStyle === "overlay" ? "bg-primary-foreground" : "bg-primary",
+            )}
+          />
+        </div>
+      )}
+
+      {/* Card row — reflects cardStyle + radius */}
+      <div className="grid grid-cols-3 gap-1.5">
+        <div className={miniCard} />
+        <div className={miniCard} />
+        <div className={miniCard} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/layouts/clinic-public-layout.tsx
+++ b/src/components/layouts/clinic-public-layout.tsx
@@ -28,7 +28,7 @@ export async function ClinicPublicLayout({ children }: { children: React.ReactNo
   const useOriginalFooter = template.footerVariant === "classic-3col";
 
   return (
-    <div style={buildPublicThemeStyle(branding)}>
+    <div style={buildPublicThemeStyle(branding, template.borderRadius)}>
       {useOriginalHeader ? (
         <PublicHeader logoUrl={branding.logoUrl} clinicName={branding.clinicName} />
       ) : (

--- a/src/components/public/hero-section.tsx
+++ b/src/components/public/hero-section.tsx
@@ -8,15 +8,66 @@ interface HeroOverrides {
   subtitle?: string;
 }
 
+/** Hero layout, taken from the clinic's chosen template `heroStyle`. */
+type HeroVariant = "split" | "centered" | "fullwidth" | "overlay";
+
 interface HeroSectionProps {
   overrides?: HeroOverrides;
+  /** Layout variant from the template. Defaults to the classic split layout. */
+  variant?: HeroVariant;
 }
 
-export function HeroSection({ overrides }: HeroSectionProps) {
+export function HeroSection({ overrides, variant = "split" }: HeroSectionProps) {
   const cfg = {
     ...defaultWebsiteConfig.hero,
     ...overrides,
   };
+
+  const ctas = (align: "center" | "start") => (
+    <div
+      className={`mt-10 flex flex-wrap items-center gap-4 ${
+        align === "center" ? "justify-center" : "justify-center lg:justify-start"
+      }`}
+    >
+      <Link href="/book" className={buttonVariants({ size: "lg" })}>
+        {cfg.ctaPrimary}
+      </Link>
+      <Link href="/services" className={buttonVariants({ variant: "outline", size: "lg" })}>
+        {cfg.ctaSecondary}
+      </Link>
+    </div>
+  );
+
+  // Centered / fullwidth / overlay all use a single stacked column. They
+  // differ in background treatment and vertical rhythm.
+  if (variant === "centered" || variant === "fullwidth" || variant === "overlay") {
+    const bg =
+      variant === "overlay"
+        ? "bg-primary text-primary-foreground"
+        : variant === "fullwidth"
+          ? "bg-gradient-to-b from-primary/10 via-primary/5 to-transparent"
+          : "bg-gradient-to-br from-primary/5 to-primary/10";
+    const isOverlay = variant === "overlay";
+    return (
+      <section className={`relative ${bg} ${variant === "fullwidth" ? "py-32" : "py-24"}`}>
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-3xl text-center">
+            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+              {cfg.title}
+            </h1>
+            <p
+              className={`mx-auto mt-6 max-w-2xl text-lg ${
+                isOverlay ? "text-primary-foreground/80" : "text-muted-foreground"
+              }`}
+            >
+              {cfg.subtitle}
+            </p>
+            {ctas("center")}
+          </div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className="relative bg-gradient-to-br from-primary/5 to-primary/10 py-24">
@@ -29,14 +80,7 @@ export function HeroSection({ overrides }: HeroSectionProps) {
             <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground lg:mx-0">
               {cfg.subtitle}
             </p>
-            <div className="mt-10 flex items-center justify-center gap-4 lg:justify-start">
-              <Link href="/book" className={buttonVariants({ size: "lg" })}>
-                {cfg.ctaPrimary}
-              </Link>
-              <Link href="/services" className={buttonVariants({ variant: "outline", size: "lg" })}>
-                {cfg.ctaSecondary}
-              </Link>
-            </div>
+            {ctas("start")}
           </div>
 
           <div className="hidden lg:flex justify-center">

--- a/src/components/public/sections/doctors-section.tsx
+++ b/src/components/public/sections/doctors-section.tsx
@@ -2,8 +2,14 @@ import Image from "next/image";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
 import { getPublicDoctors } from "@/lib/data/public";
+import { publicCardClass } from "@/lib/public-theme";
+import type { TemplateDefinition } from "@/lib/templates";
 
-export async function DoctorsSection() {
+interface DoctorsSectionProps {
+  cardStyle?: TemplateDefinition["cardStyle"];
+}
+
+export async function DoctorsSection({ cardStyle = "shadow" }: DoctorsSectionProps) {
   const doctors = await getPublicDoctors();
 
   return (
@@ -16,7 +22,7 @@ export async function DoctorsSection() {
         {doctors.length > 0 ? (
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-4xl mx-auto">
             {doctors.map((doctor) => (
-              <Card key={doctor.id}>
+              <Card key={doctor.id} className={publicCardClass(cardStyle)}>
                 <CardContent className="pt-6 text-center">
                   {doctor.avatar ? (
                     <Image

--- a/src/components/public/services-preview.tsx
+++ b/src/components/public/services-preview.tsx
@@ -1,11 +1,18 @@
 import { ArrowRight, Stethoscope } from "lucide-react";
 import Link from "next/link";
 import { getPublicServices } from "@/lib/data/public";
+import { publicCardClass } from "@/lib/public-theme";
+import type { TemplateDefinition } from "@/lib/templates";
+import { cn } from "@/lib/utils";
 
 const linkBtnOutline =
   "inline-flex items-center justify-center rounded-lg border border-border bg-background px-2.5 py-1.5 text-sm font-medium hover:bg-muted hover:text-foreground transition-colors";
 
-export async function ServicesPreview() {
+interface ServicesPreviewProps {
+  cardStyle?: TemplateDefinition["cardStyle"];
+}
+
+export async function ServicesPreview({ cardStyle = "shadow" }: ServicesPreviewProps) {
   const services = await getPublicServices();
   const activeServices = services.filter((s) => s.active).slice(0, 3);
 
@@ -16,7 +23,10 @@ export async function ServicesPreview() {
         <div className="grid gap-8 md:grid-cols-3">
           {activeServices.length > 0 ? (
             activeServices.map((service) => (
-              <div key={service.id} className="rounded-xl border bg-card p-6 text-center shadow-sm">
+              <div
+                key={service.id}
+                className={cn("rounded-xl bg-card p-6 text-center", publicCardClass(cardStyle))}
+              >
                 <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
                   <Stethoscope className="h-6 w-6 text-primary" />
                 </div>

--- a/src/lib/__tests__/public-theme.test.ts
+++ b/src/lib/__tests__/public-theme.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildPublicThemeStyle, readableForeground } from "@/lib/public-theme";
+import {
+  buildPublicThemeStyle,
+  publicCardClass,
+  readableForeground,
+  templateRadius,
+} from "@/lib/public-theme";
 
 describe("readableForeground", () => {
   it("returns light (bone) text on dark brand colors", () => {
@@ -48,5 +53,44 @@ describe("buildPublicThemeStyle", () => {
     expect(style["--brand-secondary"]).toBe("#0F6E56");
     expect(style["--brand-heading-font"]).toBe("Geist");
     expect(style["--brand-body-font"]).toBe("Geist");
+  });
+
+  it("omits --radius when no borderRadius is provided", () => {
+    const style = buildPublicThemeStyle(branding) as Record<string, string>;
+    expect(style["--radius"]).toBeUndefined();
+  });
+
+  it("sets --radius from the template borderRadius token", () => {
+    expect((buildPublicThemeStyle(branding, "none") as Record<string, string>)["--radius"]).toBe(
+      "0rem",
+    );
+    expect((buildPublicThemeStyle(branding, "xl") as Record<string, string>)["--radius"]).toBe(
+      "0.875rem",
+    );
+  });
+});
+
+describe("templateRadius", () => {
+  it("maps every borderRadius token to a concrete rem value", () => {
+    expect(templateRadius("none")).toBe("0rem");
+    expect(templateRadius("sm")).toBe("0.25rem");
+    expect(templateRadius("md")).toBe("0.375rem");
+    expect(templateRadius("lg")).toBe("0.5rem");
+    expect(templateRadius("xl")).toBe("0.875rem");
+    expect(templateRadius("full")).toBe("1.5rem");
+  });
+});
+
+describe("publicCardClass", () => {
+  it("returns distinct, tailwind-merge-friendly classes per cardStyle", () => {
+    expect(publicCardClass("bordered")).toContain("border-2");
+    expect(publicCardClass("flat")).toContain("shadow-none");
+    expect(publicCardClass("elevated")).toContain("shadow-lg");
+    expect(publicCardClass("shadow")).toContain("shadow-sm");
+  });
+
+  it("gives each cardStyle a unique class string", () => {
+    const styles = (["shadow", "bordered", "flat", "elevated"] as const).map(publicCardClass);
+    expect(new Set(styles).size).toBe(4);
   });
 });

--- a/src/lib/public-theme.ts
+++ b/src/lib/public-theme.ts
@@ -13,9 +13,50 @@
  */
 
 import type { CSSProperties } from "react";
+import type { TemplateDefinition } from "@/lib/templates";
 
 const INK = "#0b0f0e"; // dark foreground (matches --ink)
 const BONE = "#f4f1ea"; // light foreground (matches --bone)
+
+/**
+ * Base `--radius` value per template. Every Tailwind radius utility
+ * (`rounded-sm` … `rounded-4xl`) is derived from `--radius` in
+ * `globals.css`, so overriding this one variable scales the corner
+ * roundness of the whole public subtree to match the chosen template.
+ * `rounded-full` (9999px) is unaffected by design.
+ */
+const RADIUS_REM: Record<TemplateDefinition["borderRadius"], string> = {
+  none: "0rem",
+  sm: "0.25rem",
+  md: "0.375rem",
+  lg: "0.5rem",
+  xl: "0.875rem",
+  full: "1.5rem",
+};
+
+/** Resolve a template's borderRadius token to a concrete `--radius` value. */
+export function templateRadius(borderRadius: TemplateDefinition["borderRadius"]): string {
+  return RADIUS_REM[borderRadius] ?? RADIUS_REM.lg;
+}
+
+/**
+ * Tailwind classes that give a card the look of the template's `cardStyle`.
+ * Written to be tailwind-merge friendly (these are appended after a card's
+ * base classes, so the later utilities here win over the defaults).
+ */
+export function publicCardClass(cardStyle: TemplateDefinition["cardStyle"]): string {
+  switch (cardStyle) {
+    case "bordered":
+      return "border-2 border-border shadow-none";
+    case "flat":
+      return "border-transparent bg-muted/40 shadow-none";
+    case "elevated":
+      return "border-0 shadow-lg";
+    case "shadow":
+    default:
+      return "border border-border/60 shadow-sm";
+  }
+}
 
 /** Parse a #rgb / #rrggbb string into [r, g, b] (0–255), or null if invalid. */
 function parseHex(hex: string): [number, number, number] | null {
@@ -62,8 +103,16 @@ export interface PublicThemeBranding {
 /**
  * Build the inline style object that re-themes the public site to the
  * clinic's branding. Spread onto the public layout wrapper `<div>`.
+ *
+ * When a `borderRadius` token is passed (from the clinic's chosen
+ * template), `--radius` is overridden so the corner roundness of the
+ * whole public subtree matches the template — sharp for "minimal",
+ * generous for "elegant", etc.
  */
-export function buildPublicThemeStyle(branding: PublicThemeBranding): CSSProperties {
+export function buildPublicThemeStyle(
+  branding: PublicThemeBranding,
+  borderRadius?: TemplateDefinition["borderRadius"],
+): CSSProperties {
   const primaryFg = readableForeground(branding.primaryColor);
   return {
     // Raw brand values (kept for any component reading them directly).
@@ -78,5 +127,7 @@ export function buildPublicThemeStyle(branding: PublicThemeBranding): CSSPropert
     "--ring": branding.primaryColor,
     "--sidebar-primary": branding.primaryColor,
     "--sidebar-primary-foreground": primaryFg,
+    // Template corner roundness (drives all rounded-* utilities).
+    ...(borderRadius ? { "--radius": templateRadius(borderRadius) } : {}),
   } as CSSProperties;
 }


### PR DESCRIPTION
## Summary

Phase 2 of per-clinic public-site design. Phase 1 (#1305) applied each clinic's brand colors, template header/footer, and section order. This PR makes the remaining template dimensions actually affect the rendered public site, so different templates look genuinely different — not just recolored.

What now renders from `template`:

- **`borderRadius`** → drives the whole public subtree's corner roundness. `buildPublicThemeStyle(branding, template.borderRadius)` sets `--radius`, from which every Tailwind `rounded-*` utility is derived in `globals.css`. So `minimal` = sharp corners, `elegant` = generous, etc. Scoped to public wrappers only — admin/clinical/auth UIs keep the app radius.
- **`cardStyle`** (`shadow` | `bordered` | `flat` | `elevated`) → `publicCardClass(cardStyle)` returns tailwind-merge-friendly classes appended to the service, doctor, and review cards so later utilities win over the defaults.
- **`heroStyle`** (`split` | `centered` | `fullwidth` | `overlay`) → `HeroSection` gained a `variant` prop. `split` keeps the existing two-column layout; the others render a stacked, centered hero (`overlay` inverts to a solid primary band with readable foreground).
- **Admin template picker** → replaced the ad-hoc inline preview with a `TemplateThumbnail` component that renders a structurally-accurate mini preview (real hero layout, card style, corner radius, bg mode, RTL) so the picker reflects what the site will look like.

Pseudocode of the render wiring in `(public)/page.tsx`:

```tsx
<HeroSection variant={template.heroStyle} overrides={...} />
<ServicesPreview cardStyle={template.cardStyle} />
<DoctorsSection cardStyle={template.cardStyle} />
<Card className={publicCardClass(template.cardStyle)}>  // reviews
```

All new props default to the previous behavior (`variant="split"`, `cardStyle="shadow"`, no `borderRadius` → `--radius` untouched), so legacy/`modern` clinics render identically to before.

## Type of change

- [x] New feature

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Unit tests added/updated

Extended `src/lib/__tests__/public-theme.test.ts` (11 passing) covering `templateRadius`, `publicCardClass` (distinct per style), and `buildPublicThemeStyle` `--radius` behavior. `npm run typecheck` and `eslint` clean on all touched files.

## Observability

- [x] N/A — no observability changes

## Rollback

Revert this commit. Purely presentational; no data or schema changes.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes (touched files)
- [x] `npm run typecheck` passes
