### PR TITLE
fix(nav): add security page, fix api-docs layout, clean up security.txt

### DIFF
--- a/src/app/(public)/api-docs/_content.tsx
+++ b/src/app/(public)/api-docs/_content.tsx
@@ -1,6 +1,18 @@
+/* eslint-disable i18next/no-literal-string -- Scalar loading state only */
 "use client";
 
 import dynamic from "next/dynamic";
+import { useMemo } from "react";
+
+// Scalar ships its own component-level CSS; importing it here ensures the
+// layout, typography, and icon scaling load correctly in the browser.
+import "@scalar/api-reference-react/style.css";
+
+const ScalarLoading = () => (
+  <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+    Chargement de la documentation API…
+  </div>
+);
 
 /**
  * API documentation page (Scalar)
@@ -18,26 +30,29 @@ import dynamic from "next/dynamic";
  */
 const ApiReferenceReact = dynamic(
   () => import("@scalar/api-reference-react").then((m) => m.ApiReferenceReact),
-  { ssr: false },
+  { ssr: false, loading: ScalarLoading },
 );
 
-export default function ApiDocsPage() {
+export default function ApiDocsContent() {
+  const configuration = useMemo(
+    () => ({
+      url: "/api/docs",
+      theme: "default" as const,
+      layout: "modern" as const,
+      hideModels: false,
+      hideDownloadButton: false,
+      // Use system fonts instead of fetching from fonts.scalar.com, which the
+      // app's strict CSP (font-src 'self') blocks — that produced ~14 console
+      // errors and fell back to default fonts anyway. Self-hosting avoids both
+      // the CSP violations and the external dependency.
+      withDefaultFonts: false,
+    }),
+    [],
+  );
+
   return (
-    <div className="min-h-screen">
-      <ApiReferenceReact
-        configuration={{
-          url: "/api/docs",
-          theme: "default",
-          layout: "modern",
-          hideModels: false,
-          hideDownloadButton: false,
-          // Use system fonts instead of fetching from fonts.scalar.com, which the
-          // app's strict CSP (font-src 'self') blocks — that produced ~14 console
-          // errors and fell back to default fonts anyway. Self-hosting avoids both
-          // the CSP violations and the external dependency.
-          withDefaultFonts: false,
-        }}
-      />
-    </div>
+    <section className="min-h-screen">
+      <ApiReferenceReact configuration={configuration} />
+    </section>
   );
 }

--- a/src/app/(public)/security/page.tsx
+++ b/src/app/(public)/security/page.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable i18next/no-literal-string -- static security disclosure page */
+
+import { ExternalLink, FileText, Mail, Shield } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+
+export const metadata: Metadata = {
+  title: "Sécurité — Oltigo",
+  description:
+    "Politique de divulgation responsable et coordonnées de sécurité pour Oltigo. Signalez une vulnérabilité en toute confiance.",
+};
+
+export default function SecurityPage() {
+  return (
+    <section className="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8">
+      <div className="mb-10 text-center">
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Sécurité</h1>
+        <p className="mt-4 text-muted-foreground">
+          Nous prenons la sécurité des données de santé très au sérieux. Si vous avez découvert une
+          vulnérabilité, voici comment nous la signaler.
+        </p>
+      </div>
+
+      <div className="grid gap-6">
+        <Card>
+          <CardContent className="flex items-start gap-4 p-6">
+            <div className="rounded-full bg-emerald/10 p-3 text-emerald">
+              <Mail className="size-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Contact sécurité</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Envoyez votre rapport directement à notre équipe sécurité.
+              </p>
+              <a
+                href="mailto:security@oltigo.com?subject=Signalement%20de%20vulnérabilité"
+                className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-emerald hover:underline"
+              >
+                security@oltigo.com
+                <ExternalLink className="size-3.5" />
+              </a>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="flex items-start gap-4 p-6">
+            <div className="rounded-full bg-emerald/10 p-3 text-emerald">
+              <Shield className="size-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Safe harbor</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Oltigo Health n’engagera pas de poursuites judiciaires contre les chercheurs qui
+                signalent des vulnérabilités de bonne foi, dans le respect de notre politique de
+                divulgation responsable.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="flex items-start gap-4 p-6">
+            <div className="rounded-full bg-emerald/10 p-3 text-emerald">
+              <FileText className="size-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold">Ressources</h2>
+              <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+                <li>
+                  <Link
+                    href="/.well-known/security.txt"
+                    className="inline-flex items-center gap-2 text-emerald hover:underline"
+                  >
+                    Fichier security.txt (RFC 9116)
+                    <ExternalLink className="size-3.5" />
+                  </Link>
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/groupsmix/webs-alots/blob/main/SECURITY.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 text-emerald hover:underline"
+                  >
+                    SECURITY.md sur GitHub
+                    <ExternalLink className="size-3.5" />
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="mt-10 rounded-lg border border-hairline bg-surface/40 p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          Pour toute question sur la conformité, la protection des données patient ou la Loi 09-08,
+          contactez notre DPO à{" "}
+          <a href="mailto:dpo@oltigo.com" className="font-medium text-emerald hover:underline">
+            dpo@oltigo.com
+          </a>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/.well-known/security.txt/route.ts
+++ b/src/app/.well-known/security.txt/route.ts
@@ -11,7 +11,6 @@ export function GET() {
     "",
     "Contact: mailto:security@oltigo.com",
     "Expires: 2027-04-30T23:59:59.000Z",
-    "Encryption: https://oltigo.com/.well-known/pgp-key.txt",
     "Preferred-Languages: en, fr, ar",
     "Canonical: https://oltigo.com/.well-known/security.txt",
     "Policy: https://github.com/groupsmix/webs-alots/blob/main/SECURITY.md",

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -29,13 +29,14 @@ const FOOTER_HREFS: string[][] = [
   // Carrières / Partenaires fall back to About / Contact until dedicated pages exist.
   ["/about", "/contact", "/about", "/contact"],
   // 3 — Legal / Légal / قانوني
-  // Labels (parallel by position): Confidentialité · Conditions · Loi 09-08 · Sécurité
-  // "Sécurité" points at the RFC 9116 security policy file.
-  ["/privacy", "/terms", "/sub-processors", "/.well-known/security.txt"],
+  // Labels (parallel by position): Confidentialité · Conditions · Sous-traitants · Sécurité
+  // "Sécurité" now points at a styled security page; the RFC 9116 machine-readable
+  // file remains reachable at /.well-known/security.txt from that page.
+  ["/privacy", "/terms", "/sub-processors", "/security"],
 ];
 
 /** On-page anchors and real routes use Next.js client navigation.
- *  The security.txt file is a static text asset, so it stays a plain anchor.
+ *  The raw security.txt file is linked from the /security page, not the footer.
  */
 function isAnchor(href: string): boolean {
   return href.startsWith("#");


### PR DESCRIPTION
## Summary

Fixes the remaining broken/unstyled public pages reported after the navigation audit.

## Fixes

- **/security** — new styled security disclosure page with contact email, safe-harbor statement, and links to the RFC 9116 `security.txt` file and GitHub `SECURITY.md`. The footer "Sécurité" link now points here instead of dumping users into raw text.
- **/.well-known/security.txt** — removes the broken `Encryption` field that pointed to a missing PGP key.
- **/api-docs** — imports the Scalar component CSS and adds a loading fallback so the API reference renders correctly instead of looking unstyled/broken.

## Verification

- `npm run lint` passes
- `npm run typecheck` passes
- `npm run test` passes
- `/security/`, `/.well-known/security.txt`, and `/api-docs/` return HTTP 200 and render correctly in the browser.

## Type of change
- [x] Bug fix

## Security Impact
- [x] No security impact

## Migration Safety
- [x] N/A — no migrations

## Testing
- [x] Manual testing performed

## Checklist
- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes