### PR TITLE
feat(public): human-readable /plan-du-site page + footer/sitemap/robots links

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -10,6 +10,7 @@
         "http://localhost:3000/faq/",
         "http://localhost:3000/contact/",
         "http://localhost:3000/compare/",
+        "http://localhost:3000/plan-du-site/",
         "http://localhost:3000/tutoriel/",
         "http://localhost:3000/api-docs/"
       ],

--- a/src/app/(public)/plan-du-site/page.tsx
+++ b/src/app/(public)/plan-du-site/page.tsx
@@ -1,0 +1,146 @@
+/* eslint-disable i18next/no-literal-string */
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { BreadcrumbJsonLd, JsonLdScript } from "@/components/seo/json-ld";
+import { getSiteUrl } from "@/lib/env";
+import { buildMetadata } from "@/lib/metadata";
+import { getTenant } from "@/lib/tenant";
+
+export const metadata: Metadata = buildMetadata({
+  title: "Plan du site — Oltigo",
+  description:
+    "Retrouvez toutes les pages publiques d'Oltigo : services, fonctionnalités, tarifs, ressources, carrière et mentions légales.",
+  path: "/plan-du-site",
+});
+
+interface SitemapLink {
+  href: string;
+  label: string;
+}
+
+interface SitemapGroup {
+  title: string;
+  links: SitemapLink[];
+}
+
+const sitemapGroups: SitemapGroup[] = [
+  {
+    title: "Accueil",
+    links: [{ href: "/", label: "Page d’accueil" }],
+  },
+  {
+    title: "Produit",
+    links: [
+      { href: "/services", label: "Services" },
+      { href: "/features/appointments", label: "Rendez-vous" },
+      { href: "/features/records", label: "Dossier patient" },
+      { href: "/features/whatsapp", label: "Rappels WhatsApp" },
+      { href: "/pricing", label: "Tarifs" },
+      { href: "/compare", label: "Comparatif" },
+      { href: "/register-clinic", label: "Créer votre clinique" },
+    ],
+  },
+  {
+    title: "Ressources",
+    links: [
+      { href: "/api-docs", label: "Documentation API" },
+      { href: "/how-to-book", label: "Guide de démarrage" },
+      { href: "/faq", label: "FAQ" },
+      { href: "/tutoriel", label: "Tutoriels" },
+      { href: "/status", label: "Statut" },
+      { href: "/blog", label: "Blog" },
+      { href: "/plan-du-site", label: "Plan du site" },
+    ],
+  },
+  {
+    title: "Entreprise",
+    links: [
+      { href: "/about", label: "À propos" },
+      { href: "/contact", label: "Contact" },
+      { href: "/carriere", label: "Carrières" },
+      { href: "/partenaires", label: "Partenaires" },
+      { href: "/versions", label: "Versions" },
+      { href: "/testimonials", label: "Témoignages" },
+    ],
+  },
+  {
+    title: "Légal",
+    links: [
+      { href: "/privacy", label: "Confidentialité" },
+      { href: "/terms", label: "Conditions" },
+      { href: "/sub-processors", label: "Sous-traitants" },
+      { href: "/security", label: "Sécurité" },
+      { href: "/cookies", label: "Cookies" },
+      { href: "/accessibility", label: "Accessibilité" },
+      { href: "/loi-09-08", label: "Loi 09-08" },
+    ],
+  },
+];
+
+function SitemapSection({ group }: { group: SitemapGroup }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-5">
+      <h2 className="mb-4 text-lg font-semibold tracking-tight">{group.title}</h2>
+      <ul className="space-y-2">
+        {group.links.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="inline-block text-sm text-primary underline-offset-4 hover:underline min-h-11"
+            >
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default async function PlanDuSitePage() {
+  await getTenant();
+  const h = await headers();
+  const nonce = h.get("x-nonce") || undefined;
+  const siteUrl = getSiteUrl() || "https://oltigo.com";
+
+  const webPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: "Plan du site — Oltigo",
+    url: `${siteUrl}/plan-du-site`,
+  };
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 py-16">
+      <JsonLdScript data={webPageJsonLd} nonce={nonce} />
+      <BreadcrumbJsonLd
+        nonce={nonce}
+        items={[
+          { name: "Accueil", url: siteUrl },
+          { name: "Plan du site", url: `${siteUrl}/plan-du-site` },
+        ]}
+      />
+
+      <div className="mb-10">
+        <p className="mb-3 font-mono text-xs font-medium uppercase tracking-[0.2em] text-primary">
+          Navigation
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Plan du site
+        </h1>
+        <p className="mt-3 max-w-2xl text-muted-foreground">
+          Toutes les pages publiques d&apos;Oltigo classées par thème.
+        </p>
+      </div>
+
+      <nav aria-label="Plan du site">
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {sitemapGroups.map((group) => (
+            <SitemapSection key={group.title} group={group} />
+          ))}
+        </div>
+      </nav>
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -43,6 +43,7 @@ export default function robots(): MetadataRoute.Robots {
           "/loi-09-08",
           "/versions",
           "/tutoriel",
+          "/plan-du-site",
           "/doctor-profile",
           "/doctor-services",
           "/annuaire",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -70,6 +70,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: "/loi-09-08", priority: 0.3, changeFrequency: "yearly" as const },
     { path: "/versions", priority: 0.4, changeFrequency: "monthly" as const },
     { path: "/tutoriel", priority: 0.6, changeFrequency: "monthly" as const },
+    { path: "/plan-du-site", priority: 0.5, changeFrequency: "monthly" as const },
   ];
 
   const entries: MetadataRoute.Sitemap = staticPages.map((page) => ({

--- a/src/components/landing/oltigo/components/sections/footer.tsx
+++ b/src/components/landing/oltigo/components/sections/footer.tsx
@@ -25,8 +25,8 @@ const FOOTER_HREFS: string[][] = [
   // Appointments · Records · WhatsApp · Pricing · Comparison
   ["/features/appointments", "/features/records", "/features/whatsapp", "/pricing", "/compare"],
   // 1 — Resources / Ressources / الموارد
-  // API docs · Getting started · FAQ · Tutorials · Status · Blog
-  ["/api-docs", "/how-to-book", "/faq", "/tutoriel", "/status", "/blog"],
+  // API docs · Getting started · FAQ · Tutorials · Status · Blog · Sitemap
+  ["/api-docs", "/how-to-book", "/faq", "/tutoriel", "/status", "/blog", "/plan-du-site"],
   // 2 — Company / Entreprise / الشركة
   // About · Contact · Careers · Partners · Changelog
   ["/about", "/contact", "/carriere", "/partenaires", "/versions"],

--- a/src/components/landing/oltigo/i18n/dictionaries.ts
+++ b/src/components/landing/oltigo/i18n/dictionaries.ts
@@ -454,7 +454,15 @@ const fr: Dictionary = {
       },
       {
         title: "Ressources",
-        links: ["Documentation", "Guide de démarrage", "FAQ", "Tutoriels", "Statut", "Blog"],
+        links: [
+          "Documentation",
+          "Guide de démarrage",
+          "FAQ",
+          "Tutoriels",
+          "Statut",
+          "Blog",
+          "Plan du site",
+        ],
       },
       {
         title: "Entreprise",
@@ -746,7 +754,15 @@ const ar: Dictionary = {
       },
       {
         title: "الموارد",
-        links: ["التوثيق", "دليل البدء", "الأسئلة الشائعة", "الدروس", "الحالة", "المدونة"],
+        links: [
+          "التوثيق",
+          "دليل البدء",
+          "الأسئلة الشائعة",
+          "الدروس",
+          "الحالة",
+          "المدونة",
+          "خريطة الموقع",
+        ],
       },
       { title: "الشركة", links: ["من نحن", "اتصل بنا", "وظائف", "شركاء", "الإصدارات"] },
       {
@@ -1057,7 +1073,15 @@ const en: Dictionary = {
       },
       {
         title: "Resources",
-        links: ["Documentation", "Getting started", "FAQ", "Tutorials", "Status", "Blog"],
+        links: [
+          "Documentation",
+          "Getting started",
+          "FAQ",
+          "Tutorials",
+          "Status",
+          "Blog",
+          "Sitemap",
+        ],
       },
       { title: "Company", links: ["About", "Contact", "Careers", "Partners", "Changelog"] },
       { title: "Legal", links: ["Privacy", "Terms", "Sub-processors", "Security", "Cookies"] },


### PR DESCRIPTION
## Summary

Adds a human-readable `/plan-du-site` HTML sitemap grouped by the footer categories (Accueil, Produit, Ressources, Entreprise, Légal).

- New `src/app/(public)/plan-du-site/page.tsx` with `WebPage` and `BreadcrumbList` JSON-LD, accessible grouped link lists, and responsive cards.
- Footer Resources column now links to `/plan-du-site` in FR (`Plan du site`), AR (`خريطة الموقع`) and EN (`Sitemap`).
- `robots.ts`, `sitemap.ts` and `lighthouserc.json` updated to include `/plan-du-site/`.

## Type of change

- [x] New feature
- [x] Documentation

## Security Impact

- [x] No security impact

## Migration Safety

- [x] N/A — no migrations

## Testing

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Local `CI=true npm start` serves `/plan-du-site/` with the correct title and JSON-LD.

## Observability

- [x] N/A — no observability changes

## Rollback

Revert this commit.

## SLO / Metrics Impact

- [x] N/A — no SLO/metrics impact

## Drive-by Refactors

- None

## Checklist

- [x] Code follows the project's style guide
- [x] Self-review completed
- [x] No secrets or PHI in the diff
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes