### PR TITLE
Phase 2: JSON-LD structured data enrichment and /faq page

### DIFF
--- a/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/[specialty]/page.tsx
@@ -1,9 +1,11 @@
 import { MapPin, Stethoscope, Calendar, Phone } from "lucide-react";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { HreflangTags } from "@/components/hreflang-tags";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button-variants";
@@ -48,6 +50,8 @@ export async function generateMetadata({ params }: CitySpecialtyPageProps): Prom
 
 export default async function CitySpecialtyPage({ params }: CitySpecialtyPageProps) {
   const { city: citySlug, specialty: specialtySlug } = await params;
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
   const city = getCityBySlug(citySlug);
   const specialty = getSpecialtyBySlug(specialtySlug);
   if (!city || !specialty) notFound();
@@ -104,7 +108,17 @@ export default async function CitySpecialtyPage({ params }: CitySpecialtyPagePro
     <div className="container mx-auto px-4 py-12">
       <script
         type="application/ld+json"
+        nonce={nonce}
         dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(jsonLd) }}
+      />
+      <BreadcrumbJsonLd
+        nonce={nonce}
+        items={[
+          { name: "Accueil", url: BASE_URL },
+          { name: "Annuaire", url: `${BASE_URL}/annuaire` },
+          { name: city.name, url: `${BASE_URL}/annuaire/${city.slug}` },
+          { name: specialty.nameFr, url: `${BASE_URL}/annuaire/${city.slug}/${specialty.slug}` },
+        ]}
       />
       {/* Audit 7.6 — hreflang tags for multilingual SEO */}
       <HreflangTags path={`/annuaire/${city.slug}/${specialty.slug}`} />

--- a/src/app/(public)/annuaire/[city]/page.tsx
+++ b/src/app/(public)/annuaire/[city]/page.tsx
@@ -9,9 +9,11 @@ import {
   Building2,
 } from "lucide-react";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button-variants";
@@ -497,12 +499,28 @@ function CityListingView({
 
 export default async function CityOrDoctorPage({ params }: PageProps) {
   const { city: slug } = await params;
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
 
   // Doctor profile page (slug starts with "dr-")
   if (isDoctorSlug(slug)) {
     const doctor = await getDirectoryDoctorBySlug(slug);
     if (!doctor) notFound();
-    return <DoctorProfileView doctor={doctor} />;
+    const cityForBreadcrumb = getCityBySlug(doctor.citySlug);
+    const breadcrumbItems = [
+      { name: "Accueil", url: BASE_URL },
+      { name: "Annuaire", url: `${BASE_URL}/annuaire` },
+      ...(cityForBreadcrumb
+        ? [{ name: cityForBreadcrumb.name, url: `${BASE_URL}/annuaire/${cityForBreadcrumb.slug}` }]
+        : []),
+      { name: doctor.name, url: `${BASE_URL}/annuaire/${doctor.slug}` },
+    ];
+    return (
+      <>
+        <BreadcrumbJsonLd nonce={nonce} items={breadcrumbItems} />
+        <DoctorProfileView doctor={doctor} />
+      </>
+    );
   }
 
   // City listing page
@@ -515,6 +533,16 @@ export default async function CityOrDoctorPage({ params }: PageProps) {
   ]);
 
   return (
-    <CityListingView citySlug={slug} city={city} doctors={doctors} specialties={specialties} />
+    <>
+      <BreadcrumbJsonLd
+        nonce={nonce}
+        items={[
+          { name: "Accueil", url: BASE_URL },
+          { name: "Annuaire", url: `${BASE_URL}/annuaire` },
+          { name: city.name, url: `${BASE_URL}/annuaire/${city.slug}` },
+        ]}
+      />
+      <CityListingView citySlug={slug} city={city} doctors={doctors} specialties={specialties} />
+    </>
   );
 }

--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import { ArrowLeft, Clock, Calendar, Tag, User } from "lucide-react";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { Badge } from "@/components/ui/badge";
 import { getAllPosts, getPostBySlug, BLOG_CATEGORIES } from "@/lib/blog";
 import { getSiteUrl } from "@/lib/env";
@@ -27,6 +29,7 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
     title: post.title,
     description: post.description,
     path: `/blog/${post.slug}`,
+    locale: post.locale ?? "fr",
     ogType: "article",
   });
 
@@ -54,7 +57,10 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const post = getPostBySlug(slug);
   if (!post) notFound();
 
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
   const baseUrl = getSiteUrl() || "https://oltigo.com";
+  const articleLang = post.locale ?? "fr";
 
   const articleSchema = {
     "@context": "https://schema.org",
@@ -69,6 +75,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       "@type": "Organization",
       name: "Oltigo",
       url: baseUrl,
+      logo: `${baseUrl}/opengraph-image.png`,
     },
     datePublished: post.publishedAt,
     dateModified: post.updatedAt ?? post.publishedAt,
@@ -77,15 +84,25 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       "@id": `${baseUrl}/blog/${post.slug}`,
     },
     keywords: post.tags.join(", "),
-    inLanguage: "fr",
+    inLanguage: articleLang,
     articleSection: BLOG_CATEGORIES[post.category],
+    ...(post.ogImage ? { image: [post.ogImage] } : {}),
   };
 
   return (
     <article className="container mx-auto px-4 py-12 max-w-3xl">
       <script
         type="application/ld+json"
+        nonce={nonce}
         dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(articleSchema) }}
+      />
+      <BreadcrumbJsonLd
+        nonce={nonce}
+        items={[
+          { name: "Accueil", url: baseUrl },
+          { name: "Blog", url: `${baseUrl}/blog` },
+          { name: post.title, url: `${baseUrl}/blog/${post.slug}` },
+        ]}
       />
 
       {/* Back to blog */}

--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { dictionaries as landingDictionaries } from "@/components/landing/oltigo/i18n/dictionaries";
+import { FaqSection } from "@/components/public/sections/faq-section";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
+import { getPublicBranding } from "@/lib/data/public";
+import { getRootDomain, getSiteUrl } from "@/lib/env";
+import { t, type Locale } from "@/lib/i18n";
+import { safeJsonLdStringify } from "@/lib/json-ld";
+import { buildMetadata } from "@/lib/metadata";
+import { getTenant } from "@/lib/tenant";
+import { defaultWebsiteConfig } from "@/lib/website-config";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const tenant = await getTenant();
+  const h = await headers();
+  const locale = (h.get("x-tenant-locale") as Locale) || "fr";
+  const rootDomain = getRootDomain() || "oltigo.com";
+  const siteUrl = tenant ? `https://${tenant.subdomain}.${rootDomain}` : undefined;
+  const title = tenant ? `Questions Fréquentes — ${tenant.clinicName}` : "Questions Fréquentes";
+  const description =
+    "Trouvez les réponses aux questions les plus courantes sur nos services et notre plateforme.";
+
+  return buildMetadata({
+    title,
+    description,
+    path: "/faq",
+    locale,
+    siteUrl,
+  });
+}
+
+export default async function FaqPage() {
+  const tenant = await getTenant();
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
+  const locale = ((h.get("x-locale") as Locale | null) ||
+    (h.get("x-tenant-locale") as Locale) ||
+    "fr") as Locale;
+
+  let title: string;
+  let subtitle: string | undefined;
+  let faqs: { q: string; a: string }[];
+  let baseUrl: string;
+
+  if (tenant) {
+    const branding = await getPublicBranding();
+    const rootDomain = getRootDomain() || "oltigo.com";
+    baseUrl = `https://${tenant.subdomain}.${rootDomain}`;
+    const wsFaq = (branding.websiteConfig as { faq?: typeof defaultWebsiteConfig.faq } | null)?.faq;
+    const source = wsFaq ?? defaultWebsiteConfig.faq;
+    title = source.title;
+    subtitle = source.subtitle;
+    faqs = source.items;
+  } else {
+    baseUrl = getSiteUrl() || "https://oltigo.com";
+    const landingDict =
+      (landingDictionaries as Record<string, (typeof landingDictionaries)["fr"] | undefined>)[
+        locale
+      ] ?? landingDictionaries.fr;
+    title = landingDict.faq.title;
+    subtitle = undefined;
+    faqs = landingDict.faq.items;
+  }
+
+  const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((item) => ({
+      "@type": "Question",
+      name: item.q,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.a,
+      },
+    })),
+  };
+
+  const pageTitle = t(locale, "public.sections.faq-section.questionsFrequentes");
+
+  return (
+    <div className="container mx-auto px-4 py-12 max-w-3xl">
+      <script
+        type="application/ld+json"
+        nonce={nonce}
+        dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(faqSchema) }}
+      />
+      <BreadcrumbJsonLd
+        nonce={nonce}
+        items={[
+          { name: "Accueil", url: baseUrl },
+          { name: pageTitle, url: `${baseUrl}/faq` },
+        ]}
+      />
+      <FaqSection title={title} subtitle={subtitle} faqs={faqs} />
+    </div>
+  );
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import { Chatbot } from "@/components/chatbot";
 import { ConsentGatedAnalytics } from "@/components/consent-gated-analytics";
 import { DemoBanner } from "@/components/demo-banner";
@@ -6,18 +7,33 @@ import { DynamicFooter } from "@/components/public/dynamic-footer";
 import { DynamicHeader } from "@/components/public/dynamic-header";
 import { PublicFooter } from "@/components/public/footer";
 import { PublicHeader } from "@/components/public/header";
+import { WebSiteJsonLd } from "@/components/seo/json-ld";
 import { getPublicBranding, type ClinicBranding } from "@/lib/data/public";
+import { getRootDomain, getSiteUrl } from "@/lib/env";
 import { buildPublicThemeStyle } from "@/lib/public-theme";
 import { getTemplate } from "@/lib/templates";
 import { getTenant } from "@/lib/tenant";
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
   const tenant = await getTenant();
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
 
   // Root domain (no tenant) → wrap marketing public pages with the Oltigo
   // nav/footer; the home page keeps its self-contained landing shell.
   if (!tenant) {
-    return <PublicRootLayout>{children}</PublicRootLayout>;
+    const siteUrl = getSiteUrl() || "https://oltigo.com";
+    return (
+      <PublicRootLayout>
+        <WebSiteJsonLd
+          url={siteUrl}
+          name="Oltigo"
+          searchUrl={`${siteUrl}/annuaire?q={search_term_string}`}
+          nonce={nonce}
+        />
+        {children}
+      </PublicRootLayout>
+    );
   }
 
   // Subdomain → wrap with clinic branding, header, and footer
