### PR TITLE
Phase 4: accessibility and performance quick wins

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -201,6 +201,11 @@ export default async function RootLayout({
             <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
           </>
         )}
+        {/* Preconnect to Google Fonts and clinic image CDN for faster LCP */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="preconnect" href="https://uploads.oltigo.com" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://uploads.oltigo.com" />
       </head>
       <body className="min-h-full flex flex-col">
         <WebSiteJsonLd

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -76,14 +76,14 @@ export function Footer() {
             <div className="mt-5 space-y-1.5">
               <a
                 href={`tel:${defaultWebsiteConfig.contact.phone.replace(/\s|-/g, "")}`}
-                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text"
+                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text min-h-11"
               >
                 <Phone className="size-3.5 text-text-muted" aria-hidden="true" />
                 {defaultWebsiteConfig.contact.phone}
               </a>
               <a
                 href={`mailto:${defaultWebsiteConfig.contact.email}`}
-                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text"
+                className="flex items-center gap-2 text-[12.5px] text-text-secondary transition-colors hover:text-text min-h-11"
               >
                 <Mail className="size-3.5 text-text-muted" aria-hidden="true" />
                 {defaultWebsiteConfig.contact.email}
@@ -110,7 +110,7 @@ export function Footer() {
                           href={href}
                           rel="noopener"
                           target="_blank"
-                          className="text-[13.5px] text-text-secondary transition-colors hover:text-text"
+                          className="text-[13.5px] text-text-secondary transition-colors hover:text-text min-h-11 flex items-center"
                         >
                           {link}
                         </a>
@@ -119,7 +119,7 @@ export function Footer() {
                           href={href}
                           {...(isAnchor(href) ? {} : { rel: "noopener" })}
                           {...(isExternal(href) ? { target: "_blank", rel: "noopener" } : {})}
-                          className="text-[13.5px] text-text-secondary transition-colors hover:text-text"
+                          className="text-[13.5px] text-text-secondary transition-colors hover:text-text min-h-11 flex items-center"
                         >
                           {link}
                         </Link>

--- a/src/components/landing/oltigo/components/sections/testimonials.tsx
+++ b/src/components/landing/oltigo/components/sections/testimonials.tsx
@@ -46,6 +46,9 @@ export function Testimonials() {
                         alt=""
                         className="h-full w-full object-cover"
                         loading="lazy"
+                        sizes="40px"
+                        decoding="async"
+                        fetchPriority="low"
                       />
                     ) : (
                       getInitials(t.name)

--- a/src/components/landing/oltigo/components/ui/button.tsx
+++ b/src/components/landing/oltigo/components/ui/button.tsx
@@ -16,9 +16,9 @@ const button = cva(
         outline: "border border-hairline text-text hover:border-emerald/60",
       },
       size: {
-        sm: "h-9 px-3.5 text-[13px]",
-        md: "h-11 px-5 text-sm",
-        lg: "h-12 px-6 text-[15px]",
+        sm: "h-9 min-h-11 px-3.5 text-[13px]",
+        md: "h-11 min-h-11 px-5 text-sm",
+        lg: "h-12 min-h-11 px-6 text-[15px]",
       },
     },
     defaultVariants: { variant: "secondary", size: "md" },

--- a/src/components/public/contact-form.tsx
+++ b/src/components/public/contact-form.tsx
@@ -85,7 +85,13 @@ export function ContactForm() {
             </div>
             <div className="space-y-2">
               <Label htmlFor="phone">{t(locale, "contact.phone")}</Label>
-              <Input id="phone" name="phone" placeholder="+212 6XX XX XX XX" />
+              <Input
+                id="phone"
+                name="phone"
+                type="tel"
+                autoComplete="tel"
+                placeholder="+212 6XX XX XX XX"
+              />
             </div>
           </div>
           <div className="space-y-2">

--- a/src/components/public/header.tsx
+++ b/src/components/public/header.tsx
@@ -124,6 +124,8 @@ export function PublicHeader({
                 width={36}
                 height={36}
                 className="h-8 sm:h-9 w-auto flex-shrink-0"
+                priority
+                sizes="36px"
               />
             )}
             <span className="truncate">{displayName}</span>

--- a/src/components/public/headers/header-bottom-bar.tsx
+++ b/src/components/public/headers/header-bottom-bar.tsx
@@ -40,6 +40,8 @@ export function HeaderBottomBar({ logoUrl, clinicName, navItems, template }: Hea
                 width={28}
                 height={28}
                 className="h-7 w-auto"
+                priority
+                sizes="28px"
               />
             )}
             {displayName}

--- a/src/components/public/headers/header-floating.tsx
+++ b/src/components/public/headers/header-floating.tsx
@@ -46,6 +46,8 @@ export function HeaderFloating({ logoUrl, clinicName, navItems, template }: Head
                   width={28}
                   height={28}
                   className="h-7 w-auto flex-shrink-0"
+                  priority
+                  sizes="28px"
                 />
               )}
               <span className="hidden sm:inline truncate">{displayName}</span>

--- a/src/components/public/headers/header-top-sticky.tsx
+++ b/src/components/public/headers/header-top-sticky.tsx
@@ -107,6 +107,8 @@ export function HeaderTopSticky({
                 width={isPremium ? 44 : 36}
                 height={isPremium ? 44 : 36}
                 className="h-8 sm:h-10 w-auto flex-shrink-0"
+                priority
+                sizes={isPremium ? "44px" : "36px"}
               />
             )}
             <span className="truncate">{displayName}</span>

--- a/src/components/public/headers/header-transparent.tsx
+++ b/src/components/public/headers/header-transparent.tsx
@@ -63,6 +63,8 @@ export function HeaderTransparent({ logoUrl, clinicName, navItems, template }: H
               width={32}
               height={32}
               className="h-8 w-auto flex-shrink-0"
+              priority
+              sizes="32px"
             />
           )}
           <span className="truncate">{displayName}</span>

--- a/src/components/public/hero-section.tsx
+++ b/src/components/public/hero-section.tsx
@@ -110,11 +110,12 @@ export function HeroSection({ overrides, variant = "split", template }: HeroSect
                 {cfg.imageUrl ? (
                   <Image
                     src={cfg.imageUrl}
-                    alt="Cabinet médical"
+                    alt={cfg.title ? `Photo du cabinet ${cfg.title}` : "Cabinet médical"}
                     width={600}
                     height={500}
                     className="rounded-[1.75rem] h-80 sm:h-96 w-full object-cover"
                     priority
+                    sizes="(max-width: 1024px) 100vw, 50vw"
                   />
                 ) : (
                   <div className="flex h-80 sm:h-96 items-center justify-center rounded-[1.75rem] bg-card">
@@ -200,10 +201,12 @@ export function HeroSection({ overrides, variant = "split", template }: HeroSect
             {cfg.imageUrl ? (
               <Image
                 src={cfg.imageUrl}
-                alt="Clinic"
+                alt={cfg.title ? `Photo du cabinet ${cfg.title}` : "Cabinet médical"}
                 width={500}
                 height={384}
                 className="rounded-2xl shadow-xl max-h-96 object-cover"
+                priority
+                sizes="(max-width: 1024px) 100vw, 50vw"
               />
             ) : (
               <div className="relative h-80 w-full max-w-md" aria-hidden="true">

--- a/src/components/public/sections/contact-form-section.tsx
+++ b/src/components/public/sections/contact-form-section.tsx
@@ -39,34 +39,53 @@ export function ContactFormSection() {
               >
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
-                    <Label>Nom</Label>
-                    <Input className="min-h-11" placeholder="Votre nom" required />
+                    <Label htmlFor="contact-name">Nom</Label>
+                    <Input
+                      id="contact-name"
+                      name="name"
+                      className="min-h-11"
+                      placeholder="Votre nom"
+                      autoComplete="name"
+                      required
+                    />
                   </div>
                   <div className="space-y-2">
-                    <Label>Email</Label>
+                    <Label htmlFor="contact-email">Email</Label>
                     <Input
+                      id="contact-email"
+                      name="email"
                       className="min-h-11"
                       type="email"
                       placeholder="votre@email.com"
+                      autoComplete="email"
                       required
                     />
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label>Téléphone</Label>
-                  <Input className="min-h-11" placeholder="+212 6XX XX XX XX" />
+                  <Label htmlFor="contact-phone">Téléphone</Label>
+                  <Input
+                    id="contact-phone"
+                    name="phone"
+                    type="tel"
+                    className="min-h-11"
+                    placeholder="+212 6XX XX XX XX"
+                    autoComplete="tel"
+                  />
                 </div>
                 <div className="space-y-2">
-                  <Label>Message</Label>
+                  <Label htmlFor="contact-message">Message</Label>
                   <Textarea
+                    id="contact-message"
+                    name="message"
                     className="min-h-24"
                     placeholder="Comment pouvons-nous vous aider ?"
                     rows={4}
                     required
                   />
                 </div>
-                <Button type="submit" className="w-full">
-                  <Send className="h-4 w-4 me-2" />
+                <Button type="submit" className="w-full min-h-11">
+                  <Send className="h-4 w-4 me-2" aria-hidden="true" />
                   Envoyer le message
                 </Button>
               </form>

--- a/src/components/public/sections/doctors-section.tsx
+++ b/src/components/public/sections/doctors-section.tsx
@@ -66,10 +66,12 @@ export async function DoctorsSection({
                 {primaryDoctor.avatar ? (
                   <Image
                     src={primaryDoctor.avatar}
-                    alt={primaryDoctor.name}
+                    alt={`Dr. ${primaryDoctor.name}`}
                     width={520}
                     height={520}
                     className="relative rounded-[2rem] h-80 sm:h-[28rem] w-full object-cover shadow-2xl"
+                    priority
+                    sizes="(max-width: 1024px) 100vw, 50vw"
                   />
                 ) : (
                   <div className="relative flex h-80 sm:h-[28rem] items-center justify-center rounded-[2rem] bg-card shadow-2xl">
@@ -147,10 +149,12 @@ export async function DoctorsSection({
                 {doctor.avatar ? (
                   <Image
                     src={doctor.avatar}
-                    alt={doctor.name}
+                    alt={`Dr. ${doctor.name}`}
                     width={96}
                     height={96}
                     className="rounded-full h-24 w-24 object-cover mx-auto mb-4"
+                    loading="lazy"
+                    sizes="96px"
                   />
                 ) : (
                   <Avatar className="h-24 w-24 mx-auto mb-4">


### PR DESCRIPTION
## Summary

This PR implements Phase 4 of the public-site completion plan:

- Adds descriptive, context-aware `alt` text and responsive `sizes`/`priority`/`loading` attributes to public `next/image` usage in headers, hero, doctors section, and testimonial avatars.
- Enforces a 44×44 CSS-pixel minimum touch target on landing CTAs (`min-h-11` on all `Button` sizes) and landing footer links.
- Associates every public contact form `<Label>` with its input via `htmlFor`/`id` and adds `name`, `type="tel"`, and `autoComplete` attributes.
- Adds `preconnect`/`dns-prefetch` hints for Google Fonts and `uploads.oltigo.com` in the root layout to reduce LCP.
- Adds `decoding="async"` and `fetchPriority="low"` hints to lazy testimonial avatars.

## Type of change

- [x] New feature

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed (local `npm run dev`, `curl` checks)

`npm run lint`, `npx tsc --noEmit`, `npm run test` and `npm run build` all pass.

## Rollback

Revert this commit.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] Coverage thresholds still met (`npm run test:coverage`)
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints) — no new endpoints