### PR TITLE
Phase 6: performance and Core Web Vitals quick wins

### DIFF
--- a/src/app/tokens.css
+++ b/src/app/tokens.css
@@ -60,8 +60,11 @@
      Landing-specific font stacks. Namespaced (suffix `-landing`) so they do
      not clobber --font-sans / --font-mono which are the app-wide theme tokens
      consumed by Tailwind v4's @theme inline in globals.css. */
-  --font-sans-landing: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
-  --font-mono-landing: "JetBrains Mono", "Geist Mono", ui-monospace, "Cascadia Code", monospace;
+  --font-sans-landing:
+    var(--font-inter), Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono-landing:
+    var(--font-jetbrains-mono), "JetBrains Mono", "Geist Mono", ui-monospace, "Cascadia Code",
+    monospace;
   --font-arabic:
     var(--font-ibm-plex-arabic), "IBM Plex Sans Arabic", "Noto Sans Arabic",
     var(--font-noto-arabic), sans-serif;


### PR DESCRIPTION
## Summary

This PR implements Phase 6 of the public-site completion plan:

- Lands landing-page font stacks on the `next/font` CSS variables (`--font-inter`, `--font-jetbrains-mono`) so marketing pages use the self-hosted, swap-display font families instead of relying on system fonts.
- Confirms `next.config.ts` already optimizes images as `image/avif` then `image/webp`.
- Public hero and doctor images already carry `priority` + `sizes` from Phase 4, so they load with high fetch priority and modern formats.
- Plausible and per-clinic GA/GTM scripts already use `strategy="afterInteractive"` and are rendered in the body, not in `<head>`, so they do not block first paint.

## Type of change

- [x] New feature

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] Manual testing performed (local `npm run dev`, `curl` checks)

`npm run lint`, `npx tsc --noEmit`, `npm run test` and `npm run build` all pass.

## Rollback

Revert this commit.

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] Coverage thresholds still met (`npm run test:coverage`)
- [x] New API endpoints have rate limiting (fail-closed for PHI endpoints) — no new endpoints