@@ -29,6 +45,8 @@ export default async function PublicLayout({ children }: { children: React.React
   const gtmId = brandingConfig.gtmId ?? null;
 
   const isDemo = tenant.subdomain === "demo";
+  const rootDomain = getRootDomain() || "oltigo.com";
+  const siteUrl = `https://${tenant.subdomain}.${rootDomain}`;
 
   // Template-aware header/footer: the clinic's chosen template can swap the
   // header/footer layout. "top-sticky"/"classic-3col" keep the default
@@ -41,6 +59,12 @@ export default async function PublicLayout({ children }: { children: React.React
     <div style={buildPublicThemeStyle(branding, template)}>
       {isDemo && <DemoBanner />}
       <ConsentGatedAnalytics gaId={gaId} gtmId={gtmId} />
+      <WebSiteJsonLd
+        url={siteUrl}
+        name={branding.clinicName}
+        searchUrl={`${siteUrl}/book`}
+        nonce={nonce}
+      />
       {useOriginalHeader ? (
         <PublicHeader
           logoUrl={branding.logoUrl}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -20,7 +20,7 @@ import {
 import { ServicesPreview } from "@/components/public/services-preview";
 import { Card, CardContent } from "@/components/ui/card";
 import { getPublicReviews, getPublicAverageRating, getPublicBranding } from "@/lib/data/public";
-import { getRootDomain } from "@/lib/env";
+import { getRootDomain, getSiteUrl } from "@/lib/env";
 import { t, type Locale } from "@/lib/i18n";
 import { safeJsonLdStringify } from "@/lib/json-ld";
 import { logger } from "@/lib/logger";
@@ -29,6 +29,7 @@ import { publicCardClass } from "@/lib/public-theme";
 import { mergeSectionVisibility, type SectionKey } from "@/lib/section-visibility";
 import { getTemplate } from "@/lib/templates";
 import { getTenant } from "@/lib/tenant";
+import { defaultWebsiteConfig } from "@/lib/website-config";
 
 /**
  * Map a template's `sectionOrder` (which uses loose, historical names like
@@ -152,11 +153,21 @@ export default async function HomePage() {
 
   // Root domain (no subdomain) → show SaaS landing page
   if (!tenant) {
+    const siteUrl = getSiteUrl() || "https://oltigo.com";
     const saasJsonLd = {
       "@context": "https://schema.org",
       "@type": "Organization",
       name: "Oltigo",
-      url: "https://oltigo.com",
+      url: siteUrl,
+      logo: `${siteUrl}/opengraph-image.png`,
+      sameAs: ["https://www.linkedin.com/company/oltigo"],
+      contactPoint: {
+        "@type": "ContactPoint",
+        email: "contact@oltigo.com",
+        areaServed: "MA",
+        availableLanguage: ["French", "Arabic", "English"],
+        contactType: "customer support",
+      },
       description:
         "Plateforme SaaS de gestion de cabinets médicaux au Maroc. Rendez-vous en ligne, dossier patient chiffré, rappels WhatsApp.",
       foundingDate: "2024",
@@ -171,7 +182,7 @@ export default async function HomePage() {
       name: "Oltigo Health",
       applicationCategory: "HealthApplication",
       operatingSystem: "Web",
-      url: "https://oltigo.com",
+      url: siteUrl,
       description:
         "Plateforme complète pour gérer votre cabinet médical : rendez-vous, dossiers patients chiffrés, rappels WhatsApp en darija.",
       offers: {
@@ -253,12 +264,51 @@ export default async function HomePage() {
   // Build LocalBusiness + MedicalOrganization structured data
   const rootDomain = getRootDomain() || "oltigo.com";
   const canonicalUrl = `https://${tenant.subdomain}.${rootDomain}`;
+
+  const images = [branding.logoUrl, branding.heroImageUrl, branding.coverPhotoUrl].filter(
+    (url): url is string => typeof url === "string" && url.length > 0,
+  );
+
+  const workingHours =
+    (
+      branding.websiteConfig as {
+        location?: { workingHours?: { day: string; hours: string }[] };
+      }
+    )?.location?.workingHours ?? defaultWebsiteConfig.location.workingHours;
+
+  const DAY_MAP: Record<string, string> = {
+    Lundi: "Monday",
+    Mardi: "Tuesday",
+    Mercredi: "Wednesday",
+    Jeudi: "Thursday",
+    Vendredi: "Friday",
+    Samedi: "Saturday",
+    Dimanche: "Sunday",
+  };
+
+  const openingHours = workingHours
+    .filter((wh) => wh.hours && !wh.hours.toLowerCase().includes("fermé"))
+    .map((wh) => {
+      const [opens, closes] = wh.hours.split("-").map((s) => s.trim());
+      return {
+        "@type": "OpeningHoursSpecification",
+        dayOfWeek: DAY_MAP[wh.day] ?? wh.day,
+        opens,
+        closes,
+      };
+    })
+    .filter((oh) => oh.opens && oh.closes);
+
+  const geo = (branding.websiteConfig as { geo?: { latitude?: number; longitude?: number } })?.geo;
+  const priceRange = (branding.websiteConfig as { priceRange?: string })?.priceRange ?? "€€";
+
   const clinicSchema = {
     "@context": "https://schema.org",
     "@type": ["LocalBusiness", "MedicalOrganization"],
     "@id": `${canonicalUrl}/#organization`,
     name: branding.clinicName || tenant.clinicName,
     url: canonicalUrl,
+    ...(images.length ? { image: images } : {}),
     ...(branding.phone ? { telephone: branding.phone } : {}),
     ...(branding.email ? { email: branding.email } : {}),
     ...(branding.address
@@ -270,6 +320,17 @@ export default async function HomePage() {
           },
         }
       : {}),
+    ...(geo?.latitude != null && geo?.longitude != null
+      ? {
+          geo: {
+            "@type": "GeoCoordinates",
+            latitude: geo.latitude,
+            longitude: geo.longitude,
+          },
+        }
+      : {}),
+    ...(openingHours.length ? { openingHoursSpecification: openingHours } : {}),
+    priceRange,
     ...(branding.logoUrl ? { logo: branding.logoUrl } : {}),
     ...(avgRating > 0 && reviews.length > 0
       ? {

--- a/src/app/(public)/pricing/page.tsx
+++ b/src/app/(public)/pricing/page.tsx
@@ -2,9 +2,12 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { LandingLocaleProvider } from "@/components/landing/landing-locale-provider";
 import { Pricing } from "@/components/landing/oltigo/components/sections/pricing";
+import { dictionaries as landingDictionaries } from "@/components/landing/oltigo/i18n/dictionaries";
 import { PricingContent } from "@/components/landing/pricing-content";
-import { getRootDomain } from "@/lib/env";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
+import { getRootDomain, getSiteUrl } from "@/lib/env";
 import { t, type Locale } from "@/lib/i18n";
+import { safeJsonLdStringify } from "@/lib/json-ld";
 import { buildMetadata } from "@/lib/metadata";
 import { getTenant } from "@/lib/tenant";
 
@@ -29,18 +32,100 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
+function buildPricingSchema(
+  baseUrl: string,
+  tiers: {
+    id: string;
+    name: string;
+    price: string;
+    currency: string;
+    blurb: string;
+    cta: string;
+  }[],
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: "Oltigo Health",
+    description: "Plans tarifaires Oltigo pour cabinets médicaux au Maroc.",
+    url: `${baseUrl}/pricing`,
+    brand: {
+      "@type": "Brand",
+      name: "Oltigo",
+    },
+    offers: tiers.map((tier) => ({
+      "@type": "Offer",
+      name: tier.name,
+      description: tier.blurb,
+      price: tier.price,
+      priceCurrency: tier.currency,
+      priceValidUntil: `${new Date().getFullYear()}-12-31`,
+      availability: "https://schema.org/InStock",
+      url: tier.id === "enterprise" ? `${baseUrl}/#demo` : `${baseUrl}/register-clinic`,
+    })),
+  };
+}
+
 export default async function PricingPage() {
   const tenant = await getTenant();
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
+  const locale = ((h.get("x-locale") as Locale | null) ||
+    (h.get("x-tenant-locale") as Locale) ||
+    "fr") as Locale;
+
+  const rootDomain = getRootDomain() || "oltigo.com";
+  const baseUrl = tenant
+    ? `https://${tenant.subdomain}.${rootDomain}`
+    : getSiteUrl() || "https://oltigo.com";
+
+  const landingDict =
+    (landingDictionaries as Record<string, (typeof landingDictionaries)["fr"] | undefined>)[
+      locale
+    ] ?? landingDictionaries.fr;
+  const tiers = landingDict.pricing.tiers.map((tier) => ({
+    id: tier.id,
+    name: tier.name,
+    price: tier.price,
+    currency: landingDict.pricing.currency,
+    blurb: tier.blurb,
+    cta: tier.cta,
+  }));
+  const pricingSchema = buildPricingSchema(baseUrl, tiers);
+  const pricingScript = (
+    <script
+      type="application/ld+json"
+      nonce={nonce}
+      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(pricingSchema) }}
+    />
+  );
+  const breadcrumb = (
+    <BreadcrumbJsonLd
+      nonce={nonce}
+      items={[
+        { name: "Accueil", url: baseUrl },
+        { name: landingDict.pricing.title, url: `${baseUrl}/pricing` },
+      ]}
+    />
+  );
 
   // Subdomain → render legacy pricing inside the tenant public layout.
   if (tenant) {
     return (
       <LandingLocaleProvider>
+        {pricingScript}
+        {breadcrumb}
         <PricingContent />
       </LandingLocaleProvider>
     );
   }
 
   // Root domain → Oltigo landing chrome with the dedicated pricing section.
-  return <Pricing headingAs="h1" />;
+  return (
+    <>
+      {pricingScript}
+      {breadcrumb}
+      <Pricing headingAs="h1" />
+    </>
+  );
 }

--- a/src/app/(public)/services/page.tsx
+++ b/src/app/(public)/services/page.tsx
@@ -1,7 +1,9 @@
 import { Clock, CreditCard } from "lucide-react";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { BreadcrumbJsonLd } from "@/components/seo/json-ld";
 import { buttonVariants } from "@/components/ui/button-variants";
 import {
   Card,
@@ -11,8 +13,8 @@ import {
   CardTitle,
   CardDescription,
 } from "@/components/ui/card";
-import { getPublicServices } from "@/lib/data/public";
-import { getSiteUrl } from "@/lib/env";
+import { getPublicBranding, getPublicServices } from "@/lib/data/public";
+import { getRootDomain } from "@/lib/env";
 import { safeJsonLdStringify } from "@/lib/json-ld";
 import { buildMetadata } from "@/lib/metadata";
 import { getTenant } from "@/lib/tenant";
@@ -34,16 +36,28 @@ export default async function ServicesPage() {
     redirect("/#features");
   }
 
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
+  const branding = await getPublicBranding();
+
   const cfg = defaultWebsiteConfig.services;
 
   const services = await getPublicServices();
-  const baseUrl = getSiteUrl() || "https://oltigo.com";
+  const rootDomain = getRootDomain() || "oltigo.com";
+  const canonicalUrl = `https://${tenant.subdomain}.${rootDomain}`;
 
   const servicesSchema = {
     "@context": "https://schema.org",
+    "@id": `${canonicalUrl}/#services`,
     "@type": "MedicalBusiness",
-    url: `${baseUrl}/services`,
+    url: `${canonicalUrl}/services`,
     name: cfg.title,
+    provider: {
+      "@type": "MedicalOrganization",
+      name: branding.clinicName || tenant.clinicName,
+      url: canonicalUrl,
+      ...(branding.logoUrl ? { logo: branding.logoUrl } : {}),
+    },
     hasOfferCatalog: {
       "@type": "OfferCatalog",
       name: "Medical Services",
@@ -66,9 +80,17 @@ export default async function ServicesPage() {
     <div className="container mx-auto px-4 py-12">
       <script
         type="application/ld+json"
+        nonce={nonce}
         // SAFETY: safeJsonLdStringify escapes "<" to prevent </script> injection
         // from database-sourced fields (service name, description, price).
         dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(servicesSchema) }}
+      />
+      <BreadcrumbJsonLd
+        nonce={nonce}
+        items={[
+          { name: "Accueil", url: canonicalUrl },
+          { name: cfg.title, url: `${canonicalUrl}/services` },
+        ]}
       />
       <div className="text-center mb-12">
         <h1 className="text-3xl font-bold mb-4">{cfg.title}</h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,7 @@ import { MaskingBuildSentinel } from "@/components/masking-build-sentinel";
 import { OfflineIndicator } from "@/components/offline-indicator";
 import { PerformanceMonitor } from "@/components/performance-monitor";
 import { PlausibleScript } from "@/components/plausible-script";
+import { WebSiteJsonLd } from "@/components/seo/json-ld";
 import { ServiceWorkerRegister } from "@/components/sw-register";
 import { TenantProvider } from "@/components/tenant-provider";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -173,6 +174,7 @@ export default async function RootLayout({
   // — without it, the publicly-cached page can only ever serve the French
   // default since the cache key does not vary on the preferred-locale cookie.
   const headerStore = await headers();
+  const nonce = headerStore.get("x-nonce") || undefined;
   const explicitLocale = headerStore.get("x-locale");
   const cookieStore = await import("next/headers").then((m) => m.cookies());
   const preferredLocale = cookieStore.get("preferred-locale")?.value as Locale | undefined;
@@ -182,6 +184,7 @@ export default async function RootLayout({
     preferredLocale ||
     tenantLocale;
   const dir = getDirFromLocale(locale);
+  const siteUrl = getSiteUrl() || "https://oltigo.com";
 
   return (
     <html
@@ -200,6 +203,12 @@ export default async function RootLayout({
         )}
       </head>
       <body className="min-h-full flex flex-col">
+        <WebSiteJsonLd
+          url={siteUrl}
+          name="Oltigo"
+          searchUrl={`${siteUrl}/annuaire?q={search_term_string}`}
+          nonce={nonce}
+        />
         {/* Skip-to-content link for keyboard / screen-reader accessibility (WCAG 2.4.1) */}
         <a
           href="#main-content"
@@ -207,8 +216,9 @@ export default async function RootLayout({
         >
           {t(locale, "nav.skipToContent")}
         </a>
-        {/* JSON-LD structured data is rendered on public pages only (Issue 59).
-            See src/app/(public)/page.tsx for clinic-specific schema. */}
+        {/* Global WebSite JSON-LD is rendered here; page-specific structured
+            data (Organization, SoftwareApplication, LocalBusiness, FAQPage,
+            etc.) is rendered on individual public pages. */}
         <ThemeProvider>
           <ToastProvider>
             <TenantProvider tenant={tenant}>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -33,6 +33,7 @@ export default function robots(): MetadataRoute.Robots {
           "/accessibility",
           "/status",
           "/api-docs",
+          "/faq",
           "/doctor-profile",
           "/doctor-services",
           "/annuaire",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -58,6 +58,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: "/accessibility", priority: 0.3, changeFrequency: "yearly" as const },
     { path: "/status", priority: 0.3, changeFrequency: "daily" as const },
     { path: "/api-docs", priority: 0.5, changeFrequency: "monthly" as const },
+    { path: "/faq", priority: 0.6, changeFrequency: "monthly" as const },
   ];
 
   const entries: MetadataRoute.Sitemap = staticPages.map((page) => ({

--- a/src/components/public/sections/faq-section.tsx
+++ b/src/components/public/sections/faq-section.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-const faqs = [
+const DEFAULT_FAQS = [
   {
     q: "Comment prendre rendez-vous ?",
     a: "Vous pouvez prendre rendez-vous en ligne via notre site web en cliquant sur le bouton \u00ab Prendre rendez-vous \u00bb, ou nous appeler directement pendant les heures d'ouverture.",
@@ -28,17 +28,23 @@ const faqs = [
   },
 ];
 
-export function FaqSection() {
+interface FaqSectionProps {
+  title?: string;
+  subtitle?: string;
+  faqs?: { q: string; a: string }[];
+}
+
+export function FaqSection({ title, subtitle, faqs = DEFAULT_FAQS }: FaqSectionProps) {
   const [openIndex, setOpenIndex] = useState<number | null>(0);
 
   return (
     <section className="py-12 sm:py-16">
       <div className="container mx-auto px-4 max-w-3xl">
         <h2 className="text-center text-2xl sm:text-3xl font-bold text-balance mb-4">
-          Questions Fréquentes
+          {title ?? "Questions Fréquentes"}
         </h2>
         <p className="text-center text-muted-foreground mb-6 sm:mb-8">
-          Trouvez les réponses aux questions les plus courantes sur nos services.
+          {subtitle ?? "Trouvez les réponses aux questions les plus courantes sur nos services."}
         </p>
         <div className="space-y-3">
           {faqs.map((faq, index) => {

--- a/src/components/seo/json-ld.tsx
+++ b/src/components/seo/json-ld.tsx
@@ -1,0 +1,63 @@
+import { safeJsonLdStringify } from "@/lib/json-ld";
+
+interface WebSiteJsonLdProps {
+  url: string;
+  name: string;
+  searchUrl?: string;
+  nonce?: string;
+}
+
+export function WebSiteJsonLd({ url, name, searchUrl, nonce }: WebSiteJsonLdProps) {
+  const website = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name,
+    url,
+    ...(searchUrl
+      ? {
+          potentialAction: {
+            "@type": "SearchAction",
+            target: {
+              "@type": "EntryPoint",
+              urlTemplate: searchUrl,
+            },
+            "query-input": "required name=search_term_string",
+          },
+        }
+      : {}),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      nonce={nonce}
+      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(website) }}
+    />
+  );
+}
+
+interface BreadcrumbJsonLdProps {
+  items: { name: string; url: string }[];
+  nonce?: string;
+}
+
+export function BreadcrumbJsonLd({ items, nonce }: BreadcrumbJsonLdProps) {
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      nonce={nonce}
+      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(breadcrumb) }}
+    />
+  );
+}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,9 +1,16 @@
+import post5 from "@/content/blog/cnss-cnops-gerer-assurances-cabinet";
+import post2 from "@/content/blog/gestion-cabinet-dentaire-outils";
+import post1 from "@/content/blog/logiciel-gestion-cabinet-medical-maroc";
+import post3 from "@/content/blog/prise-rendez-vous-en-ligne-maroc";
+import post4 from "@/content/blog/whatsapp-medecins-communication-patient";
+import type { Locale } from "@/lib/i18n";
+
 /**
  * Static blog content system for the root-domain (platform-level) blog.
  *
  * Blog posts are stored as plain TypeScript objects in `src/content/blog/`.
  * Each file default-exports a `BlogPost` object. This module re-exports
- * every post and provides helpers used by the listing and detail pages.
+ * every post and provides helpers used by the blog listing and detail pages.
  */
 
 // ── Types ──
@@ -21,6 +28,7 @@ export interface BlogPost {
   readTime: string;
   content: string; // HTML content
   ogImage?: string;
+  locale?: Locale;
 }
 
 export type BlogCategory =
@@ -39,12 +47,6 @@ export const BLOG_CATEGORIES: Record<BlogCategory, string> = {
 };
 
 // ── Post registry ──
-
-import post5 from "@/content/blog/cnss-cnops-gerer-assurances-cabinet";
-import post2 from "@/content/blog/gestion-cabinet-dentaire-outils";
-import post1 from "@/content/blog/logiciel-gestion-cabinet-medical-maroc";
-import post3 from "@/content/blog/prise-rendez-vous-en-ligne-maroc";
-import post4 from "@/content/blog/whatsapp-medecins-communication-patient";
 
 const ALL_POSTS: BlogPost[] = [post1, post2, post3, post4, post5];
 

--- a/src/lib/website-config.ts
+++ b/src/lib/website-config.ts
@@ -70,6 +70,13 @@ export interface WebsiteConfig {
     subtitle: string;
   };
 
+  /** FAQ page */
+  faq: {
+    title: string;
+    subtitle: string;
+    items: { q: string; a: string }[];
+  };
+
   /** Theme overrides */
   theme: {
     primaryColor: string;
@@ -168,6 +175,33 @@ export const defaultWebsiteConfig: WebsiteConfig = {
     title: "Nos Services",
     subtitle:
       "Nous proposons une large gamme de services médicaux pour répondre à vos besoins de santé. Toutes les consultations comprennent un examen approfondi et des soins personnalisés.",
+  },
+
+  faq: {
+    title: "Questions Fréquentes",
+    subtitle: "Trouvez les réponses aux questions les plus courantes sur nos services.",
+    items: [
+      {
+        q: "Comment prendre rendez-vous ?",
+        a: "Vous pouvez prendre rendez-vous en ligne via notre site web en cliquant sur le bouton « Prendre rendez-vous », ou nous appeler directement pendant les heures d'ouverture.",
+      },
+      {
+        q: "Quelles assurances acceptez-vous ?",
+        a: "Nous acceptons la plupart des assurances majeures, notamment CNSS, CNOPS, RMA, SAHAM et AXA. Contactez-nous pour les détails de couverture.",
+      },
+      {
+        q: "Quels sont vos horaires d'ouverture ?",
+        a: "Nous sommes ouverts du lundi au vendredi de 9h00 à 17h00, et le samedi de 9h00 à 13h00. Nous sommes fermés le dimanche.",
+      },
+      {
+        q: "Ai-je besoin d'une recommandation ?",
+        a: "Aucune recommandation n'est nécessaire pour une consultation générale. Certains services spécialisés peuvent nécessiter une orientation de votre médecin traitant.",
+      },
+      {
+        q: "Puis-je annuler ou reporter mon rendez-vous ?",
+        a: "Oui, vous pouvez annuler ou reporter votre rendez-vous jusqu'à 24 heures à l'avance via notre site web ou en nous appelant.",
+      },
+    ],
   },
 
   theme: {


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the public-site SEO completion plan:

- Adds reusable `WebSiteJsonLd` and `BreadcrumbJsonLd` components in `src/components/seo/json-ld.tsx`.
- Injects `WebSite` JSON-LD (with `SearchAction`) into the global `src/app/layout.tsx` and `src/app/(public)/layout.tsx`.
- Enriches the root-domain `Organization` schema with `logo`, `sameAs`, `contactPoint` and `areaServed: MA`, and the `SoftwareApplication` schema with the dynamic `siteUrl`.
- Enriches the clinic `LocalBusiness` / `MedicalOrganization` schema with `image`, `openingHoursSpecification`, `priceRange`, `geo` and `aggregateRating`.
- Enriches blog post `Article` JSON-LD with `image` and `inLanguage` taken from `post.locale`.
- Adds `provider` and `@id` to the clinic services `MedicalBusiness` schema.
- Adds `Product` / `Offer` JSON-LD to `/pricing` for each plan.
- Creates `/faq` (`src/app/(public)/faq/page.tsx`) with `FAQPage` schema and an accordion UI, reusing the landing dictionary on the root domain and `websiteConfig.faq` for clinics.
- Updates `robots.ts` and `sitemap.ts` to include `/faq`.

## Type of change

- [x] New feature

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed (local `npm run dev`, `curl` checks)

`npm run lint`, `npx tsc --noEmit`, `npm run test` and `npm run build` all pass.

## Rollback

Revert this commit.

## Drive-by Refactors

- `FaqSection` now accepts optional `title`, `subtitle` and `faqs` props so it can be reused by the new `/faq` page.