### PR TITLE
fix(oltigo): follow-up — FAQ schema allowlist + public clinic template polish

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -55,7 +55,12 @@ export default async function PublicLayout({ children }: { children: React.React
         {children}
       </main>
       {useOriginalFooter ? (
-        <PublicFooter clinicName={branding.clinicName} />
+        <PublicFooter
+          clinicName={branding.clinicName}
+          phone={branding.phone ?? undefined}
+          email={branding.email ?? undefined}
+          address={branding.address ?? undefined}
+        />
       ) : (
         <DynamicFooter
           clinicName={branding.clinicName}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Fragment } from "react";
 import { LandingPage } from "@/components/landing/landing-page";
+import { dictionaries as landingDictionaries } from "@/components/landing/oltigo/i18n/dictionaries";
 import { HeroSection } from "@/components/public/hero-section";
 import {
   DoctorsSection,
@@ -210,6 +211,17 @@ export default async function HomePage() {
         offerCount: 4,
       },
     };
+    const landingDict =
+      landingDictionaries[locale as keyof typeof landingDictionaries] ?? landingDictionaries.fr;
+    const faqJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: landingDict.faq.items.map((item) => ({
+        "@type": "Question",
+        name: item.q,
+        acceptedAnswer: { "@type": "Answer", text: item.a },
+      })),
+    };
     return (
       <>
         <script
@@ -223,6 +235,12 @@ export default async function HomePage() {
           nonce={nonce}
           suppressHydrationWarning
           dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(softwareJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          nonce={nonce}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(faqJsonLd) }}
         />
         <LandingPage />
       </>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -411,21 +411,23 @@ export default async function HomePage() {
   // Build one renderer per *visible* section, then lay them out in the order
   // defined by the clinic's chosen template (`template.sectionOrder`).
   const renderers: Partial<Record<SectionKey, React.ReactNode>> = {};
+  const websiteHero = (
+    branding.websiteConfig as { hero?: { title?: string; subtitle?: string } } | null
+  )?.hero;
+  const heroOverrides: {
+    title?: string;
+    subtitle?: string;
+    imageUrl?: string;
+  } = {
+    title: websiteHero?.title ?? branding.clinicName,
+    imageUrl: branding.heroImageUrl ?? branding.coverPhotoUrl ?? undefined,
+  };
+  if (websiteHero?.subtitle ?? branding.tagline) {
+    heroOverrides.subtitle = (websiteHero?.subtitle ?? branding.tagline) || undefined;
+  }
+
   if (sections.hero) {
-    renderers.hero = (
-      <HeroSection
-        variant={template.heroStyle}
-        overrides={
-          branding.websiteConfig
-            ? {
-                title: (branding.websiteConfig as { hero?: { title?: string } }).hero?.title,
-                subtitle: (branding.websiteConfig as { hero?: { subtitle?: string } }).hero
-                  ?.subtitle,
-              }
-            : undefined
-        }
-      />
-    );
+    renderers.hero = <HeroSection variant={template.heroStyle} overrides={heroOverrides} />;
   }
   if (sections.services) renderers.services = <ServicesPreview cardStyle={template.cardStyle} />;
   if (sections.doctors) renderers.doctors = <DoctorsSection cardStyle={template.cardStyle} />;

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Shield } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
@@ -371,13 +372,16 @@ export function CookieConsent() {
       <div className="mx-auto max-w-5xl p-4 md:px-6">
         {/* Main banner */}
         <div className="md:flex md:items-center md:justify-between md:gap-4">
-          <p className="text-sm text-muted-foreground mb-3 md:mb-0">
-            {t(locale, "cookie.message")}{" "}
-            <a href="/privacy/" className="underline hover:text-foreground">
-              {t(locale, "cookie.privacyPolicy")}
-            </a>
-            .
-          </p>
+          <div className="flex items-start gap-3 text-sm text-muted-foreground mb-3 md:mb-0">
+            <Shield className="mt-0.5 size-4 shrink-0" aria-hidden />
+            <p>
+              {t(locale, "cookie.message")}{" "}
+              <a href="/privacy/" className="underline hover:text-foreground">
+                {t(locale, "cookie.privacyPolicy")}
+              </a>
+              .
+            </p>
+          </div>
           {/* A69-3: Decline has equal visual weight as Accept All (EDPB 03/2022). */}
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap">
             <Button className="w-full sm:w-auto" size="sm" onClick={declineAll}>

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useLocale } from "@/components/locale-switcher";
 import { Button } from "@/components/ui/button";
 import { getGaMeasurementId } from "@/lib/env";
-import { t } from "@/lib/i18n";
+import { isSupportedLocale, type Locale, t } from "@/lib/i18n";
 
 /** Cookie preference categories. */
 export interface CookiePreferences {
@@ -262,6 +262,31 @@ export function persistConsent(prefs: CookiePreferences, now: number = Date.now(
  */
 export function CookieConsent() {
   const [locale] = useLocale();
+  const [cookieLocale, setCookieLocale] = useState<Locale>(locale);
+
+  // Keep cookie banner copy in sync with the landing page locale.
+  useEffect(() => {
+    const read = () => {
+      const stored =
+        (typeof window !== "undefined" && window.localStorage.getItem("preferred-locale")) ||
+        locale;
+      if (isSupportedLocale(stored)) setCookieLocale(stored);
+    };
+    read();
+
+    const onLocale = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (isSupportedLocale(detail)) setCookieLocale(detail);
+    };
+    const onStorage = () => read();
+
+    window.addEventListener("oltigo:locale", onLocale);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("oltigo:locale", onLocale);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [locale]);
 
   // SSR-stable initial state: both server and the first client render must
   // produce identical markup (banner hidden) to avoid a hydration mismatch
@@ -366,7 +391,7 @@ export function CookieConsent() {
     <div
       id="cookie-consent-banner"
       role="dialog"
-      aria-label={t(locale, "cookie.ariaLabel")}
+      aria-label={t(cookieLocale, "cookie.ariaLabel")}
       className="fixed bottom-0 left-0 right-0 z-[60] border-t bg-background shadow-lg"
     >
       <div className="mx-auto max-w-5xl p-4 md:px-6">
@@ -375,9 +400,9 @@ export function CookieConsent() {
           <div className="flex items-start gap-3 text-sm text-muted-foreground mb-3 md:mb-0">
             <Shield className="mt-0.5 size-4 shrink-0" aria-hidden />
             <p>
-              {t(locale, "cookie.message")}{" "}
+              {t(cookieLocale, "cookie.message")}{" "}
               <a href="/privacy/" className="underline hover:text-foreground">
-                {t(locale, "cookie.privacyPolicy")}
+                {t(cookieLocale, "cookie.privacyPolicy")}
               </a>
               .
             </p>
@@ -385,7 +410,7 @@ export function CookieConsent() {
           {/* A69-3: Decline has equal visual weight as Accept All (EDPB 03/2022). */}
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap">
             <Button className="w-full sm:w-auto" size="sm" onClick={declineAll}>
-              {t(locale, "cookie.decline")}
+              {t(cookieLocale, "cookie.decline")}
             </Button>
             <Button
               className="w-full sm:w-auto"
@@ -393,10 +418,10 @@ export function CookieConsent() {
               size="sm"
               onClick={() => setShowPreferences(!showPreferences)}
             >
-              {t(locale, "cookie.managePreferences")}
+              {t(cookieLocale, "cookie.managePreferences")}
             </Button>
             <Button className="w-full sm:w-auto" size="sm" onClick={acceptAll}>
-              {t(locale, "cookie.acceptAll")}
+              {t(cookieLocale, "cookie.acceptAll")}
             </Button>
           </div>
         </div>
@@ -407,13 +432,13 @@ export function CookieConsent() {
             {/* Functional. Always on. */}
             <label className="flex items-center justify-between gap-4">
               <div>
-                <p className="text-sm font-medium">{t(locale, "cookie.functional")}</p>
+                <p className="text-sm font-medium">{t(cookieLocale, "cookie.functional")}</p>
                 <p className="text-xs text-muted-foreground">
-                  {t(locale, "cookie.functionalDesc")}
+                  {t(cookieLocale, "cookie.functionalDesc")}
                 </p>
               </div>
               <span className="text-xs font-medium text-muted-foreground">
-                {t(locale, "cookie.required")}
+                {t(cookieLocale, "cookie.required")}
               </span>
             </label>
 
@@ -421,8 +446,10 @@ export function CookieConsent() {
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- control is associated via adjacent Input/sibling element */}
             <label className="flex items-center justify-between gap-4 cursor-pointer">
               <div>
-                <p className="text-sm font-medium">{t(locale, "cookie.analytics")}</p>
-                <p className="text-xs text-muted-foreground">{t(locale, "cookie.analyticsDesc")}</p>
+                <p className="text-sm font-medium">{t(cookieLocale, "cookie.analytics")}</p>
+                <p className="text-xs text-muted-foreground">
+                  {t(cookieLocale, "cookie.analyticsDesc")}
+                </p>
               </div>
               <input
                 type="checkbox"
@@ -436,8 +463,10 @@ export function CookieConsent() {
             {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- control is associated via adjacent Input/sibling element */}
             <label className="flex items-center justify-between gap-4 cursor-pointer">
               <div>
-                <p className="text-sm font-medium">{t(locale, "cookie.marketing")}</p>
-                <p className="text-xs text-muted-foreground">{t(locale, "cookie.marketingDesc")}</p>
+                <p className="text-sm font-medium">{t(cookieLocale, "cookie.marketing")}</p>
+                <p className="text-xs text-muted-foreground">
+                  {t(cookieLocale, "cookie.marketingDesc")}
+                </p>
               </div>
               <input
                 type="checkbox"
@@ -454,7 +483,7 @@ export function CookieConsent() {
 
             <div className="flex justify-end pt-2">
               <Button size="sm" onClick={saveCustom}>
-                {t(locale, "cookie.savePreferences")}
+                {t(cookieLocale, "cookie.savePreferences")}
               </Button>
             </div>
           </div>

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -379,18 +379,19 @@ export function CookieConsent() {
             .
           </p>
           {/* A69-3: Decline has equal visual weight as Accept All (EDPB 03/2022). */}
-          <div className="flex flex-wrap gap-2 shrink-0">
-            <Button size="sm" onClick={declineAll}>
+          <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:flex-wrap">
+            <Button className="w-full sm:w-auto" size="sm" onClick={declineAll}>
               {t(locale, "cookie.decline")}
             </Button>
             <Button
+              className="w-full sm:w-auto"
               variant="outline"
               size="sm"
               onClick={() => setShowPreferences(!showPreferences)}
             >
               {t(locale, "cookie.managePreferences")}
             </Button>
-            <Button size="sm" onClick={acceptAll}>
+            <Button className="w-full sm:w-auto" size="sm" onClick={acceptAll}>
               {t(locale, "cookie.acceptAll")}
             </Button>
           </div>

--- a/src/components/landing/oltigo/components/hero/console-static.tsx
+++ b/src/components/landing/oltigo/components/hero/console-static.tsx
@@ -22,10 +22,16 @@ export function ConsoleStatic() {
         <div className="relative z-30 self-end" style={{ transform: "rotate(-1.2deg)" }}>
           <AgendaFace />
         </div>
-        <div className="relative z-20 -mt-6 self-start" style={{ transform: "rotate(1.1deg)" }}>
+        <div
+          className="relative z-20 -mt-4 md:-mt-6 self-start"
+          style={{ transform: "rotate(1.1deg)" }}
+        >
           <DossierFace dict={dict} />
         </div>
-        <div className="relative z-10 -mt-6 self-end" style={{ transform: "rotate(-0.8deg)" }}>
+        <div
+          className="relative z-10 -mt-4 md:-mt-6 self-end"
+          style={{ transform: "rotate(-0.8deg)" }}
+        >
           <WhatsappFace dict={dict} />
         </div>
       </div>

--- a/src/components/landing/oltigo/components/hero/faces.tsx
+++ b/src/components/landing/oltigo/components/hero/faces.tsx
@@ -23,15 +23,15 @@ export function AgendaFace() {
   return (
     <div className="panel w-[300px] rounded-[14px] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <span className="telemetry text-[10px] uppercase tracking-[0.2em] text-text-secondary">
+        <span className="telemetry text-[12px] uppercase tracking-[0.2em] text-text-secondary">
           Semaine 24
         </span>
-        <Calendar className="size-3.5 text-text-secondary" strokeWidth={1.5} aria-hidden />
+        <Calendar className="size-4 text-text-secondary" strokeWidth={1.5} aria-hidden />
       </div>
       <div className="grid grid-cols-[42px_repeat(5,1fr)] gap-1.5">
         <span />
         {days.map((d, i) => (
-          <span key={i} className="telemetry text-center text-[10px] text-text-secondary">
+          <span key={i} className="telemetry text-center text-[12px] text-text-secondary">
             {d}
           </span>
         ))}
@@ -46,7 +46,7 @@ export function AgendaFace() {
 function FaceRow({ time, row }: { time: string; row: number[] }) {
   return (
     <>
-      <span className="telemetry self-center text-[9.5px] text-text-secondary">{time}</span>
+      <span className="telemetry self-center text-[11px] text-text-secondary">{time}</span>
       {row.map((cell, c) => (
         <span
           key={c}
@@ -69,7 +69,7 @@ export function DossierFace({ dict }: { dict: Dictionary }) {
   return (
     <div className="panel panel-high w-[300px] rounded-[14px] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <span className="text-[13px] font-medium text-text">{dict.features[1].title}</span>
+        <span className="text-[14px] font-medium text-text">{dict.features[1].title}</span>
         {/* brushed-metal seal / lock — AES motif */}
         <span
           className="relative grid size-7 place-items-center rounded-full"
@@ -83,8 +83,8 @@ export function DossierFace({ dict }: { dict: Dictionary }) {
       </div>
 
       <div className="mb-3 inline-flex items-center gap-1.5 rounded-md border border-hairline bg-ink/60 px-2 py-1">
-        <Fingerprint className="size-3 text-cyan" strokeWidth={1.5} aria-hidden />
-        <span className="telemetry text-[10px] tracking-wide text-cyan">AES-256-GCM</span>
+        <Fingerprint className="size-3.5 text-cyan" strokeWidth={1.5} aria-hidden />
+        <span className="telemetry text-[11px] tracking-wide text-cyan">AES-256-GCM</span>
       </div>
 
       {/* redacted rows */}
@@ -99,7 +99,7 @@ export function DossierFace({ dict }: { dict: Dictionary }) {
 
       <div className="mt-3 flex items-center gap-1.5 border-t border-hairline pt-3">
         <span className="size-1.5 rounded-full bg-emerald" />
-        <span className="text-[10.5px] text-text-secondary">{dict.features[1].bullets[3]}</span>
+        <span className="text-[12px] text-text-secondary">{dict.features[1].bullets[3]}</span>
       </div>
     </div>
   );
@@ -142,18 +142,18 @@ export function WhatsappFace({ dict }: { dict: Dictionary }) {
   return (
     <div className="panel w-[300px] rounded-[14px] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <span className="telemetry text-[10px] uppercase tracking-[0.2em] text-text-secondary">
+        <span className="telemetry text-[12px] uppercase tracking-[0.2em] text-text-secondary">
           WhatsApp · Darija
         </span>
         <span className="flex items-center gap-1">
           <span className="size-1.5 rounded-full bg-emerald" />
-          <span className="telemetry text-[9.5px] text-text-secondary">live</span>
+          <span className="telemetry text-[11px] text-text-secondary">live</span>
         </span>
       </div>
 
       {/* incoming reminder */}
       <div className="mb-2 max-w-[78%] rounded-2xl rounded-ss-sm border border-hairline bg-[var(--color-surface-high)] px-3 py-2">
-        <p className="text-[11.5px] leading-snug text-text-secondary">{dict.whatsapp.incoming}</p>
+        <p className="text-[12.5px] leading-snug text-text-secondary">{dict.whatsapp.incoming}</p>
       </div>
 
       {/* patient reply OUI */}
@@ -161,7 +161,7 @@ export function WhatsappFace({ dict }: { dict: Dictionary }) {
         className="ms-auto mb-1 flex max-w-[60%] items-center justify-end gap-1.5 rounded-2xl rounded-ee-sm bg-[var(--color-emerald-dim)] px-3 py-1.5 transition-opacity duration-500"
         style={{ opacity: step >= 1 ? 1 : 0.15 }}
       >
-        <span className="text-[12px] font-medium text-text">{dict.whatsapp.reply}</span>
+        <span className="text-[13px] font-medium text-text">{dict.whatsapp.reply}</span>
         {step >= 2 ? (
           <CheckCheck className="size-3.5 text-emerald" strokeWidth={2.2} aria-hidden />
         ) : (
@@ -171,7 +171,7 @@ export function WhatsappFace({ dict }: { dict: Dictionary }) {
 
       <div className="flex items-center justify-end">
         <span
-          className="telemetry text-[9.5px] transition-colors duration-500"
+          className="telemetry text-[11px] transition-colors duration-500"
           style={{ color: step >= 2 ? "var(--color-emerald)" : "var(--color-text-secondary)" }}
         >
           {step >= 2 ? dict.whatsapp.status : "···"}

--- a/src/components/landing/oltigo/components/hero/hero.tsx
+++ b/src/components/landing/oltigo/components/hero/hero.tsx
@@ -74,7 +74,6 @@ export function Hero() {
               <TrustItem
                 value={<span className="telemetry">{dict.hero.trust.cipher}</span>}
                 label=""
-                srLabel={dict.hero.trust.cipher}
               />
               <TrustItem
                 value={<span className="text-emerald">●</span>}
@@ -83,7 +82,6 @@ export function Hero() {
               <TrustItem
                 value={<span className="telemetry">{dict.hero.trust.latency}</span>}
                 label=""
-                srLabel={dict.hero.trust.latency}
               />
             </ul>
           </Reveal>
@@ -98,23 +96,11 @@ export function Hero() {
   );
 }
 
-function TrustItem({
-  value,
-  label,
-  srLabel,
-}: {
-  value: React.ReactNode;
-  label: string;
-  srLabel?: string;
-}) {
+function TrustItem({ value, label }: { value: React.ReactNode; label: string }) {
   return (
     <li className="flex flex-col gap-1">
       <span className="text-[15px] font-medium text-text">{value}</span>
-      {label ? (
-        <span className="text-[11px] leading-tight text-text-muted">{label}</span>
-      ) : srLabel ? (
-        <span className="sr-only">{srLabel}</span>
-      ) : null}
+      {label ? <span className="text-[11px] leading-tight text-text-muted">{label}</span> : null}
     </li>
   );
 }

--- a/src/components/landing/oltigo/components/hero/hero.tsx
+++ b/src/components/landing/oltigo/components/hero/hero.tsx
@@ -1,43 +1,14 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
-import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
 import { BilingualNumeral } from "@/components/landing/oltigo/components/primitives/bilingual-numeral";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { ConsoleStatic } from "./console-static";
 
-// The 3D console is client-only WebGL. Lazy-load it so three.js stays out of
-// the shared bundle and never executes during SSR; the static console is both
-// the loading state and the WebGL-unavailable fallback.
-const Console3D = dynamic(() => import("./console-3d"), {
-  ssr: false,
-  loading: () => <ConsoleStatic />,
-});
-
 export function Hero() {
   const { dict } = useI18n();
-  const [wide, setWide] = useState(false);
-  const [focus, setFocus] = useState(-1);
-  const [reducedMotion, setReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(min-width: 768px)");
-    const update = () => setWide(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, []);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const update = () => setReducedMotion(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, []);
 
   return (
     <section className="relative overflow-hidden border-b border-hairline">
@@ -120,29 +91,7 @@ export function Hero() {
 
         {/* Object — RIGHT */}
         <div className="relative">
-          {wide && !reducedMotion ? (
-            <Console3D onFocus={setFocus} dict={dict} />
-          ) : (
-            <ConsoleStatic />
-          )}
-
-          {/* Explode captions, synced to the focused layer */}
-          <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">
-            <div className="relative h-6">
-              {dict.hero.captions.map((cap, i) => (
-                <span
-                  key={i}
-                  className="telemetry absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[11px] uppercase tracking-[0.22em] text-text-secondary transition-all duration-500"
-                  style={{
-                    opacity: focus === i ? 1 : 0,
-                    transform: `translateX(-50%) translateY(${focus === i ? 0 : 6}px)`,
-                  }}
-                >
-                  {cap}
-                </span>
-              ))}
-            </div>
-          </div>
+          <ConsoleStatic />
         </div>
       </div>
     </section>

--- a/src/components/landing/oltigo/components/hero/hero.tsx
+++ b/src/components/landing/oltigo/components/hero/hero.tsx
@@ -1,14 +1,43 @@
 "use client";
 
 import { ArrowRight } from "lucide-react";
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 import { BilingualNumeral } from "@/components/landing/oltigo/components/primitives/bilingual-numeral";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { ConsoleStatic } from "./console-static";
 
+// The 3D console is client-only WebGL. Lazy-load it so three.js stays out of
+// the shared bundle and never executes during SSR; the static console is both
+// the loading state and the WebGL-unavailable fallback.
+const Console3D = dynamic(() => import("./console-3d"), {
+  ssr: false,
+  loading: () => <ConsoleStatic />,
+});
+
 export function Hero() {
   const { dict } = useI18n();
+  const [wide, setWide] = useState(false);
+  const [focus, setFocus] = useState(-1);
+  const [reducedMotion, setReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const update = () => setWide(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReducedMotion(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
 
   return (
     <section className="relative overflow-hidden border-b border-hairline">
@@ -63,7 +92,10 @@ export function Hero() {
 
           {/* Trust strip */}
           <Reveal delay={260}>
-            <dl className="mt-12 grid grid-cols-2 gap-x-6 gap-y-5 border-t border-hairline pt-6 sm:grid-cols-4">
+            <ul
+              className="mt-12 grid grid-cols-2 gap-x-6 gap-y-5 border-t border-hairline pt-6 sm:grid-cols-4"
+              aria-label={dict.hero.eyebrow}
+            >
               <TrustItem
                 value={<BilingualNumeral value={dict.hero.trust.uptime} />}
                 label={dict.hero.trust.uptimeLabel}
@@ -71,6 +103,7 @@ export function Hero() {
               <TrustItem
                 value={<span className="telemetry">{dict.hero.trust.cipher}</span>}
                 label=""
+                srLabel={dict.hero.trust.cipher}
               />
               <TrustItem
                 value={<span className="text-emerald">●</span>}
@@ -79,25 +112,60 @@ export function Hero() {
               <TrustItem
                 value={<span className="telemetry">{dict.hero.trust.latency}</span>}
                 label=""
+                srLabel={dict.hero.trust.latency}
               />
-            </dl>
+            </ul>
           </Reveal>
         </div>
 
         {/* Object — RIGHT */}
         <div className="relative">
-          <ConsoleStatic />
+          {wide && !reducedMotion ? (
+            <Console3D onFocus={setFocus} dict={dict} />
+          ) : (
+            <ConsoleStatic />
+          )}
+
+          {/* Explode captions, synced to the focused layer */}
+          <div className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center">
+            <div className="relative h-6">
+              {dict.hero.captions.map((cap, i) => (
+                <span
+                  key={i}
+                  className="telemetry absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-[11px] uppercase tracking-[0.22em] text-text-secondary transition-all duration-500"
+                  style={{
+                    opacity: focus === i ? 1 : 0,
+                    transform: `translateX(-50%) translateY(${focus === i ? 0 : 6}px)`,
+                  }}
+                >
+                  {cap}
+                </span>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </section>
   );
 }
 
-function TrustItem({ value, label }: { value: React.ReactNode; label: string }) {
+function TrustItem({
+  value,
+  label,
+  srLabel,
+}: {
+  value: React.ReactNode;
+  label: string;
+  srLabel?: string;
+}) {
   return (
-    <div className="flex flex-col gap-1">
-      <dd className="text-[15px] font-medium text-text">{value}</dd>
-      {label ? <dt className="text-[11px] leading-tight text-text-muted">{label}</dt> : null}
-    </div>
+    <li className="flex flex-col gap-1">
+      <span className="text-[15px] font-medium text-text">{value}</span>
+      {label ? (
+        <span className="text-[11px] leading-tight text-text-muted">{label}</span>
+      ) : srLabel ? (
+        <span className="sr-only">{srLabel}</span>
+      ) : null}
+    </li>
   );
 }

--- a/src/components/landing/oltigo/components/sections/cta-demo.tsx
+++ b/src/components/landing/oltigo/components/sections/cta-demo.tsx
@@ -9,16 +9,33 @@ import { Eyebrow } from "./section-kit";
 
 type Status = "idle" | "submitting" | "success" | "error";
 
-const WHATSAPP_NUMBER = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? "212600000000";
+const rawWhatsAppNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? "";
+
+function formatWhatsAppNumber(num: string): string | null {
+  const digits = num.replace(/\D/g, "");
+  // E.164-ish: 10-15 digits total. Reject empty/short and known placeholder.
+  if (!digits || digits.length < 10 || digits.length > 15) return null;
+  return digits;
+}
+
+const whatsAppHref = (() => {
+  const formatted = formatWhatsAppNumber(rawWhatsAppNumber);
+  return formatted ? `https://wa.me/${formatted}` : null;
+})();
 
 export function CtaDemo() {
   const { dict, locale } = useI18n();
   const c = dict.cta;
   const [status, setStatus] = useState<Status>("idle");
+  const [consent, setConsent] = useState(false);
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget;
+    if (!consent) {
+      setStatus("error");
+      return;
+    }
     // Snapshot the values before any await — React reuses the synthetic
     // event and form.reset() would clear the fields out from under us.
     const fd = new FormData(form);
@@ -72,15 +89,17 @@ export function CtaDemo() {
             <p className="mt-4 max-w-md text-[15px] leading-relaxed text-text-secondary">{c.sub}</p>
           </Reveal>
           <Reveal delay={180}>
-            <a
-              href={`https://wa.me/${WHATSAPP_NUMBER}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-8 inline-flex items-center gap-2.5 rounded-[10px] border border-hairline bg-surface/40 px-4 py-2.5 text-sm text-text-secondary transition-colors hover:border-emerald/50 hover:text-text"
-            >
-              <MessageCircle className="size-4 text-emerald" strokeWidth={1.75} aria-hidden />
-              {c.whatsapp}
-            </a>
+            {whatsAppHref ? (
+              <a
+                href={whatsAppHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-8 inline-flex items-center gap-2.5 rounded-[10px] border border-hairline bg-surface/40 px-4 py-2.5 text-sm text-text-secondary transition-colors hover:border-emerald/50 hover:text-text"
+              >
+                <MessageCircle className="size-4 text-emerald" strokeWidth={1.75} aria-hidden />
+                {c.whatsapp}
+              </a>
+            ) : null}
           </Reveal>
         </div>
 
@@ -108,12 +127,26 @@ export function CtaDemo() {
               ))}
             </div>
 
+            <label className="mt-4 flex cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                name="consent"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-hairline bg-ink text-emerald accent-emerald"
+                required
+              />
+              <span className="text-[12.5px] leading-relaxed text-text-secondary">
+                {c.consentCheckbox}
+              </span>
+            </label>
+
             <Button
               type="submit"
               variant="primary"
               size="lg"
-              className="mt-6 w-full"
-              disabled={status === "submitting"}
+              className="mt-5 w-full"
+              disabled={status === "submitting" || !consent}
             >
               {status === "submitting" ? c.submitting : c.submit}
               {status !== "submitting" && (

--- a/src/components/landing/oltigo/components/sections/cta-demo.tsx
+++ b/src/components/landing/oltigo/components/sections/cta-demo.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { ArrowRight, MessageCircle } from "lucide-react";
+import { AlertCircle, ArrowRight, CheckCircle2, MessageCircle } from "lucide-react";
 import { useState } from "react";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { cn } from "@/lib/utils";
 import { Eyebrow } from "./section-kit";
 
 type Status = "idle" | "submitting" | "success" | "error";
@@ -112,8 +113,13 @@ export function CtaDemo() {
                   key={f.id}
                   className={f.id === "clinic" || f.id === "doctor" ? "sm:col-span-2" : ""}
                 >
-                  <span className="telemetry mb-1.5 block text-[10.5px] uppercase tracking-[0.16em] text-text-secondary">
+                  <span className="mb-1.5 block text-[12px] font-medium text-text-secondary">
                     {c.fields[f.id]}
+                    {f.id !== "city" ? (
+                      <span className="ms-1 text-emerald" aria-hidden="true">
+                        *
+                      </span>
+                    ) : null}
                   </span>
                   <input
                     name={f.id}
@@ -156,16 +162,21 @@ export function CtaDemo() {
 
             <p
               aria-live="polite"
-              className="mt-3 min-h-[1.25rem] text-[12.5px]"
-              style={{
-                color:
-                  status === "success"
-                    ? "var(--color-emerald)"
-                    : status === "error"
-                      ? "#e08a7a"
-                      : "var(--color-text-muted)",
-              }}
+              role="status"
+              className={cn(
+                "mt-3 flex min-h-[1.25rem] items-center gap-1.5 text-[12.5px] font-medium",
+                status === "success"
+                  ? "text-emerald"
+                  : status === "error"
+                    ? "text-[#e08a7a]"
+                    : "text-text-muted",
+              )}
             >
+              {status === "success" ? (
+                <CheckCircle2 className="size-4 shrink-0" aria-hidden />
+              ) : status === "error" ? (
+                <AlertCircle className="size-4 shrink-0" aria-hidden />
+              ) : null}
               {status === "success" ? c.success : status === "error" ? c.error : c.consent}
             </p>
           </form>

--- a/src/components/landing/oltigo/components/sections/faq.tsx
+++ b/src/components/landing/oltigo/components/sections/faq.tsx
@@ -4,31 +4,8 @@ import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Accordion } from "@/components/landing/oltigo/components/ui/accordion";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
-import { safeJsonLdStringify } from "@/lib/json-ld";
 import { cn } from "@/lib/utils";
 import { SectionHeading } from "./section-kit";
-
-export function FaqSchema() {
-  const { dict } = useI18n();
-  const jsonLd = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: dict.faq.items.map((item) => ({
-      "@type": "Question",
-      name: item.q,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: item.a,
-      },
-    })),
-  };
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
-    />
-  );
-}
 
 export function Faq() {
   const { dict } = useI18n();

--- a/src/components/landing/oltigo/components/sections/faq.tsx
+++ b/src/components/landing/oltigo/components/sections/faq.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Accordion } from "@/components/landing/oltigo/components/ui/accordion";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { safeJsonLdStringify } from "@/lib/json-ld";
+import { cn } from "@/lib/utils";
 import { SectionHeading } from "./section-kit";
 
 export function FaqSchema() {
@@ -29,12 +32,43 @@ export function FaqSchema() {
 
 export function Faq() {
   const { dict } = useI18n();
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return dict.faq.items;
+    return dict.faq.items.filter(
+      (item) => item.q.toLowerCase().includes(q) || item.a.toLowerCase().includes(q),
+    );
+  }, [dict.faq.items, query]);
+
   return (
     <section id="faq" className="relative border-b border-hairline py-24 sm:py-32">
       <div className="mx-auto grid max-w-7xl gap-12 px-6 lg:grid-cols-[0.8fr_1.2fr]">
         <SectionHeading eyebrow={dict.faq.eyebrow} title={dict.faq.title} />
         <div className="lg:pt-2">
-          <Accordion items={dict.faq.items} />
+          <div className="relative mb-6">
+            <Search
+              className="absolute start-3 top-1/2 size-4 -translate-y-1/2 text-text-muted"
+              aria-hidden="true"
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={dict.faq.searchPlaceholder}
+              aria-label={dict.faq.searchPlaceholder}
+              className={cn(
+                "w-full rounded-xl border border-hairline bg-surface/40 py-2.5 pe-4 text-[14px] text-text placeholder:text-text-muted focus:border-emerald/50 focus:outline-none focus:ring-2 focus:ring-emerald/20",
+                "ps-10",
+              )}
+            />
+          </div>
+          {filtered.length > 0 ? (
+            <Accordion key={query} items={filtered} />
+          ) : (
+            <p className="text-[14px] text-text-secondary">{dict.faq.noResults}</p>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/landing/oltigo/components/sections/faq.tsx
+++ b/src/components/landing/oltigo/components/sections/faq.tsx
@@ -2,7 +2,30 @@
 
 import { Accordion } from "@/components/landing/oltigo/components/ui/accordion";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { safeJsonLdStringify } from "@/lib/json-ld";
 import { SectionHeading } from "./section-kit";
+
+export function FaqSchema() {
+  const { dict } = useI18n();
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: dict.faq.items.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+    />
+  );
+}
 
 export function Faq() {
   const { dict } = useI18n();

--- a/src/components/landing/oltigo/components/sections/feature-screens.tsx
+++ b/src/components/landing/oltigo/components/sections/feature-screens.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/* eslint-disable i18next/no-literal-string -- realistic product UI mockup strings */
+
+import { Calendar, Clock, FileText, Pill, Shield, User } from "lucide-react";
+import type { Dictionary } from "@/components/landing/oltigo/i18n/dictionaries";
+
+/** Realistic in-code product screenshot for the Appointments feature. */
+export function AppointmentScreen({ dict }: { dict: Dictionary }) {
+  const days = ["L", "M", "M", "J", "V"];
+  const slots = [
+    { time: "09:00", cells: [1, 0, 0, 1, 2] },
+    { time: "10:30", cells: [0, 2, 1, 0, 1] },
+    { time: "12:00", cells: [1, 1, 0, 2, 0] },
+    { time: "14:30", cells: [0, 0, 2, 1, 1] },
+  ];
+
+  return (
+    <div className="panel w-full max-w-[340px] overflow-hidden rounded-[16px] p-4 sm:max-w-[400px]">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="grid size-8 place-items-center rounded-lg bg-emerald/10 text-emerald">
+            <Calendar className="size-4" strokeWidth={1.75} aria-hidden />
+          </div>
+          <div>
+            <p className="text-[13px] font-medium text-text">{dict.features[0].title}</p>
+            <p className="text-[11px] text-text-muted">Semaine 24 · 3 praticiens</p>
+          </div>
+        </div>
+        <span className="telemetry rounded-md border border-hairline bg-ink px-2 py-1 text-[10px] text-text-secondary">
+          Vue semaine
+        </span>
+      </div>
+
+      <div className="grid gap-1.5" style={{ gridTemplateColumns: "44px repeat(5, 1fr)" }}>
+        <span />
+        {days.map((d, i) => (
+          <span
+            key={i}
+            className="telemetry text-center text-[10px] font-medium uppercase tracking-wide text-text-secondary"
+          >
+            {d}
+          </span>
+        ))}
+        {slots.map(({ time, cells }) => (
+          <SlotRow key={time} time={time} cells={cells} />
+        ))}
+      </div>
+
+      <div className="mt-4 flex items-center gap-2 rounded-lg border border-hairline bg-ink px-3 py-2">
+        <Clock className="size-3.5 text-emerald" strokeWidth={1.75} aria-hidden />
+        <span className="text-[11.5px] text-text-secondary">12 RDV confirmés aujourd’hui</span>
+      </div>
+    </div>
+  );
+}
+
+function SlotRow({ time, cells }: { time: string; cells: number[] }) {
+  return (
+    <>
+      <span className="telemetry self-center text-[10px] text-text-secondary">{time}</span>
+      {cells.map((cell, c) => (
+        <span
+          key={c}
+          className={cn(
+            "h-7 rounded-md border",
+            cell === 0 && "border-hairline bg-transparent",
+            cell === 1 && "border-transparent bg-surface-high",
+            cell === 2 &&
+              "flex items-center justify-center border-emerald/40 bg-emerald/15 text-[9px] font-medium text-emerald",
+          )}
+        >
+          {cell === 2 ? "RDV" : null}
+        </span>
+      ))}
+    </>
+  );
+}
+
+/** Realistic in-code product screenshot for the Patient Record feature. */
+export function RecordScreen({ dict }: { dict: Dictionary }) {
+  return (
+    <div className="panel w-full max-w-[340px] overflow-hidden rounded-[16px] p-0 sm:max-w-[400px]">
+      <div className="flex items-center gap-3 border-b border-hairline p-4">
+        <div className="grid size-10 place-items-center rounded-full bg-surface text-[12px] font-medium text-text">
+          <User className="size-4 text-text-secondary" strokeWidth={1.75} aria-hidden />
+        </div>
+        <div>
+          <p className="text-[13px] font-medium text-text">Yasmine Berrada</p>
+          <p className="text-[11px] text-text-muted">{dict.features[1].title} · 32 ans</p>
+        </div>
+        <Shield className="ms-auto size-4 text-emerald" strokeWidth={1.75} aria-hidden />
+      </div>
+
+      <div className="flex gap-1 border-b border-hairline px-4 py-2">
+        {["Historique", "Ordonnances", "Documents"].map((tab, i) => (
+          <span
+            key={tab}
+            className={cn(
+              "rounded-md px-2 py-1 text-[11px]",
+              i === 1 ? "bg-surface font-medium text-text" : "text-text-secondary",
+            )}
+          >
+            {tab}
+          </span>
+        ))}
+      </div>
+
+      <div className="space-y-2 p-4">
+        <div className="rounded-lg border border-hairline bg-ink p-3">
+          <div className="mb-2 flex items-center gap-2">
+            <FileText className="size-3.5 text-cyan" strokeWidth={1.75} aria-hidden />
+            <span className="text-[11px] font-medium text-text">Ordonnance · 12 juin 2026</span>
+          </div>
+          <ul className="space-y-1.5">
+            {[
+              { name: "Paracétamol 500 mg", freq: "3× / jour" },
+              { name: "Amoxicilline 1 g", freq: "2× / jour" },
+            ].map((m) => (
+              <li
+                key={m.name}
+                className="flex items-center gap-2 text-[11.5px] text-text-secondary"
+              >
+                <Pill className="size-3 shrink-0 text-text-muted" strokeWidth={1.75} aria-hidden />
+                <span className="flex-1">{m.name}</span>
+                <span className="text-[10px] text-text-muted">{m.freq}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex items-center gap-1.5 text-[10px] text-text-muted">
+          <span className="size-1.5 rounded-full bg-emerald" />
+          {dict.features[1].bullets[3]}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Realistic in-code product screenshot for the WhatsApp reminders feature. */
+export function WhatsAppScreen({ dict }: { dict: Dictionary }) {
+  return (
+    <div className="w-full max-w-[340px] overflow-hidden rounded-[16px] border border-hairline bg-[#0b141a] sm:max-w-[400px]">
+      <div className="flex items-center gap-2.5 bg-[#1f2c34] px-3 py-2.5">
+        <div className="grid size-9 place-items-center rounded-full bg-surface text-[11px] font-medium text-text">
+          CB
+        </div>
+        <div>
+          <p className="text-[13px] font-medium text-text">Cabinet Berrada</p>
+          <p className="text-[10px] text-emerald">en ligne</p>
+        </div>
+      </div>
+
+      <div className="space-y-2 p-3">
+        <div className="max-w-[86%] rounded-lg rounded-tl-none bg-surface-high px-3 py-2">
+          <p className="text-[12px] leading-snug text-text-secondary">{dict.whatsapp.incoming}</p>
+          <p className="mt-1 text-right text-[10px] text-text-muted">14:30</p>
+        </div>
+
+        <div
+          className="ms-auto flex max-w-[64%] items-center gap-1.5 rounded-lg rounded-tr-none px-3 py-1.5"
+          style={{ background: "var(--color-emerald-dim)" }}
+        >
+          <span className="text-[13px] font-medium text-text">{dict.whatsapp.reply}</span>
+          <span className="text-[10px] font-medium text-emerald">{dict.whatsapp.status}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function cn(...inputs: (string | false | null | undefined)[]) {
+  return inputs.filter(Boolean).join(" ");
+}

--- a/src/components/landing/oltigo/components/sections/features.tsx
+++ b/src/components/landing/oltigo/components/sections/features.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { ArrowRight, Check } from "lucide-react";
-import {
-  AgendaFace,
-  DossierFace,
-  WhatsappFace,
-} from "@/components/landing/oltigo/components/hero/faces";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
+import {
+  AppointmentScreen,
+  RecordScreen,
+  WhatsAppScreen,
+} from "@/components/landing/oltigo/components/sections/feature-screens";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { SectionHeading } from "./section-kit";
@@ -14,9 +14,9 @@ import { SectionHeading } from "./section-kit";
 export function Features() {
   const { dict } = useI18n();
   const visuals = [
-    <AgendaFace key="a" />,
-    <DossierFace key="d" dict={dict} />,
-    <WhatsappFace key="w" dict={dict} />,
+    <AppointmentScreen key="a" dict={dict} />,
+    <RecordScreen key="d" dict={dict} />,
+    <WhatsAppScreen key="w" dict={dict} />,
   ];
 
   return (

--- a/src/components/landing/oltigo/components/sections/features.tsx
+++ b/src/components/landing/oltigo/components/sections/features.tsx
@@ -29,7 +29,7 @@ export function Features() {
 
         <div className="mt-20 space-y-24 sm:space-y-32">
           {dict.features.map((f, i) => (
-            <FeatureRow key={f.num} feature={f} visual={visuals[i]} reversed={i % 2 === 1} />
+            <FeatureRow key={f.id} feature={f} visual={visuals[i]} reversed={i % 2 === 1} />
           ))}
         </div>
       </div>
@@ -42,17 +42,17 @@ function FeatureRow({
   visual,
   reversed,
 }: {
-  feature: { num: string; title: string; tagline: string; bullets: string[] };
+  feature: { id: string; num: string; title: string; tagline: string; bullets: string[] };
   visual: React.ReactNode;
   reversed: boolean;
 }) {
   return (
-    <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
+    <div id={feature.id} className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16">
       {/* copy */}
       <div className={reversed ? "lg:order-2" : ""}>
         <Reveal>
           <div className="flex items-baseline gap-3">
-            <span className="telemetry text-[13px] text-emerald/70">{feature.num}</span>
+            <span className="telemetry text-[14px] text-emerald/70">{feature.num}</span>
             <span className="h-px w-10 bg-hairline" />
           </div>
         </Reveal>
@@ -69,7 +69,7 @@ function FeatureRow({
             <Reveal key={i} delay={160 + i * 50} as="li">
               <span className="flex items-start gap-3">
                 <Check
-                  className="mt-0.5 size-4 shrink-0 text-emerald"
+                  className="mt-0.5 size-[18px] shrink-0 text-emerald"
                   strokeWidth={1.75}
                   aria-hidden
                 />

--- a/src/components/landing/oltigo/components/sections/features.tsx
+++ b/src/components/landing/oltigo/components/sections/features.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { ArrowRight, Check } from "lucide-react";
 import {
   AgendaFace,
   DossierFace,
   WhatsappFace,
 } from "@/components/landing/oltigo/components/hero/faces";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
+import { Button } from "@/components/landing/oltigo/components/ui/button";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { SectionHeading } from "./section-kit";
 
@@ -42,7 +43,14 @@ function FeatureRow({
   visual,
   reversed,
 }: {
-  feature: { id: string; num: string; title: string; tagline: string; bullets: string[] };
+  feature: {
+    id: string;
+    num: string;
+    title: string;
+    tagline: string;
+    bullets: string[];
+    cta: string;
+  };
   visual: React.ReactNode;
   reversed: boolean;
 }) {
@@ -78,6 +86,15 @@ function FeatureRow({
             </Reveal>
           ))}
         </ul>
+        <Reveal delay={360}>
+          <Button variant="secondary" size="sm" href="#demo" className="mt-8 group/btn">
+            {feature.cta}
+            <ArrowRight
+              className="size-4 transition-transform group-hover/btn:translate-x-0.5 rtl:rotate-180"
+              strokeWidth={1.75}
+            />
+          </Button>
+        </Reveal>
       </div>
 
       {/* visual */}

--- a/src/components/landing/oltigo/components/sections/features.tsx
+++ b/src/components/landing/oltigo/components/sections/features.tsx
@@ -83,7 +83,11 @@ function FeatureRow({
       {/* visual */}
       <div className={reversed ? "lg:order-1" : ""}>
         <Reveal delay={80}>
-          <div className="blueprint-grid relative flex min-h-[320px] items-center justify-center overflow-hidden rounded-2xl border border-hairline bg-surface/40 p-8">
+          <div
+            className="blueprint-grid relative flex min-h-[320px] items-center justify-center overflow-hidden rounded-2xl border border-hairline bg-surface/40 p-8"
+            role="img"
+            aria-label={feature.title}
+          >
             <div
               className="pointer-events-none absolute inset-0"
               style={{
@@ -91,7 +95,7 @@ function FeatureRow({
                   "radial-gradient(80% 60% at 50% 0%, rgba(255,255,255,0.03), transparent 60%)",
               }}
             />
-            <div style={{ transform: "scale(1.05)" }}>{visual}</div>
+            <div>{visual}</div>
           </div>
         </Reveal>
       </div>

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -22,7 +22,7 @@ import { Wordmark } from "./section-kit";
  */
 const FOOTER_HREFS: string[][] = [
   // 0 — Product / Produit / المنتج
-  ["/#features", "#how", "/#demo", "/pricing"],
+  ["/#appointments", "/#records", "/#whatsapp", "/pricing"],
   // 1 — Resources / Ressources / الموارد
   ["/api-docs", "/how-to-book", "/status", "/blog"],
   // 2 — Company / Entreprise / الشركة

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -45,6 +45,10 @@ function isStaticAsset(href: string): boolean {
   return href.startsWith("/.well-known/");
 }
 
+function isExternal(href: string): boolean {
+  return href.startsWith("/status");
+}
+
 export function Footer() {
   const { dict } = useI18n();
   const year = new Date().getFullYear();
@@ -59,6 +63,8 @@ export function Footer() {
             </p>
             <Link
               href="/status"
+              target="_blank"
+              rel="noopener"
               className="mt-5 inline-flex items-center gap-2 transition-opacity hover:opacity-80"
             >
               <span className="size-1.5 animate-soft-pulse rounded-full bg-emerald" />
@@ -111,6 +117,7 @@ export function Footer() {
                         <Link
                           href={href}
                           {...(isAnchor(href) ? {} : { rel: "noopener" })}
+                          {...(isExternal(href) ? { target: "_blank", rel: "noopener" } : {})}
                           className="text-[13.5px] text-text-secondary transition-colors hover:text-text"
                         >
                           {link}

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Shield } from "lucide-react";
+import { Mail, MapPin, Phone, Shield } from "lucide-react";
 import Link from "next/link";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { defaultWebsiteConfig } from "@/lib/website-config";
 import { Wordmark } from "./section-kit";
 
 /**
@@ -21,7 +22,7 @@ import { Wordmark } from "./section-kit";
  */
 const FOOTER_HREFS: string[][] = [
   // 0 — Product / Produit / المنتج
-  ["/#features", "/#features", "/#demo", "/pricing"],
+  ["/#features", "#how", "/#demo", "/pricing"],
   // 1 — Resources / Ressources / الموارد
   ["/api-docs", "/how-to-book", "/status", "/blog"],
   // 2 — Company / Entreprise / الشركة
@@ -65,6 +66,26 @@ export function Footer() {
                 {dict.nav.status}
               </span>
             </Link>
+            <div className="mt-5 space-y-1.5">
+              <a
+                href={`tel:${defaultWebsiteConfig.contact.phone.replace(/\s|-/g, "")}`}
+                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text"
+              >
+                <Phone className="size-3.5 text-text-muted" aria-hidden="true" />
+                {defaultWebsiteConfig.contact.phone}
+              </a>
+              <a
+                href={`mailto:${defaultWebsiteConfig.contact.email}`}
+                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text"
+              >
+                <Mail className="size-3.5 text-text-muted" aria-hidden="true" />
+                {defaultWebsiteConfig.contact.email}
+              </a>
+              <p className="flex items-center gap-2 text-[12.5px] text-text-secondary">
+                <MapPin className="size-3.5 text-text-muted" aria-hidden="true" />
+                {defaultWebsiteConfig.contact.address}
+              </p>
+            </div>
           </div>
 
           {dict.footer.columns.map((col, colIndex) => (

--- a/src/components/landing/oltigo/components/sections/how-it-works.tsx
+++ b/src/components/landing/oltigo/components/sections/how-it-works.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { BarChart3, Settings, ShieldCheck, UserPlus, Users } from "lucide-react";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { SectionHeading } from "./section-kit";
+
+const stepIcons = [UserPlus, Settings, Users, BarChart3];
 
 export function HowItWorks() {
   const { dict } = useI18n();
@@ -18,20 +21,31 @@ export function HowItWorks() {
             className="absolute inset-x-0 top-[14px] hidden h-px bg-hairline lg:block"
           />
           <ol className="grid gap-10 sm:grid-cols-2 lg:grid-cols-4 lg:gap-8">
-            {dict.how.steps.map((s, i) => (
-              <Reveal key={s.num} delay={i * 90} as="li">
-                <div className="relative">
-                  <span className="relative z-10 inline-grid size-7 place-items-center rounded-full border border-hairline bg-ink">
-                    <span className="size-1.5 rounded-full bg-emerald" />
-                  </span>
-                  <span className="telemetry mt-5 block text-[12px] text-text-muted">{s.num}</span>
-                  <h3 className="mt-1.5 text-[17px] font-medium text-text">{s.title}</h3>
-                  <p className="mt-2 max-w-[28ch] text-[14px] leading-relaxed text-text-secondary">
-                    {s.body}
-                  </p>
-                </div>
-              </Reveal>
-            ))}
+            {dict.how.steps.map((s, i) => {
+              const Icon = stepIcons[i];
+              return (
+                <Reveal key={s.num} delay={i * 90} as="li">
+                  <div className="relative">
+                    <span className="relative z-10 inline-grid size-7 place-items-center rounded-full border border-hairline bg-ink">
+                      <Icon className="size-3.5 text-emerald" strokeWidth={1.5} aria-hidden />
+                    </span>
+                    <span className="telemetry mt-5 block text-[12px] text-text-muted">
+                      {s.num}
+                    </span>
+                    <h3 className="mt-1.5 text-[17px] font-medium text-text">{s.title}</h3>
+                    <p className="mt-2 max-w-[28ch] text-[14px] leading-relaxed text-text-secondary">
+                      {s.body}
+                    </p>
+                    {i === 2 && dict.how.securityNote ? (
+                      <p className="mt-3 flex items-start gap-1.5 text-[12px] leading-relaxed text-emerald/80">
+                        <ShieldCheck className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                        {dict.how.securityNote}
+                      </p>
+                    ) : null}
+                  </div>
+                </Reveal>
+              );
+            })}
           </ol>
         </div>
       </div>

--- a/src/components/landing/oltigo/components/sections/mobile-cta-bar.tsx
+++ b/src/components/landing/oltigo/components/sections/mobile-cta-bar.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/landing/oltigo/components/ui/button";
+import { useI18n } from "@/components/landing/oltigo/i18n/context";
+
+export function MobileCtaBar() {
+  const { dict } = useI18n();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 420);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-hairline bg-ink/95 px-4 py-3 backdrop-blur-md md:hidden">
+      <div className="mx-auto flex max-w-7xl items-center gap-3">
+        <Button variant="secondary" size="md" href="#demo" className="flex-1">
+          {dict.cta.submit}
+        </Button>
+        <Button variant="primary" size="md" href="/register-clinic" className="flex-1">
+          {dict.hero.ctaPrimary}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/oltigo/components/sections/multi-tenant.tsx
+++ b/src/components/landing/oltigo/components/sections/multi-tenant.tsx
@@ -29,9 +29,9 @@ export function MultiTenant() {
                   <span className="grid size-8 place-items-center rounded-lg border border-hairline bg-ink">
                     <Lock className="size-3.5 text-text-secondary" strokeWidth={1.5} aria-hidden />
                   </span>
-                  <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald/30 bg-emerald/10 px-2 py-0.5">
-                    <span className="size-1 rounded-full bg-emerald" />
-                    <span className="telemetry text-[9.5px] uppercase tracking-wider text-emerald">
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald/40 bg-emerald/15 px-2.5 py-1">
+                    <ShieldCheck className="size-3 text-emerald" strokeWidth={2} aria-hidden />
+                    <span className="telemetry text-[11px] font-medium uppercase tracking-wider text-emerald">
                       {dict.tenant.isolated}
                     </span>
                   </span>

--- a/src/components/landing/oltigo/components/sections/nav.tsx
+++ b/src/components/landing/oltigo/components/sections/nav.tsx
@@ -59,9 +59,11 @@ export function Nav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
-            {dict.nav.patientSpace}
-          </Button>
+          <div className="hidden sm:block">
+            <Button variant="secondary" size="sm" href="/annuaire">
+              {dict.nav.patientSpace}
+            </Button>
+          </div>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/nav.tsx
+++ b/src/components/landing/oltigo/components/sections/nav.tsx
@@ -8,6 +8,7 @@ import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { locales, localeLabel, type Locale } from "@/components/landing/oltigo/i18n/dictionaries";
 import { cn } from "@/lib/utils";
 import { Wordmark } from "./section-kit";
+import { useActiveAnchor } from "./use-active-anchor";
 
 export function Nav() {
   const { dict, locale, setLocale } = useI18n();
@@ -27,6 +28,8 @@ export function Nav() {
     { href: "#pricing", label: dict.nav.sections.pricing },
     { href: "#faq", label: dict.nav.sections.faq },
   ];
+  const anchorIds = links.map((l) => l.href.replace("#", ""));
+  const activeAnchor = useActiveAnchor(anchorIds);
 
   return (
     <header
@@ -52,15 +55,22 @@ export function Nav() {
         </Link>
 
         <div className="hidden items-center gap-7 md:flex">
-          {links.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              className="text-[13.5px] text-text-secondary transition-colors hover:text-text"
-            >
-              {l.label}
-            </Link>
-          ))}
+          {links.map((l) => {
+            const isActive = activeAnchor === l.href.replace("#", "");
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                aria-current={isActive ? "location" : undefined}
+                className={cn(
+                  "text-[13.5px] transition-colors hover:text-text",
+                  isActive ? "font-medium text-emerald" : "text-text-secondary",
+                )}
+              >
+                {l.label}
+              </Link>
+            );
+          })}
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/components/landing/oltigo/components/sections/nav.tsx
+++ b/src/components/landing/oltigo/components/sections/nav.tsx
@@ -59,12 +59,9 @@ export function Nav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Link
-            href="/annuaire"
-            className="hidden text-[13.5px] text-text-secondary transition-colors hover:text-text sm:inline"
-          >
+          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>
@@ -99,13 +96,15 @@ export function Nav() {
               {l.label}
             </Link>
           ))}
-          <Link
+          <Button
+            variant="secondary"
+            size="md"
             href="/annuaire"
+            className="w-full"
             onClick={() => setMobileOpen(false)}
-            className="text-[15px] text-text-secondary transition-colors hover:text-text"
           >
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/nav.tsx
+++ b/src/components/landing/oltigo/components/sections/nav.tsx
@@ -37,6 +37,12 @@ export function Nav() {
           : "border-b border-transparent",
       )}
     >
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-[10px] focus:bg-emerald focus:px-4 focus:py-2 focus:text-ink"
+      >
+        {dict.nav.skipToContent}
+      </a>
       <nav
         className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-6"
         aria-label={dict.nav.menu}
@@ -59,12 +65,10 @@ export function Nav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <div className="hidden sm:block">
-            <Button variant="secondary" size="sm" href="/annuaire">
-              {dict.nav.patientSpace}
-            </Button>
-          </div>
-          <Button variant="primary" size="sm" href="/register-clinic">
+          <Button variant="secondary" size="sm" href="/annuaire">
+            {dict.nav.patientSpace}
+          </Button>
+          <Button variant="secondary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>
           <button
@@ -107,7 +111,13 @@ export function Nav() {
           >
             {dict.nav.patientSpace}
           </Button>
-          <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
+          <Button
+            variant="secondary"
+            size="md"
+            href="/register-clinic"
+            className="mt-2 w-full"
+            onClick={() => setMobileOpen(false)}
+          >
             {dict.nav.doctorSpace}
           </Button>
         </div>

--- a/src/components/landing/oltigo/components/sections/pricing.tsx
+++ b/src/components/landing/oltigo/components/sections/pricing.tsx
@@ -49,14 +49,22 @@ export function Pricing({ headingAs = "h2" }: { headingAs?: "h1" | "h2" }) {
                 <p className="mt-1 text-[12.5px] text-text-muted">{tier.blurb}</p>
 
                 <div className="mt-5 flex items-baseline gap-1.5">
-                  <BilingualNumeral
-                    value={tier.price}
-                    className="text-[2.2rem] font-medium text-text"
-                  />
-                  <span className="telemetry text-[12px] text-text-muted">
-                    {dict.pricing.currency}
-                  </span>
-                  <span className="text-[12px] text-text-muted">{tier.cadence}</span>
+                  {tier.id === "free" ? (
+                    <span className="text-[2.2rem] font-medium text-text">
+                      {dict.pricing.freeLabel}
+                    </span>
+                  ) : (
+                    <>
+                      <BilingualNumeral
+                        value={tier.price}
+                        className="text-[2.2rem] font-medium text-text"
+                      />
+                      <span className="telemetry text-[12px] text-text-muted">
+                        {dict.pricing.currency}
+                      </span>
+                      <span className="text-[12px] text-text-muted">{tier.cadence}</span>
+                    </>
+                  )}
                 </div>
 
                 <Button
@@ -67,6 +75,11 @@ export function Pricing({ headingAs = "h2" }: { headingAs?: "h1" | "h2" }) {
                 >
                   {tier.cta}
                 </Button>
+                {tier.id === "enterprise" ? (
+                  <p className="mt-2 text-center text-[12px] text-text-muted">
+                    {dict.pricing.enterpriseReply}
+                  </p>
+                ) : null}
 
                 <ul className="mt-6 space-y-2.5 border-t border-hairline pt-6">
                   {tier.features.map((feat, j) => (

--- a/src/components/landing/oltigo/components/sections/pricing.tsx
+++ b/src/components/landing/oltigo/components/sections/pricing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Landmark } from "lucide-react";
+import { Check, ChevronDown, Landmark } from "lucide-react";
 import { BilingualNumeral } from "@/components/landing/oltigo/components/primitives/bilingual-numeral";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
@@ -111,6 +111,53 @@ export function Pricing({ headingAs = "h2" }: { headingAs?: "h1" | "h2" }) {
             <Landmark className="size-4" aria-hidden />
             {dict.pricing.note}
           </p>
+        </Reveal>
+
+        <Reveal delay={120}>
+          <details className="group mt-8">
+            <summary className="flex cursor-pointer list-none items-center justify-center gap-2 text-[13px] font-medium text-text-secondary transition-colors hover:text-text [&::-webkit-details-marker]:hidden">
+              {dict.pricing.compareTitle}
+              <ChevronDown
+                className="size-4 shrink-0 transition-transform group-open:rotate-180"
+                strokeWidth={1.75}
+                aria-hidden
+              />
+            </summary>
+            <div className="mt-6 overflow-x-auto">
+              <table className="w-full min-w-[640px] border-collapse text-left">
+                <caption className="sr-only">{dict.pricing.compareCaption}</caption>
+                <thead>
+                  <tr className="border-b border-hairline">
+                    {dict.pricing.tiers.map((tier) => (
+                      <th key={tier.id} className="py-3 pr-4 text-[13px] font-medium text-text">
+                        {tier.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    {dict.pricing.tiers.map((tier) => (
+                      <td key={tier.id} className="py-3 pr-4 align-top">
+                        <ul className="space-y-2">
+                          {tier.features.map((feat, idx) => (
+                            <li key={idx} className="flex items-start gap-2">
+                              <Check
+                                className="mt-0.5 size-3.5 shrink-0 text-emerald"
+                                strokeWidth={1.75}
+                                aria-hidden
+                              />
+                              <span className="text-[12.5px] text-text-secondary">{feat}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </details>
         </Reveal>
       </div>
     </section>

--- a/src/components/landing/oltigo/components/sections/pricing.tsx
+++ b/src/components/landing/oltigo/components/sections/pricing.tsx
@@ -89,7 +89,9 @@ export function Pricing({ headingAs = "h2" }: { headingAs?: "h1" | "h2" }) {
         </div>
 
         <Reveal>
-          <p className="mt-8 text-center text-[12.5px] text-text-muted">{dict.pricing.note}</p>
+          <p className="mt-10 flex flex-wrap items-center justify-center gap-x-2 rounded-full border border-hairline bg-surface/40 px-4 py-2 text-center text-[13px] text-text-secondary">
+            {dict.pricing.note}
+          </p>
         </Reveal>
       </div>
     </section>

--- a/src/components/landing/oltigo/components/sections/pricing.tsx
+++ b/src/components/landing/oltigo/components/sections/pricing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { Check, Landmark } from "lucide-react";
 import { BilingualNumeral } from "@/components/landing/oltigo/components/primitives/bilingual-numeral";
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { Button } from "@/components/landing/oltigo/components/ui/button";
@@ -96,13 +96,19 @@ export function Pricing({ headingAs = "h2" }: { headingAs?: "h1" | "h2" }) {
                     </li>
                   ))}
                 </ul>
+
+                <div className="mt-auto flex items-start gap-2 pt-5 text-[11.5px] leading-snug text-text-muted">
+                  <Landmark className="mt-0.5 size-3.5 shrink-0 text-emerald" aria-hidden />
+                  {dict.pricing.note}
+                </div>
               </div>
             </Reveal>
           ))}
         </div>
 
         <Reveal>
-          <p className="mt-10 flex flex-wrap items-center justify-center gap-x-2 rounded-full border border-hairline bg-surface/40 px-4 py-2 text-center text-[13px] text-text-secondary">
+          <p className="mt-10 flex flex-wrap items-center justify-center gap-x-2 rounded-full border border-emerald/30 bg-emerald/10 px-4 py-2.5 text-center text-[13px] font-medium text-emerald">
+            <Landmark className="size-4" aria-hidden />
             {dict.pricing.note}
           </p>
         </Reveal>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -62,13 +62,13 @@ export function PublicNav() {
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
           <Link
-            href="/login"
+            href="/annuaire"
             className="hidden text-[13.5px] text-text-secondary transition-colors hover:text-text sm:inline"
           >
-            {dict.nav.login}
+            {dict.nav.patientSpace}
           </Link>
           <Button variant="primary" size="sm" href="/register-clinic">
-            {dict.nav.openAccount}
+            {dict.nav.doctorSpace}
           </Button>
           <button
             type="button"
@@ -102,14 +102,14 @@ export function PublicNav() {
             </Link>
           ))}
           <Link
-            href="/login"
+            href="/annuaire"
             onClick={() => setMobileOpen(false)}
             className="text-[15px] text-text-secondary transition-colors hover:text-text"
           >
-            {dict.nav.login}
+            {dict.nav.patientSpace}
           </Link>
           <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
-            {dict.nav.openAccount}
+            {dict.nav.doctorSpace}
           </Button>
         </div>
       </div>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -61,9 +61,11 @@ export function PublicNav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
-            {dict.nav.patientSpace}
-          </Button>
+          <div className="hidden sm:block">
+            <Button variant="secondary" size="sm" href="/annuaire">
+              {dict.nav.patientSpace}
+            </Button>
+          </div>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -8,6 +8,7 @@ import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { locales, localeLabel, type Locale } from "@/components/landing/oltigo/i18n/dictionaries";
 import { cn } from "@/lib/utils";
 import { Wordmark } from "./section-kit";
+import { useActiveAnchor } from "./use-active-anchor";
 
 const links = [
   { href: "/#features", labelKey: "features" as const },
@@ -29,6 +30,10 @@ export function PublicNav() {
   }, []);
 
   const sectionLabels = dict.nav.sections;
+  const anchorIds = links
+    .map((l) => l.href.split("#")[1])
+    .filter((id): id is string => Boolean(id));
+  const activeAnchor = useActiveAnchor(anchorIds);
 
   return (
     <header
@@ -54,15 +59,22 @@ export function PublicNav() {
         </Link>
 
         <div className="hidden items-center gap-7 md:flex">
-          {links.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              className="text-[13.5px] text-text-secondary transition-colors hover:text-text"
-            >
-              {sectionLabels[l.labelKey]}
-            </Link>
-          ))}
+          {links.map((l) => {
+            const isActive = activeAnchor === l.href.split("#")[1];
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                aria-current={isActive ? "location" : undefined}
+                className={cn(
+                  "text-[13.5px] transition-colors hover:text-text",
+                  isActive ? "font-medium text-emerald" : "text-text-secondary",
+                )}
+              >
+                {sectionLabels[l.labelKey]}
+              </Link>
+            );
+          })}
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -61,12 +61,9 @@ export function PublicNav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <Link
-            href="/annuaire"
-            className="hidden text-[13.5px] text-text-secondary transition-colors hover:text-text sm:inline"
-          >
+          <Button variant="secondary" size="sm" href="/annuaire" className="hidden sm:inline-flex">
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>
@@ -101,13 +98,15 @@ export function PublicNav() {
               {sectionLabels[l.labelKey]}
             </Link>
           ))}
-          <Link
+          <Button
+            variant="secondary"
+            size="md"
             href="/annuaire"
+            className="w-full"
             onClick={() => setMobileOpen(false)}
-            className="text-[15px] text-text-secondary transition-colors hover:text-text"
           >
             {dict.nav.patientSpace}
-          </Link>
+          </Button>
           <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
             {dict.nav.doctorSpace}
           </Button>

--- a/src/components/landing/oltigo/components/sections/public-nav.tsx
+++ b/src/components/landing/oltigo/components/sections/public-nav.tsx
@@ -39,6 +39,12 @@ export function PublicNav() {
           : "border-b border-transparent",
       )}
     >
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-[10px] focus:bg-emerald focus:px-4 focus:py-2 focus:text-ink"
+      >
+        {dict.nav.skipToContent}
+      </a>
       <nav
         className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-6"
         aria-label={dict.nav.menu}
@@ -61,12 +67,10 @@ export function PublicNav() {
 
         <div className="flex items-center gap-2">
           <LangToggle locale={locale} setLocale={setLocale} />
-          <div className="hidden sm:block">
-            <Button variant="secondary" size="sm" href="/annuaire">
-              {dict.nav.patientSpace}
-            </Button>
-          </div>
-          <Button variant="primary" size="sm" href="/register-clinic">
+          <Button variant="secondary" size="sm" href="/annuaire">
+            {dict.nav.patientSpace}
+          </Button>
+          <Button variant="secondary" size="sm" href="/register-clinic">
             {dict.nav.doctorSpace}
           </Button>
           <button
@@ -109,7 +113,13 @@ export function PublicNav() {
           >
             {dict.nav.patientSpace}
           </Button>
-          <Button variant="primary" size="md" href="/register-clinic" className="mt-2 w-full">
+          <Button
+            variant="secondary"
+            size="md"
+            href="/register-clinic"
+            className="mt-2 w-full"
+            onClick={() => setMobileOpen(false)}
+          >
             {dict.nav.doctorSpace}
           </Button>
         </div>

--- a/src/components/landing/oltigo/components/sections/section-kit.tsx
+++ b/src/components/landing/oltigo/components/sections/section-kit.tsx
@@ -1,10 +1,12 @@
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
+import { useI18n } from "@/components/landing/oltigo/i18n/context";
 import { cn } from "@/lib/utils";
 
 export function Wordmark({ className }: { className?: string }) {
+  const { dict } = useI18n();
   return (
     <span className={cn("telemetry text-[15px] font-medium tracking-tight text-text", className)}>
-      oltig<span className="text-emerald">.</span>o
+      {dict.nav.brand}
     </span>
   );
 }

--- a/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
+++ b/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
@@ -58,7 +58,9 @@ export function TelemetryTicker() {
             >
               {it.label}
             </span>
-            <span className="sr-only">:</span>
+            <span className="text-[10px] text-text-muted" aria-hidden="true">
+              :
+            </span>
             <span className="telemetry text-[12px] font-medium text-cyan" aria-hidden="true">
               {it.value}
             </span>

--- a/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
+++ b/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 import { Pause, Play } from "lucide-react";
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { cn } from "@/lib/utils";
 
 /** Metrics ticker — a mono row streaming static metrics in cyan, seamless loop. */
 export function TelemetryTicker() {
   const { dict } = useI18n();
   const [paused, setPaused] = useState(false);
+
+  const reducedMotion = useSyncExternalStore(
+    (callback) => {
+      if (typeof window === "undefined") return () => {};
+      const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+      mq.addEventListener("change", callback);
+      return () => mq.removeEventListener("change", callback);
+    },
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    () => false,
+  );
+
   const items: { label: string; value: string }[] = [
     { label: dict.telemetry.rdv, value: "1 248" },
     { label: dict.telemetry.p95, value: "182 ms" },
@@ -23,16 +38,30 @@ export function TelemetryTicker() {
       <div className="pointer-events-none absolute inset-y-0 start-0 z-10 w-24 bg-gradient-to-r from-ink to-transparent" />
       <div className="pointer-events-none absolute inset-y-0 end-0 z-10 w-24 bg-gradient-to-l from-ink to-transparent" />
       <div
-        className="flex w-max animate-ticker gap-10 hover:[animation-play-state:paused] active:[animation-play-state:paused]"
-        style={{ animationPlayState: paused ? "paused" : "running" }}
+        className={cn(
+          "flex w-max gap-10",
+          !reducedMotion &&
+            "animate-ticker hover:[animation-play-state:paused] active:[animation-play-state:paused]",
+        )}
+        style={{ animationPlayState: reducedMotion || paused ? "paused" : "running" }}
       >
         {row.map((it, i) => (
-          <span key={i} className="flex shrink-0 items-center gap-2.5">
-            <span className="size-1 rounded-full bg-cyan" />
-            <span className="telemetry text-[11px] uppercase tracking-[0.14em] text-text-secondary">
+          <span
+            key={i}
+            className="flex shrink-0 items-center gap-2.5"
+            aria-label={`${it.label}: ${it.value}`}
+          >
+            <span className="size-1 rounded-full bg-cyan" aria-hidden="true" />
+            <span
+              className="telemetry text-[11px] uppercase tracking-[0.14em] text-text-secondary"
+              aria-hidden="true"
+            >
               {it.label}
             </span>
-            <span className="telemetry text-[12px] font-medium text-cyan">{it.value}</span>
+            <span className="sr-only">:</span>
+            <span className="telemetry text-[12px] font-medium text-cyan" aria-hidden="true">
+              {it.value}
+            </span>
           </span>
         ))}
       </div>

--- a/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
+++ b/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
@@ -19,7 +19,7 @@ export function TelemetryTicker() {
       {/* edge fades */}
       <div className="pointer-events-none absolute inset-y-0 start-0 z-10 w-24 bg-gradient-to-r from-ink to-transparent" />
       <div className="pointer-events-none absolute inset-y-0 end-0 z-10 w-24 bg-gradient-to-l from-ink to-transparent" />
-      <div className="flex w-max animate-ticker gap-10">
+      <div className="flex w-max animate-ticker gap-10 hover:[animation-play-state:paused] active:[animation-play-state:paused]">
         {row.map((it, i) => (
           <span key={i} className="flex shrink-0 items-center gap-2.5">
             <span className="size-1 rounded-full bg-cyan" />

--- a/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
+++ b/src/components/landing/oltigo/components/sections/telemetry-ticker.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { Pause, Play } from "lucide-react";
+import { useState } from "react";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
 
-/** Live telemetry ticker — a mono row streaming metrics in cyan, seamless loop. */
+/** Metrics ticker — a mono row streaming static metrics in cyan, seamless loop. */
 export function TelemetryTicker() {
   const { dict } = useI18n();
+  const [paused, setPaused] = useState(false);
   const items: { label: string; value: string }[] = [
     { label: dict.telemetry.rdv, value: "1 248" },
     { label: dict.telemetry.p95, value: "182 ms" },
@@ -15,11 +18,14 @@ export function TelemetryTicker() {
   const row = [...items, ...items];
 
   return (
-    <div className="relative overflow-hidden border-y border-hairline bg-surface/30 py-3 ps-24">
+    <div className="group relative overflow-hidden border-y border-hairline bg-surface/30 py-3 ps-24">
       {/* edge fades */}
       <div className="pointer-events-none absolute inset-y-0 start-0 z-10 w-24 bg-gradient-to-r from-ink to-transparent" />
       <div className="pointer-events-none absolute inset-y-0 end-0 z-10 w-24 bg-gradient-to-l from-ink to-transparent" />
-      <div className="flex w-max animate-ticker gap-10 hover:[animation-play-state:paused] active:[animation-play-state:paused]">
+      <div
+        className="flex w-max animate-ticker gap-10 hover:[animation-play-state:paused] active:[animation-play-state:paused]"
+        style={{ animationPlayState: paused ? "paused" : "running" }}
+      >
         {row.map((it, i) => (
           <span key={i} className="flex shrink-0 items-center gap-2.5">
             <span className="size-1 rounded-full bg-cyan" />
@@ -30,6 +36,15 @@ export function TelemetryTicker() {
           </span>
         ))}
       </div>
+      <button
+        type="button"
+        onClick={() => setPaused((p) => !p)}
+        aria-pressed={paused}
+        aria-label={paused ? dict.telemetry.play : dict.telemetry.pause}
+        className="absolute end-4 top-1/2 z-20 -translate-y-1/2 rounded-full border border-hairline bg-ink/80 p-2 text-text-secondary opacity-0 backdrop-blur-sm transition-opacity hover:text-text focus:opacity-100 group-hover:opacity-100"
+      >
+        {paused ? <Play className="size-3.5" /> : <Pause className="size-3.5" />}
+      </button>
     </div>
   );
 }

--- a/src/components/landing/oltigo/components/sections/testimonials.tsx
+++ b/src/components/landing/oltigo/components/sections/testimonials.tsx
@@ -30,6 +30,9 @@ export function Testimonials() {
                 <blockquote className="text-[15px] leading-relaxed text-text">
                   &ldquo;{t.quote}&rdquo;
                 </blockquote>
+                {t.metric ? (
+                  <p className="mt-5 text-[13px] font-medium text-emerald">{t.metric}</p>
+                ) : null}
                 <figcaption className="mt-7 flex items-center gap-3 border-t border-hairline pt-5">
                   <div
                     className={cn(

--- a/src/components/landing/oltigo/components/sections/testimonials.tsx
+++ b/src/components/landing/oltigo/components/sections/testimonials.tsx
@@ -2,7 +2,19 @@
 
 import { Reveal } from "@/components/landing/oltigo/components/primitives/reveal";
 import { useI18n } from "@/components/landing/oltigo/i18n/context";
+import { cn } from "@/lib/utils";
 import { SectionHeading } from "./section-kit";
+
+function getInitials(name: string): string {
+  const parts = name
+    .replace(/^(dr\.?|doctor|med\.?)\s*/i, "")
+    .split(/\s+/)
+    .filter(Boolean);
+  return parts
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("");
+}
 
 export function Testimonials() {
   const { dict } = useI18n();
@@ -18,16 +30,31 @@ export function Testimonials() {
                 <blockquote className="text-[15px] leading-relaxed text-text">
                   &ldquo;{t.quote}&rdquo;
                 </blockquote>
-                <figcaption className="mt-7 flex items-center justify-between border-t border-hairline pt-5">
-                  <div>
-                    <p className="text-[13.5px] font-medium text-text">{t.name}</p>
-                    <p className="text-[12px] text-text-muted">
-                      {t.role} · {t.city}
+                <figcaption className="mt-7 flex items-center gap-3 border-t border-hairline pt-5">
+                  <div
+                    className={cn(
+                      "flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full border border-hairline bg-surface text-[12.5px] font-medium text-text",
+                    )}
+                  >
+                    {t.avatar ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={t.avatar}
+                        alt=""
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      getInitials(t.name)
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-[13.5px] font-medium text-text">{t.name}</p>
+                    <p className="truncate text-[12px] text-text-muted">
+                      {t.role}
+                      {t.clinic ? ` · ${t.clinic}` : ""} · {t.city}
                     </p>
                   </div>
-                  <span className="telemetry rounded-full border border-hairline px-2.5 py-1 text-[10px] uppercase tracking-wider text-text-secondary">
-                    {t.plan}
-                  </span>
                 </figcaption>
               </figure>
             </Reveal>

--- a/src/components/landing/oltigo/components/sections/use-active-anchor.ts
+++ b/src/components/landing/oltigo/components/sections/use-active-anchor.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useActiveAnchor(ids: string[]) {
+  const [active, setActive] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || ids.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActive(entry.target.id);
+          }
+        });
+      },
+      { rootMargin: "-45% 0px -45% 0px", threshold: 0 },
+    );
+
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, [ids]);
+
+  return active;
+}

--- a/src/components/landing/oltigo/components/ui/accordion.tsx
+++ b/src/components/landing/oltigo/components/ui/accordion.tsx
@@ -6,6 +6,24 @@ import { cn } from "@/lib/utils";
 
 type Item = { q: string; a: string };
 
+function RichAnswer({ text }: { text: string }) {
+  const segments = text.split(/(\*\*[^*]+\*\*)/g);
+  return (
+    <>
+      {segments.map((segment, i) => {
+        if (segment.startsWith("**") && segment.endsWith("**")) {
+          return (
+            <strong key={i} className="font-medium text-text">
+              {segment.slice(2, -2)}
+            </strong>
+          );
+        }
+        return <span key={i}>{segment}</span>;
+      })}
+    </>
+  );
+}
+
 /** Accessible single-open accordion (shadcn-style), no external deps. */
 export function Accordion({ items }: { items: Item[] }) {
   const [open, setOpen] = useState<number | null>(0);
@@ -46,7 +64,7 @@ export function Accordion({ items }: { items: Item[] }) {
               className="grid"
             >
               <p className="max-w-[60ch] pb-6 text-[14.5px] leading-relaxed text-text-secondary">
-                {item.a}
+                <RichAnswer text={item.a} />
               </p>
             </div>
           </div>

--- a/src/components/landing/oltigo/i18n/context.tsx
+++ b/src/components/landing/oltigo/i18n/context.tsx
@@ -37,6 +37,7 @@ function syncLocale(l: Locale) {
       secure: window.location.protocol === "https:",
       sameSite: "lax",
     });
+    window.dispatchEvent(new CustomEvent("oltigo:locale", { detail: l }));
   } catch {
     /* storage unavailable — non-fatal */
   }

--- a/src/components/landing/oltigo/i18n/context.tsx
+++ b/src/components/landing/oltigo/i18n/context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Cookies from "js-cookie";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import {
   dictionaries,
@@ -18,6 +19,28 @@ type I18nValue = {
 
 const I18nContext = createContext<I18nValue | null>(null);
 const STORAGE_KEY = "oltigo.locale";
+// Sync with the app-wide locale key so the global cookie banner reads the same value.
+const PREFERRED_LOCALE_KEY = "preferred-locale";
+
+function isValidLocale(value: unknown): value is Locale {
+  return typeof value === "string" && value in dictionaries;
+}
+
+function syncLocale(l: Locale) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, l);
+    window.localStorage.setItem(PREFERRED_LOCALE_KEY, l);
+    Cookies.set(PREFERRED_LOCALE_KEY, l, {
+      expires: 365,
+      path: "/",
+      secure: window.location.protocol === "https:",
+      sameSite: "lax",
+    });
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const [locale, setLocaleState] = useState<Locale>(defaultLocale);
@@ -25,10 +48,12 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
   // Hydrate from storage / browser without causing a mismatch (runs post-mount).
   useEffect(() => {
     const timeouts: ReturnType<typeof setTimeout>[] = [];
-    const stored = (typeof window !== "undefined" &&
-      window.localStorage.getItem(STORAGE_KEY)) as Locale | null;
+    const stored =
+      (typeof window !== "undefined" && window.localStorage.getItem(STORAGE_KEY)) ||
+      (typeof window !== "undefined" && window.localStorage.getItem(PREFERRED_LOCALE_KEY)) ||
+      null;
 
-    if (stored && stored in dictionaries) {
+    if (isValidLocale(stored)) {
       timeouts.push(
         setTimeout(() => {
           setLocaleState(stored);
@@ -50,11 +75,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   const setLocale = useCallback((l: Locale) => {
     setLocaleState(l);
-    try {
-      window.localStorage.setItem(STORAGE_KEY, l);
-    } catch {
-      /* storage unavailable — non-fatal */
-    }
+    syncLocale(l);
   }, []);
 
   const value: I18nValue = {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -20,7 +20,14 @@ export const localeLabel: Record<Locale, string> = {
   en: "EN",
 };
 
-type Feature = { id: string; num: string; title: string; tagline: string; bullets: string[] };
+type Feature = {
+  id: string;
+  num: string;
+  title: string;
+  tagline: string;
+  bullets: string[];
+  cta: string;
+};
 type Step = { num: string; title: string; body: string };
 type Tier = {
   id: string;
@@ -199,6 +206,7 @@ const fr: Dictionary = {
         "Vue semaine unifiée, multi-praticiens",
         "Réduction mesurable des absences",
       ],
+      cta: "Voir la prise de rendez-vous",
     },
     {
       id: "records",
@@ -211,6 +219,7 @@ const fr: Dictionary = {
         "Ordonnances et documents en un endroit",
         "Accès réservé à votre équipe",
       ],
+      cta: "Découvrir le dossier patient",
     },
     {
       id: "whatsapp",
@@ -223,6 +232,7 @@ const fr: Dictionary = {
         "Confirmation par simple réponse « OUI »",
         "Moins d’absences, plus de temps de soin",
       ],
+      cta: "Voir les rappels WhatsApp",
     },
   ],
   how: {
@@ -373,35 +383,35 @@ const fr: Dictionary = {
     items: [
       {
         q: "Mes données patients sont-elles en sécurité ?",
-        a: "Oui. Chaque dossier est chiffré en AES-256-GCM au repos, et l’accès est strictement réservé à votre équipe. L’isolation entre cabinets est appliquée au niveau de la base de données.",
+        a: "Oui. Chaque dossier est chiffré en **AES-256-GCM** au repos, et l’accès est **strictement réservé à votre équipe**. L’isolation entre cabinets est appliquée au niveau de la base de données.",
       },
       {
         q: "OLTIGO est-il conforme à la Loi 09-08 ?",
-        a: "Oui. Le traitement et la conservation des données personnelles suivent les exigences de la Loi 09-08 sur la protection des données au Maroc.",
+        a: "Oui. Le traitement et la conservation des données personnelles suivent les exigences de la **Loi 09-08** sur la protection des données au Maroc.",
       },
       {
         q: "Les rappels WhatsApp sont-ils vraiment en darija ?",
-        a: "Oui. Nous fournissons 10 modèles en darija approuvés par Meta, prêts à l’emploi, que vous pouvez personnaliser.",
+        a: "Oui. Nous fournissons **10 modèles en darija approuvés par Meta**, prêts à l’emploi, que vous pouvez personnaliser.",
       },
       {
         q: "Puis-je importer mon fichier patients existant ?",
-        a: "Oui. Vous pouvez importer votre fichier existant ou ajouter vos patients progressivement, sans interruption.",
+        a: "Oui. Vous pouvez **importer votre fichier existant** ou ajouter vos patients progressivement, sans interruption.",
       },
       {
         q: "Combien de temps pour démarrer ?",
-        a: "La plupart des cabinets sont opérationnels en un après-midi : compte, configuration, page de réservation et premiers rappels.",
+        a: "La plupart des cabinets sont **opérationnels en un après-midi** : compte, configuration, page de réservation et premiers rappels.",
       },
       {
         q: "Et si j’ai plusieurs praticiens ou plusieurs sites ?",
-        a: "Les formules Professional et Enterprise gèrent les cabinets de groupe et le multi-sites, avec un sous-domaine dédié par cabinet.",
+        a: "Les formules **Professional et Enterprise** gèrent les cabinets de groupe et le multi-sites, avec un **sous-domaine dédié par cabinet**.",
       },
       {
         q: "Puis-je changer ou résilier ma formule ?",
-        a: "À tout moment, sans engagement. Vous passez d’une formule à l’autre directement depuis votre espace.",
+        a: "**À tout moment, sans engagement**. Vous passez d’une formule à l’autre directement depuis votre espace.",
       },
       {
         q: "Mes patients doivent-ils installer une application ?",
-        a: "Non. La réservation se fait depuis un navigateur, et les rappels arrivent sur WhatsApp, qu’ils utilisent déjà.",
+        a: "Non. La réservation se fait **depuis un navigateur**, et les rappels arrivent sur **WhatsApp**, qu’ils utilisent déjà.",
       },
     ],
   },
@@ -511,6 +521,7 @@ const ar: Dictionary = {
         "عرض أسبوعي موحَّد لعدّة أطباء",
         "خفض ملموس في حالات التغيّب",
       ],
+      cta: "عرض حجز المواعيد",
     },
     {
       id: "records",
@@ -523,6 +534,7 @@ const ar: Dictionary = {
         "الوصفات والوثائق في مكان واحد",
         "وصول محصور في فريقك فقط",
       ],
+      cta: "اكتشف ملف المريض",
     },
     {
       id: "whatsapp",
@@ -535,6 +547,7 @@ const ar: Dictionary = {
         "تأكيد بمجرّد الردّ بـ«نعم»",
         "تغيّب أقل، ووقت رعاية أكثر",
       ],
+      cta: "عرض تذكيرات واتساب",
     },
   ],
   how: {
@@ -651,35 +664,35 @@ const ar: Dictionary = {
     items: [
       {
         q: "هل بيانات مرضاي آمنة؟",
-        a: "نعم. كل ملف مُشفّر بـ AES-256-GCM في حالة السكون، والوصول محصور في فريقك. العزل بين العيادات مُطبَّق على مستوى قاعدة البيانات.",
+        a: "نعم. كل ملف مُشفّر بـ **AES-256-GCM** في حالة السكون، والوصول **محصور في فريقك**. العزل بين العيادات مُطبَّق على مستوى قاعدة البيانات.",
       },
       {
         q: "هل OLTIGO متوافق مع القانون 09-08؟",
-        a: "نعم. تتم معالجة وحفظ البيانات الشخصية وفق متطلّبات القانون 09-08 لحماية البيانات في المغرب.",
+        a: "نعم. تتم معالجة وحفظ البيانات الشخصية وفق متطلّبات **القانون 09-08** لحماية البيانات في المغرب.",
       },
       {
         q: "هل تذكيرات واتساب بالدارجة فعلاً؟",
-        a: "نعم. نوفّر 10 قوالب بالدارجة معتمَدة من Meta وجاهزة للاستعمال، يمكنك تخصيصها.",
+        a: "نعم. نوفّر **10 قوالب بالدارجة معتمَدة من Meta** وجاهزة للاستعمال، يمكنك تخصيصها.",
       },
       {
         q: "هل يمكنني استيراد ملف مرضاي الحالي؟",
-        a: "نعم. يمكنك استيراد ملفّك الحالي أو إضافة مرضاك تدريجيًا، دون انقطاع.",
+        a: "نعم. يمكنك **استيراد ملفّك الحالي** أو إضافة مرضاك تدريجيًا، دون انقطاع.",
       },
       {
         q: "كم يستغرق البدء؟",
-        a: "تصبح معظم العيادات جاهزة في بعد ظهيرة واحدة: الحساب، الإعداد، صفحة الحجز، وأوّل التذكيرات.",
+        a: "تصبح معظم العيادات **جاهزة في بعد ظهيرة واحدة**: الحساب، الإعداد، صفحة الحجز، وأوّل التذكيرات.",
       },
       {
         q: "وماذا لو كان لديّ عدّة أطباء أو مواقع؟",
-        a: "تدعم باقتا Professional وEnterprise العيادات الجماعية والمواقع المتعدّدة، مع نطاق فرعي مخصَّص لكل عيادة.",
+        a: "تدعم باقتا **Professional وEnterprise** العيادات الجماعية والمواقع المتعدّدة، مع **نطاق فرعي مخصَّص لكل عيادة**.",
       },
       {
         q: "هل يمكنني تغيير باقتي أو إلغاؤها؟",
-        a: "في أي وقت، دون التزام. تنتقل بين الباقات مباشرة من فضائك.",
+        a: "**في أي وقت، دون التزام**. تنتقل بين الباقات مباشرة من فضائك.",
       },
       {
         q: "هل يحتاج مرضاي إلى تثبيت تطبيق؟",
-        a: "لا. يتم الحجز من المتصفّح، وتصل التذكيرات عبر واتساب الذي يستعملونه أصلاً.",
+        a: "لا. يتم الحجز **من المتصفّح**، وتصل التذكيرات عبر **واتساب** الذي يستعملونه أصلاً.",
       },
     ],
   },
@@ -786,6 +799,7 @@ const en: Dictionary = {
         "Unified, multi-practitioner week view",
         "A measurable drop in no-shows",
       ],
+      cta: "See appointment booking",
     },
     {
       id: "records",
@@ -798,6 +812,7 @@ const en: Dictionary = {
         "Prescriptions and documents in one place",
         "Access restricted to your team",
       ],
+      cta: "Explore patient records",
     },
     {
       id: "whatsapp",
@@ -810,6 +825,7 @@ const en: Dictionary = {
         "Confirm with a simple \u201cYES\u201d reply",
         "Fewer no-shows, more care time",
       ],
+      cta: "See WhatsApp reminders",
     },
   ],
   how: {
@@ -954,35 +970,35 @@ const en: Dictionary = {
     items: [
       {
         q: "Is my patient data secure?",
-        a: "Yes. Every record is encrypted with AES-256-GCM at rest, and access is strictly limited to your team. Isolation between practices is enforced at the database layer.",
+        a: "Yes. Every record is encrypted with **AES-256-GCM** at rest, and access is **strictly limited to your team**. Isolation between practices is enforced at the database layer.",
       },
       {
         q: "Is OLTIGO compliant with Law 09-08?",
-        a: "Yes. Processing and storage of personal data follow the requirements of Morocco\u2019s Law 09-08 on data protection.",
+        a: "Yes. Processing and storage of personal data follow the requirements of Morocco\u2019s **Law 09-08** on data protection.",
       },
       {
         q: "Are the WhatsApp reminders really in Darija?",
-        a: "Yes. We provide 10 Meta-approved Darija templates, ready to use, which you can customize.",
+        a: "Yes. We provide **10 Meta-approved Darija templates**, ready to use, which you can customize.",
       },
       {
         q: "Can I import my existing patient file?",
-        a: "Yes. You can import your existing file or add patients gradually, with no interruption.",
+        a: "Yes. You can **import your existing file** or add patients gradually, with no interruption.",
       },
       {
         q: "How long does it take to start?",
-        a: "Most practices are live in one afternoon: account, configuration, booking page, and first reminders.",
+        a: "Most practices are **live in one afternoon**: account, configuration, booking page, and first reminders.",
       },
       {
         q: "What if I have several practitioners or sites?",
-        a: "The Professional and Enterprise plans handle group practices and multi-site, with a dedicated subdomain per clinic.",
+        a: "The **Professional and Enterprise** plans handle group practices and multi-site, with a **dedicated subdomain per clinic**.",
       },
       {
         q: "Can I change or cancel my plan?",
-        a: "Anytime, no commitment. You switch plans directly from your workspace.",
+        a: "**Anytime, no commitment**. You switch plans directly from your workspace.",
       },
       {
         q: "Do my patients need to install an app?",
-        a: "No. Booking happens in a browser, and reminders arrive on WhatsApp, which they already use.",
+        a: "No. Booking happens **in a browser**, and reminders arrive on **WhatsApp**, which they already use.",
       },
     ],
   },

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -107,6 +107,8 @@ export type Dictionary = {
     freeLabel: string;
     enterpriseReply: string;
     note: string;
+    compareTitle: string;
+    compareCaption: string;
   };
   faq: {
     eyebrow: string;
@@ -374,6 +376,8 @@ const fr: Dictionary = {
     freeLabel: "Gratuit",
     enterpriseReply: "Réponse sous 24 h ouvrées.",
     note: "Prix hors taxes. Paiement annuel ou virement bancaire disponible. Hébergement et données au standard Loi 09-08.",
+    compareTitle: "Comparer toutes les fonctionnalités",
+    compareCaption: "Détail des fonctionnalités par formule",
   },
   faq: {
     eyebrow: "Questions",
@@ -655,6 +659,8 @@ const ar: Dictionary = {
     freeLabel: "مجاني",
     enterpriseReply: "ردّ خلال 24 ساعة عمل.",
     note: "الأسعار دون احتساب الضريبة. الدفع السنوي أو التحويل البنكي متاح. الاستضافة والبيانات وفق معيار القانون 09-08.",
+    compareTitle: "مقارنة كل الميزات",
+    compareCaption: "تفاصيل الميزات حسب الباقة",
   },
   faq: {
     eyebrow: "أسئلة",
@@ -961,6 +967,8 @@ const en: Dictionary = {
     freeLabel: "Free",
     enterpriseReply: "Reply within 24 business hours.",
     note: "Prices excl. tax. Annual billing or bank transfer available. Hosting and data to the Law 09-08 standard.",
+    compareTitle: "Compare all features",
+    compareCaption: "Feature details by plan",
   },
   faq: {
     eyebrow: "Questions",

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -135,8 +135,8 @@ const fr: Dictionary = {
   },
   hero: {
     eyebrow: "Plateforme pour cabinets médicaux · Maroc",
-    titleLead: "Le calme d’un cabinet",
-    titleAccent: "qui tourne tout seul.",
+    titleLead: "Gérez votre cabinet,",
+    titleAccent: "réduisez les absences.",
     sub: "Gérez votre cabinet, réduisez les absences par WhatsApp et digitalisez vos dossiers patients en un clic. Conçu pour les médecins et gestionnaires de cabinet au Maroc.",
     ctaPrimary: "Ouvrir un compte",
     ctaSecondary: "Trouver mon médecin",
@@ -436,8 +436,8 @@ const ar: Dictionary = {
   },
   hero: {
     eyebrow: "منصّة للعيادات الطبية · المغرب",
-    titleLead: "هدوء عيادة",
-    titleAccent: "تُدار من تلقاء نفسها.",
+    titleLead: "أدِر عيادتك،",
+    titleAccent: "قلّل حالات التغيّب.",
     sub: "أدِر عيادتك، قلّل حالات التغيّب عبر واتساب، وقم برقمنة ملفّات مرضاك بنقرة واحدة. مصمَّمة للأطباء ومسيّري العيادات في المغرب.",
     ctaPrimary: "افتح حسابًا",
     ctaSecondary: "ابحث عن طبيبي",
@@ -700,8 +700,8 @@ const en: Dictionary = {
   },
   hero: {
     eyebrow: "Platform for medical practices · Morocco",
-    titleLead: "The calm of a practice",
-    titleAccent: "that runs itself.",
+    titleLead: "Manage your practice,",
+    titleAccent: "cut no-shows.",
     sub: "Manage your practice, cut no-shows via WhatsApp, and digitize patient records in one click. Built for doctors and clinic managers across Morocco.",
     ctaPrimary: "Open an account",
     ctaSecondary: "Find my doctor",

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -52,6 +52,7 @@ export type Dictionary = {
     patientSpace: string;
     doctorSpace: string;
     menu: string;
+    skipToContent: string;
     sections: { features: string; how: string; pricing: string; faq: string };
   };
   hero: {
@@ -100,7 +101,13 @@ export type Dictionary = {
     enterpriseReply: string;
     note: string;
   };
-  faq: { eyebrow: string; title: string; items: Faq[] };
+  faq: {
+    eyebrow: string;
+    title: string;
+    searchPlaceholder: string;
+    noResults: string;
+    items: Faq[];
+  };
   cta: {
     eyebrow: string;
     title: string;
@@ -136,6 +143,7 @@ const fr: Dictionary = {
     patientSpace: "Espace Patient",
     doctorSpace: "Espace Médecin",
     menu: "Menu",
+    skipToContent: "Passer au contenu principal",
     sections: {
       features: "Fonctionnalités",
       how: "Comment ça marche",
@@ -360,6 +368,8 @@ const fr: Dictionary = {
   faq: {
     eyebrow: "Questions",
     title: "Ce que les cabinets nous demandent.",
+    searchPlaceholder: "Rechercher dans la FAQ…",
+    noResults: "Aucune question ne correspond à votre recherche.",
     items: [
       {
         q: "Mes données patients sont-elles en sécurité ?",
@@ -450,6 +460,7 @@ const ar: Dictionary = {
     patientSpace: "فضاء المريض",
     doctorSpace: "فضاء الطبيب",
     menu: "القائمة",
+    skipToContent: "تخطي إلى المحتوى الرئيسي",
     sections: { features: "الميزات", how: "كيف يعمل", pricing: "الأسعار", faq: "الأسئلة" },
   },
   hero: {
@@ -635,6 +646,8 @@ const ar: Dictionary = {
   faq: {
     eyebrow: "أسئلة",
     title: "ما تسألنا عنه العيادات.",
+    searchPlaceholder: "البحث في الأسئلة…",
+    noResults: "لا توجد أسئلة تطابق بحثك.",
     items: [
       {
         q: "هل بيانات مرضاي آمنة؟",
@@ -722,6 +735,7 @@ const en: Dictionary = {
     patientSpace: "Patient Portal",
     doctorSpace: "Doctor Portal",
     menu: "Menu",
+    skipToContent: "Skip to main content",
     sections: { features: "Features", how: "How it works", pricing: "Pricing", faq: "FAQ" },
   },
   hero: {
@@ -935,6 +949,8 @@ const en: Dictionary = {
   faq: {
     eyebrow: "Questions",
     title: "What practices ask us.",
+    searchPlaceholder: "Search questions…",
+    noResults: "No questions match your search.",
     items: [
       {
         q: "Is my patient data secure?",

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -51,7 +51,6 @@ export type Dictionary = {
     patientSpace: string;
     doctorSpace: string;
     menu: string;
-    skipToContent: string;
     sections: { features: string; how: string; pricing: string; faq: string };
   };
   hero: {
@@ -125,7 +124,6 @@ const fr: Dictionary = {
     patientSpace: "Espace Patient",
     doctorSpace: "Espace Médecin",
     menu: "Menu",
-    skipToContent: "Passer au contenu",
     sections: {
       features: "Fonctionnalités",
       how: "Comment ça marche",
@@ -431,7 +429,6 @@ const ar: Dictionary = {
     patientSpace: "فضاء المريض",
     doctorSpace: "فضاء الطبيب",
     menu: "القائمة",
-    skipToContent: "تجاوز إلى المحتوى",
     sections: { features: "الميزات", how: "كيف يعمل", pricing: "الأسعار", faq: "الأسئلة" },
   },
   hero: {
@@ -695,7 +692,6 @@ const en: Dictionary = {
     patientSpace: "Patient Portal",
     doctorSpace: "Doctor Portal",
     menu: "Menu",
-    skipToContent: "Skip to content",
     sections: { features: "Features", how: "How it works", pricing: "Pricing", faq: "FAQ" },
   },
   hero: {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -20,7 +20,7 @@ export const localeLabel: Record<Locale, string> = {
   en: "EN",
 };
 
-type Feature = { num: string; title: string; tagline: string; bullets: string[] };
+type Feature = { id: string; num: string; title: string; tagline: string; bullets: string[] };
 type Step = { num: string; title: string; body: string };
 type Tier = {
   id: string;
@@ -39,12 +39,13 @@ type Quote = {
   city: string;
   clinic?: string;
   avatar?: string;
-  plan?: string;
+  metric?: string;
 };
 type Faq = { q: string; a: string };
 
 export type Dictionary = {
   nav: {
+    brand: string;
     status: string;
     login: string;
     openAccount: string;
@@ -65,10 +66,18 @@ export type Dictionary = {
     trust: { uptime: string; uptimeLabel: string; cipher: string; law: string; latency: string };
   };
   whatsapp: { incoming: string; reply: string; status: string };
-  telemetry: { rdv: string; p95: string; uptime: string; clinics: string; reminders: string };
+  telemetry: {
+    rdv: string;
+    p95: string;
+    uptime: string;
+    clinics: string;
+    reminders: string;
+    pause: string;
+    play: string;
+  };
   featuresHeading: { eyebrow: string; title: string; sub: string };
   features: Feature[];
-  how: { eyebrow: string; title: string; sub: string; steps: Step[] };
+  how: { eyebrow: string; title: string; sub: string; securityNote: string; steps: Step[] };
   tenant: {
     eyebrow: string;
     title: string;
@@ -87,6 +96,8 @@ export type Dictionary = {
     currency: string;
     popular: string;
     tiers: Tier[];
+    freeLabel: string;
+    enterpriseReply: string;
     note: string;
   };
   faq: { eyebrow: string; title: string; items: Faq[] };
@@ -118,6 +129,7 @@ export type Dictionary = {
 /* ========================================================================== */
 const fr: Dictionary = {
   nav: {
+    brand: "oltigo",
     status: "Tous les systèmes opérationnels",
     login: "Connexion",
     openAccount: "Ouvrir un compte",
@@ -159,6 +171,8 @@ const fr: Dictionary = {
     uptime: "Disponibilité · 30 j",
     clinics: "Cabinets actifs",
     reminders: "Rappels envoyés · 24 h",
+    pause: "Pause le défilement",
+    play: "Reprendre le défilement",
   },
   featuresHeading: {
     eyebrow: "Le produit",
@@ -167,6 +181,7 @@ const fr: Dictionary = {
   },
   features: [
     {
+      id: "appointments",
       num: "01",
       title: "Rendez-vous",
       tagline: "Une page de réservation publique et une vue semaine unifiée pour tout le cabinet.",
@@ -178,6 +193,7 @@ const fr: Dictionary = {
       ],
     },
     {
+      id: "records",
       num: "02",
       title: "Dossier patient",
       tagline: "Un coffre chiffré pour l’historique, les ordonnances et les documents.",
@@ -189,6 +205,7 @@ const fr: Dictionary = {
       ],
     },
     {
+      id: "whatsapp",
       num: "03",
       title: "Rappels WhatsApp",
       tagline: "Des messages en darija, approuvés par Meta, envoyés au bon moment.",
@@ -204,6 +221,7 @@ const fr: Dictionary = {
     eyebrow: "Mise en route",
     title: "Opérationnel en un après-midi.",
     sub: "Quatre étapes, sans informaticien.",
+    securityNote: "Votre fichier reste chiffré et ne quitte jamais le territoire marocain.",
     steps: [
       {
         num: "01",
@@ -231,7 +249,7 @@ const fr: Dictionary = {
     eyebrow: "Architecture",
     title: "Chaque cabinet, dans son propre coffre.",
     sub: "Un sous-domaine dédié par cabinet, des données strictement cloisonnées. Le cabinet d’à côté n’existe pas pour le vôtre.",
-    rlsTitle: "Row Level Security",
+    rlsTitle: "Isolation des données par cabinet",
     rlsBody:
       "L’isolation est appliquée au niveau de la base de données : chaque requête est filtrée par cabinet. Aucune fuite possible entre locataires.",
     subdomains: ["cabinet-a.oltigo.com", "cabinet-b.oltigo.com", "cabinet-c.oltigo.com"],
@@ -248,7 +266,7 @@ const fr: Dictionary = {
         role: "Médecin généraliste",
         city: "Casablanca",
         clinic: "Cabinet Berrada",
-        plan: "Professional",
+        metric: "−47 % d'absences",
       },
       {
         quote:
@@ -257,7 +275,7 @@ const fr: Dictionary = {
         role: "Cardiologue",
         city: "Rabat",
         clinic: "Clinique El Fassi",
-        plan: "Enterprise",
+        metric: "Dossier chiffré en 24 h",
       },
       {
         quote: "Installé en une après-midi. Mon assistante a tout pris en main sans formation.",
@@ -265,7 +283,7 @@ const fr: Dictionary = {
         role: "Pédiatre",
         city: "Marrakech",
         clinic: "Cabinet Ouazzani",
-        plan: "Starter",
+        metric: "Opérationnel en 1 après-midi",
       },
     ],
   },
@@ -335,6 +353,8 @@ const fr: Dictionary = {
         cta: "Parler à l’équipe",
       },
     ],
+    freeLabel: "Gratuit",
+    enterpriseReply: "Réponse sous 24 h ouvrées.",
     note: "Prix hors taxes. Paiement annuel ou virement bancaire disponible. Hébergement et données au standard Loi 09-08.",
   },
   faq: {
@@ -423,6 +443,7 @@ const fr: Dictionary = {
 /* ========================================================================== */
 const ar: Dictionary = {
   nav: {
+    brand: "oltigo",
     status: "كل الأنظمة تعمل بشكل سليم",
     login: "تسجيل الدخول",
     openAccount: "افتح حسابًا",
@@ -459,6 +480,8 @@ const ar: Dictionary = {
     uptime: "زمن التشغيل · 30 يومًا",
     clinics: "عيادات نشطة",
     reminders: "تذكيرات مُرسَلة · 24 ساعة",
+    pause: "إيقاف التمرير",
+    play: "استئناف التمرير",
   },
   featuresHeading: {
     eyebrow: "المنتج",
@@ -467,6 +490,7 @@ const ar: Dictionary = {
   },
   features: [
     {
+      id: "appointments",
       num: "٠١",
       title: "المواعيد",
       tagline: "صفحة حجز عمومية وعرض أسبوعي موحَّد للعيادة بأكملها.",
@@ -478,6 +502,7 @@ const ar: Dictionary = {
       ],
     },
     {
+      id: "records",
       num: "٠٢",
       title: "ملف المريض",
       tagline: "خزنة مُشفّرة للتاريخ الطبي والوصفات والوثائق.",
@@ -489,6 +514,7 @@ const ar: Dictionary = {
       ],
     },
     {
+      id: "whatsapp",
       num: "٠٣",
       title: "تذكيرات واتساب",
       tagline: "رسائل بالدارجة، معتمَدة من Meta، تُرسَل في الوقت المناسب.",
@@ -504,6 +530,7 @@ const ar: Dictionary = {
     eyebrow: "البدء",
     title: "جاهزة في بعد ظهيرة واحدة.",
     sub: "أربع خطوات، دون الحاجة إلى تقني.",
+    securityNote: "ملفّك يبقى مُشفّرًا ولا يغادر التراب المغربي.",
     steps: [
       { num: "٠١", title: "أنشئ حسابك", body: "افتح عيادتك على OLTIGO في دقائق، دون بطاقة بنكية." },
       { num: "٠٢", title: "اضبط عيادتك", body: "الأطباء، الأوقات، أسباب الاستشارة، وصفحة الحجز." },
@@ -519,7 +546,7 @@ const ar: Dictionary = {
     eyebrow: "البنية",
     title: "كل عيادة في خزنتها الخاصة.",
     sub: "نطاق فرعي مخصَّص لكل عيادة، وبيانات معزولة تمامًا. العيادة المجاورة غير موجودة بالنسبة لعيادتك.",
-    rlsTitle: "Row Level Security",
+    rlsTitle: "عزل البيانات حسب العيادة",
     rlsBody:
       "العزل مُطبَّق على مستوى قاعدة البيانات: كل استعلام مُرشَّح حسب العيادة. لا تسرّب ممكن بين المستأجرين.",
     subdomains: ["cabinet-a.oltigo.com", "cabinet-b.oltigo.com", "cabinet-c.oltigo.com"],
@@ -535,7 +562,7 @@ const ar: Dictionary = {
         role: "طبيبة عامة",
         city: "الدار البيضاء",
         clinic: "عيادة برادة",
-        plan: "Professional",
+        metric: "انخفاض 47% في حالات التغيّب",
       },
       {
         quote: "أخيرًا ملف مريض لا أخشى فتحه. مُشفّر، واضح، وسريع.",
@@ -543,7 +570,7 @@ const ar: Dictionary = {
         role: "طبيب قلب",
         city: "الرباط",
         clinic: "مصحة الفاسي",
-        plan: "Enterprise",
+        metric: "ملف مُشفّر في 24 ساعة",
       },
       {
         quote: "تم التركيب في بعد ظهيرة واحدة. تولّت مساعدتي كل شيء دون تكوين.",
@@ -551,7 +578,7 @@ const ar: Dictionary = {
         role: "طبيبة أطفال",
         city: "مراكش",
         clinic: "عيادة وزاني",
-        plan: "Starter",
+        metric: "جاهز في بعد ظهيرة واحدة",
       },
     ],
   },
@@ -601,6 +628,8 @@ const ar: Dictionary = {
         cta: "تحدّث مع الفريق",
       },
     ],
+    freeLabel: "مجاني",
+    enterpriseReply: "ردّ خلال 24 ساعة عمل.",
     note: "الأسعار دون احتساب الضريبة. الدفع السنوي أو التحويل البنكي متاح. الاستضافة والبيانات وفق معيار القانون 09-08.",
   },
   faq: {
@@ -686,6 +715,7 @@ const ar: Dictionary = {
 /* ========================================================================== */
 const en: Dictionary = {
   nav: {
+    brand: "oltigo",
     status: "All systems operational",
     login: "Log in",
     openAccount: "Open an account",
@@ -722,6 +752,8 @@ const en: Dictionary = {
     uptime: "Uptime · 30d",
     clinics: "Active clinics",
     reminders: "Reminders sent · 24h",
+    pause: "Pause scrolling",
+    play: "Resume scrolling",
   },
   featuresHeading: {
     eyebrow: "The product",
@@ -730,6 +762,7 @@ const en: Dictionary = {
   },
   features: [
     {
+      id: "appointments",
       num: "01",
       title: "Appointments",
       tagline: "A public booking page and one unified week view for the whole practice.",
@@ -741,6 +774,7 @@ const en: Dictionary = {
       ],
     },
     {
+      id: "records",
       num: "02",
       title: "Patient record",
       tagline: "An encrypted vault for history, prescriptions, and documents.",
@@ -752,6 +786,7 @@ const en: Dictionary = {
       ],
     },
     {
+      id: "whatsapp",
       num: "03",
       title: "WhatsApp reminders",
       tagline: "Darija messages, Meta-approved, sent at exactly the right moment.",
@@ -767,6 +802,7 @@ const en: Dictionary = {
     eyebrow: "Getting started",
     title: "Live in a single afternoon.",
     sub: "Four steps, no IT person required.",
+    securityNote: "Your file stays encrypted and never leaves Moroccan territory.",
     steps: [
       {
         num: "01",
@@ -794,7 +830,7 @@ const en: Dictionary = {
     eyebrow: "Architecture",
     title: "Every practice in its own vault.",
     sub: "A dedicated subdomain per clinic, data strictly partitioned. The practice next door does not exist for yours.",
-    rlsTitle: "Row Level Security",
+    rlsTitle: "Row-level data isolation",
     rlsBody:
       "Isolation is enforced at the database layer: every query is filtered by clinic. No leakage is possible between tenants.",
     subdomains: ["cabinet-a.oltigo.com", "cabinet-b.oltigo.com", "cabinet-c.oltigo.com"],
@@ -811,7 +847,7 @@ const en: Dictionary = {
         role: "General practitioner",
         city: "Casablanca",
         clinic: "Berrada Practice",
-        plan: "Professional",
+        metric: "47% fewer no-shows",
       },
       {
         quote: "Finally a patient record I\u2019m not afraid to open. Encrypted, clear, fast.",
@@ -819,7 +855,7 @@ const en: Dictionary = {
         role: "Cardiologist",
         city: "Rabat",
         clinic: "El Fassi Clinic",
-        plan: "Enterprise",
+        metric: "Encrypted record in 24 h",
       },
       {
         quote: "Set up in one afternoon. My assistant took it all in hand with no training.",
@@ -827,7 +863,7 @@ const en: Dictionary = {
         role: "Pediatrician",
         city: "Marrakech",
         clinic: "Ouazzani Pediatrics",
-        plan: "Starter",
+        metric: "Live in one afternoon",
       },
     ],
   },
@@ -892,6 +928,8 @@ const en: Dictionary = {
         cta: "Talk to the team",
       },
     ],
+    freeLabel: "Free",
+    enterpriseReply: "Reply within 24 business hours.",
     note: "Prices excl. tax. Annual billing or bank transfer available. Hosting and data to the Law 09-08 standard.",
   },
   faq: {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -51,6 +51,7 @@ export type Dictionary = {
     patientSpace: string;
     doctorSpace: string;
     menu: string;
+    skipToContent: string;
     sections: { features: string; how: string; pricing: string; faq: string };
   };
   hero: {
@@ -124,6 +125,7 @@ const fr: Dictionary = {
     patientSpace: "Espace Patient",
     doctorSpace: "Espace Médecin",
     menu: "Menu",
+    skipToContent: "Passer au contenu",
     sections: {
       features: "Fonctionnalités",
       how: "Comment ça marche",
@@ -429,6 +431,7 @@ const ar: Dictionary = {
     patientSpace: "فضاء المريض",
     doctorSpace: "فضاء الطبيب",
     menu: "القائمة",
+    skipToContent: "تجاوز إلى المحتوى",
     sections: { features: "الميزات", how: "كيف يعمل", pricing: "الأسعار", faq: "الأسئلة" },
   },
   hero: {
@@ -692,6 +695,7 @@ const en: Dictionary = {
     patientSpace: "Patient Portal",
     doctorSpace: "Doctor Portal",
     menu: "Menu",
+    skipToContent: "Skip to content",
     sections: { features: "Features", how: "How it works", pricing: "Pricing", faq: "FAQ" },
   },
   hero: {

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -32,7 +32,15 @@ type Tier = {
   cta: string;
   highlight?: boolean;
 };
-type Quote = { quote: string; name: string; role: string; city: string; plan: string };
+type Quote = {
+  quote: string;
+  name: string;
+  role: string;
+  city: string;
+  clinic?: string;
+  avatar?: string;
+  plan?: string;
+};
 type Faq = { q: string; a: string };
 
 export type Dictionary = {
@@ -94,6 +102,7 @@ export type Dictionary = {
     error: string;
     whatsapp: string;
     consent: string;
+    consentCheckbox: string;
   };
   footer: {
     tagline: string;
@@ -238,6 +247,7 @@ const fr: Dictionary = {
         name: "Dr. Yasmine Berrada",
         role: "Médecin généraliste",
         city: "Casablanca",
+        clinic: "Cabinet Berrada",
         plan: "Professional",
       },
       {
@@ -246,6 +256,7 @@ const fr: Dictionary = {
         name: "Dr. Karim El Fassi",
         role: "Cardiologue",
         city: "Rabat",
+        clinic: "Clinique El Fassi",
         plan: "Enterprise",
       },
       {
@@ -253,6 +264,7 @@ const fr: Dictionary = {
         name: "Dr. Salima Ouazzani",
         role: "Pédiatre",
         city: "Marrakech",
+        clinic: "Cabinet Ouazzani",
         plan: "Starter",
       },
     ],
@@ -387,6 +399,7 @@ const fr: Dictionary = {
     error: "Un souci est survenu. Réessayez ou écrivez-nous sur WhatsApp.",
     whatsapp: "Écrire sur WhatsApp",
     consent: "En envoyant ce formulaire, vous acceptez d’être recontacté au sujet d’OLTIGO.",
+    consentCheckbox: "J’accepte d’être recontacté(e) au sujet d’OLTIGO.",
   },
   footer: {
     tagline: "Le système d’exploitation discret des cabinets médicaux au Maroc.",
@@ -521,6 +534,7 @@ const ar: Dictionary = {
         name: "د. ياسمين برادة",
         role: "طبيبة عامة",
         city: "الدار البيضاء",
+        clinic: "عيادة برادة",
         plan: "Professional",
       },
       {
@@ -528,6 +542,7 @@ const ar: Dictionary = {
         name: "د. كريم الفاسي",
         role: "طبيب قلب",
         city: "الرباط",
+        clinic: "مصحة الفاسي",
         plan: "Enterprise",
       },
       {
@@ -535,6 +550,7 @@ const ar: Dictionary = {
         name: "د. سليمة وزاني",
         role: "طبيبة أطفال",
         city: "مراكش",
+        clinic: "عيادة وزاني",
         plan: "Starter",
       },
     ],
@@ -649,6 +665,7 @@ const ar: Dictionary = {
     error: "حدث خطأ. أعد المحاولة أو راسلنا عبر واتساب.",
     whatsapp: "راسلنا عبر واتساب",
     consent: "بإرسال هذا النموذج، توافق على أن نعاود الاتصال بك بخصوص OLTIGO.",
+    consentCheckbox: "أوافق على أن يتم الاتصال بي بخصوص OLTIGO.",
   },
   footer: {
     tagline: "نظام التشغيل الهادئ للعيادات الطبية في المغرب.",
@@ -793,6 +810,7 @@ const en: Dictionary = {
         name: "Dr. Yasmine Berrada",
         role: "General practitioner",
         city: "Casablanca",
+        clinic: "Berrada Practice",
         plan: "Professional",
       },
       {
@@ -800,6 +818,7 @@ const en: Dictionary = {
         name: "Dr. Karim El Fassi",
         role: "Cardiologist",
         city: "Rabat",
+        clinic: "El Fassi Clinic",
         plan: "Enterprise",
       },
       {
@@ -807,6 +826,7 @@ const en: Dictionary = {
         name: "Dr. Salima Ouazzani",
         role: "Pediatrician",
         city: "Marrakech",
+        clinic: "Ouazzani Pediatrics",
         plan: "Starter",
       },
     ],
@@ -930,6 +950,7 @@ const en: Dictionary = {
     error: "Something went wrong. Try again or message us on WhatsApp.",
     whatsapp: "Message on WhatsApp",
     consent: "By submitting this form, you agree to be contacted about OLTIGO.",
+    consentCheckbox: "I agree to be contacted about OLTIGO.",
   },
   footer: {
     tagline: "The quiet operating system for medical practices in Morocco.",

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -15,19 +15,6 @@ import { Pricing } from "@/components/landing/oltigo/components/sections/pricing
 import { TelemetryTicker } from "@/components/landing/oltigo/components/sections/telemetry-ticker";
 import { Testimonials } from "@/components/landing/oltigo/components/sections/testimonials";
 import { LanguageProvider } from "@/components/landing/oltigo/i18n/context";
-import { useI18n } from "@/components/landing/oltigo/i18n/context";
-
-function SkipLink() {
-  const { dict } = useI18n();
-  return (
-    <a
-      href="#top"
-      className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-50 focus:rounded-[10px] focus:bg-emerald focus:px-4 focus:py-2.5 focus:text-ink focus:shadow-lg"
-    >
-      {dict.nav.skipToContent}
-    </a>
-  );
-}
 
 /**
  * Oltigo marketing landing — ported from groupsmix/oltigo-landing.
@@ -46,13 +33,12 @@ export function OltigoLanding() {
   }, []);
 
   return (
-    <div className="oltigo-landing">
+    <div id="top" className="oltigo-landing">
       <LanguageProvider>
-        <SkipLink />
         <Grain />
         <Nav />
         <ProgressRail />
-        <main id="top">
+        <main id="main-content">
           <Hero />
           <TelemetryTicker />
           <Features />

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -5,7 +5,7 @@ import { Hero } from "@/components/landing/oltigo/components/hero/hero";
 import { Grain } from "@/components/landing/oltigo/components/primitives/grain";
 import { ProgressRail } from "@/components/landing/oltigo/components/primitives/progress-rail";
 import { CtaDemo } from "@/components/landing/oltigo/components/sections/cta-demo";
-import { Faq, FaqSchema } from "@/components/landing/oltigo/components/sections/faq";
+import { Faq } from "@/components/landing/oltigo/components/sections/faq";
 import { Features } from "@/components/landing/oltigo/components/sections/features";
 import { Footer } from "@/components/landing/oltigo/components/sections/footer";
 import { HowItWorks } from "@/components/landing/oltigo/components/sections/how-it-works";
@@ -51,7 +51,6 @@ export function OltigoLanding() {
           <CtaDemo />
         </main>
         <MobileCtaBar />
-        <FaqSchema />
         <Footer />
       </LanguageProvider>
     </div>

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -5,7 +5,7 @@ import { Hero } from "@/components/landing/oltigo/components/hero/hero";
 import { Grain } from "@/components/landing/oltigo/components/primitives/grain";
 import { ProgressRail } from "@/components/landing/oltigo/components/primitives/progress-rail";
 import { CtaDemo } from "@/components/landing/oltigo/components/sections/cta-demo";
-import { Faq } from "@/components/landing/oltigo/components/sections/faq";
+import { Faq, FaqSchema } from "@/components/landing/oltigo/components/sections/faq";
 import { Features } from "@/components/landing/oltigo/components/sections/features";
 import { Footer } from "@/components/landing/oltigo/components/sections/footer";
 import { HowItWorks } from "@/components/landing/oltigo/components/sections/how-it-works";
@@ -63,6 +63,7 @@ export function OltigoLanding() {
           <Faq />
           <CtaDemo />
         </main>
+        <FaqSchema />
         <Footer />
       </LanguageProvider>
     </div>

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -9,6 +9,7 @@ import { Faq, FaqSchema } from "@/components/landing/oltigo/components/sections/
 import { Features } from "@/components/landing/oltigo/components/sections/features";
 import { Footer } from "@/components/landing/oltigo/components/sections/footer";
 import { HowItWorks } from "@/components/landing/oltigo/components/sections/how-it-works";
+import { MobileCtaBar } from "@/components/landing/oltigo/components/sections/mobile-cta-bar";
 import { MultiTenant } from "@/components/landing/oltigo/components/sections/multi-tenant";
 import { Nav } from "@/components/landing/oltigo/components/sections/nav";
 import { Pricing } from "@/components/landing/oltigo/components/sections/pricing";
@@ -49,6 +50,7 @@ export function OltigoLanding() {
           <Faq />
           <CtaDemo />
         </main>
+        <MobileCtaBar />
         <FaqSchema />
         <Footer />
       </LanguageProvider>

--- a/src/components/landing/oltigo/oltigo-landing.tsx
+++ b/src/components/landing/oltigo/oltigo-landing.tsx
@@ -15,6 +15,19 @@ import { Pricing } from "@/components/landing/oltigo/components/sections/pricing
 import { TelemetryTicker } from "@/components/landing/oltigo/components/sections/telemetry-ticker";
 import { Testimonials } from "@/components/landing/oltigo/components/sections/testimonials";
 import { LanguageProvider } from "@/components/landing/oltigo/i18n/context";
+import { useI18n } from "@/components/landing/oltigo/i18n/context";
+
+function SkipLink() {
+  const { dict } = useI18n();
+  return (
+    <a
+      href="#top"
+      className="sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-50 focus:rounded-[10px] focus:bg-emerald focus:px-4 focus:py-2.5 focus:text-ink focus:shadow-lg"
+    >
+      {dict.nav.skipToContent}
+    </a>
+  );
+}
 
 /**
  * Oltigo marketing landing — ported from groupsmix/oltigo-landing.
@@ -35,6 +48,7 @@ export function OltigoLanding() {
   return (
     <div className="oltigo-landing">
       <LanguageProvider>
+        <SkipLink />
         <Grain />
         <Nav />
         <ProgressRail />

--- a/src/components/landing/oltigo/public-shell.tsx
+++ b/src/components/landing/oltigo/public-shell.tsx
@@ -18,7 +18,9 @@ export function OltigoPublicShell({
       <div className="oltigo-landing">
         <Grain />
         <PublicNav />
-        <main className={cn("min-h-screen", mainClassName)}>{children}</main>
+        <main id="main-content" className={cn("min-h-screen", mainClassName)}>
+          {children}
+        </main>
         <Footer />
       </div>
     </LanguageProvider>

--- a/src/components/public/footer.tsx
+++ b/src/components/public/footer.tsx
@@ -1,7 +1,6 @@
 import { Shield } from "lucide-react";
 import Link from "next/link";
 import { t, type Locale } from "@/lib/i18n";
-import { defaultWebsiteConfig } from "@/lib/website-config";
 import { CookieSettingsLink } from "./cookie-settings-link";
 import { CopyrightYear } from "./copyright-year";
 
@@ -20,11 +19,7 @@ export function PublicFooter({
   address,
   locale = "fr",
 }: PublicFooterProps) {
-  const contact = defaultWebsiteConfig.contact;
   const displayName = clinicName || "Oltigo";
-  const displayPhone = phone || contact.phone;
-  const displayEmail = email || contact.email;
-  const displayAddress = address || contact.address;
 
   return (
     <footer className="border-t bg-muted/50 py-8" role="contentinfo" aria-label="Pied de page">
@@ -32,7 +27,7 @@ export function PublicFooter({
         <div className="grid gap-8 md:grid-cols-3">
           <div>
             <h2 className="text-base font-semibold mb-2">{displayName}</h2>
-            <p className="text-sm text-muted-foreground">{displayAddress}</p>
+            {address ? <p className="text-sm text-muted-foreground">{address}</p> : null}
           </div>
 
           <div>
@@ -74,8 +69,8 @@ export function PublicFooter({
 
           <div>
             <h2 className="text-base font-semibold mb-2">{t(locale, "public.contact")}</h2>
-            <p className="text-sm text-muted-foreground">{displayPhone}</p>
-            <p className="text-sm text-muted-foreground">{displayEmail}</p>
+            {phone ? <p className="text-sm text-muted-foreground">{phone}</p> : null}
+            {email ? <p className="text-sm text-muted-foreground">{email}</p> : null}
           </div>
         </div>
 

--- a/src/components/public/hero-section.tsx
+++ b/src/components/public/hero-section.tsx
@@ -6,6 +6,7 @@ import { defaultWebsiteConfig } from "@/lib/website-config";
 interface HeroOverrides {
   title?: string;
   subtitle?: string;
+  imageUrl?: string;
 }
 
 /** Hero layout, taken from the clinic's chosen template `heroStyle`. */

--- a/src/components/public/sections/blog-section.tsx
+++ b/src/components/public/sections/blog-section.tsx
@@ -11,6 +11,9 @@ export async function BlogSection() {
   const blogPosts = await getPublicBlogPosts();
   const previewPosts = blogPosts.slice(0, 3);
 
+  // Hide the section entirely when there is nothing to show.
+  if (previewPosts.length === 0) return null;
+
   return (
     <section className="py-16">
       <div className="container mx-auto px-4">
@@ -18,26 +21,20 @@ export async function BlogSection() {
         <p className="text-center text-muted-foreground mb-8 max-w-xl mx-auto">
           Restez informé avec les derniers conseils santé et actualités médicales de notre équipe.
         </p>
-        {previewPosts.length > 0 ? (
-          <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
-            {previewPosts.map((post) => (
-              <Card key={post.id}>
-                <CardContent className="pt-6">
-                  <div className="flex items-center gap-2 text-xs text-muted-foreground mb-3">
-                    <FileText className="h-3.5 w-3.5" />
-                    {formatDisplayDate(post.date, "fr", "long")}
-                  </div>
-                  <h3 className="font-semibold mb-2">{post.title}</h3>
-                  <p className="text-sm text-muted-foreground">{post.excerpt}</p>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        ) : (
-          <p className="text-center text-muted-foreground">
-            Aucun article publié pour le moment. Revenez bientôt !
-          </p>
-        )}
+        <div className="grid gap-6 md:grid-cols-3 max-w-4xl mx-auto">
+          {previewPosts.map((post) => (
+            <Card key={post.id}>
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground mb-3">
+                  <FileText className="h-3.5 w-3.5" />
+                  {formatDisplayDate(post.date, "fr", "long")}
+                </div>
+                <h3 className="font-semibold mb-2">{post.title}</h3>
+                <p className="text-sm text-muted-foreground">{post.excerpt}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
         <div className="mt-10 text-center">
           <Link href="/blog" className={linkBtnOutline}>
             Voir tous les articles

--- a/src/components/public/sections/doctors-section.tsx
+++ b/src/components/public/sections/doctors-section.tsx
@@ -12,6 +12,17 @@ interface DoctorsSectionProps {
 export async function DoctorsSection({ cardStyle = "shadow" }: DoctorsSectionProps) {
   const doctors = await getPublicDoctors();
 
+  // Deduplicate by name and prefer entries with a specialty/avatar.
+  const seen = new Map<string, (typeof doctors)[number]>();
+  for (const doctor of doctors) {
+    const key = doctor.name.trim().toLowerCase();
+    const existing = seen.get(key);
+    if (!existing || doctor.specialty || doctor.avatar) {
+      seen.set(key, doctor);
+    }
+  }
+  const uniqueDoctors = Array.from(seen.values());
+
   return (
     <section className="py-16 bg-muted/30">
       <div className="container mx-auto px-4">
@@ -19,9 +30,9 @@ export async function DoctorsSection({ cardStyle = "shadow" }: DoctorsSectionPro
         <p className="text-center text-muted-foreground mb-12 max-w-2xl mx-auto">
           Découvrez nos professionnels de santé dédiés à votre bien-être.
         </p>
-        {doctors.length > 0 ? (
+        {uniqueDoctors.length > 0 ? (
           <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-4xl mx-auto">
-            {doctors.map((doctor) => (
+            {uniqueDoctors.map((doctor) => (
               <Card key={doctor.id} className={publicCardClass(cardStyle)}>
                 <CardContent className="pt-6 text-center">
                   {doctor.avatar ? (

--- a/src/components/public/services-preview.tsx
+++ b/src/components/public/services-preview.tsx
@@ -14,15 +14,26 @@ interface ServicesPreviewProps {
 
 export async function ServicesPreview({ cardStyle = "shadow" }: ServicesPreviewProps) {
   const services = await getPublicServices();
-  const activeServices = services.filter((s) => s.active).slice(0, 3);
+
+  // Deduplicate by name (case-insensitive) and prefer active services.
+  const seen = new Set<string>();
+  const uniqueServices = services
+    .filter((s) => s.active)
+    .filter((s) => {
+      const key = s.name.trim().toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .slice(0, 3);
 
   return (
     <section className="py-16">
       <div className="container mx-auto px-4">
         <h2 className="text-center text-3xl font-bold mb-12">Nos Services</h2>
         <div className="grid gap-8 md:grid-cols-3">
-          {activeServices.length > 0 ? (
-            activeServices.map((service) => (
+          {uniqueServices.length > 0 ? (
+            uniqueServices.map((service) => (
               <div
                 key={service.id}
                 className={cn("rounded-xl bg-card p-6 text-center", publicCardClass(cardStyle))}
@@ -31,7 +42,9 @@ export async function ServicesPreview({ cardStyle = "shadow" }: ServicesPreviewP
                   <Stethoscope className="h-6 w-6 text-primary" />
                 </div>
                 <h3 className="text-lg font-semibold mb-2">{service.name}</h3>
-                <p className="text-sm text-muted-foreground">{service.description}</p>
+                {service.description ? (
+                  <p className="text-sm text-muted-foreground">{service.description}</p>
+                ) : null}
               </div>
             ))
           ) : (


### PR DESCRIPTION
## Summary

Follow-up to PR #1321. This PR fixes the CI `dangerouslySetInnerHTML` allowlist issue and applies a first pass of public clinic template improvements so tenant sites stop looking like a placeholder-heavy demo.

### Landing page
- Moved the FAQ JSON-LD schema into the allowlisted `src/app/(public)/page.tsx` server page.
- Rebased on the merged landing audit work.

### Public clinic template
- Hero title/subtitle now fall back to the clinic name and tagline instead of generic default copy.
- Hero image override is wired to `branding.heroImageUrl` or `coverPhotoUrl` when available.
- Services preview deduplicates by name (case-insensitive) and no longer renders empty descriptions.
- Doctors section deduplicates by name and prefers entries with a specialty/avatar.
- Blog section is hidden entirely when no posts exist.
- Public footer now receives and displays the clinic's real `phone`, `email`, and `address` from branding; placeholder contact details are no longer shown when no data is provided.

### Asset/data items still requiring user input
- Clinic-specific photos, service descriptions, staff bios, and contact info entered in the clinic admin/DB will make the public site look complete.

## Type of change

- [x] Bug fix
- [x] New feature

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

## Checklist
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes