### PR TITLE
ui(public): mobile-first responsive pass for clinic headers, hero, sections and footers

### DIFF
--- a/src/components/public/footer.tsx
+++ b/src/components/public/footer.tsx
@@ -23,12 +23,12 @@ export function PublicFooter({
 
   return (
     <footer
-      className="border-t border-border bg-background py-12"
+      className="border-t border-border bg-background py-10 sm:py-12"
       role="contentinfo"
       aria-label={t(locale, "public.footerLabel")}
     >
       <div className="container mx-auto px-4">
-        <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-8 sm:gap-10 md:grid-cols-2 lg:grid-cols-4">
           {/* Brand column */}
           <div className="lg:col-span-1">
             <h2 className="text-lg font-bold text-primary mb-3">{displayName}</h2>

--- a/src/components/public/footers/footer-centered.tsx
+++ b/src/components/public/footers/footer-centered.tsx
@@ -25,7 +25,7 @@ export function FooterCentered({ clinicName, template, phone, email, address }: 
       dir={isRtl ? "rtl" : undefined}
       aria-label={t(locale, "public.footerLabel")}
     >
-      <div className="container mx-auto flex flex-col items-center gap-6 px-4 py-10">
+      <div className="container mx-auto flex flex-col items-center gap-6 px-4 py-8 sm:py-10">
         {/* Clinic name */}
         <h3 className="text-xl font-bold text-primary">{clinicName}</h3>
 

--- a/src/components/public/footers/footer-classic.tsx
+++ b/src/components/public/footers/footer-classic.tsx
@@ -24,8 +24,8 @@ export function FooterClassic({ clinicName, template, phone, email, address }: F
       dir={isRtl ? "rtl" : undefined}
       aria-label={t(locale, "public.footerLabel")}
     >
-      <div className="container mx-auto px-4 py-12">
-        <div className="grid gap-10 md:grid-cols-3">
+      <div className="container mx-auto px-4 py-10 sm:py-12">
+        <div className="grid gap-8 sm:gap-10 md:grid-cols-3">
           {/* Column 1 — Clinic info */}
           <div>
             <h3 className="text-lg font-bold text-primary mb-3">{clinicName}</h3>

--- a/src/components/public/footers/footer-minimal.tsx
+++ b/src/components/public/footers/footer-minimal.tsx
@@ -24,7 +24,7 @@ export function FooterMinimal({ clinicName, template, phone, email, address }: F
       dir={isRtl ? "rtl" : undefined}
       aria-label={t(locale, "public.footerLabel")}
     >
-      <div className="container mx-auto px-4 py-6">
+      <div className="container mx-auto px-4 py-5 sm:py-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-muted-foreground">
             © {year} {clinicName}

--- a/src/components/public/header.tsx
+++ b/src/components/public/header.tsx
@@ -78,27 +78,30 @@ export function PublicHeader({
 
   return (
     <header className="sticky top-0 z-50">
-      {/* Top contact bar */}
+      {/* Top contact bar — phone-only on very small screens, full row on sm+ */}
       {hasContact && (
         <div className="bg-primary text-primary-foreground py-1.5 text-xs">
-          <div className="container mx-auto px-4 flex flex-wrap items-center justify-center gap-4 sm:justify-end">
+          <div className="container mx-auto px-4 flex flex-wrap items-center justify-center gap-2 sm:gap-4 sm:justify-end">
             {phone && (
-              <a href={`tel:${phone}`} className="inline-flex items-center gap-1.5 hover:underline">
-                <Phone className="h-3 w-3" aria-hidden="true" />
-                {phone}
+              <a
+                href={`tel:${phone}`}
+                className="inline-flex items-center gap-1.5 hover:underline truncate max-w-[60vw] sm:max-w-none"
+              >
+                <Phone className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                <span className="truncate">{phone}</span>
               </a>
             )}
             {email && (
               <a
                 href={`mailto:${email}`}
-                className="inline-flex items-center gap-1.5 hover:underline"
+                className="hidden sm:inline-flex items-center gap-1.5 hover:underline"
               >
                 <Mail className="h-3 w-3" aria-hidden="true" />
                 {email}
               </a>
             )}
             {address && (
-              <span className="inline-flex items-center gap-1.5">
+              <span className="hidden sm:inline-flex items-center gap-1.5">
                 <MapPin className="h-3 w-3" aria-hidden="true" />
                 {address}
               </span>
@@ -110,17 +113,20 @@ export function PublicHeader({
       {/* Main nav */}
       <div className="border-b bg-background/95 backdrop-blur">
         <div className="container mx-auto flex h-16 items-center justify-between px-4">
-          <Link href="/" className="flex items-center gap-2 text-xl font-bold text-foreground">
+          <Link
+            href="/"
+            className="flex items-center gap-2 text-lg sm:text-xl font-bold text-foreground min-w-0"
+          >
             {logoUrl && (
               <Image
                 src={logoUrl}
                 alt={displayName}
                 width={36}
                 height={36}
-                className="h-9 w-auto"
+                className="h-8 sm:h-9 w-auto flex-shrink-0"
               />
             )}
-            {displayName}
+            <span className="truncate">{displayName}</span>
           </Link>
 
           {/* Desktop navigation */}
@@ -173,7 +179,7 @@ export function PublicHeader({
         <nav
           id="clinic-mobile-nav"
           aria-label={t(locale, "public.navMobile")}
-          className="border-b border-border bg-background/95 backdrop-blur px-4 py-4 md:hidden"
+          className="border-b border-border bg-background/95 backdrop-blur px-4 py-4 md:hidden max-h-[calc(100dvh-8rem)] overflow-y-auto"
         >
           <div className="flex flex-col gap-3">
             {navLinks.map((link) => {
@@ -194,15 +200,17 @@ export function PublicHeader({
                 </Link>
               );
             })}
-            <Link
-              href="/login"
-              className={buttonVariants({ variant: "outline", className: "mt-2" })}
-            >
-              {t(locale, "public.doctorSpace")}
-            </Link>
-            <Link href="/book" className={buttonVariants({ className: "mt-2" })}>
-              {t(locale, "public.patientSpace")}
-            </Link>
+            <div className="grid grid-cols-2 gap-3 pt-2">
+              <Link
+                href="/login"
+                className={buttonVariants({ variant: "outline", className: "w-full" })}
+              >
+                {t(locale, "public.doctorSpace")}
+              </Link>
+              <Link href="/book" className={buttonVariants({ className: "w-full" })}>
+                {t(locale, "public.patientSpace")}
+              </Link>
+            </div>
           </div>
         </nav>
       )}

--- a/src/components/public/headers/header-floating.tsx
+++ b/src/components/public/headers/header-floating.tsx
@@ -33,19 +33,22 @@ export function HeaderFloating({ logoUrl, clinicName, navItems, template }: Head
   return (
     <header className="fixed top-4 left-0 right-0 z-50" dir={isRtl ? "rtl" : undefined}>
       <div className="container mx-auto px-4">
-        <div className="mx-auto max-w-4xl rounded-full border bg-background/80 backdrop-blur-lg shadow-lg px-6 py-2">
-          <div className="flex items-center justify-between">
-            <Link href="/" className="flex items-center gap-2 text-lg font-bold">
+        <div className="mx-auto max-w-4xl rounded-full border bg-background/80 backdrop-blur-lg shadow-lg px-4 sm:px-6 py-2">
+          <div className="flex items-center justify-between min-w-0">
+            <Link
+              href="/"
+              className="flex items-center gap-2 text-base sm:text-lg font-bold min-w-0"
+            >
               {logoUrl && (
                 <Image
                   src={logoUrl}
                   alt={displayName}
                   width={28}
                   height={28}
-                  className="h-7 w-auto"
+                  className="h-7 w-auto flex-shrink-0"
                 />
               )}
-              <span className="hidden sm:inline">{displayName}</span>
+              <span className="hidden sm:inline truncate">{displayName}</span>
             </Link>
 
             {/* Desktop navigation */}
@@ -89,11 +92,11 @@ export function HeaderFloating({ logoUrl, clinicName, navItems, template }: Head
 
         {/* Mobile navigation — drops down below the floating bar */}
         {mobileMenuOpen && (
-          <div className="mx-auto max-w-4xl mt-2">
+          <div className="mx-auto max-w-4xl mt-2 px-4 sm:px-0">
             <nav
               id="floating-mobile-nav"
               aria-label="Navigation mobile"
-              className="rounded-2xl border bg-background/95 backdrop-blur-lg shadow-lg px-4 py-4"
+              className="rounded-2xl border bg-background/95 backdrop-blur-lg shadow-lg px-4 py-4 max-h-[calc(100dvh-8rem)] overflow-y-auto"
             >
               <div className="flex flex-col gap-2">
                 {navItems.map((item) => (
@@ -111,7 +114,10 @@ export function HeaderFloating({ logoUrl, clinicName, navItems, template }: Head
                     {item.label}
                   </Link>
                 ))}
-                <Link href="/book" className={buttonVariants({ className: "mt-2 rounded-full" })}>
+                <Link
+                  href="/book"
+                  className={buttonVariants({ className: "mt-2 rounded-full w-full" })}
+                >
                   {t(locale, "public.bookAppointment")}
                 </Link>
               </div>

--- a/src/components/public/headers/header-top-sticky.tsx
+++ b/src/components/public/headers/header-top-sticky.tsx
@@ -42,24 +42,27 @@ export function HeaderTopSticky({
     <header className="sticky top-0 z-50" dir={isRtl ? "rtl" : undefined}>
       {hasContact && (
         <div className="bg-primary text-primary-foreground py-1.5 text-xs">
-          <div className="container mx-auto px-4 flex flex-wrap items-center justify-center gap-4 sm:justify-end">
+          <div className="container mx-auto px-4 flex flex-wrap items-center justify-center gap-2 sm:gap-4 sm:justify-end">
             {phone && (
-              <a href={`tel:${phone}`} className="inline-flex items-center gap-1.5 hover:underline">
-                <Phone className="h-3 w-3" aria-hidden="true" />
-                {phone}
+              <a
+                href={`tel:${phone}`}
+                className="inline-flex items-center gap-1.5 hover:underline truncate max-w-[60vw] sm:max-w-none"
+              >
+                <Phone className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                <span className="truncate">{phone}</span>
               </a>
             )}
             {email && (
               <a
                 href={`mailto:${email}`}
-                className="inline-flex items-center gap-1.5 hover:underline"
+                className="hidden sm:inline-flex items-center gap-1.5 hover:underline"
               >
                 <Mail className="h-3 w-3" aria-hidden="true" />
                 {email}
               </a>
             )}
             {address && (
-              <span className="inline-flex items-center gap-1.5">
+              <span className="hidden sm:inline-flex items-center gap-1.5">
                 <MapPin className="h-3 w-3" aria-hidden="true" />
                 {address}
               </span>
@@ -70,17 +73,20 @@ export function HeaderTopSticky({
 
       <div className="border-b bg-background/95 backdrop-blur">
         <div className="container mx-auto flex h-16 items-center justify-between px-4">
-          <Link href="/" className="flex items-center gap-2 text-xl font-bold text-foreground">
+          <Link
+            href="/"
+            className="flex items-center gap-2 text-lg sm:text-xl font-bold text-foreground min-w-0"
+          >
             {logoUrl && (
               <Image
                 src={logoUrl}
                 alt={displayName}
                 width={36}
                 height={36}
-                className="h-9 w-auto"
+                className="h-8 sm:h-9 w-auto flex-shrink-0"
               />
             )}
-            {displayName}
+            <span className="truncate">{displayName}</span>
           </Link>
 
           {/* Desktop navigation */}
@@ -130,7 +136,7 @@ export function HeaderTopSticky({
         <nav
           id="header-mobile-nav"
           aria-label="Navigation mobile"
-          className="border-b border-border bg-background/95 backdrop-blur px-4 py-4 md:hidden"
+          className="border-b border-border bg-background/95 backdrop-blur px-4 py-4 md:hidden max-h-[calc(100dvh-8rem)] overflow-y-auto"
         >
           <div className="flex flex-col gap-3">
             {navItems.map((item) => {
@@ -151,15 +157,17 @@ export function HeaderTopSticky({
                 </Link>
               );
             })}
-            <Link
-              href="/login"
-              className={buttonVariants({ variant: "outline", className: "mt-2" })}
-            >
-              {t(locale, "public.doctorSpace")}
-            </Link>
-            <Link href="/book" className={buttonVariants({ className: "mt-2" })}>
-              {t(locale, "public.patientSpace")}
-            </Link>
+            <div className="grid grid-cols-2 gap-3 pt-2">
+              <Link
+                href="/login"
+                className={buttonVariants({ variant: "outline", className: "w-full" })}
+              >
+                {t(locale, "public.doctorSpace")}
+              </Link>
+              <Link href="/book" className={buttonVariants({ className: "w-full" })}>
+                {t(locale, "public.patientSpace")}
+              </Link>
+            </div>
           </div>
         </nav>
       )}

--- a/src/components/public/headers/header-transparent.tsx
+++ b/src/components/public/headers/header-transparent.tsx
@@ -54,12 +54,18 @@ export function HeaderTransparent({ logoUrl, clinicName, navItems, template }: H
       <div className="container mx-auto flex h-16 items-center justify-between px-4">
         <Link
           href="/"
-          className={`flex items-center gap-2 text-xl font-bold transition-colors ${scrolled ? "text-foreground" : textColor}`}
+          className={`flex items-center gap-2 text-lg sm:text-xl font-bold transition-colors min-w-0 ${scrolled ? "text-foreground" : textColor}`}
         >
           {logoUrl && (
-            <Image src={logoUrl} alt={displayName} width={32} height={32} className="h-8 w-auto" />
+            <Image
+              src={logoUrl}
+              alt={displayName}
+              width={32}
+              height={32}
+              className="h-8 w-auto flex-shrink-0"
+            />
           )}
-          {displayName}
+          <span className="truncate">{displayName}</span>
         </Link>
 
         {/* Desktop navigation */}
@@ -106,7 +112,7 @@ export function HeaderTransparent({ logoUrl, clinicName, navItems, template }: H
         <nav
           id="transparent-mobile-nav"
           aria-label="Navigation mobile"
-          className="border-t bg-background/95 backdrop-blur px-4 py-4 md:hidden"
+          className="border-t bg-background/95 backdrop-blur px-4 py-4 md:hidden max-h-[calc(100dvh-5rem)] overflow-y-auto"
         >
           <div className="flex flex-col gap-3">
             {navItems.map((item) => (
@@ -114,13 +120,15 @@ export function HeaderTransparent({ logoUrl, clinicName, navItems, template }: H
                 key={item.href}
                 href={item.href}
                 aria-current={pathname === item.href ? "page" : undefined}
-                className="text-sm text-muted-foreground min-h-11 flex items-center"
+                className={`text-sm min-h-11 flex items-center ${
+                  pathname === item.href ? "text-primary font-medium" : "text-muted-foreground"
+                }`}
                 onClick={() => setMobileMenuOpen(false)}
               >
                 {item.label}
               </Link>
             ))}
-            <Link href="/book" className={buttonVariants({ className: "mt-2" })}>
+            <Link href="/book" className={buttonVariants({ className: "mt-2 w-full" })}>
               {t(locale, "public.bookAppointment")}
             </Link>
           </div>

--- a/src/components/public/hero-section.tsx
+++ b/src/components/public/hero-section.tsx
@@ -26,14 +26,21 @@ export function HeroSection({ overrides, variant = "split" }: HeroSectionProps) 
 
   const ctas = (align: "center" | "start") => (
     <div
-      className={`mt-10 flex flex-wrap items-center gap-4 ${
+      className={`mt-8 sm:mt-10 flex flex-col sm:flex-row items-center gap-3 ${
         align === "center" ? "justify-center" : "justify-center lg:justify-start"
       }`}
     >
-      <Link href="/book" className={buttonVariants({ size: "lg" })}>
+      <Link href="/book" className={buttonVariants({ size: "lg", className: "w-full sm:w-auto" })}>
         {cfg.ctaPrimary}
       </Link>
-      <Link href="/services" className={buttonVariants({ variant: "outline", size: "lg" })}>
+      <Link
+        href="/services"
+        className={buttonVariants({
+          variant: "outline",
+          size: "lg",
+          className: "w-full sm:w-auto",
+        })}
+      >
         {cfg.ctaSecondary}
       </Link>
     </div>
@@ -50,14 +57,16 @@ export function HeroSection({ overrides, variant = "split" }: HeroSectionProps) 
           : "bg-gradient-to-br from-primary/5 to-primary/10";
     const isOverlay = variant === "overlay";
     return (
-      <section className={`relative ${bg} ${variant === "fullwidth" ? "py-32" : "py-24"}`}>
+      <section
+        className={`relative ${bg} ${variant === "fullwidth" ? "py-20 sm:py-32" : "py-16 sm:py-24"}`}
+      >
         <div className="container mx-auto px-4">
           <div className="mx-auto max-w-3xl text-center">
-            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+            <h1 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl lg:text-5xl">
               {cfg.title}
             </h1>
             <p
-              className={`mx-auto mt-6 max-w-2xl text-lg ${
+              className={`mx-auto mt-4 sm:mt-6 max-w-2xl text-base sm:text-lg ${
                 isOverlay ? "text-primary-foreground/80" : "text-muted-foreground"
               }`}
             >
@@ -71,14 +80,14 @@ export function HeroSection({ overrides, variant = "split" }: HeroSectionProps) 
   }
 
   return (
-    <section className="relative bg-gradient-to-br from-primary/5 to-primary/10 py-24">
+    <section className="relative bg-gradient-to-br from-primary/5 to-primary/10 py-16 sm:py-24">
       <div className="container mx-auto px-4">
-        <div className="grid items-center gap-12 lg:grid-cols-2">
+        <div className="grid items-center gap-10 lg:gap-12 lg:grid-cols-2">
           <div className="text-center lg:text-start">
-            <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl">
+            <h1 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl lg:text-5xl">
               {cfg.title}
             </h1>
-            <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground lg:mx-0">
+            <p className="mx-auto mt-4 sm:mt-6 max-w-2xl text-base sm:text-lg text-muted-foreground lg:mx-0">
               {cfg.subtitle}
             </p>
             {ctas("start")}

--- a/src/components/public/sections/booking-section.tsx
+++ b/src/components/public/sections/booking-section.tsx
@@ -5,14 +5,14 @@ const linkBtnPrimary =
 
 export function BookingSection() {
   return (
-    <section className="py-16 bg-primary/5">
+    <section className="py-12 sm:py-16 bg-primary/5">
       <div className="container mx-auto px-4 text-center">
-        <h2 className="text-3xl font-bold mb-4">Prêt à réserver ?</h2>
-        <p className="text-muted-foreground mb-8 max-w-xl mx-auto">
+        <h2 className="text-2xl sm:text-3xl font-bold text-balance mb-4">Prêt à réserver ?</h2>
+        <p className="text-muted-foreground mb-6 sm:mb-8 max-w-xl mx-auto">
           Prenez rendez-vous en ligne en quelques clics. Nous nous réjouissons de vous offrir des
           soins de qualité.
         </p>
-        <Link href="/book" className={linkBtnPrimary}>
+        <Link href="/book" className={`${linkBtnPrimary} w-full sm:w-auto`}>
           Prendre rendez-vous
         </Link>
       </div>

--- a/src/components/public/sections/contact-form-section.tsx
+++ b/src/components/public/sections/contact-form-section.tsx
@@ -12,10 +12,12 @@ export function ContactFormSection() {
   const [submitted, setSubmitted] = useState(false);
 
   return (
-    <section className="py-16">
+    <section className="py-12 sm:py-16">
       <div className="container mx-auto px-4 max-w-xl">
-        <h2 className="text-center text-3xl font-bold mb-4">Contactez-nous</h2>
-        <p className="text-center text-muted-foreground mb-8">
+        <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-4">
+          Contactez-nous
+        </h2>
+        <p className="text-center text-muted-foreground mb-6 sm:mb-8">
           Vous avez une question ? Envoyez-nous un message et nous vous répondrons rapidement.
         </p>
         <Card>

--- a/src/components/public/sections/doctors-section.tsx
+++ b/src/components/public/sections/doctors-section.tsx
@@ -24,14 +24,16 @@ export async function DoctorsSection({ cardStyle = "shadow" }: DoctorsSectionPro
   const uniqueDoctors = Array.from(seen.values());
 
   return (
-    <section className="py-16 bg-muted/30">
+    <section className="py-12 sm:py-16 bg-muted/30">
       <div className="container mx-auto px-4">
-        <h2 className="text-center text-3xl font-bold mb-4">Notre Équipe</h2>
-        <p className="text-center text-muted-foreground mb-12 max-w-2xl mx-auto">
+        <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-4">
+          Notre Équipe
+        </h2>
+        <p className="text-center text-muted-foreground mb-8 sm:mb-12 max-w-2xl mx-auto">
           Découvrez nos professionnels de santé dédiés à votre bien-être.
         </p>
         {uniqueDoctors.length > 0 ? (
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-4xl mx-auto">
+          <div className="grid gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-4xl mx-auto">
             {uniqueDoctors.map((doctor) => (
               <Card key={doctor.id} className={publicCardClass(cardStyle)}>
                 <CardContent className="pt-6 text-center">

--- a/src/components/public/sections/faq-section.tsx
+++ b/src/components/public/sections/faq-section.tsx
@@ -25,10 +25,12 @@ const faqs = [
 
 export function FaqSection() {
   return (
-    <section className="py-16">
+    <section className="py-12 sm:py-16">
       <div className="container mx-auto px-4 max-w-3xl">
-        <h2 className="text-center text-3xl font-bold mb-4">Questions Fréquentes</h2>
-        <p className="text-center text-muted-foreground mb-8">
+        <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-4">
+          Questions Fréquentes
+        </h2>
+        <p className="text-center text-muted-foreground mb-6 sm:mb-8">
           Trouvez les réponses aux questions les plus courantes sur nos services.
         </p>
         <div className="space-y-4">

--- a/src/components/public/sections/insurance-section.tsx
+++ b/src/components/public/sections/insurance-section.tsx
@@ -13,14 +13,16 @@ const insuranceProviders = [
 
 export function InsuranceSection() {
   return (
-    <section className="py-16 bg-muted/30">
+    <section className="py-12 sm:py-16 bg-muted/30">
       <div className="container mx-auto px-4">
-        <h2 className="text-center text-3xl font-bold mb-4">Assurances Acceptées</h2>
-        <p className="text-center text-muted-foreground mb-8 max-w-xl mx-auto">
+        <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-4">
+          Assurances Acceptées
+        </h2>
+        <p className="text-center text-muted-foreground mb-6 sm:mb-8 max-w-xl mx-auto">
           Nous acceptons la plupart des assurances majeures. Contactez-nous si votre assurance ne
           figure pas dans la liste.
         </p>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 max-w-2xl mx-auto">
+        <div className="grid grid-cols-2 gap-3 sm:gap-4 sm:grid-cols-4 max-w-2xl mx-auto">
           {insuranceProviders.map((provider) => (
             <div key={provider} className="flex items-center gap-2 rounded-lg border bg-card p-3">
               <Shield className="h-4 w-4 text-primary flex-shrink-0" />

--- a/src/components/public/sections/location-section.tsx
+++ b/src/components/public/sections/location-section.tsx
@@ -27,11 +27,15 @@ export function LocationSection({ address, websiteConfig }: LocationSectionProps
   const displayAddress = displayAddressParts.filter(Boolean).join(", ");
 
   return (
-    <section className="py-16 bg-muted/30">
+    <section className="py-12 sm:py-16 bg-muted/30">
       <div className="container mx-auto px-4">
-        <h2 className="text-center text-3xl font-bold mb-4">{loc.title}</h2>
-        <p className="text-center text-muted-foreground mb-8 max-w-xl mx-auto">{loc.subtitle}</p>
-        <div className="grid gap-8 lg:grid-cols-2 max-w-4xl mx-auto">
+        <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-4">
+          {loc.title}
+        </h2>
+        <p className="text-center text-muted-foreground mb-6 sm:mb-8 max-w-xl mx-auto">
+          {loc.subtitle}
+        </p>
+        <div className="grid gap-6 sm:gap-8 lg:grid-cols-2 max-w-4xl mx-auto">
           {/* Map */}
           <Card>
             <CardContent className="pt-6">
@@ -43,11 +47,11 @@ export function LocationSection({ address, websiteConfig }: LocationSectionProps
                   allowFullScreen
                   loading="lazy"
                   referrerPolicy="no-referrer-when-downgrade"
-                  className="rounded-lg border-0"
+                  className="rounded-lg border-0 min-h-[220px]"
                   title="Localisation du cabinet"
                 />
               ) : (
-                <div className="h-[300px] rounded-lg bg-muted flex items-center justify-center">
+                <div className="min-h-[220px] h-[300px] rounded-lg bg-muted flex items-center justify-center">
                   <MapPin className="h-8 w-8 text-muted-foreground" />
                 </div>
               )}

--- a/src/components/public/services-preview.tsx
+++ b/src/components/public/services-preview.tsx
@@ -28,10 +28,12 @@ export async function ServicesPreview({ cardStyle = "shadow" }: ServicesPreviewP
     .slice(0, 3);
 
   return (
-    <section className="py-16">
+    <section className="py-12 sm:py-16">
       <div className="container mx-auto px-4">
-        <h2 className="text-center text-3xl font-bold mb-12">Nos Services</h2>
-        <div className="grid gap-8 md:grid-cols-3">
+        <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-8 sm:mb-12">
+          Nos Services
+        </h2>
+        <div className="grid gap-6 sm:gap-8 md:grid-cols-3">
           {uniqueServices.length > 0 ? (
             uniqueServices.map((service) => (
               <div
@@ -53,8 +55,8 @@ export async function ServicesPreview({ cardStyle = "shadow" }: ServicesPreviewP
             </p>
           )}
         </div>
-        <div className="mt-10 text-center">
-          <Link href="/services" className={linkBtnOutline}>
+        <div className="mt-8 sm:mt-10 text-center">
+          <Link href="/services" className={`${linkBtnOutline} w-full sm:w-auto`}>
             Voir tous les services
             <ArrowRight className="ms-2 h-4 w-4" />
           </Link>


### PR DESCRIPTION
## Summary

This is the follow-up mobile pass for the public clinic templates that landed in #1325.

- Smaller hero fonts, spacing, and padding on narrow screens (`text-3xl` → `sm:text-4xl` → `lg:text-5xl`, `py-16` → `sm:py-24`, etc.).
- Hero CTAs now stack full-width on mobile and shrink to auto on tablet+.
- Added `text-balance` to every public section heading so long titles don't leave orphan words on narrow viewports.
- Headers (`PublicHeader`, `HeaderTopSticky`, `HeaderFloating`, `HeaderTransparent`) now truncate the clinic name, reduce logo/padding size on mobile, collapse the top contact bar to the phone number only on very small screens, and make the mobile nav scrollable with full-width CTAs.
- All footer variants shrink vertical padding on mobile and keep their 1-column mobile layout.
- Sections (services, doctors, location, insurance, FAQ, contact, booking) all have reduced mobile padding, smaller mobile titles, tighter gaps, and responsive CTA widths.

## Type of change

- [x] Bug fix
- [x] Refactor / cleanup

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual responsive review against the `dr-ahmed.oltigo.com` template code paths
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes

## Rollback

Revert commit `1cd46e89` on branch `devin/mobile-clinic-followup`.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes