### PR TITLE
fix(upload): allow AVIF image uploads

### DIFF
--- a/src/app/api/__tests__/branding-upload-validation.test.ts
+++ b/src/app/api/__tests__/branding-upload-validation.test.ts
@@ -11,6 +11,7 @@ const ALLOWED_IMAGE_TYPES = new Set([
   "image/jpeg",
   "image/png",
   "image/webp",
+  "image/avif",
   "image/x-icon",
   "image/vnd.microsoft.icon",
 ]);
@@ -24,6 +25,13 @@ const MAGIC_BYTES: Record<string, Uint8Array[]> = {
 };
 
 function validateFileContent(buffer: Buffer, declaredType: string): boolean {
+  if (declaredType === "image/avif") {
+    if (buffer.length < 12) return false;
+    const ftyp = buffer.toString("ascii", 4, 8);
+    const brand = buffer.toString("ascii", 8, 12);
+    return ftyp === "ftyp" && (brand === "avif" || brand === "avis");
+  }
+
   const signatures = MAGIC_BYTES[declaredType];
   if (!signatures) return false;
   return signatures.some((sig) => sig.every((byte, i) => i < buffer.length && buffer[i] === byte));
@@ -68,6 +76,14 @@ describe("branding upload — validateFileContent", () => {
   it("validates an ICO file", () => {
     const buf = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]);
     expect(validateFileContent(buf, "image/x-icon")).toBe(true);
+  });
+
+  it("validates an AVIF file", () => {
+    const buf = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x1c]),
+      Buffer.from("ftypavif", "ascii"),
+    ]);
+    expect(validateFileContent(buf, "image/avif")).toBe(true);
   });
 
   it("validates vnd.microsoft.icon the same as x-icon", () => {

--- a/src/app/api/branding/route.ts
+++ b/src/app/api/branding/route.ts
@@ -26,6 +26,7 @@ const ALLOWED_IMAGE_TYPES = new Set([
   "image/jpeg",
   "image/png",
   "image/webp",
+  "image/avif",
   // SVG removed: can contain embedded <script> tags leading to XSS
   "image/x-icon",
   "image/vnd.microsoft.icon",
@@ -41,6 +42,15 @@ const MAGIC_BYTES: Record<string, Uint8Array[]> = {
 };
 
 function validateFileContent(buffer: Buffer, declaredType: string): boolean {
+  if (declaredType === "image/avif") {
+    // AVIF is HEIF-based: the first box is a 'ftyp' box whose type starts at byte 4
+    // and whose major brand ('avif' or 'avis') starts at byte 8.
+    if (buffer.length < 12) return false;
+    const ftyp = buffer.toString("ascii", 4, 8);
+    const brand = buffer.toString("ascii", 8, 12);
+    return ftyp === "ftyp" && (brand === "avif" || brand === "avis");
+  }
+
   const signatures = MAGIC_BYTES[declaredType];
   if (!signatures) return false;
   return signatures.some((sig) => sig.every((byte, i) => i < buffer.length && buffer[i] === byte));

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -121,6 +121,7 @@ const ALLOWED_TYPES = new Set([
   "image/jpeg",
   "image/png",
   "image/webp",
+  "image/avif",
   // A52.3: image/gif removed — GIF files can contain animation frames that
   // bypass static analysis, and polyglot GIF/JS files are a known XSS vector.
   // SVG removed: can contain embedded <script> tags leading to XSS.
@@ -156,6 +157,15 @@ const MAGIC_BYTES: Record<string, Uint8Array[]> = {
 };
 
 function validateFileContent(buffer: Buffer, declaredType: string): boolean {
+  if (declaredType === "image/avif") {
+    // AVIF is HEIF-based: the first box is a 'ftyp' box whose type starts at byte 4
+    // and whose major brand ('avif' or 'avis') starts at byte 8.
+    if (buffer.length < 12) return false;
+    const ftyp = buffer.toString("ascii", 4, 8);
+    const brand = buffer.toString("ascii", 8, 12);
+    return ftyp === "ftyp" && (brand === "avif" || brand === "avis");
+  }
+
   const signatures = MAGIC_BYTES[declaredType];
   if (!signatures) return false;
   return signatures.some((sig) => sig.every((byte, i) => i < buffer.length && buffer[i] === byte));


### PR DESCRIPTION
## Summary

Adds `image/avif` to the allowlists and magic-byte validation for both the branding image upload endpoint (`/api/branding`) and the general upload endpoint (`/api/upload`), so clinic admins can drop AVIF logos/hero/cover photos in `/admin/branding` without getting "File type not allowed".

## Type of change

- [x] Bug fix

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Changes

- `src/app/api/branding/route.ts`:
  - Added `"image/avif"` to `ALLOWED_IMAGE_TYPES`.
  - Updated `validateFileContent` to recognize AVIF's HEIF/ftyp magic bytes (`ftyp` at offset 4, brand `avif` or `avis` at offset 8).
- `src/app/api/upload/route.ts`:
  - Added `"image/avif"` to `ALLOWED_TYPES`.
  - Updated `validateFileContent` with the same AVIF check.
- `src/app/api/__tests__/branding-upload-validation.test.ts`:
  - Added AVIF to the inline `ALLOWED_IMAGE_TYPES` copy and `validateFileContent` helper.
  - Added a test case that validates a minimal AVIF `ftypavif` header.

## Testing

- `npm run lint` passes
- `npx tsc --noEmit` passes
- Full `npm run test` passes (2282 passed, 117 skipped)

## Rollback

Revert this commit.