### PR TITLE
UI/UX audit follow-up: critical, high, and medium fixes for Oltigo landing

### DIFF
--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -379,18 +379,19 @@ export function CookieConsent() {
             .
           </p>
           {/* A69-3: Decline has equal visual weight as Accept All (EDPB 03/2022). */}
-          <div className="flex flex-wrap gap-2 shrink-0">
-            <Button size="sm" onClick={declineAll}>
+          <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap">
+            <Button className="w-full sm:w-auto" size="sm" onClick={declineAll}>
               {t(locale, "cookie.decline")}
             </Button>
             <Button
+              className="w-full sm:w-auto"
               variant="outline"
               size="sm"
               onClick={() => setShowPreferences(!showPreferences)}
             >
               {t(locale, "cookie.managePreferences")}
             </Button>
-            <Button size="sm" onClick={acceptAll}>
+            <Button className="w-full sm:w-auto" size="sm" onClick={acceptAll}>
               {t(locale, "cookie.acceptAll")}
             </Button>
           </div>

--- a/src/components/landing/oltigo/components/hero/hero.tsx
+++ b/src/components/landing/oltigo/components/hero/hero.tsx
@@ -1,43 +1,14 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
-import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
 import { BilingualNumeral } from "@/components/landing/oltigo/components/primitives/bilingual-numeral";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { ConsoleStatic } from "./console-static";
 
-// The 3D console is client-only WebGL. Lazy-load it so three.js stays out of
-// the shared bundle and never executes during SSR; the static console is both
-// the loading state and the WebGL-unavailable fallback.
-const Console3D = dynamic(() => import("./console-3d"), {
-  ssr: false,
-  loading: () => <ConsoleStatic />,
-});
-
 export function Hero() {
   const { dict } = useI18n();
-  const [wide, setWide] = useState(false);
-  const [focus, setFocus] = useState(-1);
-  const [reducedMotion, setReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(min-width: 768px)");
-    const update = () => setWide(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, []);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const update = () => setReducedMotion(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, []);
 
   return (
     <section className="relative overflow-hidden border-b border-hairline">
@@ -120,29 +91,7 @@ export function Hero() {
 
         {/* Object — RIGHT */}
         <div className="relative">
-          {wide && !reducedMotion ? (
-            <Console3D onFocus={setFocus} dict={dict} />
-          ) : (
-            <ConsoleStatic />
-          )}
-
-          {/* Explode captions, synced to the focused layer */}
-          <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">
-            <div className="relative h-6">
-              {dict.hero.captions.map((cap, i) => (
-                <span
-                  key={i}
-                  className="telemetry absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[11px] uppercase tracking-[0.22em] text-text-secondary transition-all duration-500"
-                  style={{
-                    opacity: focus === i ? 1 : 0,
-                    transform: `translateX(-50%) translateY(${focus === i ? 0 : 6}px)`,
-                  }}
-                >
-                  {cap}
-                </span>
-              ))}
-            </div>
-          </div>
+          <ConsoleStatic />
         </div>
       </div>
     </section>

--- a/src/components/landing/oltigo/components/hero/hero.tsx
+++ b/src/components/landing/oltigo/components/hero/hero.tsx
@@ -1,14 +1,43 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 import { BilingualNumeral } from "@/components/landing/oltigo/components/primitives/bilingual-numeral";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { ConsoleStatic } from "./console-static";
 
+// The 3D console is client-only WebGL. Lazy-load it so three.js stays out of
+// the shared bundle and never executes during SSR; the static console is both
+// the loading state and the WebGL-unavailable fallback.
+const Console3D = dynamic(() => import("./console-3d"), {
+  ssr: false,
+  loading: () => <ConsoleStatic />,
+});
+
 export function Hero() {
   const { dict } = useI18n();
+  const [wide, setWide] = useState(false);
+  const [focus, setFocus] = useState(-1);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const update = () => setWide(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReducedMotion(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
 
   return (
     <section className="relative overflow-hidden border-b border-hairline">
@@ -63,7 +92,10 @@ export function Hero() {
 
           {/* Trust strip */}
           <Reveal delay={260}>
-            <dl className="mt-12 grid grid-cols-2 gap-x-6 gap-y-5 border-t border-hairline pt-6 sm:grid-cols-4">
+            <ul
+              className="mt-12 grid grid-cols-2 gap-x-6 gap-y-5 border-t border-hairline pt-6 sm:grid-cols-4"
+              aria-label={dict.hero.eyebrow}
+            >
               <TrustItem
                 value={<BilingualNumeral value={dict.hero.trust.uptime} />}
                 label={dict.hero.trust.uptimeLabel}
@@ -71,6 +103,7 @@ export function Hero() {
               <TrustItem
                 value={<span className="telemetry">{dict.hero.trust.cipher}</span>}
                 label=""
+                srLabel={dict.hero.trust.cipher}
               />
               <TrustItem
                 value={<span className="text-emerald">●</span>}
@@ -79,25 +112,60 @@ export function Hero() {
               <TrustItem
                 value={<span className="telemetry">{dict.hero.trust.latency}</span>}
                 label=""
+                srLabel={dict.hero.trust.latency}
               />
-            </dl>
+            </ul>
           </Reveal>
         </div>
 
         {/* Object — RIGHT */}
         <div className="relative">
-          <ConsoleStatic />
+          {wide && !reducedMotion ? (
+            <Console3D onFocus={setFocus} dict={dict} />
+          ) : (
+            <ConsoleStatic />
+          )}
+
+          {/* Explode captions, synced to the focused layer */}
+          <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">
+            <div className="relative h-6">
+              {dict.hero.captions.map((cap, i) => (
+                <span
+                  key={i}
+                  className="telemetry absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[11px] uppercase tracking-[0.22em] text-text-secondary transition-all duration-500"
+                  style={{
+                    opacity: focus === i ? 1 : 0,
+                    transform: `translateX(-50%) translateY(${focus === i ? 0 : 6}px)`,
+                  }}
+                >
+                  {cap}
+                </span>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </section>
   );
 }
 
-function TrustItem({ value, label }: { value: React.ReactNode; label: string }) {
+function TrustItem({
+  value,
+  label,
+  srLabel,
+}: {
+  value: React.ReactNode;
+  label: string;
+  srLabel?: string;
+}) {
   return (
-    <div className="flex flex-col gap-1">
-      <dd className="text-[15px] font-medium text-text">{value}</dd>
-      {label ? <dt className="text-[11px] leading-tight text-text-muted">{label}</dt> : null}
-    </div>
+    <li className="flex flex-col gap-1">
+      <span className="text-[15px] font-medium text-text">{value}</span>
+      {label ? (
+        <span className="text-[11px] leading-tight text-text-muted">{label}</span>
+      ) : srLabel ? (
+        <span className="sr-only">{srLabel}</span>
+      ) : null}
+    </li>
   );
 }

--- a/src/components/landing/oltigo/components/sections/cta-demo.tsx
+++ b/src/components/landing/oltigo/components/sections/cta-demo.tsx
@@ -9,16 +9,33 @@ import { Eyebrow } from "./section-kit";
 
 type Status = "idle" | "submitting" | "success" | "error";
 
-const WHATSAPP_NUMBER = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? "212600000000";
+const rawWhatsAppNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? "";
+
+function formatWhatsAppNumber(num: string): string | null {
+  const digits = num.replace(/\D/g, "");
+  // E.164-ish: 10-15 digits total. Reject empty/short and known placeholder.
+  if (!digits || digits.length < 10 || digits.length > 15) return null;
+  return digits;
+}
+
+const whatsAppHref = (() => {
+  const formatted = formatWhatsAppNumber(rawWhatsAppNumber);
+  return formatted ? `https://wa.me/${formatted}` : null;
+})();
 
 export function CtaDemo() {
   const { dict, locale } = useI18n();
   const c = dict.cta;
   const [status, setStatus] = useState<Status>("idle");
+  const [consent, setConsent] = useState(false);
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
+    if (!consent) {
+      setStatus("error");
+      return;
+    }
     // Snapshot the values before any await — React reuses the synthetic
     // event and form.reset() would clear the fields out from under us.
     const fd = new FormData(form);
@@ -72,15 +89,17 @@ export function CtaDemo() {
             <p className="mt-4 max-w-md text-[15px] leading-relaxed text-text-secondary">{c.sub}</p>
           </Reveal>
           <Reveal delay={180}>
-            <a
-              href={`https://wa.me/${WHATSAPP_NUMBER}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-8 inline-flex items-center gap-2.5 rounded-[10px] border border-hairline bg-surface/40 px-4 py-2.5 text-sm text-text-secondary transition-colors hover:border-emerald/50 hover:text-text"
-            >
-              <MessageCircle className="size-4 text-emerald" strokeWidth={1.75} aria-hidden />
-              {c.whatsapp}
-            </a>
+            {whatsAppHref ? (
+              <a
+                href={whatsAppHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-8 inline-flex items-center gap-2.5 rounded-[10px] border border-hairline bg-surface/40 px-4 py-2.5 text-sm text-text-secondary transition-colors hover:border-emerald/50 hover:text-text"
+              >
+                <MessageCircle className="size-4 text-emerald" strokeWidth={1.75} aria-hidden />
+                {c.whatsapp}
+              </a>
+            ) : null}
           </Reveal>
         </div>
 
@@ -108,12 +127,26 @@ export function CtaDemo() {
               ))}
             </div>
 
+            <label className="mt-4 flex cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                name="consent"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-hairline bg-ink text-emerald accent-emerald"
+                required
+              />
+              <span className="text-[12.5px] leading-relaxed text-text-secondary">
+                {c.consentCheckbox}
+              </span>
+            </label>
+
             <Button
               type="submit"
               variant="primary"
               size="lg"
-              className="mt-6 w-full"
-              disabled={status === "submitting"}
+              className="mt-5 w-full"
+              disabled={status === "submitting" || !consent}
             >
               {status === "submitting" ? c.submitting : c.submit}
               {status !== "submitting" && (

--- a/src/components/landing/oltigo/components/sections/faq.tsx
+++ b/src/components/landing/oltigo/components/sections/faq.tsx
@@ -2,7 +2,30 @@
 
 import { Accordion } from "@/components/landing/oltigo/components/ui/accordion";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { safeJsonLdStringify } from "@/lib/json-ld";
 import { SectionHeading } from "./section-kit";
+
+export function FaqSchema() {
+  const { dict } = useI18n();
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: dict.faq.items.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+    />
+  );
+}
 
 export function Faq() {
   const { dict } = useI18n();

--- a/src/components/landing/oltigo/components/sections/features.tsx
+++ b/src/components/landing/oltigo/components/sections/features.tsx
@@ -83,7 +83,11 @@ function FeatureRow({
       {/* visual */}
       <div className={reversed ? "lg:order-1" : ""}>
         <Reveal delay={80}>
-          <div className="blueprint-grid relative flex min-h-[320px] items-center justify-center overflow-hidden rounded-2xl border border-hairline bg-surface/40 p-8">
+          <div
+            className="blueprint-grid relative flex min-h-[320px] items-center justify-center overflow-hidden rounded-2xl border border-hairline bg-surface/40 p-8"
+            role="img"
+            aria-label={feature.title}
+          >
             <div
               className="pointer-events-none absolute inset-0"
               style={{
@@ -91,7 +95,7 @@ function FeatureRow({
                   "radial-gradient(80% 60% at 50% 0%, rgba(255,255,255,0.03), transparent 60%)",
               }}
             />
-            <div style={{ transform: "scale(1.05)" }}>{visual}</div>
+            <div>{visual}</div>
           </div>
         </Reveal>
       </div>

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Shield } from "lucide-react";
+import { Mail, MapPin, Phone, Shield } from "lucide-react";
 import Link from "next/link";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { defaultWebsiteConfig } from "@/lib/website-config";
 import { Wordmark } from "./section-kit";
 
 /**
@@ -21,7 +22,7 @@ import { Wordmark } from "./section-kit";
  */
 const FOOTER_HREFS: string[][] = [
   // 0 — Product / Produit / المنتج
-  ["/#features", "/#features", "/#demo", "/pricing"],
+  ["/#features", "#how", "/#demo", "/pricing"],
   // 1 — Resources / Ressources / الموارد
   ["/api-docs", "/how-to-book", "/status", "/blog"],
   // 2 — Company / Entreprise / الشركة
@@ -65,6 +66,26 @@ export function Footer() {
                 {dict.nav.status}
               </span>
             </Link>
+            <div className="mt-5 space-y-1.5">
+              <a
+                href={`tel:${defaultWebsiteConfig.contact.phone.replace(/\s|-/g, "")}`}
+                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text"
+              >
+                <Phone className="size-3.5 text-text-muted" aria-hidden="true" />
+                {defaultWebsiteConfig.contact.phone}
+              </a>
+              <a
+                href={`mailto:${defaultWebsiteConfig.contact.email}`}
+                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text"
+              >
+                <Mail className="size-3.5 text-text-muted" aria-hidden="true" />
+                {defaultWebsiteConfig.contact.email}
+              </a>
+              <p className="flex items-center gap-2 text-[12.5px] text-text-secondary">
+                <MapPin className="size-3.5 text-text-muted" aria-hidden="true" />
+                {defaultWebsiteConfig.contact.address}
+              </p>
+            </div>
           </div>
 
           {dict.footer.columns.map((col, colIndex) => (

--- a/src/components/landing/oltigo/components/sections/nav.tsx
+++ b/src/components/landing/oltigo/components/sections/nav.tsx
@@ -59,9 +59,11 @@ export function Nav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
-            {dict.nav.patientSpace}
-          </Button>
+          <div className="hidden sm:block">
+            <Button variant="secondary" size="sm" href="/annuaire">
+              {dict.nav.patientSpace}
+            </Button>
+          </div>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/nav.tsx
+++ b/src/components/landing/oltigo/components/sections/nav.tsx
@@ -59,12 +59,9 @@ export function Nav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Link
-            href="/annuaire"
-            className="hidden text-[13.5px] text-text-secondary transition-colors hover:text-text sm:inline"
-          >
+          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>
@@ -99,13 +96,15 @@ export function Nav() {
               {l.label}
             </Link>
           ))}
-          <Link
+          <Button
+            variant="secondary"
+            size="md"
             href="/annuaire"
+            className="w-full"
             onClick={() => setMobileOpen(false)}
-            className="text-[15px] text-text-secondary transition-colors hover:text-text"
           >
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/pricing.tsx
+++ b/src/components/landing/oltigo/components/sections/pricing.tsx
@@ -89,7 +89,9 @@ export function Pricing({ headingAs = "h2" }: { headingAs?: "h1" | "h2" }) {
         </div>
 
         <Reveal>
-          <p className="mt-8 text-center text-[12.5px] text-text-muted">{dict.pricing.note}</p>
+          <p className="mt-10 flex flex-wrap items-center justify-center gap-x-2 rounded-full border border-hairline bg-surface/40 px-4 py-2 text-center text-[13px] text-text-secondary">
+            {dict.pricing.note}
+          </p>
         </Reveal>
       </div>
     </section>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -62,13 +62,13 @@ export function PublicNav() {
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
           <Link
-            href="/login"
+            href="/annuaire"
             className="hidden text-[13.5px] text-text-secondary transition-colors hover:text-text sm:inline"
           >
-            {dict.nav.login}
+            {dict.nav.patientSpace}
           </Link>
           <Button variant="primary" size="sm" href="/register-clinic">
-            {dict.nav.openAccount}
+            {dict.nav.doctorSpace}
           </Button>
           <button
             type="button"
@@ -102,14 +102,14 @@ export function PublicNav() {
             </Link>
           ))}
           <Link
-            href="/login"
+            href="/annuaire"
             onClick={() => setMobileOpen(false)}
             className="text-[15px] text-text-secondary transition-colors hover:text-text"
           >
-            {dict.nav.login}
+            {dict.nav.patientSpace}
           </Link>
           <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
-            {dict.nav.openAccount}
+            {dict.nav.doctorSpace}
           </Button>
         </div>
       </div>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -61,9 +61,11 @@ export function PublicNav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
-            {dict.nav.patientSpace}
-          </Button>
+          <div className="hidden sm:block">
+            <Button variant="secondary" size="sm" href="/annuaire">
+              {dict.nav.patientSpace}
+            </Button>
+          </div>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -61,12 +61,9 @@ export function PublicNav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Link
-            href="/annuaire"
-            className="hidden text-[13.5px] text-text-secondary transition-colors hover:text-text sm:inline"
-          >
+          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>
@@ -101,13 +98,15 @@ export function PublicNav() {
               {sectionLabels[l.labelKey]}
             </Link>
           ))}
-          <Link
+          <Button
+            variant="secondary"
+            size="md"
             href="/annuaire"
+            className="w-full"
             onClick={() => setMobileOpen(false)}
-            className="text-[15px] text-text-secondary transition-colors hover:text-text"
           >
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
+++ b/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
@@ -19,7 +19,7 @@ export function TelemetryTicker() {
       {/* edge fades */}
       <div className="pointer-events-none absolute inset-y-0 start-0 z-10 w-24 bg-gradient-to-r from-ink to-transparent" />
       <div className="pointer-events-none absolute inset-y-0 end-0 z-10 w-24 bg-gradient-to-l from-ink to-transparent" />
-      <div className="flex w-max animate-ticker gap-10">
+      <div className="flex w-max animate-ticker gap-10 hover:[animation-play-state:paused] active:[animation-play-state:paused]">
         {row.map((it, i) => (
           <span key={i} className="flex shrink-0 items-center gap-2.5">
             <span className="size-1 rounded-full bg-cyan" />

--- a/src/components/landing/oltigo/components/sections/testimonials.tsx
+++ b/src/components/landing/oltigo/components/sections/testimonials.tsx
@@ -2,7 +2,19 @@
 
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { cn } from "@/lib/utils";
 import { SectionHeading } from "./section-kit";
+
+function getInitials(name: string): string {
+  const parts = name
+    .replace(/^(dr\.?|doctor|med\.?)\s*/i, "")
+    .split(/\s+/)
+    .filter(Boolean);
+  return parts
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("");
+}
 
 export function Testimonials() {
   const { dict } = useI18n();
@@ -18,16 +30,31 @@ export function Testimonials() {
                 <blockquote className="text-[15px] leading-relaxed text-text">
                   &ldquo;{t.quote}&rdquo;
                 </blockquote>
-                <figcaption className="mt-7 flex items-center justify-between border-t border-hairline pt-5">
-                  <div>
-                    <p className="text-[13.5px] font-medium text-text">{t.name}</p>
-                    <p className="text-[12px] text-text-muted">
-                      {t.role} · {t.city}
+                <figcaption className="mt-7 flex items-center gap-3 border-t border-hairline pt-5">
+                  <div
+                    className={cn(
+                      "flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full border border-hairline bg-surface text-[12.5px] font-medium text-text",
+                    )}
+                  >
+                    {t.avatar ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={t.avatar}
+                        alt=""
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      getInitials(t.name)
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-[13.5px] font-medium text-text">{t.name}</p>
+                    <p className="truncate text-[12px] text-text-muted">
+                      {t.role}
+                      {t.clinic ? ` · ${t.clinic}` : ""} · {t.city}
                     </p>
                   </div>
-                  <span className="telemetry rounded-full border border-hairline px-2.5 py-1 text-[10px] uppercase tracking-wider text-text-secondary">
-                    {t.plan}
-                  </span>
                 </figcaption>
               </figure>
             </Reveal>

--- a/src/components/landing/oltigo/i18n/context.tsx
+++ b/src/components/landing/oltigo/i18n/context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Cookies from "js-cookie";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import {
   dictionaries,
@@ -18,6 +19,28 @@ type I18nValue = {
 
 const I18nContext = createContext<I18nValue | null>(null);
 const STORAGE_KEY = "oltigo.locale";
+// Sync with the app-wide locale key so the global cookie banner reads the same value.
+const PREFERRED_LOCALE_KEY = "preferred-locale";
+
+function isValidLocale(value: unknown): value is Locale {
+  return typeof value === "string" && value in dictionaries;
+}
+
+function syncLocale(l: Locale) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, l);
+    window.localStorage.setItem(PREFERRED_LOCALE_KEY, l);
+    Cookies.set(PREFERRED_LOCALE_KEY, l, {
+      expires: 365,
+      path: "/",
+      secure: window.location.protocol === "https:",
+      sameSite: "lax",
+    });
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(defaultLocale);
@@ -25,10 +48,12 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   // Hydrate from storage / browser without causing a mismatch (runs post-mount).
   useEffect(() => {
     const timeouts: ReturnType<typeof setTimeout>[] = [];
-    const stored = (typeof window !== "undefined" &&
-      window.localStorage.getItem(STORAGE_KEY)) as Locale | null;
+    const stored =
+      (typeof window !== "undefined" && window.localStorage.getItem(STORAGE_KEY)) ||
+      (typeof window !== "undefined" && window.localStorage.getItem(PREFERRED_LOCALE_KEY)) ||
+      null;
 
-    if (stored && stored in dictionaries) {
+    if (isValidLocale(stored)) {
       timeouts.push(
         setTimeout(() => {
           setLocaleState(stored);
@@ -50,11 +75,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   const setLocale = useCallback((l: Locale) => {
     setLocaleState(l);
-    try {
-      window.localStorage.setItem(STORAGE_KEY, l);
-    } catch {
-      /* storage unavailable — non-fatal */
-    }
+    syncLocale(l);
   }, []);
 
   const value: I18nValue = {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -135,8 +135,8 @@ const fr: Dictionary = {
   },
   hero: {
     eyebrow: "Plateforme pour cabinets médicaux · Maroc",
-    titleLead: "Le calme d’un cabinet",
-    titleAccent: "qui tourne tout seul.",
+    titleLead: "Gérez votre cabinet,",
+    titleAccent: "réduisez les absences.",
     sub: "Gérez votre cabinet, réduisez les absences par WhatsApp et digitalisez vos dossiers patients en un clic. Conçu pour les médecins et gestionnaires de cabinet au Maroc.",
     ctaPrimary: "Ouvrir un compte",
     ctaSecondary: "Trouver mon médecin",
@@ -436,8 +436,8 @@ const ar: Dictionary = {
   },
   hero: {
     eyebrow: "منصّة للعيادات الطبية · المغرب",
-    titleLead: "هدوء عيادة",
-    titleAccent: "تُدار من تلقاء نفسها.",
+    titleLead: "أدِر عيادتك،",
+    titleAccent: "قلّل حالات التغيّب.",
     sub: "أدِر عيادتك، قلّل حالات التغيّب عبر واتساب، وقم برقمنة ملفّات مرضاك بنقرة واحدة. مصمَّمة للأطباء ومسيّري العيادات في المغرب.",
     ctaPrimary: "افتح حسابًا",
     ctaSecondary: "ابحث عن طبيبي",
@@ -700,8 +700,8 @@ const en: Dictionary = {
   },
   hero: {
     eyebrow: "Platform for medical practices · Morocco",
-    titleLead: "The calm of a practice",
-    titleAccent: "that runs itself.",
+    titleLead: "Manage your practice,",
+    titleAccent: "cut no-shows.",
     sub: "Manage your practice, cut no-shows via WhatsApp, and digitize patient records in one click. Built for doctors and clinic managers across Morocco.",
     ctaPrimary: "Open an account",
     ctaSecondary: "Find my doctor",

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -51,7 +51,6 @@ export type Dictionary = {
     patientSpace: string;
     doctorSpace: string;
     menu: string;
-    skipToContent: string;
     sections: { features: string; how: string; pricing: string; faq: string };
   };
   hero: {
@@ -125,7 +124,6 @@ const fr: Dictionary = {
     patientSpace: "Espace Patient",
     doctorSpace: "Espace Médecin",
     menu: "Menu",
-    skipToContent: "Passer au contenu",
     sections: {
       features: "Fonctionnalités",
       how: "Comment ça marche",
@@ -431,7 +429,6 @@ const ar: Dictionary = {
     patientSpace: "فضاء المريض",
     doctorSpace: "فضاء الطبيب",
     menu: "القائمة",
-    skipToContent: "تجاوز إلى المحتوى",
     sections: { features: "الميزات", how: "كيف يعمل", pricing: "الأسعار", faq: "الأسئلة" },
   },
   hero: {
@@ -695,7 +692,6 @@ const en: Dictionary = {
     patientSpace: "Patient Portal",
     doctorSpace: "Doctor Portal",
     menu: "Menu",
-    skipToContent: "Skip to content",
     sections: { features: "Features", how: "How it works", pricing: "Pricing", faq: "FAQ" },
   },
   hero: {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -51,6 +51,7 @@ export type Dictionary = {
     patientSpace: string;
     doctorSpace: string;
     menu: string;
+    skipToContent: string;
     sections: { features: string; how: string; pricing: string; faq: string };
   };
   hero: {
@@ -124,6 +125,7 @@ const fr: Dictionary = {
     patientSpace: "Espace Patient",
     doctorSpace: "Espace Médecin",
     menu: "Menu",
+    skipToContent: "Passer au contenu",
     sections: {
       features: "Fonctionnalités",
       how: "Comment ça marche",
@@ -429,6 +431,7 @@ const ar: Dictionary = {
     patientSpace: "فضاء المريض",
     doctorSpace: "فضاء الطبيب",
     menu: "القائمة",
+    skipToContent: "تجاوز إلى المحتوى",
     sections: { features: "الميزات", how: "كيف يعمل", pricing: "الأسعار", faq: "الأسئلة" },
   },
   hero: {
@@ -692,6 +695,7 @@ const en: Dictionary = {
     patientSpace: "Patient Portal",
     doctorSpace: "Doctor Portal",
     menu: "Menu",
+    skipToContent: "Skip to content",
     sections: { features: "Features", how: "How it works", pricing: "Pricing", faq: "FAQ" },
   },
   hero: {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -32,7 +32,15 @@ type Tier = {
   cta: string;
   highlight?: boolean;
 };
-type Quote = { quote: string; name: string; role: string; city: string; plan: string };
+type Quote = {
+  quote: string;
+  name: string;
+  role: string;
+  city: string;
+  clinic?: string;
+  avatar?: string;
+  plan?: string;
+};
 type Faq = { q: string; a: string };
 
 export type Dictionary = {
@@ -94,6 +102,7 @@ export type Dictionary = {
     error: string;
     whatsapp: string;
     consent: string;
+    consentCheckbox: string;
   };
   footer: {
     tagline: string;
@@ -238,6 +247,7 @@ const fr: Dictionary = {
         name: "Dr. Yasmine Berrada",
         role: "Médecin généraliste",
         city: "Casablanca",
+        clinic: "Cabinet Berrada",
         plan: "Professional",
       },
       {
@@ -246,6 +256,7 @@ const fr: Dictionary = {
         name: "Dr. Karim El Fassi",
         role: "Cardiologue",
         city: "Rabat",
+        clinic: "Clinique El Fassi",
         plan: "Enterprise",
       },
       {
@@ -253,6 +264,7 @@ const fr: Dictionary = {
         name: "Dr. Salima Ouazzani",
         role: "Pédiatre",
         city: "Marrakech",
+        clinic: "Cabinet Ouazzani",
         plan: "Starter",
       },
     ],
@@ -387,6 +399,7 @@ const fr: Dictionary = {
     error: "Un souci est survenu. Réessayez ou écrivez-nous sur WhatsApp.",
     whatsapp: "Écrire sur WhatsApp",
     consent: "En envoyant ce formulaire, vous acceptez d’être recontacté au sujet d’OLTIGO.",
+    consentCheckbox: "J’accepte d’être recontacté(e) au sujet d’OLTIGO.",
   },
   footer: {
     tagline: "Le système d’exploitation discret des cabinets médicaux au Maroc.",
@@ -521,6 +534,7 @@ const ar: Dictionary = {
         name: "د. ياسمين برادة",
         role: "طبيبة عامة",
         city: "الدار البيضاء",
+        clinic: "عيادة برادة",
         plan: "Professional",
       },
       {
@@ -528,6 +542,7 @@ const ar: Dictionary = {
         name: "د. كريم الفاسي",
         role: "طبيب قلب",
         city: "الرباط",
+        clinic: "مصحة الفاسي",
         plan: "Enterprise",
       },
       {
@@ -535,6 +550,7 @@ const ar: Dictionary = {
         name: "د. سليمة وزاني",
         role: "طبيبة أطفال",
         city: "مراكش",
+        clinic: "عيادة وزاني",
         plan: "Starter",
       },
     ],
@@ -649,6 +665,7 @@ const ar: Dictionary = {
     error: "حدث خطأ. أعد المحاولة أو راسلنا عبر واتساب.",
     whatsapp: "راسلنا عبر واتساب",
     consent: "بإرسال هذا النموذج، توافق على أن نعاود الاتصال بك بخصوص OLTIGO.",
+    consentCheckbox: "أوافق على أن يتم الاتصال بي بخصوص OLTIGO.",
   },
   footer: {
     tagline: "نظام التشغيل الهادئ للعيادات الطبية في المغرب.",
@@ -793,6 +810,7 @@ const en: Dictionary = {
         name: "Dr. Yasmine Berrada",
         role: "General practitioner",
         city: "Casablanca",
+        clinic: "Berrada Practice",
         plan: "Professional",
       },
       {
@@ -800,6 +818,7 @@ const en: Dictionary = {
         name: "Dr. Karim El Fassi",
         role: "Cardiologist",
         city: "Rabat",
+        clinic: "El Fassi Clinic",
         plan: "Enterprise",
       },
       {
@@ -807,6 +826,7 @@ const en: Dictionary = {
         name: "Dr. Salima Ouazzani",
         role: "Pediatrician",
         city: "Marrakech",
+        clinic: "Ouazzani Pediatrics",
         plan: "Starter",
       },
     ],
@@ -930,6 +950,7 @@ const en: Dictionary = {
     error: "Something went wrong. Try again or message us on WhatsApp.",
     whatsapp: "Message on WhatsApp",
     consent: "By submitting this form, you agree to be contacted about OLTIGO.",
+    consentCheckbox: "I agree to be contacted about OLTIGO.",
   },
   footer: {
     tagline: "The quiet operating system for medical practices in Morocco.",

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -15,19 +15,6 @@ import { Pricing } from "@/components/landing/oltigo/components/sections/pricing
 import { TelemetryTicker } from "@/components/landing/oltigo/components/sections/telemetry-ticker";
 import { Testimonials } from "@/components/landing/oltigo/components/sections/testimonials";
 import { LanguageProvider } from "@/components/landing/oltigo/i18n/context";
-import { useI18n } from "@/components/landing/oltigo/i18n/context";
-
-function SkipLink() {
-  const { dict } = useI18n();
-  return (
-    <a
-      href="#top"
-      className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-50 focus:rounded-[10px] focus:bg-emerald focus:px-4 focus:py-2.5 focus:text-ink focus:shadow-lg"
-    >
-      {dict.nav.skipToContent}
-    </a>
-  );
-}
 
 /**
  * Oltigo marketing landing — ported from groupsmix/oltigo-landing.
@@ -46,13 +33,12 @@ export function OltigoLanding() {
   }, []);
 
   return (
-    <div className="oltigo-landing">
+    <div id="top" className="oltigo-landing">
       <LanguageProvider>
-        <SkipLink />
         <Grain />
         <Nav />
         <ProgressRail />
-        <main id="top">
+        <main id="main-content">
           <Hero />
           <TelemetryTicker />
           <Features />

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -5,7 +5,7 @@ import { Hero } from "@/components/landing/oltigo/components/hero/hero";
 import { Grain } from "@/components/landing/oltigo/components/primitives/grain";
 import { ProgressRail } from "@/components/landing/oltigo/components/primitives/progress-rail";
 import { CtaDemo } from "@/components/landing/oltigo/components/sections/cta-demo";
-import { Faq } from "@/components/landing/oltigo/components/sections/faq";
+import { Faq, FaqSchema } from "@/components/landing/oltigo/components/sections/faq";
 import { Features } from "@/components/landing/oltigo/components/sections/features";
 import { Footer } from "@/components/landing/oltigo/components/sections/footer";
 import { HowItWorks } from "@/components/landing/oltigo/components/sections/how-it-works";
@@ -63,6 +63,7 @@ export function OltigoLanding() {
           <Faq />
           <CtaDemo />
         </main>
+        <FaqSchema />
         <Footer />
       </LanguageProvider>
     </div>

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -15,6 +15,19 @@ import { Pricing } from "@/components/landing/oltigo/components/sections/pricing
 import { TelemetryTicker } from "@/components/landing/oltigo/components/sections/telemetry-ticker";
 import { Testimonials } from "@/components/landing/oltigo/components/sections/testimonials";
 import { LanguageProvider } from "@/components/landing/oltigo/i18n/context";
+import { useI18n } from "@/components/landing/oltigo/i18n/context";
+
+function SkipLink() {
+  const { dict } = useI18n();
+  return (
+    <a
+      href="#top"
+      className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-50 focus:rounded-[10px] focus:bg-emerald focus:px-4 focus:py-2.5 focus:text-ink focus:shadow-lg"
+    >
+      {dict.nav.skipToContent}
+    </a>
+  );
+}
 
 /**
  * Oltigo marketing landing — ported from groupsmix/oltigo-landing.
@@ -35,6 +48,7 @@ export function OltigoLanding() {
   return (
     <div className="oltigo-landing">
       <LanguageProvider>
+        <SkipLink />
         <Grain />
         <Nav />
         <ProgressRail />

--- a/src/components/landing/oltigo/public-shell.tsx
+++ b/src/components/landing/oltigo/public-shell.tsx
@@ -18,7 +18,9 @@ export function OltigoPublicShell({
       <div className="oltigo-landing">
         <Grain />
         <PublicNav />
-        <main className={cn("min-h-screen", mainClassName)}>{children}</main>
+        <main id="main-content" className={cn("min-h-screen", mainClassName)}>
+          {children}
+        </main>
         <Footer />
       </div>
     </LanguageProvider>


### PR DESCRIPTION
## Summary

Follow-up to #1319. Implements the remaining UI/UX audit findings for the Oltigo landing page in four phases, addressing critical trust/accessibility blockers, high-impact navigation and motion issues, and medium polish.

## What changed

**Phase 1 — Critical blockers**
- Cookie banner buttons now stack vertically on small screens and text wraps without truncation.
- Replaced invalid hero `<dl>` markup with a semantic `<ul>` and `TrustItem` component.
- Demo form now requires an explicit consent checkbox before submit.
- WhatsApp CTA in the demo form validates `NEXT_PUBLIC_WHATSAPP_NUMBER` and hides the link when no valid number is configured.
- Testimonials now render initials/avatar slots and include clinic + city credentials.
- Hero uses the static console; no scroll-jacked or motion-heavy WebGL fallback needed.

**Phase 2 — High-impact fixes**
- Telemetry ticker pauses on hover/touch (`active`/`hover`) and respects `prefers-reduced-motion`.
- Added `id="main-content"` to landing and public shells so the existing app skip-link works across marketing pages.
- Footer now surfaces phone, email, and city from the default contact config.
- Patient and Doctor entry buttons in the nav/mobile menu now have balanced visual weight.
- Footer product links no longer duplicate the same destination.

**Phase 3 — Medium polish**
- Rewrote hero headline to be outcome-driven (`Gérez votre cabinet, réduisez les absences.` and localized equivalents).
- Feature visuals now carry `role="img"` / `aria-label` for accessibility.
- Promoted the annual/bank-transfer pricing note into a more visible pill.
- Landing language selection now syncs to the app-wide `preferred-locale` key so the global cookie banner stays localized on reload.
- Added FAQ schema JSON-LD (`FAQPage`) to the landing page.

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes

## Observability

- [x] N/A — no observability changes

## Rollback

Revert these commits.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- Removed a redundant landing-only skip-link and reused the global `app/layout.tsx` skip-link, fixing its target on marketing pages.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Coverage thresholds still met (`npm run test`)