### PR TITLE
ci: run CI on pull requests to any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, staging]
 
 # A34.12: Cancel redundant runs for the same PR — prevents duplicate
 # CodeQL/Gitleaks/Semgrep jobs from racing and wasting runner minutes.


### PR DESCRIPTION
## Summary

The `CI` workflow was only triggered for PRs targeting `main` or `staging`. Stacked feature PRs (e.g. `devin/public-seo-phase*`) therefore showed no checks.

This change removes the `branches` filter so lint/type/tests run on every pull request, including stacked branches, while still respecting the existing `concurrency` group per PR.

## Type of change

- [x] Configuration / CI

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A

## Testing

- [x] N/A — workflow change

## Rollback

Revert this commit.

## Checklist

- [x] Self-review completed